### PR TITLE
Change the OpenShift logic to use Patch instead of Update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.7.0
-	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
+	github.com/openshift/api v3.9.1-0.20190927182313-d4a64ec2cbd8+incompatible
 	github.com/openshift/library-go v0.0.0-20190924092619-a8c1174d4ee7
 	github.com/operator-framework/operator-sdk v0.10.1-0.20190910171846-947a464dbe96
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible h1:q2JBuObKafI7B4Eli6eLd+2T5JsU9ioWZ82zQwyjJPg=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v3.9.1-0.20190927182313-d4a64ec2cbd8+incompatible h1:YwFnUQ5RQ17CmkxHyjpQnWAQOGkLKXY0shOUEyqaCGk=
+github.com/openshift/api v3.9.1-0.20190927182313-d4a64ec2cbd8+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/library-go v0.0.0-20190924092619-a8c1174d4ee7 h1:Q9i20WvQEe8Wi7oLoYgsvYKZDb8ooUyup8a+d2U7Uqs=
 github.com/openshift/library-go v0.0.0-20190924092619-a8c1174d4ee7/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -455,7 +455,8 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 			// value, so might not perform the best but will work everywhere.
 			openshiftConfig.Status.ClusterNetworkMTU = 1410
 		}
-		if err = r.client.Update(ctx, openshiftConfig); err != nil {
+		patch := client.MergeFrom(openshiftConfig)
+		if err = r.client.Patch(ctx, openshiftConfig, patch); err != nil {
 			r.status.SetDegraded("Error updating openshift network status", err.Error())
 			return reconcile.Result{}, err
 		}


### PR DESCRIPTION
Changes the logic for updating the OpenShift resources to `Patch` from `Update`. This prevents us from stomping on any user updates to fields that the OpenShift devs have not given us public access to (like the `ExternalIP` field on the `Status` resource.

This is a workaround for https://github.com/tigera/operator/pull/268 . While #268 would be better for `externalIP` handling, it requires us to get updates through the OpenShift API and to also keep up to date with their changes. This change will keep us from needing to update the OpenShift API constantly.