### PR TITLE
Support running without the TSEE CRDs

### DIFF
--- a/deploy/crds/operator_v1_installation_cr.yaml
+++ b/deploy/crds/operator_v1_installation_cr.yaml
@@ -2,4 +2,3 @@ apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:
   name: default
-spec:

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -25,7 +25,11 @@ var log = logf.Log.WithName("controller_apiserver")
 
 // Add creates a new APIServer Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, openshift bool) error {
+func Add(mgr manager.Manager, openshift bool, tsee bool) error {
+	if !tsee {
+		// No need to start this controller.
+		return nil
+	}
 	return add(mgr, newReconciler(mgr, openshift))
 }
 

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -25,7 +25,11 @@ var log = logf.Log.WithName("controller_compliance")
 
 // Add creates a new Compliance Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, openshift bool) error {
+func Add(mgr manager.Manager, openshift bool, tsee bool) error {
+	if !tsee {
+		// No need to start this controller.
+		return nil
+	}
 	return add(mgr, newReconciler(mgr, openshift))
 }
 

--- a/pkg/controller/console/console_controller.go
+++ b/pkg/controller/console/console_controller.go
@@ -27,7 +27,11 @@ var log = logf.Log.WithName("controller_console")
 
 // Add creates a new Console Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, openshift bool) error {
+func Add(mgr manager.Manager, openshift bool, tsee bool) error {
+	if !tsee {
+		// No need to start this controller.
+		return nil
+	}
 	return add(mgr, newReconciler(mgr, openshift))
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,13 +19,14 @@ import (
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-// Each func takes the manager as well as a boolean indicating if we're running on openshift.
-var AddToManagerFuncs []func(manager.Manager, bool) error
+// Each func takes the manager as well as a boolean indicating if we're running on openshift,
+// as well as a boolean indicating whether we need to start TSEE controllers.
+var AddToManagerFuncs []func(manager.Manager, bool, bool) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, openshift bool) error {
+func AddToManager(m manager.Manager, openshift bool, tsee bool) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, openshift); err != nil {
+		if err := f(m, openshift, tsee); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -25,7 +25,11 @@ var log = logf.Log.WithName("controller_intrusiondetection")
 
 // Add creates a new IntrusionDetection Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, openshift bool) error {
+func Add(mgr manager.Manager, openshift bool, tsee bool) error {
+	if !tsee {
+		// No need to start this controller.
+		return nil
+	}
 	return add(mgr, newReconciler(mgr, openshift))
 }
 

--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("discovery")
+
+// RequiresTigeraSecure determines if the configuration requires we start the tigera secure
+// controllers.
+func RequiresTigeraSecure(cfg *rest.Config) (bool, error) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return false, err
+	}
+
+	// Use the discovery client to determine if the tigera secure specific APIs exist.
+	resources, err := clientset.Discovery().ServerResourcesForGroupVersion("operator.tigera.io/v1")
+	if err != nil {
+		return false, err
+	}
+	for _, r := range resources.APIResources {
+		if r.Kind == "APIServer" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -357,7 +357,9 @@ func setupManager() (client.Client, manager.Manager) {
 	err = apis.AddToScheme(mgr.GetScheme())
 	Expect(err).NotTo(HaveOccurred())
 	// Setup all Controllers
-	err = controller.AddToManager(mgr, false)
+	openshift := false
+	runTSEEControllers := true
+	err = controller.AddToManager(mgr, openshift, runTSEEControllers)
 	Expect(err).NotTo(HaveOccurred())
 	return mgr.GetClient(), mgr
 }


### PR DESCRIPTION
Updates the Tigera operator so that it doesn't need all of the Tigera Secure CRDs to be present, if the user is intending to just run Calico.