### PR TITLE
Add Kibana resource on LogStorage installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,8 @@ deploy-crds: kubectl
 		./kubectl apply -f deploy/crds/operator_v1_installation_crd.yaml && \
 		./kubectl apply -f deploy/crds/operator_v1_tigerastatus_crd.yaml && \
 		./kubectl apply -f deploy/crds/operator_v1_logstorage_crd.yaml && \
-		./kubectl apply -f deploy/crds/elastic/elasticsearch-crd.yaml
+		./kubectl apply -f deploy/crds/elastic/elasticsearch-crd.yaml && \
+		./kubectl apply -f deploy/crds/elastic/kibana-crd.yaml
 
 create-tigera-operator-namespace: kubectl
 	KUBECONFIG=$(KUBECONFIG) kubectl create ns tigera-operator

--- a/deploy/crds/elastic/kibana-crd.yaml
+++ b/deploy/crds/elastic/kibana-crd.yaml
@@ -1,0 +1,200 @@
+# Elasticsearch operator CRDs
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: kibanas.kibana.k8s.elastic.co
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.health
+      name: health
+      type: string
+    - JSONPath: .status.availableNodes
+      description: Available nodes
+      name: nodes
+      type: integer
+    - JSONPath: .spec.version
+      description: Kibana version
+      name: version
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: age
+      type: date
+  group: kibana.k8s.elastic.co
+  names:
+    categories:
+      - elastic
+    kind: Kibana
+    plural: kibanas
+    shortNames:
+      - kb
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            config:
+              description: Config represents Kibana configuration.
+              type: object
+            elasticsearch:
+              description: Elasticsearch configures how Kibana connects to Elasticsearch
+              properties:
+                auth:
+                  description: Auth configures authentication for Kibana to use.
+                  properties:
+                    inline:
+                      description: Inline is auth provided as plaintext inline credentials.
+                      properties:
+                        password:
+                          description: Password is the password to use.
+                          type: string
+                        username:
+                          description: User is the username to use.
+                          type: string
+                      required:
+                        - username
+                        - password
+                      type: object
+                    secret:
+                      description: SecretKeyRef is a secret that contains the credentials
+                        to use.
+                      type: object
+                  type: object
+                certificateAuthorities:
+                  description: CertificateAuthorities names a secret that contains
+                    a CA file entry to use.
+                  properties:
+                    secretName:
+                      type: string
+                  type: object
+                url:
+                  description: ElasticsearchURL is the URL to the target Elasticsearch
+                  type: string
+              required:
+                - url
+              type: object
+            elasticsearchRef:
+              description: ElasticsearchRef references an Elasticsearch resource in
+                the Kubernetes cluster. If the namespace is not specified, the current
+                resource namespace will be used.
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+                - name
+              type: object
+            featureFlags:
+              description: FeatureFlags are instance-specific flags that enable or
+                disable specific experimental features
+              type: object
+            http:
+              description: HTTP contains settings for HTTP.
+              properties:
+                service:
+                  description: Service is a template for the Kubernetes Service
+                  properties:
+                    metadata:
+                      description: ObjectMeta is metadata for the service. The name
+                        and namespace provided here is managed by ECK and will be
+                        ignored.
+                      type: object
+                    spec:
+                      description: Spec defines the behavior of the service.
+                      type: object
+                  type: object
+                tls:
+                  description: TLS describe additional options to consider when generating
+                    HTTP TLS certificates.
+                  properties:
+                    certificate:
+                      description: 'Certificate is a reference to a secret that contains
+                        the certificate and private key to be used.  The secret should
+                        have the following content:  - `tls.crt`: The certificate
+                        (or a chain). - `tls.key`: The private key to the first certificate
+                        in the certificate chain.'
+                      properties:
+                        secretName:
+                          type: string
+                      type: object
+                    selfSignedCertificate:
+                      description: SelfSignedCertificate define options to apply to
+                        self-signed certificate managed by the operator.
+                      properties:
+                        disabled:
+                          description: Disabled turns off the provisioning of self-signed
+                            HTTP TLS certificates.
+                          type: boolean
+                        subjectAltNames:
+                          description: 'SubjectAlternativeNames is a list of SANs
+                            to include in the HTTP TLS certificates. For example:
+                            a wildcard DNS to expose the cluster.'
+                          items:
+                            properties:
+                              dns:
+                                type: string
+                              ip:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            image:
+              description: Image represents the docker image that will be used.
+              type: string
+            nodeCount:
+              description: NodeCount defines how many nodes the Kibana deployment
+                must have.
+              format: int32
+              type: integer
+            podTemplate:
+              description: PodTemplate can be used to propagate configuration to Kibana
+                pods. This allows specifying custom annotations, labels, environment
+                variables, affinity, resources, etc. for the pods created from this
+                NodeSpec.
+              type: object
+            secureSettings:
+              description: SecureSettings reference a secret containing secure settings,
+                to be injected into Kibana keystore on each node. Each individual
+                key/value entry in the referenced secret is considered as an individual
+                secure setting to be injected. The secret must exist in the same namespace
+                as the Kibana resource.
+              properties:
+                secretName:
+                  type: string
+              type: object
+            version:
+              description: Version represents the version of Kibana
+              type: string
+          type: object
+        status:
+          properties:
+            associationStatus:
+              type: string
+            controllerVersion:
+              description: ControllerVersion is the version of the controller that
+                last updated the Kibana instance
+              type: string
+            health:
+              type: string
+          type: object
+  version: v1alpha1

