### PR TITLE
Create the ECK operator (and required components) in the log-storage …

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -36,4 +36,7 @@ const (
 	VersionConsoleManager = "v2.4.2"
 	VersionConsoleProxy   = "v1.0.0.rc1"
 	VersionConsoleEsProxy = "v2.4.0"
+
+	VersionECKOperator      = "0.9.0"
+	VersionECKElasticsearch = "7.3.0"
 )

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -5,7 +5,10 @@ import (
 	cmneckalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	eckv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/components"
+	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,27 +16,32 @@ import (
 )
 
 const (
-	ElasticsearchClusterName  = "tigera-elasticsearch"
+	ECKOperatorName           = "elastic-operator"
+	ECKOperatorNamespace      = "tigera-eck-operator"
+	ECKWebhookSecretName      = "webhook-server-secret"
 	ElasticsearchStorageClass = "tigera-elasticsearch"
 	ElasticsearchNamespace    = "tigera-elasticsearch"
-	ElasticsearchClusterHTTP  = "tigera-elasticsearch-es-http"
-	ElasticsearchVersion      = "7.3.0"
+	ElasticsearchClusterHTTP  = "tigera-secure-es-http"
+	ElasticsearchName         = "tigera-secure"
 )
 
-func Elasticsearch(logStorage operatorv1.LogStorage, openShift bool) (Component, error) {
+func Elasticsearch(logStorage *operatorv1.LogStorage, openShift bool, registry string) (Component, error) {
 	return &elasticsearchComponent{
 		logStorage: logStorage,
 		openShift:  openShift,
+		registry:   registry,
 	}, nil
 }
 
 type elasticsearchComponent struct {
-	logStorage operatorv1.LogStorage
+	logStorage *operatorv1.LogStorage
 	openShift  bool
+	registry   string
 }
 
 func (es *elasticsearchComponent) Objects() []runtime.Object {
 	var objs []runtime.Object
+	objs = append(objs, es.eckOperator()...)
 	objs = append(objs, createNamespace(ElasticsearchNamespace, es.openShift))
 	if es.logStorage.StorageClass() == nil {
 		objs = append(objs, esDefaultStorageClass())
@@ -107,15 +115,15 @@ func (es elasticsearchComponent) elasticsearchCluster() *eckv1alpha1.Elasticsear
 	return &eckv1alpha1.Elasticsearch{
 		TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch", APIVersion: "elasticsearch.k8s.elastic.co/v1alpha1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-secure",
+			Name:      ElasticsearchName,
 			Namespace: ElasticsearchNamespace,
 			Annotations: map[string]string{
-				// TODO when the eck operator is created through the TSEE operator we need to make sure this is in sync
-				"common.k8s.elastic.co/controller-version": "0.9.0",
+				"common.k8s.elastic.co/controller-version": components.VersionECKOperator,
 			},
 		},
 		Spec: eckv1alpha1.ElasticsearchSpec{
-			Version: ElasticsearchVersion,
+			Version: components.VersionECKElasticsearch,
+			Image:   constructImage(ECKElasticsearchImageName, es.registry),
 			HTTP: cmneckalpha1.HTTPConfig{
 				TLS: tls,
 			},
@@ -130,6 +138,199 @@ func (es elasticsearchComponent) elasticsearchCluster() *eckv1alpha1.Elasticsear
 						},
 					},
 					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{es.pvcTemplate()},
+				},
+			},
+		},
+	}
+}
+
+func (es elasticsearchComponent) eckOperator() []runtime.Object {
+
+	return []runtime.Object{
+		createNamespace(ECKOperatorNamespace, es.openShift),
+		es.eckOperatorWebhookSecret(),
+		es.eckOperatorClusterRole(),
+		es.eckOperatorClusterRoleBinding(),
+		es.eckOperatorServiceAccount(),
+		es.eckOperatorStatefulSet(),
+	}
+}
+
+func (es elasticsearchComponent) eckOperatorWebhookSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ECKWebhookSecretName,
+			Namespace: ECKOperatorNamespace,
+		},
+	}
+}
+
+func (es elasticsearchComponent) eckOperatorClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "elastic-operator",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "endpoints", "events", "persistentvolumeclaims", "secrets", "services", "configmaps"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"batch"},
+				Resources: []string{"cronjobs"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"policy"},
+				Resources: []string{"poddisruptionbudgets"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"elasticsearch.k8s.elastic.co"},
+				Resources: []string{"elasticsearches", "elasticsearches/status", "elasticsearches/finalizers", "enterpriselicenses", "enterpriselicenses/status"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"kibana.k8s.elastic.co"},
+				Resources: []string{"kibanas", "kibanas/status", "kibanas/finalizers"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"apm.k8s.elastic.co"},
+				Resources: []string{"apmservers", "apmservers/status", "apmservers/finalizers"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"associations.k8s.elastic.co"},
+				Resources: []string{"apmserverelasticsearchassociations", "apmserverelasticsearchassociations/status"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"admissionregistration.k8s.io"},
+				Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+		},
+	}
+}
+
+func (es elasticsearchComponent) eckOperatorClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ECKOperatorName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     ECKOperatorName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "elastic-operator",
+				Namespace: ECKOperatorNamespace,
+			},
+		},
+	}
+}
+
+func (es elasticsearchComponent) eckOperatorServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ECKOperatorName,
+			Namespace: ECKOperatorNamespace,
+		},
+	}
+}
+
+func (es elasticsearchComponent) eckOperatorStatefulSet() *apps.StatefulSet {
+	cpu1, _ := resource.ParseQuantity("1")
+	cpu2, _ := resource.ParseQuantity("100m")
+	mem1, _ := resource.ParseQuantity("100Mi")
+	mem2, _ := resource.ParseQuantity("20Mi")
+	gracePeriod := int64(10)
+	defaultMode := int32(420)
+
+	return &apps.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ECKOperatorName,
+			Namespace: ECKOperatorNamespace,
+			Labels: map[string]string{
+				"control-plane": "elastic-operator",
+				"k8s-app":       "elastic-operator",
+			},
+		},
+		Spec: apps.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"control-plane": "elastic-operator",
+					"k8s-app":       "elastic-operator",
+				},
+			},
+			ServiceName: ECKOperatorName,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"control-plane": "elastic-operator",
+						"k8s-app":       "elastic-operator",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "elastic-operator",
+					Containers: []corev1.Container{{
+						Image: constructImage(ECKOperatorImageName, es.registry),
+						Name:  "manager",
+						Args:  []string{"manager", "--operator-roles", "all", "--enable-debug-logs=false"},
+						Env: []corev1.EnvVar{
+							{
+								Name: "OPERATOR_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
+									},
+								},
+							},
+							{Name: "WEBHOOK_SECRET", Value: ECKWebhookSecretName},
+							{Name: "WEBHOOK_PODS_LABEL", Value: "elastic-operator"},
+							{Name: "OPERATOR_IMAGE", Value: "docker.elastic.co/eck/eck-operator:0.9.0"},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu":    cpu1,
+								"memory": mem1,
+							},
+							Requests: corev1.ResourceList{
+								"cpu":    cpu2,
+								"memory": mem2,
+							},
+						},
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 9876,
+							Name:          "webhook-server",
+							Protocol:      corev1.ProtocolTCP,
+						}},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "cert",
+							MountPath: "/tmp/cert",
+							ReadOnly:  true,
+						}},
+					}},
+					TerminationGracePeriodSeconds: &gracePeriod,
+					Volumes: []corev1.Volume{{
+						Name: "cert",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								DefaultMode: &defaultMode,
+								SecretName:  ECKWebhookSecretName,
+							},
+						},
+					}},
 				},
 			},
 		},

