### PR TITLE
Install calico/node metrics service

### DIFF
--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Node rendering tests", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		component := render.Node(defaultInstance, notOpenshift)
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(5))
+		Expect(len(resources)).To(Equal(6))
 
 		// Should render the correct resources.
 		ExpectResource(resources[0], "calico-node", "calico-system", "", "v1", "ServiceAccount")
@@ -278,6 +278,7 @@ var _ = Describe("Node rendering tests", func() {
 		ExpectResource(resources[2], "calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
 		ExpectResource(resources[3], "cni-config", "calico-system", "", "v1", "ConfigMap")
 		ExpectResource(resources[4], "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+		ExpectResource(resources[5], "calico-node-metrics", "calico-system", "", "v1", "Service")
 
 		// The DaemonSet should have the correct configuration.
 		ds := resources[4].(*apps.DaemonSet)
@@ -385,7 +386,7 @@ var _ = Describe("Node rendering tests", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		component := render.Node(defaultInstance, openshift)
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(5))
+		Expect(len(resources)).To(Equal(6))
 
 		// Should render the correct resources.
 		ExpectResource(resources[0], "calico-node", "calico-system", "", "v1", "ServiceAccount")
@@ -393,6 +394,7 @@ var _ = Describe("Node rendering tests", func() {
 		ExpectResource(resources[2], "calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
 		ExpectResource(resources[3], "cni-config", "calico-system", "", "v1", "ConfigMap")
 		ExpectResource(resources[4], "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+		ExpectResource(resources[5], "calico-node-metrics", "calico-system", "", "v1", "Service")
 
 		// The DaemonSet should have the correct configuration.
 		ds := resources[4].(*apps.DaemonSet)

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -70,11 +70,12 @@ var _ = Describe("Rendering tests", func() {
 	It("should render all resources when variant is Tigera Secure", func() {
 		// For this scenario, we expect the basic resources plus the following for Tigera Secure:
 		// - X Same as default config
+		// - 1 Service to expose calico/node metrics.
 		// - 1 ns (calico-monitoring)
 		// - 6 TSEE crds
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		c := render.Calico(instance, nil, notOpenshift)
-		Expect(componentCount(c.Render())).To(Equal((25 + 1 + 6)))
+		Expect(componentCount(c.Render())).To(Equal((25 + 1 + 1 + 6)))
 	})
 })
 


### PR DESCRIPTION
The operator needs to install the service for TSEE in order to expose prometheus metrics. 