### PR TITLE
Fix compliance benchmarker env and report-type spec

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -654,7 +654,7 @@ func (c *complianceComponent) complianceBenchmarkerClusterRoleBinding() *rbacv1.
 
 func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet {
 	envVars := []corev1.EnvVar{
-		{Name: "LOG_LEVEL", Value: "debug"},
+		{Name: "LOG_LEVEL", Value: "info"},
 		{Name: "NODENAME", ValueFrom: &corev1.EnvVarSource{ FieldRef: &corev1.ObjectFieldSelector { FieldPath: "spec.nodeName" } }},
 	}
 


### PR DESCRIPTION
Fix compliance benchmarker env and report-type spec:
* Add NODENAME to Benchmarker ds.
* Update ReportType-_s_ spec.
* Verified that CIS benchmark reports work as expected.

Fixes CNX-10054 (remainder of)
https://tigera.atlassian.net/browse/CNX-10054