### PR TITLE
Remove need for passing in explicit APIServer URL

### DIFF
--- a/pkg/controller/core/defaults.go
+++ b/pkg/controller/core/defaults.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -56,6 +57,11 @@ func fillDefaults(instance *operatorv1alpha1.Core) {
 			// Openshift's latest release uses Kubernetes 1.13. This is the latest stable kube-proxy version under that
 			// release as of 5.21.19.
 			instance.Spec.Components.KubeProxy.Image = "k8s.gcr.io/kube-proxy:v1.13.6"
+		}
+		if len(instance.Spec.Components.KubeProxy.APIServer) == 0 {
+			// Default to using the injected environment variables. If configured with the --url-only-kubeconfig, these will be set
+			// to the correct values based on the provided kubeconfig file.
+			instance.Spec.Components.KubeProxy.APIServer = fmt.Sprintf("https://%s:%s", os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT"))
 		}
 	}
 	if instance.Spec.Components.Node.MaxUnavailable == nil {


### PR DESCRIPTION
We already have this information if using a --url-only-kubeconfig, so we
might as well not require the user to pass it in.