### PR TITLE
Add typha and certs for Typha-Felix comms

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -130,9 +130,12 @@ func CheckLicenseKey(ctx context.Context, cli client.Client) error {
 // If there is an error accessing the secret (except NotFound) or the cert
 // does not have both a key and cert field then an appropriate error is returned.
 // If no secret exists then nil, nil is returned to represent that no cert is valid.
-func ValidateCertPair(client client.Client, certPairSecretName, keyName, certName, ns string) (*corev1.Secret, error) {
+func ValidateCertPair(client client.Client, certPairSecretName, keyName, certName string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
-	secretNamespacedName := types.NamespacedName{Name: certPairSecretName, Namespace: ns}
+	secretNamespacedName := types.NamespacedName{
+		Name:      certPairSecretName,
+		Namespace: render.OperatorNamespace(),
+	}
 	err := client.Get(context.Background(), secretNamespacedName, secret)
 	if err != nil {
 		// If the reason for the error is not found then that is acceptable

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -33,7 +33,9 @@ var _ = Describe("API server rendering tests", func() {
 
 	It("should render an API server with default configuration", func() {
 		//APIServer(registry string, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool
-		component := render.APIServer("testregistry.com/", nil, nil, openshift)
+		component, err := render.APIServer("testregistry.com/", nil, nil, openshift)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+
 		resources := component.Objects()
 
 		// Should render the correct resources.
@@ -187,7 +189,8 @@ var _ = Describe("API server rendering tests", func() {
 	})
 
 	It("should render an API server with custom configuration", func() {
-		component := render.APIServer("", nil, nil, openshift)
+		component, err := render.APIServer("", nil, nil, openshift)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources := component.Objects()
 
 		// Should render the correct resources.

--- a/pkg/render/configmap.go
+++ b/pkg/render/configmap.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ConfigMaps(cms []*corev1.ConfigMap) Component {
+	return &configMapComponent{configMaps: cms}
+}
+
+type configMapComponent struct {
+	configMaps []*corev1.ConfigMap
+}
+
+func (c *configMapComponent) Objects() []runtime.Object {
+	objs := []runtime.Object{}
+	for _, cm := range c.configMaps {
+		objs = append(objs, cm)
+	}
+	return objs
+}
+
+func (c *configMapComponent) Ready() bool {
+	return true
+}

--- a/pkg/render/console_test.go
+++ b/pkg/render/console_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Tigera Secure Console rendering tests", func() {
 	})
 
 	It("should render all resources for a default configuration", func() {
-		component := render.Console(instance, monitoring, nil, nil, notOpenshift, registry)
+		component, err := render.Console(instance, monitoring, nil, nil, notOpenshift, registry)
+		Expect(err).To(BeNil(), "Expected Console to create successfully %s", err)
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(10))
 

--- a/pkg/render/images.go
+++ b/pkg/render/images.go
@@ -14,6 +14,7 @@ const (
 const (
 	NodeImageNameCalico            = "node:v3.8.1"
 	CNIImageName                   = "cni:v3.8.1"
+	TyphaImageNameCalico           = "typha:v3.8.1"
 	KubeControllersImageNameCalico = "kube-controllers:v3.8.1"
 	FlexVolumeImageName            = "pod2daemon-flexvol:v3.8.1"
 )
@@ -22,6 +23,7 @@ const (
 const (
 	// Overrides for Calico.
 	NodeImageNameTigera            = "cnx-node:v2.5.0"
+	TyphaImageNameTigera           = "typha:v2.4.2"
 	KubeControllersImageNameTigera = "kube-controllers:v2.4.2"
 
 	// API server images.
@@ -55,7 +57,12 @@ func constructImage(imageName string, registry string) string {
 	// Otherwise, default the registry based on component.
 	reg := TigeraRegistry
 	switch imageName {
-	case NodeImageNameCalico, CNIImageName, KubeControllersImageNameCalico, FlexVolumeImageName:
+	case NodeImageNameCalico,
+		CNIImageName,
+		TyphaImageNameCalico,
+		KubeControllersImageNameCalico,
+		FlexVolumeImageName:
+
 		reg = CalicoRegistry
 	}
 	return fmt.Sprintf("%s%s", reg, imageName)

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -54,7 +54,7 @@ func (c *kubeControllersComponent) controllersServiceAccount() *v1.ServiceAccoun
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "calico-kube-controllers",
-			Namespace: calicoNamespace,
+			Namespace: CalicoNamespace,
 			Labels:    map[string]string{},
 		},
 	}
@@ -142,7 +142,7 @@ func (c *kubeControllersComponent) controllersRoleBinding() *rbacv1.ClusterRoleB
 			{
 				Kind:      "ServiceAccount",
 				Name:      "calico-kube-controllers",
-				Namespace: calicoNamespace,
+				Namespace: CalicoNamespace,
 			},
 		},
 	}
@@ -186,7 +186,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "calico-kube-controllers",
-			Namespace: calicoNamespace,
+			Namespace: CalicoNamespace,
 			Labels: map[string]string{
 				"k8s-app": "calico-kube-controllers",
 			},
@@ -204,7 +204,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "calico-kube-controllers",
-					Namespace: calicoNamespace,
+					Namespace: CalicoNamespace,
 					Labels: map[string]string{
 						"k8s-app": "calico-kube-controllers",
 					},

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	calicoNamespace           = "calico-system"
-	calicoMonitoringNamespace = "calico-monitoring"
+	CalicoNamespace           = "calico-system"
+	CalicoMonitoringNamespace = "calico-monitoring"
 )
 
 func Namespaces(cr *operator.Installation, openshift bool, pullSecrets []*corev1.Secret) Component {
@@ -42,16 +42,16 @@ type namespaceComponent struct {
 
 func (c *namespaceComponent) Objects() []runtime.Object {
 	ns := []runtime.Object{
-		createNamespace(calicoNamespace, c.openshift),
+		createNamespace(CalicoNamespace, c.openshift),
 	}
 	if len(c.pullSecrets) > 0 {
-		ns = append(ns, copyImagePullSecrets(c.pullSecrets, calicoNamespace)...)
+		ns = append(ns, copyImagePullSecrets(c.pullSecrets, CalicoNamespace)...)
 	}
 
 	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
-		ns = append(ns, createNamespace(calicoMonitoringNamespace, c.openshift))
+		ns = append(ns, createNamespace(CalicoMonitoringNamespace, c.openshift))
 		if len(c.pullSecrets) > 0 {
-			ns = append(ns, copyImagePullSecrets(c.pullSecrets, calicoMonitoringNamespace)...)
+			ns = append(ns, copyImagePullSecrets(c.pullSecrets, CalicoMonitoringNamespace)...)
 		}
 	}
 	return ns

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -15,9 +15,25 @@
 package render
 
 import (
+	"bytes"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/crypto"
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	TyphaCAConfigMapName = "typha-ca"
+	TyphaCABundleName    = "caBundle"
+	TyphaTLSSecretName   = "typha-certs"
+	FelixTLSSecretName   = "felix-certs"
+	TLSSecretCertName    = "cert.crt"
+	TLSSecretKeyName     = "key.key"
+	CommonName           = "common-name"
+	URISAN               = "uri-san"
 )
 
 type Component interface {
@@ -33,20 +49,120 @@ type Renderer interface {
 	Render() []Component
 }
 
-func Calico(cr *operator.Installation, pullSecrets []*corev1.Secret, p operator.Provider, nc NetworkConfig) Renderer {
-	return calicoRenderer{
-		installation:  cr,
-		pullSecrets:   pullSecrets,
-		provider:      p,
-		networkConfig: nc,
+func Calico(
+	cr *operator.Installation,
+	pullSecrets []*corev1.Secret,
+	typhaCAConfigMap *corev1.ConfigMap,
+	typhaSecrets []*corev1.Secret,
+	p operator.Provider,
+	nc NetworkConfig,
+) (Renderer, error) {
+
+	tcms := []*corev1.ConfigMap{}
+	tss := []*corev1.Secret{}
+
+	// Check the CA configMap and Secrets to ensure they are a valid combination and
+	// if the TLS info needs to be created.
+	// We should have them all or none.
+	if typhaCAConfigMap == nil {
+		if len(typhaSecrets) != 0 {
+			return nil, fmt.Errorf("Typha-Felix CA config map did not exist and neither should the Secrets Secrets(%v)", typhaSecrets)
+		}
+		var err error
+		typhaCAConfigMap, typhaSecrets, err = createTLS()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create Typha TLS: %s", err)
+		}
+		tcms = append(tcms, typhaCAConfigMap)
+		tss = append(tss, typhaSecrets...)
+	} else {
+		// CA ConfigMap exists
+		if len(typhaSecrets) != 2 {
+			return nil, fmt.Errorf("Typha-Felix CA config map exists and so should the Secrets.")
+		}
 	}
+
+	// Create copy to go into Calico Namespace
+	tcm := typhaCAConfigMap.DeepCopy()
+	tcm.ObjectMeta = metav1.ObjectMeta{Name: typhaCAConfigMap.Name, Namespace: CalicoNamespace}
+	tcms = append(tcms, tcm)
+
+	for _, s := range typhaSecrets {
+		x := s.DeepCopy()
+		x.ObjectMeta = metav1.ObjectMeta{Name: s.Name, Namespace: CalicoNamespace}
+		tss = append(tss, x)
+	}
+
+	return calicoRenderer{
+		installation:    cr,
+		pullSecrets:     pullSecrets,
+		typhaConfigMaps: tcms,
+		typhaSecrets:    tss,
+		provider:        p,
+		networkConfig:   nc,
+	}, nil
+}
+
+func createTLS() (*corev1.ConfigMap, []*corev1.Secret, error) {
+	// Make CA
+	ca, err := makeCA()
+	if err != nil {
+		return nil, nil, err
+	}
+	crtContent := &bytes.Buffer{}
+	keyContent := &bytes.Buffer{}
+	if err := ca.Config.WriteCertConfig(crtContent, keyContent); err != nil {
+		return nil, nil, err
+	}
+
+	// Take CA cert and create ConfigMap
+	data := make(map[string]string)
+	data[TyphaCABundleName] = crtContent.String()
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TyphaCAConfigMapName,
+			Namespace: OperatorNamespace(),
+		},
+		Data: data,
+	}
+
+	// Create TLS Secret for Felix using ca from above
+	f, err := createOperatorTLSSecret(ca,
+		FelixTLSSecretName,
+		TLSSecretKeyName,
+		TLSSecretCertName,
+		[]crypto.CertificateExtensionFunc{setClientAuth},
+		"typha-client")
+	if err != nil {
+		return nil, nil, err
+	}
+	// Set the CommonName used to create cert
+	f.Data[CommonName] = []byte("typha-client")
+
+	// Create TLS Secret for Felix using ca from above
+	t, err := createOperatorTLSSecret(ca,
+		TyphaTLSSecretName,
+		TLSSecretKeyName,
+		TLSSecretCertName,
+		[]crypto.CertificateExtensionFunc{setServerAuth},
+		"typha-server")
+	if err != nil {
+		return nil, nil, err
+	}
+	// Set the CommonName used to create cert
+	t.Data[CommonName] = []byte("typha-server")
+
+	return cm, []*corev1.Secret{f, t}, nil
 }
 
 type calicoRenderer struct {
-	installation  *operator.Installation
-	pullSecrets   []*corev1.Secret
-	provider      operator.Provider
-	networkConfig NetworkConfig
+	installation    *operator.Installation
+	pullSecrets     []*corev1.Secret
+	typhaConfigMaps []*corev1.ConfigMap
+	typhaSecrets    []*corev1.Secret
+	provider        operator.Provider
+	networkConfig   NetworkConfig
 }
 
 func (r calicoRenderer) Render() []Component {
@@ -54,6 +170,9 @@ func (r calicoRenderer) Render() []Component {
 	components = appendNotNil(components, CustomResourceDefinitions(r.installation))
 	components = appendNotNil(components, PriorityClassDefinitions(r.installation))
 	components = appendNotNil(components, Namespaces(r.installation, r.provider == operator.ProviderOpenShift, r.pullSecrets))
+	components = appendNotNil(components, ConfigMaps(r.typhaConfigMaps))
+	components = appendNotNil(components, Secrets(r.typhaSecrets))
+	components = appendNotNil(components, Typha(r.installation, r.provider))
 	components = appendNotNil(components, Node(r.installation, r.provider, r.networkConfig))
 	components = appendNotNil(components, KubeControllers(r.installation))
 	return components

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -59,12 +59,16 @@ var _ = Describe("Rendering tests", func() {
 		// For this scenario, we expect the basic resources
 		// created by the controller without any optional ones. These include:
 		// - 5 node resources (ServiceAccount, ClusterRole, Binding, ConfigMap, DaemonSet)
+		// - 4 secrets for Typha comms (2 in operator namespace and 2 in calico namespace)
+		// - 2 ConfigMap for Typha comms (1 in operator namespace and 1 in calico namespace)
+		// - 5 typha resources (Service, SA, Role, Binding, Deployment)
 		// - 4 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment)
 		// - 1 namespace
 		// - 1 PriorityClass
 		// - 14 custom resource definitions
-		c := render.Calico(instance, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico})
-		Expect(componentCount(c.Render())).To(Equal(25))
+		c, err := render.Calico(instance, nil, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico})
+		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
+		Expect(componentCount(c.Render())).To(Equal(36))
 	})
 
 	It("should render all resources when variant is Tigera Secure", func() {
@@ -74,8 +78,9 @@ var _ = Describe("Rendering tests", func() {
 		// - 1 ns (calico-monitoring)
 		// - 6 TSEE crds
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
-		c := render.Calico(instance, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico})
-		Expect(componentCount(c.Render())).To(Equal((25 + 1 + 1 + 6)))
+		c, err := render.Calico(instance, nil, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico})
+		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
+		Expect(componentCount(c.Render())).To(Equal((36 + 1 + 1 + 6)))
 	})
 })
 

--- a/pkg/render/secrets.go
+++ b/pkg/render/secrets.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Secrets(secrets []*corev1.Secret) Component {
+	return &secretsComponent{secrets: secrets}
+}
+
+type secretsComponent struct {
+	secrets []*corev1.Secret
+}
+
+func (c *secretsComponent) Objects() []runtime.Object {
+	objs := []runtime.Object{}
+	for _, s := range c.secrets {
+		objs = append(objs, s)
+	}
+	return objs
+}
+
+func (c *secretsComponent) Ready() bool {
+	return true
+}


### PR DESCRIPTION
- Changes around cert generation, mostly so they could be used for Typha-Felix but also I think it gives a better path for reporting errors during that generation.
- Add Typha, it's service, created new SA, role, and binding only for Typha. Currently the role is just a copy of the node one.
- Add to Felix the mounts and other EnvVar for using Typha certs.