### PR TITLE
[release-v1.0] cherrypick: tigera-network-admin role should have list access to clusterinformation

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -636,7 +636,7 @@ func (c *managerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"clusterinformations"},
-				Verbs:     []string{"get", "watch"},
+				Verbs:     []string{"get", "list"},
 			},
 		},
 	}


### PR DESCRIPTION
Cherrypicks #255 