### PR TITLE
Add ECK versions to writeVersions so our builds can add the ECK versions

### DIFF
--- a/hack/gen-versions/main.go
+++ b/hack/gen-versions/main.go
@@ -105,6 +105,9 @@ func writeVersions(osVersions, eeVersions Components) error {
 		`	VersionAPIServer   = "` + eeVersions.get("cnx-apiserver") + `"`,
 		`	VersionQueryServer = "` + eeVersions.get("cnx-queryserver") + `"`,
 		"",
+		"	// Logging",
+		`	VersionFluentd = "` + eeVersions.get("fluentd") + `"`,
+		"",
 		"	// Compliance images",
 		`	VersionComplianceController  = "` + eeVersions.get("compliance-controller") + `"`,
 		`	VersionComplianceReporter    = "` + eeVersions.get("compliance-reporter") + `"`,
@@ -120,6 +123,11 @@ func writeVersions(osVersions, eeVersions Components) error {
 		`	VersionManager = "` + eeVersions.get("cnx-manager") + `"`,
 		`	VersionManagerProxy   = "` + eeVersions.get("voltron") + `"`,
 		`	VersionManagerEsProxy = "` + eeVersions.get("es-proxy") + `"`,
+		"",
+		"	// ECK Elasticsearch images",
+		`	VersionECKOperator = "` + eeVersions.get("elasticsearch-operator") + `"`,
+		`	VersionECKElasticsearch = "` + eeVersions.get("elasticsearch") + `"`,
+		`	VersionECKKibana = "` + eeVersions.get("kibana") + `"`,
 		")",
 	}
 

--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -40,6 +40,7 @@ const (
 	VersionManagerProxy   = "v1.0.0.rc1"
 	VersionManagerEsProxy = "v2.4.0"
 
+	// ECK Elasticsearch images
 	VersionECKOperator      = "0.9.0"
 	VersionECKElasticsearch = "7.3.0"
 )


### PR DESCRIPTION
Helps fix an issue with the hashrelease build. Related to https://github.com/tigera/calico-private/pull/1500