### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ foss-checks: vendor
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: image test
+ci: clean image test
 
 ## Deploys images to registry
 cd:


### PR DESCRIPTION
- Use builtin `CURDIR` instead of PWD
- We need to clean in `ci`