### PR TITLE
Static OIDC configuration support in CNX manager.

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -260,6 +260,10 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		r.status.SetDegraded("OIDC configuration not available, waiting to become available", err.Error())
 		return reconcile.Result{}, nil
 	}
+	if oidcConfig != nil && instance.Spec.Auth.Authority != "" {
+		r.status.SetDegraded("Both OIDC configuration and Authority cannot be set at the same time", "")
+		return reconcile.Result{}, nil
+	}
 
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -333,18 +333,10 @@ func (c *managerComponent) managerOAuth2EnvVars() []v1.EnvVar {
 	switch c.cr.Spec.Auth.Type {
 	case operator.AuthTypeOIDC:
 		oidcEnvs := []corev1.EnvVar{
+			{Name: "CNX_WEB_OIDC_AUTHORITY", Value: c.cr.Spec.Auth.Authority},
 			{Name: "CNX_WEB_OIDC_CLIENT_ID", Value: c.cr.Spec.Auth.ClientID},
 		}
 		envs = append(envs, oidcEnvs...)
-		// If OIDC configuration is defined, provided configuration should be
-		// used via manager instead of reaching out to the OIDC IdP. Presence
-		// of Authority environment variable instructs OIDC client in manager
-		// to reach out to IdP specified in Authority value (e.g.
-		// accounts.google.com). Not setting the Authority value instructs OIDC
-		// client to use manager for populating OIDC configuration.
-		if c.oidcConfig == nil {
-			envs = append(envs, corev1.EnvVar{Name: "CNX_WEB_OIDC_AUTHORITY", Value: c.cr.Spec.Auth.Authority})
-		}
 	case operator.AuthTypeOAuth:
 		oauthEnvs := []corev1.EnvVar{
 			{Name: "CNX_WEB_OAUTH_AUTHORITY", Value: c.cr.Spec.Auth.Authority},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(GetResource(resources, render.ManagerOIDCConfig, "tigera-manager", "", "v1", "ConfigMap")).ToNot(BeNil())
 		d := resources[8].(*v1.Deployment)
 
-		Expect(d.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(oidcEnvVar))
+		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
 
 		// Make sure well-known and JWKS are accessible from manager.
 		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(3))
@@ -153,6 +153,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	It("should set OIDC Authority environment when auth-type is OIDC", func() {
 		instance.Spec.Auth.Type = operator.AuthTypeOIDC
+
+		const authority = "https://foo.bar"
+		instance.Spec.Auth.Authority = authority
+		oidcEnvVar.Value = authority
+
 		component, err := render.Manager(instance, nil, nil, "clusterTestName", nil, nil, notOpenshift, registry, nil)
 		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 


### PR DESCRIPTION
This task adds operator support for static OIDC configuration (well-known, jwks-URI configuration) in CNX manager.

* [x] `make test`
* [x] verified that the update operator image loads fine, can copy the configmap from tigera-operator to tigera-manager namespace
* [x] functionality verification
  * [x] Check OIDC auth-type without OIDC configuration
  * [x] Check OIDC auth-type works with prepopulated configuration
  * [x] If OIDC auth-type is set, manager state is _degraded_ when both authority and OIDC config is set.