### PR TITLE
Remove hostname from self signed Kibana certificate

### DIFF
--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -63,7 +63,7 @@ func Elasticsearch(
 			TigeraKibanaCertSecret,
 			"tls.key",
 			"tls.crt",
-			nil, KibanaHTTPURL,
+			nil,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Having the hostname set to the serivce name would restrict them from being able to use Kibana with whatever ingress they choose to expose Kibana to the web.