### PR TITLE
[CNX-10261] Adding access to dns logs

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -507,7 +507,7 @@ func (c *managerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{"lma.tigera.io"},
 				Resources: []string{"index"},
 				ResourceNames: []string{
-					"flows", "audit*", "events",
+					"flows", "audit*", "events", "dns",
 				},
 				Verbs: []string{"get"},
 			},
@@ -582,7 +582,7 @@ func (c *managerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{"lma.tigera.io"},
 				Resources: []string{"index"},
 				ResourceNames: []string{
-					"flows", "audit*", "events",
+					"flows", "audit*", "events", "dns",
 				},
 				Verbs: []string{"get"},
 			},


### PR DESCRIPTION
Using tigera-ui-user and tigera-ui-network-admin bindings causes error to show for dns flow logs when accessing Alert page.

Jira issue : https://tigera.atlassian.net/browse/CNX-10261

![b7f66b6c-088b-4edd-88d4-c220c293a643](https://user-images.githubusercontent.com/41362174/67895794-6394e500-fb18-11e9-8b6a-79f15140e7c8.png)
