### PR TITLE
Proxy Kibana through Voltron (SAAS-465)

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -36,7 +36,7 @@ const (
 
 	// Manager images.
 	VersionManager        = "v2.5.0-347-gb01f72d0"
-	VersionManagerProxy   = "v2.5.0-mcm0.1-32-gdd59369"
+	VersionManagerProxy   = "v2.7.0-0.dev-14-g0421b7b"
 	VersionManagerEsProxy = "v2.6.0-0.dev-96-g38d646f"
 
 	// ECK Elasticsearch images

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	})
 
 	It("should render all resources for a default configuration", func() {
-		component, err := render.Manager(instance, nil, "clusterTestName", nil, nil, notOpenshift, registry)
+		component, err := render.Manager(instance, nil, nil, "clusterTestName", nil, nil, notOpenshift, registry)
 		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(12))
@@ -94,7 +94,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 					"tech-preview.operator.tigera.io/policy-recommendation": tcValues.annotationValue,
 				}
 			}
-			component, err := render.Manager(instance, nil, "clusterTestName", nil, nil, notOpenshift, registry)
+			component, err := render.Manager(instance, nil, nil, "clusterTestName", nil, nil, notOpenshift, registry)
 			Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 			resources := component.Objects()
 


### PR DESCRIPTION
This commit updates manager, voltron, and kiban to allow proxying through voltron to kibana. This commit
- updates the basePath for kibana
- adds the required env variables and secrets to voltron
- sets the correct url to kibana in the manager