### PR TITLE
fix gen-versions builds and add to ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ foss-checks:
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: clean images test
+ci: clean images test $(BINDIR)/gen-versions
 
 ## Deploys images to registry
 cd:
@@ -425,8 +425,10 @@ endif
 	$(BINDIR)/gen-versions -os-versions=$(OS_VERSIONS) -ee-versions=$(EE_VERSIONS)
 
 $(BINDIR)/gen-versions:
-	mkdir -p bin
-	$(CONTAINERIZED) go build -o $(BINDIR)/gen-versions ./hack/gen-versions
+	mkdir -p $(BINDIR)
+	$(CONTAINERIZED) \
+	sh -c '$(GIT_CONFIG_SSH) && \
+	go build -o $(BINDIR)/gen-versions ./hack/gen-versions'
 
 .PHONY: help
 ## Display this help text


### PR DESCRIPTION
gen-versions builds (which are crucial to hash releases) keep breaking. This PR adds building of that binary to CI to hopefully prevent failures.

And this PR fixes a current build failure where containerized builds of gen-versions fail to pull the private tigera/api repository.