### PR TITLE
Pick 235: Overwrite ObjectMeta on manager tls Secret

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -63,7 +63,9 @@ func Manager(
 		tlsSecrets = []*corev1.Secret{tlsKeyPair}
 	}
 	copy := tlsKeyPair.DeepCopy()
-	copy.ObjectMeta.Namespace = ManagerNamespace
+	// Overwrite the ObjectMeta to ensure we do not keep the resourceVersion or any other information
+	// that should not be set on a new object.
+	copy.ObjectMeta = metav1.ObjectMeta{Name: ManagerTLSSecretName, Namespace: ManagerNamespace}
 	tlsSecrets = append(tlsSecrets, copy)
 	return &managerComponent{
 		cr:          cr,


### PR DESCRIPTION
Overwriting the ObjectMeta on the manager Secret removes any fields that
should not be set on initial creation of a Secret.

Pick #235 into release-v1.0