### PR TITLE
Make curator settings more conservative

### DIFF
--- a/pkg/render/elastic_curator.go
+++ b/pkg/render/elastic_curator.go
@@ -18,24 +18,23 @@ var (
 
 // These constants should be moved to `logstorage_types` in 2.6.1
 const (
-	// Elasticsearch by default sets a high watermark threshold at 90% for disk usage. We use
-	// this as the default threshold for rotating the indices in the Tigera Elasticsearch
-	// cluster. As soon as the total disk utilization exceeds this value, indices will be removed
-	// starting with the oldest. Picking a low value leads to low disk utilization, while a high
-	// value might result in unexpected behaviour.
-	// Default: 90
+	// As soon as the total disk utilization exceeds the max-total-storage-percent,
+	// indices will be removed starting with the oldest. Picking a low value leads
+	// to low disk utilization, while a high value might result in unexpected
+	// behaviour.
+	// Default: 80
 	// +optional
-	maxTotalStoragePercent int32 = 90
+	maxTotalStoragePercent int32 = 80
 
 	// TSEE will remove dns and flow log indices once the combined data exceeds this
-	// threshold. The default value (80% of the cluster size) is used because flow
+	// threshold. The default value (70% of the cluster size) is used because flow
 	// logs and dns logs often use the most disk space; this allows compliance and
 	// security indices to be retained longer. The oldest indices are removed first.
 	// Set this value to be lower than or equal to, the value for
 	// max-total-storage-pct.
-	// Default: 80
+	// Default: 70
 	// +optional
-	maxLogsStoragePercent int32 = 80
+	maxLogsStoragePercent int32 = 70
 )
 
 func ElasticCurator(logStorage operatorv1.LogStorage, esSecrets, pullSecrets []*corev1.Secret, registry, clusterName string) Component {


### PR DESCRIPTION
CNX-10476
We decided to err on the safe side with curator settings at the expense of lower disk utilization.

Some context: 
While working on curator and elasticsearch, I learned some things the hard way in small clusters (14GiB and 19.5 GiB):
- With out of the box settings, elasticsearch will use thresholds for watermarks of storage utilizayion 85% 90% 95%. Cross the highest one and your cluster becomes read-only.
- These values do not necessarily reflect the actual usage you can get from either ssh-ing into your data node and check the mounted disk, nor the values that elasticsearch gives you when you check it's disk utilization. When the real disk utilization was 85% and the cluster indicated 85% the cluster went into read-only
- Curator will start removing dns and flow logs when combined they exceed 80% of the total cluster size and other types of indices when all data together exceeds 90% of the cluster.
- It seems that curator does exactly what we tell it to do. However, there is a hidden bit of storage that is not counted by curator, nor elasticsearch for that matter: translog files.
- Translog files can take up to 512 (or 1024?)MB per shard. This means that for very tiny clusters, like in my test, cases this played a huge impact on how curator works. If a cluster is very large, this impact is barely worth mentioning.
- So in a setup with a cluster with total disk size of 14GiB, but 5 shards per index, I could encounter a situation where the whole cluster is full, but the sum of all index sizes was only 7GiB.