### PR TITLE
add horizontal-autoscaler image to gen-versions

### DIFF
--- a/hack/gen-versions/main.go
+++ b/hack/gen-versions/main.go
@@ -91,6 +91,7 @@ func writeVersions(osVersions, eeVersions Components) error {
 		`	VersionCalicoTypha           = "` + osVersions.get("typha") + `"`,
 		`	VersionCalicoKubeControllers = "` + osVersions.get("calico/kube-controllers") + `"`,
 		`	VersionFlexVolume            = "` + osVersions.get("flexvol") + `"`,
+		`	VersionCPHAutoscaler         = "` + eeVersions.get("cpHorizontalAutoscaler") + `"`,
 		")",
 		"",
 		"// This section contains images used when installing Tigera Secure.",


### PR DESCRIPTION
This PR adds the horizontal autoscaler image to the gen-versions script.

However, it should be noted that this is a pretty weird scenario.

The horizontal-autoscaler (HA) is technically used in both OS and EE mode by the operator. But it's only [included in the EE versions.yml](https://github.com/tigera/calico-private/blob/0861f46a0cd9d9ad8faf2d4b43aacacbeed95838/_data/versions.yml#L78-L81), not the OS versions.yml, because it's not actually used in any of the manifests hosted on the Calico docs site - only on manifests hosted in external repositories.

We're trying to make versions.yml be the source of truth for versioning information for OS /EE. So maybe the "correct" thing to do is specify the horizontal-autoscaler image in the os versions.yml.

For now, this PR just pulls it from EE since it's already there.