### PR TITLE
Use image pull secrets for ECK / don't overwrite ECK webhook secret data

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -100,7 +100,10 @@ func addNamespacedWatch(c controller.Controller, obj runtime.Object) error {
 			return e.MetaNew.GetNamespace() == objMeta.GetNamespace()
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return false
+			if objMeta.GetName() != "" && e.Meta.GetName() != objMeta.GetName() {
+				return false
+			}
+			return e.Meta.GetNamespace() == objMeta.GetNamespace()
 		},
 	}
 	return c.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}, pred)

--- a/pkg/render/elasticsearch_test.go
+++ b/pkg/render/elasticsearch_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/gomega"
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/render"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Elasticsearch rendering tests", func() {
@@ -29,9 +31,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 	})
 
 	It("should render an elasticsearchComponent", func() {
-		component, err := render.Elasticsearch(logStorage, nil, false, "docker.elastic.co/eck/")
+		component, err := render.Elasticsearch(logStorage, nil, false, nil, false, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(10))
+		Expect(len(resources)).To(Equal(9))
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedResources := []struct {
@@ -42,7 +44,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			kind    string
 		}{
 			{"tigera-eck-operator", "", "", "v1", "Namespace"},
-			{"webhook-server-secret", "tigera-eck-operator", "", "", ""},
 			{"elastic-operator", "", "", "", ""},
 			{"elastic-operator", "", "", "", ""},
 			{"elastic-operator", "tigera-eck-operator", "", "", ""},
@@ -58,8 +59,69 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		}
 	})
 
+	It("should render pull secrets", func() {
+		component, err := render.Elasticsearch(logStorage, nil, false,
+			[]*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"}}}, false, "docker.elastic.co/eck/")
+		resources := component.Objects()
+		Expect(len(resources)).To(Equal(11))
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{"tigera-eck-operator", "", "", "v1", "Namespace"},
+			{"elastic-operator", "", "", "", ""},
+			{"elastic-operator", "", "", "", ""},
+			{"elastic-operator", "tigera-eck-operator", "", "", ""},
+			{"pull-secret", "tigera-eck-operator", "", "", ""},
+			{"elastic-operator", "tigera-eck-operator", "", "", ""},
+			{"tigera-elasticsearch", "", "", "v1", "Namespace"},
+			{"pull-secret", "tigera-elasticsearch", "", "", ""},
+			{"tigera-secure-elasticsearch-cert", "tigera-operator", "", "v1", "Secret"},
+			{"tigera-secure-elasticsearch-cert", "tigera-elasticsearch", "", "v1", "Secret"},
+			{"tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch"},
+		}
+
+		for i, expectedRes := range expectedResources {
+			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+		}
+	})
+
 	It("should render an elasticsearchComponent with openShift", func() {
-		component, err := render.Elasticsearch(logStorage, nil, true, "docker.elastic.co/eck/")
+		component, err := render.Elasticsearch(logStorage, nil, false, nil, true, "docker.elastic.co/eck/")
+		resources := component.Objects()
+		Expect(len(resources)).To(Equal(9))
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{"tigera-eck-operator", "", "", "v1", "Namespace"},
+			{"elastic-operator", "", "", "", ""},
+			{"elastic-operator", "", "", "", ""},
+			{"elastic-operator", "tigera-eck-operator", "", "", ""},
+			{"elastic-operator", "tigera-eck-operator", "", "", ""},
+			{"tigera-elasticsearch", "", "", "v1", "Namespace"},
+			{"tigera-secure-elasticsearch-cert", "tigera-operator", "", "v1", "Secret"},
+			{"tigera-secure-elasticsearch-cert", "tigera-elasticsearch", "", "v1", "Secret"},
+			{"tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch"},
+		}
+
+		for i, expectedRes := range expectedResources {
+			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+		}
+	})
+
+	It("should render an elasticsearchComponent with a webhook secret", func() {
+		component, err := render.Elasticsearch(logStorage, nil, true, nil, true, "docker.elastic.co/eck/")
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(10))
 		Expect(err).NotTo(HaveOccurred())
@@ -72,10 +134,10 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			kind    string
 		}{
 			{"tigera-eck-operator", "", "", "v1", "Namespace"},
-			{"webhook-server-secret", "tigera-eck-operator", "", "", ""},
 			{"elastic-operator", "", "", "", ""},
 			{"elastic-operator", "", "", "", ""},
 			{"elastic-operator", "tigera-eck-operator", "", "", ""},
+			{"webhook-server-secret", "tigera-eck-operator", "", "", ""},
 			{"elastic-operator", "tigera-eck-operator", "", "", ""},
 			{"tigera-elasticsearch", "", "", "v1", "Namespace"},
 			{"tigera-secure-elasticsearch-cert", "tigera-operator", "", "v1", "Secret"},


### PR DESCRIPTION
This commit does the following:
- Change the utils watch logic to notify on delete events so we can recreate deleted secrets
- Copy the pull secrets to the tigera-elasticsearch and tigera-eck-operator namespaces and use those secrets in the ECK Operator and Elasticsearch pods
- Don't create the webhook secret if it exists. This secret is for use by the ECK operator and we don't want to overwrite any data that the ECK operator writes to that secret