### PR TITLE
Always enable ALP

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -231,7 +231,7 @@ func (c *managerComponent) managerEnvVars() []v1.EnvVar {
 		{Name: "CNX_ELASTICSEARCH_API_URL", Value: "/tigera-elasticsearch"},
 		{Name: "CNX_ELASTICSEARCH_KIBANA_URL", Value: DefaultKibanaURL},
 		{Name: "CNX_ENABLE_ERROR_TRACKING", Value: "false"},
-		{Name: "CNX_ALP_SUPPORT", Value: "false"},
+		{Name: "CNX_ALP_SUPPORT", Value: "true"},
 		{Name: "CNX_CLUSTER_NAME", Value: "cluster"},
 	}
 


### PR DESCRIPTION
This allows us to remove the "patch" command from the docs. 

We should turn this on always, and instruct the user that in order to use these features they need to install Istio. This is what we do for calico/node as well. 