### PR TITLE
Configure namespaces

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -10,6 +10,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - pods
   - services
   - endpoints

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -1,6 +1,8 @@
 package render
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+)
 
 // setCustomVolumeMounts merges a custom list of volume mounts into a default list. A custom volume mount
 // overrides a default volume mount if they have the same name.
@@ -62,7 +64,7 @@ func setCustomTolerations(defaults []v1.Toleration, custom []v1.Toleration) []v1
 }
 
 // setCustomEnv merges a custom list of envvars into a default list. A custom envvar overrides a default envvar if
-// they have the same name
+// they have the same name.
 func setCustomEnv(defaults []v1.EnvVar, custom []v1.EnvVar) []v1.EnvVar {
 	for _, c := range custom {
 		var found bool

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -42,7 +42,7 @@ func controllersServiceAccount(cr *operatorv1alpha1.Core) *v1.ServiceAccount {
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "calico-kube-controllers",
-			Namespace: "kube-system",
+			Namespace: calicoNamespace,
 			Labels:    map[string]string{},
 		},
 	}
@@ -104,7 +104,7 @@ func controllersRoleBinding(cr *operatorv1alpha1.Core) *rbacv1.ClusterRoleBindin
 			{
 				Kind:      "ServiceAccount",
 				Name:      "calico-kube-controllers",
-				Namespace: "kube-system",
+				Namespace: calicoNamespace,
 			},
 		},
 	}
