### PR TITLE
print component version info with '--version'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ endif
 ## Verifies the release artifacts produces by `make release-build` are correct.
 release-verify: release-prereqs
 	# Check the reported version is correct for each release artifact.
-	if ! docker run quay.io/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version | grep '^$(VERSION)$$'; then echo "Reported version:" `docker run quay.io/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version ` "\nExpected version: $(VERSION)"; false; else echo "\nVersion check passed\n"; fi
+	if ! docker run quay.io/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version | grep '^Operator: $(VERSION)$$'; then echo "Reported version:" `docker run quay.io/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version ` "\nExpected version: $(VERSION)"; false; else echo "\nVersion check passed\n"; fi
 
 ## Pushes a github release and release artifacts produced by `make release-build`.
 release-publish: release-prereqs

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/daemon"
 	"github.com/tigera/operator/version"
 
@@ -68,7 +69,28 @@ func main() {
 	pflag.Parse()
 
 	if showVersion {
-		fmt.Printf("%s\n", version.VERSION)
+		fmt.Println("Operator:", version.VERSION)
+		fmt.Println("CalicoNode:", components.VersionCalicoNode)
+		fmt.Println("CalicoCNI:", components.VersionCalicoCNI)
+		fmt.Println("CalicoTypha:", components.VersionCalicoTypha)
+		fmt.Println("CalicoKubeControllers:", components.VersionCalicoKubeControllers)
+		fmt.Println("FlexVolume:", components.VersionFlexVolume)
+		fmt.Println("TigeraNode:", components.VersionTigeraNode)
+		fmt.Println("TigeraTypha:", components.VersionTigeraTypha)
+		fmt.Println("TigeraKubeControllers:", components.VersionTigeraKubeControllers)
+		fmt.Println("APIServer:", components.VersionAPIServer)
+		fmt.Println("QueryServer:", components.VersionQueryServer)
+		fmt.Println("ComplianceController:", components.VersionComplianceController)
+		fmt.Println("ComplianceReporter:", components.VersionComplianceReporter)
+		fmt.Println("ComplianceServer:", components.VersionComplianceServer)
+		fmt.Println("ComplianceSnapshotter:", components.VersionComplianceSnapshotter)
+		fmt.Println("ComplianceBenchmarker:", components.VersionComplianceBenchmarker)
+		fmt.Println("IntrusionDetectionController:", components.VersionIntrusionDetectionController)
+		fmt.Println("IntrusionDetectionJobInstaller:", components.VersionIntrusionDetectionJobInstaller)
+		fmt.Println("ConsoleManager:", components.VersionConsoleManager)
+		fmt.Println("ConsoleProxy:", components.VersionConsoleProxy)
+		fmt.Println("ConsoleEsProxy:", components.VersionConsoleEsProxy)
+
 		os.Exit(0)
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION is filled out during the build process (using git describe output)
-var VERSION string
+var VERSION = "unknown"


### PR DESCRIPTION
Idea for a QoL improvement now that versions can be more in flight.

Sample output:

```
$ go run ./cmd/manager/main.go --version
Operator: master
CalicoNode: v3.8.1
CalicoCNI: v3.8.1
CalicoTypha: v3.8.1
CalicoKubeControllers: v3.8.1
FlexVolume: v3.8.1
TigeraNode: v2.5.0
TigeraTypha: v2.4.2
TigeraKubeControllers: v2.4.2
APIServer: v2.5.0
QueryServer: v2.4.0
ComplianceController: v2.4.2
ComplianceReporter: v2.4.2
ComplianceServer: v2.4.2
ComplianceSnapshotter: v2.4.2
ComplianceBenchmarker: v2.5.0
IntrusionDetectionController: v2.4.2
IntrusionDetectionJobInstaller: v2.4.2
ConsoleManager: v2.4.2
ConsoleProxy: v2.4.2
ConsoleEsProxy: v2.4.0
```