### PR TITLE
Fix / integrate intrusion detection installer job with Kibana

### DIFF
--- a/pkg/apis/operator/v1/logstorage_types.go
+++ b/pkg/apis/operator/v1/logstorage_types.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	LogStorageStatusReady = "Ready"
+	LogStorageStatusDegraded = "Degraded"
+	LogStorageStatusReady    = "Ready"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -33,7 +33,7 @@ const (
 
 	// Intrusion detection images.
 	VersionIntrusionDetectionController   = "es7-v2.5.1-dev-1"
-	VersionIntrusionDetectionJobInstaller = "es7-v2.5.1-dev-1"
+	VersionIntrusionDetectionJobInstaller = "es7-v2.6.0-0-dev-6045051"
 
 	// Manager images.
 	VersionManager        = "v2.4.2"

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -62,6 +62,10 @@ func AddComplianceWatch(c controller.Controller) error {
 	return c.Watch(&source.Kind{Type: &operatorv1.Compliance{}}, &handler.EnqueueRequestForObject{})
 }
 
+func AddLogStorageWatch(c controller.Controller) error {
+	return c.Watch(&source.Kind{Type: &operatorv1.LogStorage{}}, &handler.EnqueueRequestForObject{})
+}
+
 func AddSecretsWatch(c controller.Controller, name, namespace string) error {
 	s := &v1.Secret{
 		TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "V1"},
@@ -126,6 +130,22 @@ func IsAPIServerReady(client client.Client, l logr.Logger) bool {
 		return false
 	}
 	return true
+}
+
+func IsLogStorageReady(ctx context.Context, cli client.Client) (bool, error) {
+	instance := &operatorv1.LogStorage{}
+	err := cli.Get(ctx, DefaultTSEEInstanceKey, instance)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if instance.Status.State != operatorv1.LogStorageStatusReady {
+		return false, nil
+	}
+	return true, nil
 }
 
 // CheckLicenseKey checks if a license has been installed. It's useful

--- a/pkg/elasticsearch/elasticsearch.go
+++ b/pkg/elasticsearch/elasticsearch.go
@@ -42,14 +42,21 @@ func (u User) SecretName() string {
 
 // Role represents an Elasticsearch role that may be attached to a User
 type Role struct {
-	Name    string      `json:"-"`
-	Cluster []string    `json:"cluster"`
-	Indices []RoleIndex `json:"indices"`
+	Name         string        `json:"-"`
+	Cluster      []string      `json:"cluster"`
+	Indices      []RoleIndex   `json:"indices"`
+	Applications []Application `json:"applications,omitempty"`
 }
 
 type RoleIndex struct {
 	Names      []string `json:"names"`
 	Privileges []string `json:"privileges"`
+}
+
+type Application struct {
+	Application string   `json:"application"`
+	Privileges  []string `json:"privileges"`
+	Resources   []string `json:"resources"`
 }
 
 func NewClient(url, username, password string, roots *x509.CertPool) (*Client, error) {

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -31,6 +31,7 @@ const (
 	KibanaNamespace        = "tigera-kibana"
 	KibanaPublicCertSecret = "tigera-secure-kb-http-certs-public"
 	TigeraKibanaCertSecret = "tigera-secure-kibana-cert"
+	KibanaDefaultCertPath  = "/etc/ssl/kibana/ca.pem"
 )
 
 func Elasticsearch(

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -20,14 +20,17 @@ import (
 	"github.com/tigera/operator/pkg/elasticsearch"
 	esusers "github.com/tigera/operator/pkg/elasticsearch/users"
 	"github.com/tigera/operator/pkg/render"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Intrusion Detection rendering tests", func() {
 	esusers.AddUser(elasticsearch.User{Username: render.ElasticsearchUserIntrusionDetection})
+	esusers.AddUser(elasticsearch.User{Username: render.ElasticsearchUserIntrusionDetectionJob})
 	It("should render all resources for a default configuration", func() {
-		component := render.IntrusionDetection(nil, "testregistry.com/", "clusterTestName", nil, notOpenshift)
+		component := render.IntrusionDetection(nil, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}}, "testregistry.com/", "clusterTestName", nil, notOpenshift)
 		resources := component.Objects()
-		Expect(len(resources)).To(Equal(8))
+		Expect(len(resources)).To(Equal(9))
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -38,6 +41,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-intrusion-detection", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.TigeraKibanaCertSecret, ns: "tigera-intrusion-detection", group: "", version: "", kind: ""},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},


### PR DESCRIPTION
This commit does the following to the intrusion detection job installer
- Create the proper role for the job to have proper access to elasticsearch and kibana
- Update the intrusion detection image to a later one that allows for setting the cert
- Copy over required secrets for kibana access to the intrusion detection namespace
- Set the LogStorage status to "Degraded" if an error has occured in the logstorage controller or it is waiting for a Elasticsearch or Kibana to be operational. This is required now because the intrusion detection is checking if the LogStorage resource is in a Ready state, and if we recreate either the Elasticsearch or Kibana resources it will no longer be in that state.