### PR TITLE
Add new curator default env vars. Mount secret under the same name as helm install

### DIFF
--- a/pkg/render/elasticsearch_decorator.go
+++ b/pkg/render/elasticsearch_decorator.go
@@ -60,6 +60,7 @@ func ElasticsearchContainerDecorateENVVars(c corev1.Container, cluster, esUserna
 		},
 		{Name: "ELASTIC_CA", Value: ElasticsearchDefaultCertPath},
 		{Name: "ES_CA_CERT", Value: ElasticsearchDefaultCertPath},
+		{Name: "ES_CURATOR_BACKEND_CERT", Value: ElasticsearchDefaultCertPath},
 	}
 
 	c.Env = append(c.Env, envVars...)


### PR DESCRIPTION
Curator was unable to verify the https requests, because the secret was mounted under a different name than for the helm installation.

Added 2 default environment variables. It has been decided not to expose them through the api as of yet, so they are placed in constants that can easily be copied over after the 2.6.0 cut.