--- a/pkg/apis/addtoscheme_operator_v1.go
+++ b/pkg/apis/addtoscheme_operator_v1.go
@@ -1,7 +1,8 @@
 package apis
 
 import (
-	eckv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	esalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	kibanaalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	ocsv1 "github.com/openshift/api/security/v1"
 	tigera "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -20,5 +21,6 @@ func init() {
 	AddToSchemes = append(AddToSchemes, apiextensions.AddToScheme)
 	AddToSchemes = append(AddToSchemes, tigera.AddToScheme)
 	AddToSchemes = append(AddToSchemes, ocsv1.AddToScheme)
-	AddToSchemes = append(AddToSchemes, eckv1alpha1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, esalpha1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, kibanaalpha1.SchemeBuilder.AddToScheme)
 }

--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -42,5 +42,6 @@ const (
 
 	// ECK Elasticsearch images
 	VersionECKOperator      = "0.9.0"
-	VersionECKElasticsearch = "7.3.0"
+	VersionECKElasticsearch = "7.3.2"
+	VersionECKKibana        = "7.3.2"
 )

--- a/pkg/controller/logstorage/elasticsearch.go
+++ b/pkg/controller/logstorage/elasticsearch.go
@@ -20,7 +20,7 @@ const (
 	ElasticsearchUserPasswordLength = 100
 	DefaultElasticsearchUser        = "elastic"
 	ElasticsearchUserSecret         = "tigera-secure-es-elastic-user"
-	ElasticsearchHTTPEndpoint       = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
+	ElasticsearchHTTPSEndpoint      = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
 )
 
 // elasticsearchUsers creates / updates all the Elasticsearch users returned by esusers.GetUsers, along with the roles attached
@@ -65,7 +65,7 @@ func elasticsearchUsers(ctx context.Context, rootsSecret *corev1.Secret, cli cli
 			return nil, err
 		}
 