@@ -148,7 +148,7 @@ func controllersDeployment(cr *operatorv1alpha1.Core) *apps.Deployment {
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "calico-kube-controllers",
-			Namespace: "kube-system",
+			Namespace: calicoNamespace,
 			Labels: map[string]string{
 				"k8s-app": "calico-kube-controllers",
 			},
@@ -169,7 +169,7 @@ func controllersDeployment(cr *operatorv1alpha1.Core) *apps.Deployment {
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "calico-kube-controllers",
-					Namespace: "kube-system",
+					Namespace: calicoNamespace,
 					Labels: map[string]string{
 						"k8s-app": "calico-kube-controllers",
 					},

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -100,10 +100,10 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(resources)).To(Equal(4))
 
 		// Should render the correct resources.
-		ExpectResource(resources[0], "calico-kube-controllers", "kube-system", "", "v1", "ServiceAccount")
+		ExpectResource(resources[0], "calico-kube-controllers", "calico-system", "", "v1", "ServiceAccount")
 		ExpectResource(resources[1], "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole")
 		ExpectResource(resources[2], "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
-		ExpectResource(resources[3], "calico-kube-controllers", "kube-system", "apps", "v1", "Deployment")
+		ExpectResource(resources[3], "calico-kube-controllers", "calico-system", "apps", "v1", "Deployment")
 
 		// The Deployment should have the correct configuration.
 		ds := resources[3].(*apps.Deployment)

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -1,0 +1,28 @@
+package render
+
+import (
+	operatorv1alpha1 "github.com/tigera/operator/pkg/apis/operator/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	calicoNamespace       = "calico-system"
+	tigeraSecureNamespace = "tigera-system"
+)
+
+func Namespaces(cr *operatorv1alpha1.Core) []runtime.Object {
+	return []runtime.Object{
+		calicoComponentsNamespace(cr),
+	}
+}
+
+func calicoComponentsNamespace(cr *operatorv1alpha1.Core) *v1.Namespace {
+	return &v1.Namespace{
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: calicoNamespace,
+		},
+	}
+}

--- a/pkg/render/namespaces_test.go
+++ b/pkg/render/namespaces_test.go
@@ -1,0 +1,42 @@
+package render_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	operatorv1alpha1 "github.com/tigera/operator/pkg/apis/operator/v1alpha1"
+	"github.com/tigera/operator/pkg/render"
+)
+
+var _ = Describe("Namespace rendering tests", func() {
+	var instance *operatorv1alpha1.Core
+	BeforeEach(func() {
+		// Initialize a default instance to use. Each test can override this to its
+		// desired configuration.
+		instance = &operatorv1alpha1.Core{
+			Spec: operatorv1alpha1.CoreSpec{
+				IPPools: []operatorv1alpha1.IPPool{
+					{CIDR: "192.168.1.0/16"},
+				},
+				Version:   "test",
+				Registry:  "test-reg/",
+				CNINetDir: "/test/cni/net/dir",
+				CNIBinDir: "/test/cni/bin/dir",
+				Components: operatorv1alpha1.ComponentsSpec{
+					KubeProxy: operatorv1alpha1.KubeProxySpec{
+						Required:  true,
+						APIServer: "https://apiserver:443",
+						Image:     "k8s.gcr.io/kube-proxy:v1.13.6",
+					},
+				},
+			},
+		}
+
+	})
+
+	It("should render a namespace", func() {
+		resources := render.Namespaces(instance)
+		Expect(len(resources)).To(Equal(1))
+		ExpectResource(resources[0], "calico-system", "", "", "v1", "Namespace")
+	})
+})

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -26,11 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var nodeMeta = metav1.ObjectMeta{
-	Name:      "calico-node",
-	Namespace: "kube-system",
-}
-
 func Node(cr *operatorv1alpha1.Core) []runtime.Object {
 	return []runtime.Object{
 		nodeServiceAccount(cr),
@@ -43,8 +38,11 @@ func Node(cr *operatorv1alpha1.Core) []runtime.Object {
 
 func nodeServiceAccount(cr *operatorv1alpha1.Core) *v1.ServiceAccount {
 	return &v1.ServiceAccount{
-		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
-		ObjectMeta: nodeMeta,
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "calico-node",
+			Namespace: calicoNamespace,
+		},
 	}
 }
 
@@ -64,7 +62,7 @@ func nodeRoleBinding(cr *operatorv1alpha1.Core) *rbacv1.ClusterRoleBinding {
 			{
 				Kind:      "ServiceAccount",
 				Name:      "calico-node",
-				Namespace: "kube-system",
+				Namespace: calicoNamespace,
 			},
 		},
 	}
@@ -206,7 +204,7 @@ func nodeCNIConfigMap(cr *operatorv1alpha1.Core) *v1.ConfigMap {
 		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cni-config",
-			Namespace: "kube-system",
+			Namespace: calicoNamespace,
 			Labels:    map[string]string{},
 		},
 		Data: map[string]string{
@@ -312,8 +310,11 @@ func nodeDaemonset(cr *operatorv1alpha1.Core) *apps.DaemonSet {
 	trueBool := true
 
 	return &apps.DaemonSet{
-		TypeMeta:   metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"},
-		ObjectMeta: nodeMeta,
+		TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "calico-node",
+			Namespace: calicoNamespace,
+		},
 		Spec: apps.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "calico-node"}},
 			Template: v1.PodTemplateSpec{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -131,18 +131,17 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(len(resources)).To(Equal(5))
 
 		// Should render the correct resources.
-		ExpectResource(resources[0], "calico-node", "kube-system", "", "v1", "ServiceAccount")
+		ExpectResource(resources[0], "calico-node", "calico-system", "", "v1", "ServiceAccount")
 		ExpectResource(resources[1], "calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRole")
 		ExpectResource(resources[2], "calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
-		ExpectResource(resources[3], "cni-config", "kube-system", "", "v1", "ConfigMap")
-		ExpectResource(resources[4], "calico-node", "kube-system", "apps", "v1", "DaemonSet")
+		ExpectResource(resources[3], "cni-config", "calico-system", "", "v1", "ConfigMap")
+		ExpectResource(resources[4], "calico-node", "calico-system", "apps", "v1", "DaemonSet")
 
 		// The DaemonSet should have the correct configuration.
 		ds := resources[4].(*apps.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/calico/node:test"))
 		ExpectEnv(ds.Spec.Template.Spec.Containers[0].Env, "CALICO_IPV4POOL_CIDR", "192.168.1.0/16")
 		ExpectEnv(ds.Spec.Template.Spec.InitContainers[0].Env, "CNI_NET_DIR", "/test/cni/net/dir")
-		//ExpectEnv(ds.Spec.Template.Spec.InitContainers[0].Env, "CNI_BIN_DIR", "/opt/cni/bin")
 	})
 
 	It("should render all resources for a custom configuration", func() {
@@ -150,11 +149,11 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(len(resources)).To(Equal(5))
 
 		// Should render the correct resources.
-		ExpectResource(resources[0], "calico-node", "kube-system", "", "v1", "ServiceAccount")
+		ExpectResource(resources[0], "calico-node", "calico-system", "", "v1", "ServiceAccount")
 		ExpectResource(resources[1], "calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRole")
 		ExpectResource(resources[2], "calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
-		ExpectResource(resources[3], "cni-config", "kube-system", "", "v1", "ConfigMap")
-		ExpectResource(resources[4], "calico-node", "kube-system", "apps", "v1", "DaemonSet")
+		ExpectResource(resources[3], "cni-config", "calico-system", "", "v1", "ConfigMap")
+		ExpectResource(resources[4], "calico-node", "calico-system", "apps", "v1", "DaemonSet")
 
 		// The DaemonSet should have the correct configuration.
 		ds := resources[4].(*apps.DaemonSet)

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -25,6 +25,7 @@ func Render(cr *operatorv1alpha1.Core) []runtime.Object {
 		// Only install KubeProxy if required, and do so before installing Node.
 		objs = KubeProxy(cr)
 	}
+	objs = append(objs, Namespaces(cr)...)
 	objs = append(objs, Node(cr)...)
 	objs = append(objs, KubeControllers(cr)...)
 	return objs

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 5 node resources (ServiceAccount, ClusterRole, Binding, ConfigMap, DaemonSet)
 		// - 4 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment)
 		resources := render.Render(instance)
-		Expect(len(resources)).To(Equal(9))
+		Expect(len(resources)).To(Equal(10))
 	})
 
 	It("should render all resources when kube-proxy is enabled", func() {
@@ -60,6 +60,6 @@ var _ = Describe("Rendering tests", func() {
 		// - kube-proxy DaemonSet
 		instance.Spec.Components.KubeProxy.Required = true
 		resources := render.Render(instance)
-		Expect(len(resources)).To(Equal(13))
+		Expect(len(resources)).To(Equal(14))
 	})
 })

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -104,9 +104,9 @@ var _ = Describe("Mainline component function tests", func() {
 		defer close(stopChan)
 
 		By("Verifying the resources were created")
-		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "kube-system"}}
+		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "calico-system"}}
 		ExpectResourceCreated(c, ds)
-		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "kube-system"}}
+		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "calico-system"}}
 		ExpectResourceCreated(c, kc)
 
 		By("Verifying the resources are ready")
