### PR TITLE
SAAS 484 backport kibana proxy changes to 2.6

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -36,7 +36,7 @@ const (
 
 	// Manager images.
 	VersionManager        = "v2.6.0"
-	VersionManagerProxy   = "v2.6.0"
+	VersionManagerProxy   = "v2.6.0-5-g65ffc3d"
 	VersionManagerEsProxy = "v2.6.0"
 
 	// ECK Elasticsearch images

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	})
 
 	It("should render all resources for a default configuration", func() {
-		component, err := render.Manager(instance, nil, "clusterTestName", nil, nil, notOpenshift, registry)
+		component, err := render.Manager(instance, nil, nil, "clusterTestName", nil, nil, notOpenshift, registry)
 		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(12))
@@ -94,7 +94,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 					"tech-preview.operator.tigera.io/policy-recommendation": tcValues.annotationValue,
 				}
 			}
-			component, err := render.Manager(instance, nil, "clusterTestName", nil, nil, notOpenshift, registry)
+			component, err := render.Manager(instance, nil, nil, "clusterTestName", nil, nil, notOpenshift, registry)
 			Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 			resources := component.Objects()
 


### PR DESCRIPTION
This commit updates manager, voltron, and kiban to allow proxying through voltron to kibana. This commit
- updates the basePath for kibana
- adds the required env variables and secrets to voltron
- sets the correct url to kibana in the manager

The versions file is the only thing to change in this commit