-		if err := upsertElasticsearchUser(ElasticsearchHTTPEndpoint, esUser, roots, esUserSecret); err != nil {
+		if err := upsertElasticsearchUser(ElasticsearchHTTPSEndpoint, esUser, roots, esUserSecret); err != nil {
 			return nil, err
 		}
 		users = append(users, esUser)

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -7,7 +7,8 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/render"
 
-	eckv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	esalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	kibanaalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1alpha1"
 	"github.com/go-logr/logr"
 	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -165,10 +166,19 @@ func mergeState(desired, current runtime.Object) runtime.Object {
 			dsa.Secrets = csa.Secrets
 		}
 		return dsa
-	case *eckv1alpha1.Elasticsearch:
+	case *esalpha1.Elasticsearch:
 		// Only update if the spec has changed
-		csa := current.(*eckv1alpha1.Elasticsearch)
-		dsa := desired.(*eckv1alpha1.Elasticsearch)
+		csa := current.(*esalpha1.Elasticsearch)
+		dsa := desired.(*esalpha1.Elasticsearch)
+
+		if reflect.DeepEqual(csa.Spec, dsa.Spec) {
+			return csa
+		}
+		return dsa
+	case *kibanaalpha1.Kibana:
+		// Only update if the spec has changed
+		csa := current.(*kibanaalpha1.Kibana)
+		dsa := desired.(*kibanaalpha1.Kibana)
 
 		if reflect.DeepEqual(csa.Spec, dsa.Spec) {
 			return csa

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -2,7 +2,8 @@ package render
 
 import (
 	cmneckalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
-	eckv1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	esalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	kibanav1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1alpha1"
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/components"
 	apps "k8s.io/api/apps/v1"
@@ -14,36 +15,67 @@ import (
 )
 
 const (
-	ECKOperatorName           = "elastic-operator"
-	ECKOperatorNamespace      = "tigera-eck-operator"
-	ECKWebhookSecretName      = "webhook-server-secret"
-	ElasticsearchStorageClass = "tigera-elasticsearch"
-	ElasticsearchNamespace    = "tigera-elasticsearch"
-	ElasticsearchClusterHTTP  = "tigera-secure-es-http.tigera-elasticsearch.svc"
-	KibanaHTTP                = "https://tigera-secure-kb-http.tigera-kibana.svc:5601"
-	ElasticsearchName         = "tigera-secure"
+	ECKOperatorName      = "elastic-operator"
+	ECKOperatorNamespace = "tigera-eck-operator"
+	ECKWebhookSecretName = "webhook-server-secret"
+
+	ElasticsearchStorageClass  = "tigera-elasticsearch"
+	ElasticsearchNamespace     = "tigera-elasticsearch"
+	ElasticsearchHTTPURL       = "tigera-secure-es-http.tigera-elasticsearch.svc"
+	ElasticsearchHTTPSEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
+	ElasticsearchName          = "tigera-secure"
+
+	KibanaHTTPURL          = "tigera-secure-kb-http.tigera-kibana.svc"
+	KibanaHTTPSEndpoint    = "https://tigera-secure-kb-http.tigera-kibana.svc:5601"
+	KibanaName             = "tigera-secure"
+	KibanaNamespace        = "tigera-kibana"
+	KibanaPublicCertSecret = "tigera-secure-kb-http-certs-public"
+	TigeraKibanaCertSecret = "tigera-secure-kibana-cert"
 )
 
-func Elasticsearch(logStorage *operatorv1.LogStorage, certSecret *corev1.Secret, createWebhookSecret bool, pullSecrets []*corev1.Secret, openShift bool, registry string) (Component, error) {
-	var certSecrets []runtime.Object
-	if certSecret == nil {
+func Elasticsearch(
+	logStorage *operatorv1.LogStorage,
+	esCertSecret *corev1.Secret,
+	kibanaCertSecret *corev1.Secret,
+	createWebhookSecret bool,
+	pullSecrets []*corev1.Secret,
+	openShift bool,
+	registry string) (Component, error) {
+	var esCertSecrets, kibanaCertSecrets []runtime.Object
+	if esCertSecret == nil {
 		var err error
-		certSecret, err = createOperatorTLSSecret(nil,
+		esCertSecret, err = createOperatorTLSSecret(nil,
 			TigeraElasticsearchCertSecret,
 			"tls.key",
 			"tls.crt",
-			nil, ElasticsearchClusterHTTP,
+			nil, ElasticsearchHTTPURL,
 		)
 		if err != nil {
 			return nil, err
 		}
-		certSecrets = []runtime.Object{certSecret}
+		esCertSecrets = []runtime.Object{esCertSecret}
 	}
 
-	certSecrets = append(certSecrets, copySecrets(ElasticsearchNamespace, certSecret)...)
+	if kibanaCertSecret == nil {
+		var err error
+		kibanaCertSecret, err = createOperatorTLSSecret(nil,
+			TigeraKibanaCertSecret,
+			"tls.key",
+			"tls.crt",
+			nil, KibanaHTTPURL,
+		)
+		if err != nil {
+			return nil, err
+		}
+		kibanaCertSecrets = []runtime.Object{kibanaCertSecret}
+	}
+
+	esCertSecrets = append(esCertSecrets, copySecrets(ElasticsearchNamespace, esCertSecret)...)
+	kibanaCertSecrets = append(kibanaCertSecrets, copySecrets(KibanaNamespace, kibanaCertSecret)...)
 	return &elasticsearchComponent{
 		logStorage:          logStorage,
-		certSecrets:         certSecrets,
+		esCertSecrets:       esCertSecrets,
+		kibanaCertSecrets:   kibanaCertSecrets,
 		createWebhookSecret: createWebhookSecret,
 		pullSecrets:         pullSecrets,
 		openShift:           openShift,
@@ -53,7 +85,8 @@ func Elasticsearch(logStorage *operatorv1.LogStorage, certSecret *corev1.Secret,
 
 type elasticsearchComponent struct {
 	logStorage          *operatorv1.LogStorage
-	certSecrets         []runtime.Object
+	esCertSecrets       []runtime.Object
+	kibanaCertSecrets   []runtime.Object
 	createWebhookSecret bool
 	pullSecrets         []*corev1.Secret
 	openShift           bool
@@ -66,9 +99,10 @@ func (es *elasticsearchComponent) Objects() []runtime.Object {
 	objs = append(objs, createNamespace(ElasticsearchNamespace, es.openShift))
 
 	objs = append(objs, copySecrets(ElasticsearchNamespace, es.pullSecrets...)...)
-	objs = append(objs, es.certSecrets...)
+	objs = append(objs, es.esCertSecrets...)
 
 	objs = append(objs, es.elasticsearchCluster())
+	objs = append(objs, es.kibana()...)
 
 	return objs
 }
@@ -104,10 +138,10 @@ func (es elasticsearchComponent) pvcTemplate() corev1.PersistentVolumeClaim {
 }
 
 // render the Elasticsearch CR that the ECK operator uses to create elasticsearch cluster
-func (es elasticsearchComponent) elasticsearchCluster() *eckv1alpha1.Elasticsearch {
+func (es elasticsearchComponent) elasticsearchCluster() *esalpha1.Elasticsearch {
 	nodeConfig := es.logStorage.Spec.Nodes
 
-	return &eckv1alpha1.Elasticsearch{
+	return &esalpha1.Elasticsearch{
 		TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch", APIVersion: "elasticsearch.k8s.elastic.co/v1alpha1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ElasticsearchName,
@@ -116,7 +150,7 @@ func (es elasticsearchComponent) elasticsearchCluster() *eckv1alpha1.Elasticsear
 				"common.k8s.elastic.co/controller-version": components.VersionECKOperator,
 			},
 		},
-		Spec: eckv1alpha1.ElasticsearchSpec{
+		Spec: esalpha1.ElasticsearchSpec{
 			Version: components.VersionECKElasticsearch,
 			Image:   constructImage(ECKElasticsearchImageName, es.registry),
 			HTTP: cmneckalpha1.HTTPConfig{
@@ -126,7 +160,7 @@ func (es elasticsearchComponent) elasticsearchCluster() *eckv1alpha1.Elasticsear
 					},
 				},
 			},
-			Nodes: []eckv1alpha1.NodeSpec{
+			Nodes: []esalpha1.NodeSpec{
 				{
 					NodeCount: int32(nodeConfig.Count),
 					Config: &cmneckalpha1.Config{
@@ -341,6 +375,58 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *apps.StatefulSet {
 							},
 						},
 					}},
+				},
+			},
+		},
+	}
+}
+
+// Create resources needed to run a Kibana cluster (namespace, Kibana resource, secrets...)
+func (es elasticsearchComponent) kibana() []runtime.Object {
+	objs := []runtime.Object{createNamespace(KibanaNamespace, false)}
+	objs = append(objs, copySecrets(KibanaNamespace, es.pullSecrets...)...)
+	objs = append(objs, es.kibanaCertSecrets...)
+	objs = append(objs, es.kibanaCR())
+	return objs
+}
+
+func (es elasticsearchComponent) kibanaCR() *kibanav1alpha1.Kibana {
+	return &kibanav1alpha1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KibanaName,
+			Namespace: KibanaNamespace,
+			Labels: map[string]string{
+				"k8s-app": KibanaName,
+			},
+			Annotations: map[string]string{
+				"common.k8s.elastic.co/controller-version": components.VersionECKOperator,
+			},
+		},
+		Spec: kibanav1alpha1.KibanaSpec{
+			Version:   components.VersionECKKibana,
+			Image:     constructImage(ECKKibanaImageName, es.registry),
+			NodeCount: 1,
+			HTTP: cmneckalpha1.HTTPConfig{
+				TLS: cmneckalpha1.TLSOptions{
+					Certificate: cmneckalpha1.SecretRef{
+						SecretName: TigeraKibanaCertSecret,
+					},
+				},
+			},
+			ElasticsearchRef: cmneckalpha1.ObjectSelector{
+				Name:      ElasticsearchName,
+				Namespace: ElasticsearchNamespace,
+			},
+			PodTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: KibanaNamespace,
+					Labels: map[string]string{
+						"name":    KibanaName,
+						"k8s-app": KibanaName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
 				},
 			},
 		},

--- a/pkg/render/elasticsearch_decorator.go
+++ b/pkg/render/elasticsearch_decorator.go
@@ -36,7 +36,7 @@ func ElasticsearchContainerDecorateENVVars(c corev1.Container, cluster, esUserna
 		// The esUser should be validated before we call ElasticsearchContainerDecorateENVVars
 		panic(err)
 	}
-	esScheme, esHost, esPort, _ := ParseEndpoint(ElasticsearchHTTPEndpoint)
+	esScheme, esHost, esPort, _ := ParseEndpoint(ElasticsearchHTTPSEndpoint)
 	secretName := esUser.SecretName()
 	envVars := []corev1.EnvVar{
 		{Name: "ELASTIC_INDEX_SUFFIX", Value: cluster},
@@ -58,6 +58,7 @@ func ElasticsearchContainerDecorateENVVars(c corev1.Container, cluster, esUserna
 			ValueFrom: envVarSourceFromSecret(secretName, "password", false),
 		},
 		{Name: "ELASTIC_CA", Value: ElasticsearchDefaultCertPath},
+		{Name: "ES_CA_CERT", Value: ElasticsearchDefaultCertPath},
 	}
 
 	c.Env = append(c.Env, envVars...)

--- a/pkg/render/elasticsearch_secrets.go
+++ b/pkg/render/elasticsearch_secrets.go
@@ -21,16 +21,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// elasticsearchAccess is a Component that contains the k8s resources required for another component to have elasticsearch access.
+// elasticsearchSecrets is a Component that contains the secrets that need to be created in the tigera operator namespace
+// after Elasticsearch and Kibana are running. At this time these secrets contain elasticsearch users credentials and
+// tls certificate information.
 type elasticsearchSecrets struct {
-	esUsers            []elasticsearch.User
-	esPublicCertSecret *corev1.Secret
+	esUsers                []elasticsearch.User
+	esPublicCertSecret     *corev1.Secret
+	kibanaPublicCertSecret *corev1.Secret
 }
 
-func ElasticsearchSecrets(esUsers []elasticsearch.User, esPublicCertSecret *corev1.Secret) Component {
+func ElasticsearchSecrets(esUsers []elasticsearch.User, esPublicCertSecret *corev1.Secret, kibanaPublicCertSecret *corev1.Secret) Component {
 	return &elasticsearchSecrets{
-		esUsers:            esUsers,
-		esPublicCertSecret: esPublicCertSecret,
+		esUsers:                esUsers,
+		esPublicCertSecret:     esPublicCertSecret,
+		kibanaPublicCertSecret: kibanaPublicCertSecret,
 	}
 }
 
@@ -51,7 +55,7 @@ func (es elasticsearchSecrets) Objects() []runtime.Object {
 		objs = append(objs, secret)
 	}
 
-	objs = append(objs, copySecrets(OperatorNamespace(), es.esPublicCertSecret)...)
+	objs = append(objs, copySecrets(OperatorNamespace(), es.esPublicCertSecret, es.kibanaPublicCertSecret)...)
 	return objs
 }
 

--- a/pkg/render/elasticsearch_test.go
+++ b/pkg/render/elasticsearch_test.go
@@ -31,9 +31,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 	})
 
 	It("should render an elasticsearchComponent", func() {
-		component, err := render.Elasticsearch(logStorage, nil, false, nil, false, "docker.elastic.co/eck/")
+		component, err := render.Elasticsearch(logStorage, nil, nil, false, nil, false, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(9))
+		Expect(len(resources)).To(Equal(13))
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedResources := []struct {
@@ -52,6 +52,10 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			{"tigera-secure-elasticsearch-cert", "tigera-operator", "", "v1", "Secret"},
 			{"tigera-secure-elasticsearch-cert", "tigera-elasticsearch", "", "v1", "Secret"},
 			{"tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch"},
+			{"tigera-kibana", "", "", "v1", "Namespace"},
+			{"tigera-secure-kibana-cert", "tigera-operator", "", "v1", "Secret"},
+			{"tigera-secure-kibana-cert", "tigera-kibana", "", "v1", "Secret"},
+			{"tigera-secure", "tigera-kibana", "", "", ""},
 		}
 
 		for i, expectedRes := range expectedResources {
@@ -60,10 +64,10 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 	})
 
 	It("should render pull secrets", func() {
-		component, err := render.Elasticsearch(logStorage, nil, false,
+		component, err := render.Elasticsearch(logStorage, nil, nil, false,
 			[]*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"}}}, false, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(11))
+		Expect(len(resources)).To(Equal(16))
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedResources := []struct {
@@ -84,6 +88,11 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			{"tigera-secure-elasticsearch-cert", "tigera-operator", "", "v1", "Secret"},
 			{"tigera-secure-elasticsearch-cert", "tigera-elasticsearch", "", "v1", "Secret"},
 			{"tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch"},
+			{"tigera-kibana", "", "", "v1", "Namespace"},
+			{"pull-secret", "tigera-kibana", "", "", ""},
+			{"tigera-secure-kibana-cert", "tigera-operator", "", "v1", "Secret"},
+			{"tigera-secure-kibana-cert", "tigera-kibana", "", "v1", "Secret"},
+			{"tigera-secure", "tigera-kibana", "", "", ""},
 		}
 
 		for i, expectedRes := range expectedResources {
@@ -92,9 +101,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 	})
 
 	It("should render an elasticsearchComponent with openShift", func() {
-		component, err := render.Elasticsearch(logStorage, nil, false, nil, true, "docker.elastic.co/eck/")
+		component, err := render.Elasticsearch(logStorage, nil, nil, false, nil, true, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(9))
+		Expect(len(resources)).To(Equal(13))
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedResources := []struct {
@@ -113,6 +122,10 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			{"tigera-secure-elasticsearch-cert", "tigera-operator", "", "v1", "Secret"},
 			{"tigera-secure-elasticsearch-cert", "tigera-elasticsearch", "", "v1", "Secret"},
 			{"tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch"},
+			{"tigera-kibana", "", "", "v1", "Namespace"},
+			{"tigera-secure-kibana-cert", "tigera-operator", "", "v1", "Secret"},
+			{"tigera-secure-kibana-cert", "tigera-kibana", "", "v1", "Secret"},
+			{"tigera-secure", "tigera-kibana", "", "", ""},
 		}
 
 		for i, expectedRes := range expectedResources {
@@ -121,9 +134,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 	})
 
 	It("should render an elasticsearchComponent with a webhook secret", func() {
-		component, err := render.Elasticsearch(logStorage, nil, true, nil, true, "docker.elastic.co/eck/")
+		component, err := render.Elasticsearch(logStorage, nil, nil, true, nil, true, "docker.elastic.co/eck/")
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(10))
+		Expect(len(resources)).To(Equal(14))
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedResources := []struct {
@@ -143,6 +156,43 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			{"tigera-secure-elasticsearch-cert", "tigera-operator", "", "v1", "Secret"},
 			{"tigera-secure-elasticsearch-cert", "tigera-elasticsearch", "", "v1", "Secret"},
 			{"tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch"},
+			{"tigera-kibana", "", "", "v1", "Namespace"},
+			{"tigera-secure-kibana-cert", "tigera-operator", "", "v1", "Secret"},
+			{"tigera-secure-kibana-cert", "tigera-kibana", "", "v1", "Secret"},
+			{"tigera-secure", "tigera-kibana", "", "", ""},
+		}
+
+		for i, expectedRes := range expectedResources {
+			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+		}
+	})
+
+	It("should not render Elasticsearch or Kibana cert secrets in the operator namespace when they are provided", func() {
+		component, err := render.Elasticsearch(logStorage,
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}}, false, nil, true, "")
+		resources := component.Objects()
+		Expect(len(resources)).To(Equal(11))
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{"tigera-eck-operator", "", "", "v1", "Namespace"},
+			{"elastic-operator", "", "", "", ""},
+			{"elastic-operator", "", "", "", ""},
+			{"elastic-operator", "tigera-eck-operator", "", "", ""},
+			{"elastic-operator", "tigera-eck-operator", "", "", ""},
+			{"tigera-elasticsearch", "", "", "v1", "Namespace"},
+			{render.TigeraElasticsearchCertSecret, "tigera-elasticsearch", "", "", ""},
+			{"tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1alpha1", "Elasticsearch"},
+			{"tigera-kibana", "", "", "v1", "Namespace"},
+			{render.TigeraKibanaCertSecret, "tigera-kibana", "", "", ""},
+			{"tigera-secure", "tigera-kibana", "", "", ""},
 		}
 
 		for i, expectedRes := range expectedResources {

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -24,7 +24,6 @@ const (
 	s3CredentialHashAnnotation    = "hash.operator.tigera.io/s3-credentials"
 	fluentdDefaultFlush           = "5s"
 	ElasticsearchUserLogCollector = "tigera-fluentd"
-	ElasticsearchHTTPEndpoint     = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
 )
 
 type FluentdFilters struct {

--- a/pkg/render/images.go
+++ b/pkg/render/images.go
@@ -13,6 +13,7 @@ const (
 	K8sGcrRegistry           = "gcr.io/google-containers/"
 	ECKOperatorRegistry      = "docker.elastic.co/eck/"
 	ECKElasticsearchRegistry = "docker.elastic.co/elasticsearch/"
+	ECKKibanaRegistry        = "docker.elastic.co/kibana/"
 )
 
 // This section contains images used when installing open-source Calico.
@@ -57,6 +58,7 @@ const (
 
 	ECKOperatorImageName      = "eck-operator:" + components.VersionECKOperator
 	ECKElasticsearchImageName = "elasticsearch:" + components.VersionECKElasticsearch
+	ECKKibanaImageName        = "kibana:" + components.VersionECKKibana
 )
 
 // constructImage returns the fully qualified image to use, including registry and version.
@@ -82,6 +84,8 @@ func constructImage(imageName string, registry string) string {
 		reg = ECKElasticsearchRegistry
 	case ECKOperatorImageName:
 		reg = ECKOperatorRegistry
+	case ECKKibanaImageName:
+		reg = ECKKibanaRegistry
 	}
 	return fmt.Sprintf("%s%s", reg, imageName)
 }

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -105,7 +105,7 @@ func (c *intrusionDetectionComponent) intrusionDetectionElasticsearchJob() *batc
 }
 
 func (c *intrusionDetectionComponent) intrusionDetectionJobContainer() v1.Container {
-	kScheme, kHost, kPort, _ := ParseEndpoint(KibanaHTTP)
+	kScheme, kHost, kPort, _ := ParseEndpoint(KibanaHTTPSEndpoint)
 	return corev1.Container{
 		Name:  "elasticsearch-job-installer",
 		Image: constructImage(IntrusionDetectionJobInstallerImageName, c.registry),

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -226,7 +226,7 @@ func (c *managerComponent) managerEnvVars() []v1.EnvVar {
 		{Name: "CNX_COMPLIANCE_REPORTS_API_URL", Value: "/compliance/reports"},
 		{Name: "CNX_QUERY_API_URL", Value: "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy"},
 		{Name: "CNX_ELASTICSEARCH_API_URL", Value: "/tigera-elasticsearch"},
-		{Name: "CNX_ELASTICSEARCH_KIBANA_URL", Value: KibanaHTTP},
+		{Name: "CNX_ELASTICSEARCH_KIBANA_URL", Value: KibanaHTTPURL},
 		{Name: "CNX_ENABLE_ERROR_TRACKING", Value: "false"},
 		{Name: "CNX_ALP_SUPPORT", Value: "false"},
 		{Name: "CNX_CLUSTER_NAME", Value: "cluster"},


### PR DESCRIPTION
This commit adds the Kibana resource when the logstorage controller installs the LogStorage resource. The Kibana resource is created in the tigera-kibana namespace. The following are the new resources created for kibana:

-  the tigera-kibana namespace
-  the pull secretes, copied over from the tigera-operator namespace into the tigera-kibana namespace
-  the tigera-secure-kibana-cert secret in both the tigera-operator namespace (if it doesn't exist already) and the tigera-kibana namespace. This is the certificate used for ssl.
-  the Kibana resource, created in the tigera-kibana namespace