--- a/pkg/render/images.go
+++ b/pkg/render/images.go
@@ -8,9 +8,11 @@ import (
 
 // Default registries for Calico and Tigera.
 const (
-	CalicoRegistry = "docker.io/calico/"
-	TigeraRegistry = "quay.io/tigera/"
-	K8sGcrRegistry = "gcr.io/google-containers/"
+	CalicoRegistry           = "docker.io/calico/"
+	TigeraRegistry           = "quay.io/tigera/"
+	K8sGcrRegistry           = "gcr.io/google-containers/"
+	ECKOperatorRegistry      = "docker.elastic.co/eck/"
+	ECKElasticsearchRegistry = "docker.elastic.co/elasticsearch/"
 )
 
 // This section contains images used when installing open-source Calico.
@@ -49,6 +51,9 @@ const (
 	ConsoleManagerImageName = "cnx-manager:" + components.VersionConsoleManager
 	ConsoleProxyImageName   = "voltron:" + components.VersionConsoleProxy
 	ConsoleEsProxyImageName = "es-proxy:" + components.VersionConsoleEsProxy
+
+	ECKOperatorImageName      = "eck-operator:" + components.VersionECKOperator
+	ECKElasticsearchImageName = "elasticsearch:" + components.VersionECKElasticsearch
 )
 
 // constructImage returns the fully qualified image to use, including registry and version.
@@ -70,6 +75,10 @@ func constructImage(imageName string, registry string) string {
 		reg = CalicoRegistry
 	case HorizontalAutoScalerImageName:
 		reg = K8sGcrRegistry
+	case ECKElasticsearchImageName:
+		reg = ECKElasticsearchRegistry
+	case ECKOperatorImageName:
+		reg = ECKOperatorRegistry
 	}
 	return fmt.Sprintf("%s%s", reg, imageName)
 }


### PR DESCRIPTION
…controller

This commit creates the ECK operator (and required components), it assumes that the CRDs for ECK have been installed. The render for logstorage has also been updated to accept a registry, and if it's not specified, the default ECK registries are used.