### PR TITLE
Remove readiness probe from intrusion-detection-controller

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -313,17 +313,6 @@ func (c *intrusionDetectionComponent) intrusionDetectionControllerContainer() v1
 			},
 			InitialDelaySeconds: 5,
 		},
-		ReadinessProbe: &corev1.Probe{
-			Handler: corev1.Handler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"/healthz",
-						"readiness",
-					},
-				},
-			},
-			InitialDelaySeconds: 5,
-		},
 	}
 }
 


### PR DESCRIPTION
c.f. https://github.com/tigera/calico-private/pull/1452