### PR TITLE
Add unit tests for rendering the elasticsearchComponent

### DIFF
--- a/pkg/render/elasticsearch_test.go
+++ b/pkg/render/elasticsearch_test.go
@@ -3,7 +3,6 @@ package render_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/render"
 	corev1 "k8s.io/api/core/v1"
@@ -32,49 +31,72 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				State: "",
 			},
 		}
-
 	})
 
 	It("should render an elasticsearchComponent", func() {
-		component, err := render.Elasticsearch(*logStorage, false)
+		component, err := render.Elasticsearch(logStorage, false, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(3))
+		Expect(len(resources)).To(Equal(9))
 		Expect(err).NotTo(HaveOccurred())
-		ExpectResource(resources[0], "tigera-elasticsearch", "", "", "v1", "Namespace")
-		ExpectResource(resources[1], "tigera-elasticsearch", "", "", "", "")
-		ExpectResource(resources[2], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
+		ExpectResource(resources[0], "tigera-eck-operator", "", "", "v1", "Namespace")
+		ExpectResource(resources[1], "webhook-server-secret", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[2], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[3], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[4], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[5], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[6], "tigera-elasticsearch", "", "", "v1", "Namespace")
+		ExpectResource(resources[7], "tigera-elasticsearch", "", "", "", "")
+		ExpectResource(resources[8], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
 	})
 
 	It("should render an elasticsearchComponent with openShift", func() {
-		component, err := render.Elasticsearch(*logStorage, true)
+		component, err := render.Elasticsearch(logStorage, true, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(3))
+		Expect(len(resources)).To(Equal(9))
 		Expect(err).NotTo(HaveOccurred())
-		ExpectResource(resources[0], "tigera-elasticsearch", "", "", "v1", "Namespace")
-		ExpectResource(resources[1], "tigera-elasticsearch", "", "", "", "")
-		ExpectResource(resources[2], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
+		ExpectResource(resources[0], "tigera-eck-operator", "", "", "v1", "Namespace")
+		ExpectResource(resources[1], "webhook-server-secret", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[2], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[3], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[4], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[5], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[6], "tigera-elasticsearch", "", "", "v1", "Namespace")
+		ExpectResource(resources[7], "tigera-elasticsearch", "", "", "", "")
+		ExpectResource(resources[8], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
 	})
 
 	It("should render an elasticsearchComponent without assigning esDefaultStorageClass", func() {
 		logStorage.Spec.Nodes.StorageClass = &corev1.ObjectReference{
 			Name: "tigera-elasticsearch",
 		}
-		component, err := render.Elasticsearch(*logStorage, false)
+		component, err := render.Elasticsearch(logStorage, false, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(2))
+		Expect(len(resources)).To(Equal(8))
 		Expect(err).NotTo(HaveOccurred())
-		ExpectResource(resources[0], "tigera-elasticsearch", "", "", "v1", "Namespace")
-		ExpectResource(resources[1], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
+		ExpectResource(resources[0], "tigera-eck-operator", "", "", "v1", "Namespace")
+		ExpectResource(resources[1], "webhook-server-secret", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[2], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[3], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[4], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[5], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[6], "tigera-elasticsearch", "", "", "v1", "Namespace")
+		ExpectResource(resources[7], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
 	})
 
 	It("should render an elasticsearchComponent while logStorage.Spec.Certificate == nil", func() {
 		logStorage.Spec.Certificate = nil
-		component, err := render.Elasticsearch(*logStorage, false)
+		component, err := render.Elasticsearch(logStorage, false, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(3))
+		Expect(len(resources)).To(Equal(9))
 		Expect(err).NotTo(HaveOccurred())
-		ExpectResource(resources[0], "tigera-elasticsearch", "", "", "v1", "Namespace")
-		ExpectResource(resources[1], "tigera-elasticsearch", "", "", "", "")
-		ExpectResource(resources[2], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
+		ExpectResource(resources[0], "tigera-eck-operator", "", "", "v1", "Namespace")
+		ExpectResource(resources[1], "webhook-server-secret", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[2], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[3], "elastic-operator", "", "", "", "")
+		ExpectResource(resources[4], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[5], "elastic-operator", "tigera-eck-operator", "", "", "")
+		ExpectResource(resources[6], "tigera-elasticsearch", "", "", "v1", "Namespace")
+		ExpectResource(resources[7], "tigera-elasticsearch", "", "", "", "")
+		ExpectResource(resources[8], "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch")
 	})
 })


### PR DESCRIPTION
New tests can be ran using: `make test GINKGO_FOCUS="render_test"`