### PR TITLE
Use stdout for zap logger

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -109,7 +109,7 @@ func main() {
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
-	logf.SetLogger(zap.Logger())
+	logf.SetLogger(zap.LoggerTo(os.Stdout))
 
 	printVersion()
 


### PR DESCRIPTION
This allows us to grep the output when running operator using "go run"