### PR TITLE
k8s 1.15+ cascading deletion issue

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -103,6 +103,12 @@ func (c *apiServerComponent) Objects() []runtime.Object {
 		c.apiServiceRegistration(c.tlsSecrets[0].Data[APIServerSecretCertName]),
 		c.apiServerService(),
 	)
+
+	objs = append(objs,
+		c.k8sKubeControllerClusterRole(),
+		c.k8sRoleBinding(),
+	)
+
 	return objs
 }
 
@@ -608,4 +614,47 @@ func (c *apiServerComponent) getTLSObjects() []runtime.Object {
 	}
 
 	return objs
+}
+
+// k8sKubeControllerClusterRole creates a clusterrole that gives permissions to get tiers.
+func (c *apiServerComponent) k8sKubeControllerClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tigera-tier-getter",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"tiers",
+				},
+				Verbs: []string{"get"},
+			},
+		},
+	}
+}
+
+// k8sRoleBinding creates a rolebinding that allows the k8s kube-controller to get tiers
+// In k8s 1.15+, cascading resource deletions (for instance pods for a replicaset) failed
+// due to k8s kube-controller not having permissions to get tiers.
+func (c *apiServerComponent) k8sRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tigera-tier-getter",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "tigera-tier-getter",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "User",
+				Name:      "system:kube-controller-manager",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
 }


### PR DESCRIPTION
With k8s 1.15+ creating and then deleting for instance a replicaset,
did not remove pods created by the replicaset.
Issue is due to k8s kube-controller failing to read tiers because of
missing permissions.

This PR creates a clusterrole/clusterrolebinding giving k8s
kube-controller get permission on tier resources.