### PR TITLE
WIP: SAAS-469 Add CRD for Multicluster configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ tags
 .go-pkg-cache
 report/*
 cscope.*
+.idea/


### PR DESCRIPTION
This is the design document that describes the motivation for these changes: https://docs.google.com/document/d/1Qylx_rr4M4_CGY-5nD2Y5GzXcmsM0Bk2n5Or6a5w2-A/edit#heading=h.46y26nptnbhc

TLDR; To setup multicluster management, we allow configuration that is picked up by Voltron to establish a tunnel with Guardian in another cluster.