### PR TITLE
Update Intrusion Detection and Manager ES roles

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -39,7 +39,7 @@ func init() {
 					Privileges: []string{"read"},
 				},
 				{
-					Names:      []string{".tigera.ipset.*", "tigera_secure_ee_events.*"},
+					Names:      []string{".tigera.ipset.*", "tigera_secure_ee_events.*", ".tigera.domainnameset.*"},
 					Privileges: []string{"all"},
 				},
 			},

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -309,7 +309,7 @@ func (c *intrusionDetectionComponent) intrusionDetectionDeployment() *appsv1.Dep
 					ServiceAccountName: "intrusion-detection-controller",
 					ImagePullSecrets:   ps,
 					Containers: []corev1.Container{
-						ElasticsearchContainerDecorate(c.intrusionDetectionControllerContainer(), c.clusterName, ElasticsearchUserIntrusionDetectionJob),
+						ElasticsearchContainerDecorate(c.intrusionDetectionControllerContainer(), c.clusterName, ElasticsearchUserIntrusionDetection),
 					},
 				}),
 			},


### PR DESCRIPTION
This commit does the following:
- adds manager access to the .kibana indices
- adds intrusion detection controller access to the tigera.domainnameset indices
- use the correct es user for the intrusion detection controller