### PR TITLE
Add new resource types to compliance snapshotter

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -140,10 +140,13 @@ func (c *apiServerComponent) tieredPolicyPassthruClusterRole() *rbacv1.ClusterRo
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "tigera-tiered-policy-passthrough",
 		},
+		// If tiered policy is enabled we allow all authenticated users to access the main tier resource, instead
+		// restricting access using the tier.xxx resource type. Kubernetes NetworkPolicy and the
+		// StagedKubernetesNetworkPolicy are handled using normal (non-tiered) RBAC.
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"networkpolicies", "globalnetworkpolicies"},
+				Resources: []string{"networkpolicies", "globalnetworkpolicies", "stagednetworkpolicies", "stagedglobalnetworkpolicies"},
 				Verbs:     []string{"*"},
 			},
 		},
@@ -268,10 +271,10 @@ func (c *apiServerComponent) apiServiceAccountClusterRole() *rbacv1.ClusterRole 
 				APIGroups: []string{"crd.projectcalico.org"},
 				Resources: []string{
 					"globalnetworkpolicies",
+					"networkpolicies",
 					"stagedkubernetesnetworkpolicies",
 					"stagednetworkpolicies",
 					"stagedglobalnetworkpolicies",
-					"networkpolicies",
 					"tiers",
 					"clusterinformations",
 					"hostendpoints",
@@ -411,6 +414,9 @@ rules:
     resources:
     - globalnetworkpolicies
     - networkpolicies
+    - stagedglobalnetworkpolicies
+    - stagednetworkpolicies
+    - stagedkubernetesnetworkpolicies
     - globalnetworksets
     - networksets
     - tiers

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -524,8 +524,13 @@ func (c *complianceComponent) complianceSnapshotterClusterRole() *rbacv1.Cluster
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"globalnetworkpolicies", "networkpolicies", "tier.globalnetworkpolicies",
-					"tier.networkpolicies", "tiers", "hostendpoints", "globalnetworksets"},
+				Resources: []string{"globalnetworkpolicies", "tier.globalnetworkpolicies",
+					"stagedglobalnetworkpolicies", "tier.stagedglobalnetworkpolicies",
+					"networkpolicies", "tier.networkpolicies",
+					"stagednetworkpolicies", "tier.stagednetworkpolicies",
+					"stagedkubernetesnetworkpolicies",
+					"tiers", "hostendpoints",
+					"globalnetworksets", "networksets"},
 				Verbs: []string{"get", "list"},
 			},
 		},
@@ -924,6 +929,15 @@ func (c *complianceComponent) complianceGlobalReportPolicyAudit() *v3.GlobalRepo
 					},
 					{
 						Resource: "networkpolicies",
+					},
+					{
+						Resource: "stagedglobalnetworkpolicies",
+					},
+					{
+						Resource: "stagednetworkpolicies",
+					},
+					{
+						Resource: "stagedkubernetesnetworkpolicies",
 					},
 				},
 			},

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -419,6 +419,11 @@ func (c *managerComponent) managerPolicyImpactPreviewClusterRole() *rbacv1.Clust
 					"tier.globalnetworkpolicies",
 					"networkpolicies",
 					"tier.networkpolicies",
+					"stagedglobalnetworkpolicies",
+					"tier.stagedglobalnetworkpolicies",
+					"stagednetworkpolicies",
+					"tier.stagednetworkpolicies",
+					"stagedkubernetesnetworkpolicies",
 				},
 				Verbs: []string{"list"},
 			},
@@ -478,9 +483,9 @@ func (c *managerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 					"extensions",
 					"",
 				},
-				// Use both networkpolicies and tier.networkpolicies, and globalnetworkpolicies and tier.globalnetworkpolicies resource
-				// types to ensure identical behavior irrespective of the Calico RBAC scheme (see the ClusterRole
-				// "ee-calico-tiered-policy-passthru" for more details).
+				// Use both the networkpolicies and tier.networkpolicies resource types to ensure identical behavior
+				// irrespective of the Calico RBAC scheme (see the ClusterRole "ee-calico-tiered-policy-passthru" for
+				// more details).  Similar for all tiered policy resource types.
 				Resources: []string{
 					"tiers",
 					"networkpolicies",
@@ -489,7 +494,13 @@ func (c *managerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 					"tier.globalnetworkpolicies",
 					"namespaces",
 					"globalnetworksets",
+					"networksets",
 					"managedclusters",
+					"stagedglobalnetworkpolicies",
+					"tier.stagedglobalnetworkpolicies",
+					"stagednetworkpolicies",
+					"tier.stagednetworkpolicies",
+					"stagedkubernetesnetworkpolicies",
 				},
 				Verbs: []string{"watch", "list"},
 			},
@@ -548,16 +559,22 @@ func (c *managerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 					"networking.k8s.io",
 					"extensions",
 				},
-				// Use both networkpolicies and tier.networkpolicies, and globalnetworkpolicies and tier.globalnetworkpolicies resource
-				// types to ensure identical behavior irrespective of the Calico RBAC scheme (see the ClusterRole
-				// "ee-calico-tiered-policy-passthru" for more details).
+				// Use both the networkpolicies and tier.networkpolicies resource types to ensure identical behavior
+				// irrespective of the Calico RBAC scheme (see the ClusterRole "ee-calico-tiered-policy-passthru" for
+				// more details).  Similar for all tiered policy resource types.
 				Resources: []string{
 					"tiers",
 					"networkpolicies",
 					"tier.networkpolicies",
 					"globalnetworkpolicies",
 					"tier.globalnetworkpolicies",
+					"stagedglobalnetworkpolicies",
+					"tier.stagedglobalnetworkpolicies",
+					"stagednetworkpolicies",
+					"tier.stagednetworkpolicies",
+					"stagedkubernetesnetworkpolicies",
 					"globalnetworksets",
+					"networksets",
 					"managedclusters",
 				},
 				Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},


### PR DESCRIPTION
There appear to be a bunch of places in the docs that needed fixing up for staged policy (and one for namespaced network sets).  In particular this makes sure:
-  We audit staged policy resource types
-  We add staged policies to the passthru role so that RBAC is handled by the tiered policy handler in the AAPIS.
-  The default UI user types have access to them.