### PR TITLE
Rename annoationHash to AnnotationHash in node.go

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -330,7 +330,7 @@ func (c *nodeComponent) nodeDaemonset() *apps.DaemonSet {
 
 	annotations := make(map[string]string)
 	if len(c.birdTemplates) != 0 {
-		annotations[birdTemplateHashAnnotation] = annotationHash(c.birdTemplates)
+		annotations[birdTemplateHashAnnotation] = AnnotationHash(c.birdTemplates)
 	}
 
 	ds := apps.DaemonSet{


### PR DESCRIPTION
some how this was missed in my earlier PR and the project won't compile now