### PR TITLE
Test fixes

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -206,13 +206,16 @@ func (c *fluentdComponent) container() corev1.Container {
 		}
 	}
 
+	isPrivileged := true
+
 	return corev1.Container{
-		Name:           "fluentd",
-		Image:          constructImage(FluentdImageName, c.installation.Spec.Registry),
-		Env:            envs,
-		VolumeMounts:   volumeMounts,
-		LivenessProbe:  c.liveness(),
-		ReadinessProbe: c.readiness(),
+		Name:            "fluentd",
+		Image:           constructImage(FluentdImageName, c.installation.Spec.Registry),
+		Env:             envs,
+		SecurityContext: &corev1.SecurityContext{Privileged: &isPrivileged},
+		VolumeMounts:    volumeMounts,
+		LivenessProbe:   c.liveness(),
+		ReadinessProbe:  c.readiness(),
 	}
 }
 

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -353,9 +353,9 @@ func (c *nodeComponent) cniDirectories() (string, string) {
 	switch c.provider {
 	case operator.ProviderOpenShift:
 		cniNetDir = "/etc/kubernetes/cni/net.d"
-		cniBinDir = "/home/kubernetes/bin"
-	case operator.ProviderGKE:
 		cniBinDir = "/var/lib/cni/bin"
+	case operator.ProviderGKE:
+		cniBinDir = "/home/kubernetes/bin"
 		cniNetDir = "/etc/cni/net.d"
 	default:
 		// Default locations to match vanilla Kubernetes.

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -439,7 +439,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "var-run-calico", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/run/calico"}}},
 			{Name: "var-lib-calico", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/calico"}}},
 			{Name: "xtables-lock", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/run/xtables.lock", Type: &fileOrCreate}}},
-			{Name: "cni-bin-dir", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/home/kubernetes/bin"}}},
+			{Name: "cni-bin-dir", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/cni/bin"}}},
 			{Name: "cni-net-dir", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/cni/net.d"}}},
 			{Name: "policysync", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/run/nodeagent", Type: &dirOrCreate}}},
 			{Name: "flexvol-driver-host", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds", Type: &dirOrCreate}}},


### PR DESCRIPTION
- Add SecurityContext to fluentd
- Update Openshift CNI bin dir

It looks like the change here https://github.com/tigera/operator/commit/5e1220fc2773f234be39043004e1be19140d3f9d#diff-c0733501667d117b39a12c9d41798a94L38 was incorrect for the defaults for GKE and OpenShift for the cniBinDir.