@@ -158,9 +158,9 @@ var _ = Describe("Mainline component function tests", func() {
 		defer close(stopChan)
 
 		By("Verifying the resources were created")
-		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "kube-system"}}
+		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "calico-system"}}
 		ExpectResourceCreated(c, ds)
-		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "kube-system"}}
+		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "calico-system"}}
 		ExpectResourceCreated(c, kc)
 
 		proxyMeta := metav1.ObjectMeta{Name: "kube-proxy", Namespace: "kube-system"}
@@ -260,9 +260,9 @@ var _ = Describe("Mainline component function tests", func() {
 		defer close(stopChan)
 
 		By("Verifying the resources were created")
-		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "kube-system"}}
+		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "calico-system"}}
 		ExpectResourceCreated(c, ds)
-		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "kube-system"}}
+		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "calico-system"}}
 		ExpectResourceCreated(c, kc)
 
 		By("Verifying the resources are Ready")
@@ -323,9 +323,9 @@ var _ = Describe("Mainline component function tests with ignored resource", func
 		defer close(stopChan)
 
 		By("Verifying resources were not created")
-		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "kube-system"}}
+		ds := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-node", Namespace: "calico-system"}}
 		ExpectResourceDestroyed(c, ds)
-		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "kube-system"}}
+		kc := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-kube-controllers", Namespace: "calico-system"}}
 		ExpectResourceDestroyed(c, kc)
 		proxy := &apps.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "kube-proxy", Namespace: "kube-system"}}
 		ExpectResourceDestroyed(c, proxy)


### PR DESCRIPTION
Move Calico components into `calico-system` namespace for the Calico variant and `tigera-system` for the TigeraSecureEnterprise.