### PR TITLE
Pick into v1.0: Do not return error on missing license

### DIFF
--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -221,7 +221,7 @@ func (r *ReconcileCompliance) Reconcile(request reconcile.Request) (reconcile.Re
 
 	if err = utils.CheckLicenseKey(ctx, r.client); err != nil {
 		r.status.SetDegraded("License not found", err.Error())
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, err
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Query for the installation object.

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -3,10 +3,11 @@ package intrusiondetection
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/tigera/operator/pkg/elasticsearch"
 	esusers "github.com/tigera/operator/pkg/elasticsearch/users"
 	"k8s.io/apimachinery/pkg/types"
-	"time"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
@@ -184,7 +185,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 
 	if err = utils.CheckLicenseKey(ctx, r.client); err != nil {
 		r.status.SetDegraded("License not found", err.Error())
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, err
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Query for the installation object.

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -190,7 +190,7 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 
 	if err = utils.CheckLicenseKey(context.Background(), r.client); err != nil {
 		r.status.SetDegraded("License not found", err.Error())
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, err
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Fetch the Installation instance. We need this for a few reasons.

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -171,7 +171,7 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	if err = utils.CheckLicenseKey(ctx, r.client); err != nil {
 		r.status.SetDegraded("License not found", err.Error())
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, err
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Fetch the Installation instance. We need this for a few reasons.


### PR DESCRIPTION
Because we were returning an error when the license check failed, the
operator controllers stopped requeueing reconciliation but we want to
continue requeueing.

Pick #233 into release-v1.0