### PR TITLE
use release-v2.6 image of kibana

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -46,5 +46,5 @@ const (
 	VersionECKKibana        = "7.3.2"
 	VersionEsCurator        = "release-v2.6"
 
-	VersionKibana = "7.3"
+	VersionKibana = "release-v2.6"
 )


### PR DESCRIPTION
Uh oh. We weren't using the release-v2.6 image of kibana on the release-v1.0 branch...