### PR TITLE
move versions out of ImageName vars

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -1,0 +1,38 @@
+package components
+
+// This section contains images used when installing open-source Calico.
+const (
+	VersionCalicoNode            = "v3.8.1"
+	VersionCalicoCNI             = "v3.8.1"
+	VersionCalicoTypha           = "v3.8.1"
+	VersionCalicoKubeControllers = "v3.8.1"
+	VersionFlexVolume            = "v3.8.1"
+)
+
+// This section contains images used when installing Tigera Secure.
+const (
+	// Overrides for Calico.
+	VersionTigeraNode            = "v2.5.0"
+	VersionTigeraTypha           = "v2.4.2"
+	VersionTigeraKubeControllers = "v2.4.2"
+
+	// API server images.
+	VersionAPIServer   = "v2.5.0"
+	VersionQueryServer = "v2.4.0"
+
+	// Compliance images.
+	VersionComplianceController  = "v2.4.2"
+	VersionComplianceReporter    = "v2.4.2"
+	VersionComplianceServer      = "v2.4.2"
+	VersionComplianceSnapshotter = "v2.4.2"
+	VersionComplianceBenchmarker = "v2.5.0"
+
+	// Intrusion detection images.
+	VersionIntrusionDetectionController   = "v2.4.2"
+	VersionIntrusionDetectionJobInstaller = "v2.4.2"
+
+	// Console images.
+	VersionConsoleManager = "v2.4.2"
+	VersionConsoleProxy   = "v2.4.2"
+	VersionConsoleEsProxy = "v2.4.0"
+)

--- a/pkg/render/images.go
+++ b/pkg/render/images.go
@@ -2,6 +2,8 @@ package render
 
 import (
 	"fmt"
+
+	"github.com/tigera/operator/pkg/components"
 )
 
 // Default registries for Calico and Tigera.
@@ -12,39 +14,39 @@ const (
 
 // This section contains images used when installing open-source Calico.
 const (
-	NodeImageNameCalico            = "node:v3.8.1"
-	CNIImageName                   = "cni:v3.8.1"
-	TyphaImageNameCalico           = "typha:v3.8.1"
-	KubeControllersImageNameCalico = "kube-controllers:v3.8.1"
-	FlexVolumeImageName            = "pod2daemon-flexvol:v3.8.1"
+	NodeImageNameCalico            = "node:" + components.VersionCalicoNode
+	CNIImageName                   = "cni:" + components.VersionCalicoCNI
+	TyphaImageNameCalico           = "typha:" + components.VersionCalicoTypha
+	KubeControllersImageNameCalico = "kube-controllers:" + components.VersionCalicoKubeControllers
+	FlexVolumeImageName            = "pod2daemon-flexvol:" + components.VersionFlexVolume
 )
 
 // This section contains images used when installing Tigera Secure.
 const (
 	// Overrides for Calico.
-	NodeImageNameTigera            = "cnx-node:v2.5.0"
-	TyphaImageNameTigera           = "typha:v2.4.2"
-	KubeControllersImageNameTigera = "kube-controllers:v2.4.2"
+	NodeImageNameTigera            = "cnx-node:" + components.VersionTigeraNode
+	TyphaImageNameTigera           = "typha:" + components.VersionTigeraTypha
+	KubeControllersImageNameTigera = "kube-controllers:" + components.VersionTigeraKubeControllers
 
 	// API server images.
-	APIServerImageName   = "cnx-apiserver:v2.5.0"
-	QueryServerImageName = "cnx-queryserver:v2.4.0"
+	APIServerImageName   = "cnx-apiserver:" + components.VersionAPIServer
+	QueryServerImageName = "cnx-queryserver:" + components.VersionQueryServer
 
 	// Compliance images.
-	ComplianceControllerImage  = "compliance-controller:v2.4.2"
-	ComplianceReporterImage    = "compliance-reporter:v2.4.2"
-	ComplianceServerImage      = "compliance-server:v2.4.2"
-	ComplianceSnapshotterImage = "compliance-snapshotter:v2.4.2"
-	ComplianceBenchmarkerImage = "compliance-benchmarker:v2.5.0"
+	ComplianceControllerImage  = "compliance-controller:" + components.VersionComplianceController
+	ComplianceReporterImage    = "compliance-reporter:" + components.VersionComplianceReporter
+	ComplianceServerImage      = "compliance-server:" + components.VersionComplianceServer
+	ComplianceSnapshotterImage = "compliance-snapshotter:" + components.VersionComplianceSnapshotter
+	ComplianceBenchmarkerImage = "compliance-benchmarker:" + components.VersionComplianceBenchmarker
 
 	// Intrusion detection images.
-	IntrusionDetectionControllerImageName   = "intrusion-detection-controller:v2.4.2"
-	IntrusionDetectionJobInstallerImageName = "intrusion-detection-job-installer:v2.4.2"
+	IntrusionDetectionControllerImageName   = "intrusion-detection-controller:" + components.VersionIntrusionDetectionController
+	IntrusionDetectionJobInstallerImageName = "intrusion-detection-job-installer:" + components.VersionIntrusionDetectionJobInstaller
 
 	// Console images.
-	ConsoleManagerImageName = "cnx-manager:v2.4.2"
-	ConsoleProxyImageName   = "cnx-manager-proxy:v2.4.2"
-	ConsoleEsProxyImageName = "es-proxy:v2.4.0"
+	ConsoleManagerImageName = "cnx-manager:" + components.VersionConsoleManager
+	ConsoleProxyImageName   = "cnx-manager-proxy:" + components.VersionConsoleProxy
+	ConsoleEsProxyImageName = "es-proxy:" + components.VersionConsoleEsProxy
 )
 
 // constructImage returns the fully qualified image to use, including registry and version.


### PR DESCRIPTION
Move versions out of ImageName vars and into their own package.

The intent is that this new go package can be auto-generated using versions.yml.