### PR TITLE
Report status when pods are failing

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -101,14 +101,14 @@ func (r *ReconcileAPIServer) Reconcile(request reconcile.Request) (reconcile.Res
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.V(5).Info("APIServer CR not found", "err", err)
-			r.status.SetDegraded("APIServer not found", err.Error())
+			r.status.OnCRNotFound()
 			return reconcile.Result{}, nil
 		}
 		reqLogger.V(5).Info("failed to get APIServer CR", "err", err)
 		r.status.SetDegraded("Error querying APIServer", err.Error())
 		return reconcile.Result{}, err
 	}
-	r.status.Enable()
+	r.status.OnCRFound()
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 
 	// Query for the installation object.

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -115,13 +115,13 @@ func (r *ReconcileCompliance) Reconcile(request reconcile.Request) (reconcile.Re
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
 			reqLogger.Info("Compliance config not found")
-			r.status.SetDegraded("Compliance not found", err.Error())
+			r.status.OnCRNotFound()
 			return reconcile.Result{}, nil
 		}
 		r.status.SetDegraded("Error querying compliance", err.Error())
 		return reconcile.Result{}, err
 	}
-	r.status.Enable()
+	r.status.OnCRFound()
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 
 	if !utils.IsAPIServerReady(r.client, reqLogger) {

--- a/pkg/controller/console/console_controller.go
+++ b/pkg/controller/console/console_controller.go
@@ -125,14 +125,14 @@ func (r *ReconcileConsole) Reconcile(request reconcile.Request) (reconcile.Resul
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.Info("Console object not found")
-			r.status.SetDegraded("Console not found", err.Error())
+			r.status.OnCRNotFound()
 			return reconcile.Result{}, nil
 		}
 		r.status.SetDegraded("Error querying Console", err.Error())
 		return reconcile.Result{}, err
 	}
 	reqLogger.V(2).Info("Loaded config", "config", instance)
-	r.status.Enable()
+	r.status.OnCRFound()
 
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -197,13 +197,13 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
 			reqLogger.Info("Installation config not found")
-			r.status.SetDegraded("Installation not found", err.Error())
+			r.status.OnCRNotFound()
 			return reconcile.Result{}, nil
 		}
 		r.status.SetDegraded("Error querying installation", err.Error())
 		return reconcile.Result{}, err
 	}
-	r.status.Enable()
+	r.status.OnCRFound()
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 
 	// The operator supports running in a "Calico only" mode so that it doesn't need to run TSEE specific controllers.

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -105,10 +105,10 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.V(3).Info("IntrusionDetection CR not found", "err", err)
-			r.status.SetDegraded("IntrusionDetection not found", err.Error())
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
+			r.status.OnCRFound()
 			return reconcile.Result{}, nil
 		}
 		reqLogger.V(3).Info("failed to get IntrusionDetection CR", "err", err)
@@ -116,7 +116,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	r.status.Enable()
+	r.status.OnCRFound()
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 
 	if !utils.IsAPIServerReady(r.client, reqLogger) {

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Status reporting tests", func() {
 
 		sm = New(client, "test-component")
 		Expect(sm.IsAvailable()).To(BeFalse())
-		sm.Enable()
+		sm.OnCRFound()
 	})
 
 	It("Should handle basic state changes", func() {


### PR DESCRIPTION
There's a few things going on here. The primary driver for this change
is the desire to report a component as "Degraded" when the pods are
failing for some reason.

Until now, a CrashLoopBackOff would show itself as "Progressing"
instead of "Degraded" since the status manager wasn't aware of the
difference.

This PR allows the status manager to look deeper - at individual pods -
and determine _why_ they are not Ready.

As part of doing this, I needed to split the concept of degraded due to
pod/container status vs. degraded due to the controller telling us so
(e.g., bad configuration, missing LicenseKey, etc). 

To make this easier, "Available" and "Progressing" state are now
entirely determined based on what pod state we've read from the cluster, and
"Degraded" state is a combination of cluster/pod state and controller
provided state.