### PR TITLE
Update ci target to build all images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ foss-checks: vendor
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: clean image test
+ci: clean images test
 
 ## Deploys images to registry
 cd:


### PR DESCRIPTION
Previous changes to add init container and update Makefile left out the
important step to have the ci target actually build the new init
container.