### PR TITLE
Call the main tigerastatus 'calico'

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -66,7 +66,7 @@ func newReconciler(mgr manager.Manager, provider operator.Provider, tsee bool) *
 		scheme:       mgr.GetScheme(),
 		watches:      make(map[runtime.Object]struct{}),
 		provider:     provider,
-		status:       status.New(mgr.GetClient(), "network"),
+		status:       status.New(mgr.GetClient(), "calico"),
 		requiresTSEE: tsee,
 	}
 	r.status.Run()

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Mainline component function tests", func() {
 
 		By("Verifying the tigera status CRD is updated")
 		Eventually(func() error {
-			ts, err := getTigeraStatus(c, "network")
+			ts, err := getTigeraStatus(c, "calico")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This isn't strictly networking - it's also policy (and in some
scenarios, it's _only_ policy).