### PR TITLE
Revert "release v2.6.1"

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -12,38 +12,38 @@ const (
 // This section contains images used when installing Tigera Secure.
 const (
 	// Overrides for Calico.
-	VersionTigeraNode            = "v2.6.1"
-	VersionTigeraTypha           = "v2.6.1"
-	VersionTigeraKubeControllers = "v2.6.1"
+	VersionTigeraNode            = "release-v2.6"
+	VersionTigeraTypha           = "release-v2.6"
+	VersionTigeraKubeControllers = "release-v2.6"
 
 	// API server images.
-	VersionAPIServer   = "v2.6.1"
-	VersionQueryServer = "v2.6.1"
+	VersionAPIServer   = "release-v2.6"
+	VersionQueryServer = "release-v2.6"
 
 	// Logging
-	VersionFluentd = "v2.6.1"
+	VersionFluentd = "release-v2.6"
 
 	// Compliance images.
-	VersionComplianceController  = "v2.6.1"
-	VersionComplianceReporter    = "v2.6.1"
-	VersionComplianceServer      = "v2.6.1"
-	VersionComplianceSnapshotter = "v2.6.1"
-	VersionComplianceBenchmarker = "v2.6.1"
+	VersionComplianceController  = "release-v2.6"
+	VersionComplianceReporter    = "release-v2.6"
+	VersionComplianceServer      = "release-v2.6"
+	VersionComplianceSnapshotter = "release-v2.6"
+	VersionComplianceBenchmarker = "release-v2.6"
 
 	// Intrusion detection images.
-	VersionIntrusionDetectionController   = "v2.6.1"
-	VersionIntrusionDetectionJobInstaller = "v2.6.1"
+	VersionIntrusionDetectionController   = "release-v2.6"
+	VersionIntrusionDetectionJobInstaller = "release-v2.6"
 
 	// Manager images.
-	VersionManager        = "v2.6.1"
-	VersionManagerProxy   = "v2.6.1"
-	VersionManagerEsProxy = "v2.6.1"
+	VersionManager        = "release-v2.6"
+	VersionManagerProxy   = "release-v2.6"
+	VersionManagerEsProxy = "release-v2.6"
 
 	// ECK Elasticsearch images
 	VersionECKOperator      = "0.9.0"
 	VersionECKElasticsearch = "7.3.2"
 	VersionECKKibana        = "7.3.2"
-	VersionEsCurator        = "v2.6.1"
+	VersionEsCurator        = "release-v2.6"
 
-	VersionKibana = "v2.6.1"
+	VersionKibana = "release-v2.6"
 )

--- a/pkg/render/images.go
+++ b/pkg/render/images.go
@@ -9,7 +9,7 @@ import (
 // Default registries for Calico and Tigera.
 const (
 	CalicoRegistry = "docker.io/"
-	TigeraRegistry = "quay.io/"
+	TigeraRegistry = "gcr.io/unique-caldron-775/cnx/"
 	K8sGcrRegistry = "gcr.io/"
 	ECKRegistry    = "docker.elastic.co/"
 )


### PR DESCRIPTION
This reverts commit 94b4aea3e43c2e33581d5facba7dba6c66ff69f1.

Now that we've tagged v1.0.2, we can return the `release-v1.0` branch to using Enterprise images tagged with `release-v2.6`, and also switch back to gcr.io.