### PR TITLE
Add service to ENABLED_CONTROLLERS and update pinned versions

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -18,8 +18,8 @@ const (
 	VersionTigeraKubeControllers = "v2.6.0-0.dev-86-g506e244-dirty"
 
 	// API server images.
-	VersionAPIServer   = "v2.5.0-mcm0.1-31-g54c4ff40"
-	VersionQueryServer = "v2.6.0-0.dev-7-g5e69bfc"
+	VersionAPIServer   = "v2.5.0-mcm0.1-49-g909a7f60"
+	VersionQueryServer = "v2.6.0-0.dev-12-gca85666"
 
 	// Logging
 	VersionFluentd = "v2.6.0-0.dev-27-gdd525f5"
@@ -36,9 +36,9 @@ const (
 	VersionIntrusionDetectionJobInstaller = "v2.6.0-0.dev-53-g6045051"
 
 	// Manager images.
-	VersionManager        = "v2.6.0-0.dev-1-g68a6585"
-	VersionManagerProxy   = "v1.0.0.rc1"
-	VersionManagerEsProxy = "v2.6.0-0.dev-88-gbd4f9c3"
+	VersionManager        = "v2.5.0-347-gb01f72d0"
+	VersionManagerProxy   = "v2.5.0-mcm0.1-27-g9d85a20"
+	VersionManagerEsProxy = "v2.6.0-0.dev-96-g38d646f"
 
 	// ECK Elasticsearch images
 	VersionECKOperator      = "0.9.0"

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -17,6 +17,7 @@ package render_test
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -134,7 +135,7 @@ var _ = Describe("API server rendering tests", func() {
 		Expect(d.Spec.Template.Spec.ImagePullSecrets).To(BeEmpty())
 		Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(2))
 		Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-apiserver"))
-		Expect(d.Spec.Template.Spec.Containers[0].Image).To(Equal("testregistry.com/cnx-apiserver:v2.5.0-mcm0.1-31-g54c4ff40"))
+		Expect(d.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("testregistry.com/%s", render.APIServerImageName)))
 
 		expectedArgs := []string{
 			"--secure-port=5443",
@@ -162,7 +163,7 @@ var _ = Describe("API server rendering tests", func() {
 		Expect(*(d.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)).To(BeTrue())
 
 		Expect(d.Spec.Template.Spec.Containers[1].Name).To(Equal("tigera-queryserver"))
-		Expect(d.Spec.Template.Spec.Containers[1].Image).To(Equal("testregistry.com/cnx-queryserver:v2.6.0-0.dev-7-g5e69bfc"))
+		Expect(d.Spec.Template.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("testregistry.com/%s", render.QueryServerImageName)))
 		Expect(d.Spec.Template.Spec.Containers[1].Args).To(BeEmpty())
 		Expect(len(d.Spec.Template.Spec.Containers[1].Env)).To(Equal(2))
 

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -155,8 +155,13 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 	}
 
 	env := []v1.EnvVar{
-		{Name: "ENABLED_CONTROLLERS", Value: "node"},
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
+	}
+
+	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
+		env = append(env, v1.EnvVar{Name: "ENABLED_CONTROLLERS", Value: "node,service"})
+	} else {
+		env = append(env, v1.EnvVar{Name: "ENABLED_CONTROLLERS", Value: "node"})
 	}
 
 	// Pick which image to use based on variant.

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -15,6 +15,7 @@
 package render_test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -56,7 +57,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		ds := resources[3].(*apps.Deployment)
 
 		// Image override results in correct image.
-		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/kube-controllers:v3.10.0"))
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("test-reg/%s", render.KubeControllersImageNameCalico)))
 
 		// Verify env
 		expectedEnv := []v1.EnvVar{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -67,17 +67,17 @@ var _ = Describe("Node rendering tests", func() {
 		ExpectEnv(cniContainer.Env, "CNI_NET_DIR", "/etc/cni/net.d")
 
 		// Node image override results in correct image.
-		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("docker.io/calico/node:v3.10.0"))
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("docker.io/calico/%s", render.NodeImageNameCalico)))
 
 		// Validate correct number of init containers.
 		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(2))
 
 		// CNI container uses image override.
-		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal("docker.io/calico/cni:v3.10.0"))
+		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/calico/%s", render.CNIImageName)))
 
 		// Verify the Flex volume container image.
 
-		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal("docker.io/calico/pod2daemon-flexvol:v3.10.0"))
+		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("docker.io/calico/%s", render.FlexVolumeImageName)))
 
 		optional := true
 		// Verify env
@@ -318,7 +318,7 @@ var _ = Describe("Node rendering tests", func() {
 
 		// The DaemonSet should have the correct configuration.
 		ds := dsResource.(*apps.DaemonSet)
-		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("docker.io/calico/node:v3.10.0"))
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("docker.io/calico/%s", render.NodeImageNameCalico)))
 
 		ExpectEnv(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env, "CNI_NET_DIR", "/etc/kubernetes/cni/net.d")
 


### PR DESCRIPTION
This commit adds service to ENABLED_CONTROLLERS for the kube controllers when the installation variant is TSEE. The pinned versions have been updated as well as they were out of date