### PR TITLE
[WIP] (SAAS-595) Create ExternalName ES service to guardian for managed clu…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,7 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/controller/logstorage/elasticsearch.go
+++ b/pkg/controller/logstorage/elasticsearch.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/elasticsearch"
 	esusers "github.com/tigera/operator/pkg/elasticsearch/users"

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -1,12 +1,12 @@
 package logstorage
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
-	"time"
+	"os"
+	"regexp"
 
-	cmneckalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	esalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	kibanaalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1alpha1"
 	"github.com/go-logr/logr"
@@ -14,14 +14,10 @@ import (
 	"github.com/tigera/operator/pkg/controller/installation"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
-	"github.com/tigera/operator/pkg/elasticsearch"
 	esusers "github.com/tigera/operator/pkg/elasticsearch/users"
 	"github.com/tigera/operator/pkg/render"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -34,25 +30,9 @@ import (
 var log = logf.Log.WithName("controller_logstorage")
 
 const (
-	finalizer                  = "tigera.io/eck-cleanup"
-	defaultElasticsearchShards = 5
+	defaultResolveConfPath = "/etc/resolv.conf"
+	defaultLocalDNS        = "svc.cluster.local"
 )
-
-func init() {
-	esusers.AddUser(elasticsearch.User{
-		Username: render.ElasticsearchUserCurator,
-		Roles: []elasticsearch.Role{{
-			Name: render.ElasticsearchUserCurator,
-			Definition: &elasticsearch.RoleDefinition{
-				Cluster: []string{"monitor", "manage_index_templates"},
-				Indices: []elasticsearch.RoleIndex{{
-					Names:      []string{"tigera_secure_ee_*"},
-					Privileges: []string{"all"},
-				}},
-			},
-		}},
-	})
-}
 
 // Add creates a new LogStorage Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -60,25 +40,67 @@ func Add(mgr manager.Manager, provider operatorv1.Provider, tsee bool) error {
 	if !tsee {
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, provider))
+
+	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage"), defaultResolveConfPath, provider)
+	if err != nil {
+		return err
+	}
+
+	return add(mgr, r)
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider) reconcile.Reconciler {
+func newReconciler(cli client.Client, schema *runtime.Scheme, statusMgr *status.StatusManager, resolvConfPath string, provider operatorv1.Provider) (*ReconcileLogStorage, error) {
+	localDNS, err := getLocalDNSName(resolvConfPath)
+	if err != nil {
+		localDNS = defaultLocalDNS
+		log.Error(err, fmt.Sprintf("couldn't find the local dns name from the resolv.conf, defaulting to %s", defaultLocalDNS))
+	}
+
 	c := &ReconcileLogStorage{
-		client:   mgr.GetClient(),
-		scheme:   mgr.GetScheme(),
-		status:   status.New(mgr.GetClient(), "log-storage"),
+		client:   cli,
+		scheme:   schema,
+		status:   statusMgr,
 		provider: provider,
+		localDNS: localDNS,
 	}
 
 	c.status.Run()
-	return c
+	return c, nil
+}
+
+// getLocalDNSName parses the path to resolv.conf to find the local DNS name.
+func getLocalDNSName(resolvConfPath string) (string, error) {
+	var localDNSName string
+	file, err := os.Open(resolvConfPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	reg := regexp.MustCompile(`^search.*?\s(svc\.[^\s]*)`)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		match := reg.FindStringSubmatch(scanner.Text())
+		if len(match) > 0 {
+			localDNSName = match[1]
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	if localDNSName == "" {
+		return "", fmt.Errorf("failed to find local DNS name in resolv.conf")
+	}
+
+	return localDNSName, nil
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
-	// Create a new controller
 	c, err := controller.New("log-storage-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
@@ -122,6 +144,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 	}
 
+	if err := utils.AddServiceWatch(c, render.ElasticsearchServiceName, render.ElasticsearchNamespace); err != nil {
+		return fmt.Errorf("log-storage-controller failed to watch the Service resource: %v", err)
+	}
+
 	return nil
 }
 
@@ -136,6 +162,7 @@ type ReconcileLogStorage struct {
 	scheme   *runtime.Scheme
 	status   *status.StatusManager
 	provider operatorv1.Provider
+	localDNS string
 }
 
 func GetLogStorage(ctx context.Context, cli client.Client) (*operatorv1.LogStorage, error) {
@@ -193,45 +220,13 @@ func (r *ReconcileLogStorage) Reconcile(request reconcile.Request) (reconcile.Re
 
 	ctx := context.Background()
 
-	// Fetch the LogStorage instance
-	ls, err := GetLogStorage(ctx, r.client)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			r.status.SetDegraded("LogStorage resource not found", "")
-			r.status.OnCRNotFound()
-			return reconcile.Result{}, nil
-		}
-		r.status.SetDegraded("Error querying LogStorage", err.Error())
-		return reconcile.Result{}, err
-	}
-
-	reqLogger.V(2).Info("Loaded config", "config", ls)
-	r.status.OnCRFound()
-
-	if ls.DeletionTimestamp != nil {
-		return r.finalizeDeletion(ctx, ls)
-	}
-
-	if !stringsutil.StringInSlice(finalizer, ls.GetFinalizers()) {
-		ls.SetFinalizers(append(ls.GetFinalizers(), finalizer))
-	}
-
-	// Write back the LogStorage object to update any defaults that were set
-	if err = r.client.Update(ctx, ls); err != nil {
-		r.status.SetDegraded("Failed to update LogStorage with defaults", err.Error())
-		return reconcile.Result{}, err
-	}
-
-	// Fetch the Installation instance. We need this for a few reasons.
-	// - We need to make sure it has successfully completed installation.
-	// - We need to get the registry information from its spec.
 	network, err := installation.GetInstallation(context.Background(), r.client, r.provider)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			r.setDegraded(ctx, reqLogger, ls, "Installation not found", err)
+			r.status.SetDegraded("Installation not found", err.Error())
 			return reconcile.Result{}, err
 		}
-		r.setDegraded(ctx, reqLogger, ls, "Error querying installation", err)
+		r.status.SetDegraded("Error querying installation", err.Error())
 		return reconcile.Result{}, err
 	}
 
@@ -240,142 +235,11 @@ func (r *ReconcileLogStorage) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, nil
 	}
 
-	pullSecrets, err := utils.GetNetworkingPullSecrets(network, r.client)
-	if err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Error retrieving pull secrets", err)
-		return reconcile.Result{}, err
+	if network.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManaged {
+		return r.reconcileManaged(ctx, network, reqLogger)
 	}
 
-	if err := r.client.Get(ctx, client.ObjectKey{Name: render.ElasticsearchStorageClass}, &storagev1.StorageClass{}); err != nil {
-		r.setDegraded(ctx, reqLogger, ls, fmt.Sprintf("Couldn't find storage class %s, this must be provided", render.ElasticsearchStorageClass), err)
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
-	esCertSecret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraElasticsearchCertSecret, Namespace: render.OperatorNamespace()}, esCertSecret); err != nil {
-		if errors.IsNotFound(err) {
-			esCertSecret = nil
-		} else {
-			r.setDegraded(ctx, reqLogger, ls, "Failed to read Elasticsearch cert secret", err)
-			return reconcile.Result{}, err
-		}
-	}
-
-	kibanaCertSecret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraKibanaCertSecret, Namespace: render.OperatorNamespace()}, kibanaCertSecret); err != nil {
-		if errors.IsNotFound(err) {
-			kibanaCertSecret = nil
-		} else {
-			r.setDegraded(ctx, reqLogger, ls, "Failed to read Kibana cert secret", err)
-			return reconcile.Result{}, err
-		}
-	}
-
-	// The ECK operator requires that we provide it with a secret so it can add certificate information in for it's webhooks.
-	// If it's created we don't want to overwrite it as we'll lose the certificate information the ECK operator relies on.
-	createWebhookSecret := false
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.ECKWebhookSecretName, Namespace: render.ECKOperatorNamespace}, &corev1.Secret{}); err != nil {
-		if errors.IsNotFound(err) {
-			createWebhookSecret = true
-		} else {
-			r.setDegraded(ctx, reqLogger, ls, "Failed to read Elasticsearch webhook secret", err)
-			return reconcile.Result{}, err
-		}
-	}
-
-	esClusterConfig := render.NewElasticsearchClusterConfig("cluster", ls.Replicas(), defaultElasticsearchShards)
-
-	reqLogger.V(2).Info("Creating Elasticsearch components")
-	hdler := utils.NewComponentHandler(log, r.client, r.scheme, ls)
-	component, err := render.Elasticsearch(
-		ls,
-		esClusterConfig,
-		esCertSecret,
-		kibanaCertSecret,
-		createWebhookSecret,
-		pullSecrets,
-		r.provider,
-		network.Spec.Registry,
-	)
-	if err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Error rendering LogStorage", err)
-		return reconcile.Result{}, err
-	}
-
-	if err := hdler.CreateOrUpdate(ctx, component, r.status); err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Error creating / updating resource", err)
-		return reconcile.Result{}, err
-	}
-
-	reqLogger.V(2).Info("Checking if Elasticsearch is operational")
-	if isReady, err := r.isElasticsearchReady(ctx); err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Error figuring out if elasticsearch is operational", err)
-		return reconcile.Result{}, err
-	} else if !isReady {
-		r.setDegraded(ctx, reqLogger, ls, "Waiting for Elasticsearch cluster to be operational", nil)
-		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
-	reqLogger.V(2).Info("Checking if Kibana is operational")
-	if isReady, err := r.isKibanaReady(ctx); err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Failed to figure out if Kibana is operational", err)
-		return reconcile.Result{}, err
-	} else if !isReady {
-		r.setDegraded(ctx, reqLogger, ls, "Waiting for Kibana to be operational", nil)
-		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
-	reqLogger.V(2).Info("Elasticsearch and Kibana are operational")
-	esPublicCertSecret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.ElasticsearchPublicCertSecret, Namespace: render.ElasticsearchNamespace}, esPublicCertSecret); err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Failed to read Elasticsearch public cert secret", err)
-		return reconcile.Result{}, err
-	}
-
-	kibanaPublicCertSecret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}, kibanaPublicCertSecret); err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Failed to read Kibana public cert secret", err)
-		return reconcile.Result{}, err
-	}
-
-	updatedESUserSecrets, err := updatedElasticsearchUserSecrets(ctx, esPublicCertSecret, r.client)
-	if err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Error creating Elasticsearch credentials", err)
-		return reconcile.Result{}, err
-	}
-
-	if err := hdler.CreateOrUpdate(ctx, render.ElasticsearchSecrets(updatedESUserSecrets, esPublicCertSecret, kibanaPublicCertSecret), r.status); err != nil {
-		r.setDegraded(ctx, reqLogger, ls, "Error creating / update resource", err)
-		return reconcile.Result{}, err
-	}
-
-	esSecrets, err := utils.ElasticsearchSecrets(context.Background(), []string{render.ElasticsearchUserCurator}, r.client)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Info("Elasticsearch secrets are not available yet, waiting until they become available")
-			r.status.SetDegraded("Elasticsearch secrets are not available yet, waiting until they become available", err.Error())
-			return reconcile.Result{}, nil
-		}
-		r.status.SetDegraded("Failed to get Elasticsearch credentials", err.Error())
-		return reconcile.Result{}, err
-	}
-
-	curatorComponent := render.ElasticCurator(*ls, esSecrets, pullSecrets, network.Spec.Registry, render.DefaultElasticsearchClusterName)
-	if err := hdler.CreateOrUpdate(ctx, curatorComponent, r.status); err != nil {
-		r.status.SetDegraded("Error creating / updating resource", err.Error())
-		return reconcile.Result{}, err
-	}
-
-	r.status.SetCronJobs([]types.NamespacedName{{Name: render.EsCuratorName, Namespace: render.ElasticsearchNamespace}})
-
-	// Clear the degraded bit if we've reached this far.
-	r.status.ClearDegraded()
-	reqLogger.V(2).Info("Elasticsearch users and secrets created for components needing Elasticsearch access")
-	if err := r.updateStatus(ctx, reqLogger, ls, operatorv1.LogStorageStatusReady); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	return reconcile.Result{}, nil
+	return r.reconcileUnmanaged(ctx, network, reqLogger)
 }
 
 func (r *ReconcileLogStorage) setDegraded(ctx context.Context, reqLogger logr.Logger, ls *operatorv1.LogStorage, message string, err error) {
@@ -400,75 +264,4 @@ func (r *ReconcileLogStorage) updateStatus(ctx context.Context, reqLogger logr.L
 	}
 
 	return nil
-}
-
-func (r *ReconcileLogStorage) isElasticsearchReady(ctx context.Context) (bool, error) {
-	if es, err := r.getElasticsearch(ctx); err != nil {
-		return false, err
-	} else if es.Status.Phase == "Operational" || es.Status.Phase == esalpha1.ElasticsearchReadyPhase {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (r *ReconcileLogStorage) isKibanaReady(ctx context.Context) (bool, error) {
-	if kb, err := r.getKibana(ctx); err != nil {
-		return false, err
-	} else if kb.Status.AssociationStatus == cmneckalpha1.AssociationEstablished {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func elasticsearchKey() client.ObjectKey {
-	return client.ObjectKey{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}
-}
-
-func kibanaKey() client.ObjectKey {
-	return client.ObjectKey{Name: render.KibanaName, Namespace: render.KibanaNamespace}
-}
-
-func (r *ReconcileLogStorage) getElasticsearch(ctx context.Context) (*esalpha1.Elasticsearch, error) {
-	es := esalpha1.Elasticsearch{}
-	return &es, r.client.Get(ctx, elasticsearchKey(), &es)
-}
-
-func (r *ReconcileLogStorage) getKibana(ctx context.Context) (*kibanaalpha1.Kibana, error) {
-	kb := kibanaalpha1.Kibana{}
-	return &kb, r.client.Get(ctx, kibanaKey(), &kb)
-}
-
-// finalizeDeletion makes sure that both kibana and elasticsearch are deleted before removing the finalizers on the LogStorage
-// resource. This needs to happen because the eck operator will be deleted when the LogStorage resource is deleted, but
-// the eck operator is needed to delete elasticsearch and kibana
-func (r *ReconcileLogStorage) finalizeDeletion(ctx context.Context, ls *operatorv1.LogStorage) (reconcile.Result, error) {
-	// remove elasticsearch
-	if es, err := r.getElasticsearch(ctx); err == nil {
-		if err := r.client.Delete(ctx, es); err != nil {
-			r.status.SetDegraded("Failed to delete elasticsearch", err.Error())
-			return reconcile.Result{}, err
-		}
-	} else if !errors.IsNotFound(err) {
-		return reconcile.Result{}, err
-	}
-
-	// remove kibana
-	if kb, err := r.getKibana(ctx); err == nil {
-		if err := r.client.Delete(ctx, kb); err != nil {
-			r.status.SetDegraded("Failed to delete kibana", err.Error())
-			return reconcile.Result{}, err
-		}
-	} else if !errors.IsNotFound(err) {
-		return reconcile.Result{}, err
-	}
-
-	// remove the finalizer now that elasticsearch and kibana have been deleted
-	ls.SetFinalizers(stringsutil.RemoveStringInSlice(finalizer, ls.GetFinalizers()))
-	if err := r.client.Update(ctx, ls); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	return reconcile.Result{}, nil
 }

--- a/pkg/controller/logstorage/logstorage_controller_suite_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logstorage
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/logstorage_controller_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/controller/logstorage Suite", []Reporter{junitReporter})
+}

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -1,0 +1,160 @@
+package logstorage_test
+
+import (
+	"context"
+	"os"
+
+	esalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	kibanav1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/apis"
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/logstorage"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/render"
+	apps "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Log storage controller", func() {
+	var (
+		scheme *runtime.Scheme
+	)
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(storagev1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+	})
+	Context("Managed Cluster", func() {
+		var (
+			cli            client.Client
+			resolvConfPath string
+		)
+		BeforeEach(func() {
+			cli = fake.NewFakeClientWithScheme(scheme)
+			dir, err := os.Getwd()
+			if err != nil {
+				panic(err)
+			}
+			resolvConfPath = dir + "/testdata/resolv.conf"
+			ctx := context.Background()
+			Expect(cli.Create(ctx, &operatorv1.Installation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Status: operatorv1.InstallationStatus{
+					Variant: operatorv1.TigeraSecureEnterprise,
+				},
+				Spec: operatorv1.InstallationSpec{
+					Variant:               operatorv1.TigeraSecureEnterprise,
+					ClusterManagementType: operatorv1.ClusterManagementTypeManaged,
+				},
+			})).ShouldNot(HaveOccurred())
+		})
+		It("tests that the ExternalService is setup", func() {
+			r, err := logstorage.NewReconcilerWithShims(cli, scheme, status.New(cli, "log-storage"), operatorv1.ProviderNone, resolvConfPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			ctx := context.Background()
+
+			_, err = r.Reconcile(reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			svc := &corev1.Service{}
+			Expect(
+				cli.Get(ctx, client.ObjectKey{Name: render.ElasticsearchServiceName, Namespace: render.ElasticsearchNamespace}, svc),
+			).ShouldNot(HaveOccurred())
+
+			Expect(svc.Spec.ExternalName).Should(Equal("tigera-guardian.tigera-guardian.svc.othername.local"))
+			Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
+		})
+		It("tests an error is returned if the LogStorage resource exists", func() {
+			r, err := logstorage.NewReconcilerWithShims(cli, scheme, status.New(cli, "log-storage"), operatorv1.ProviderNone, resolvConfPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			ctx := context.Background()
+
+			Expect(cli.Create(ctx, &operatorv1.LogStorage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "tigera-secure",
+				},
+			})).ShouldNot(HaveOccurred())
+
+			_, err = r.Reconcile(reconcile.Request{})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(Equal("cluster type is Managed but logstorage still exists"))
+		})
+	})
+	Context("Non managed cluster", func() {
+		var (
+			cli            client.Client
+			resolvConfPath string
+		)
+		BeforeEach(func() {
+			cli = fake.NewFakeClientWithScheme(scheme)
+			dir, err := os.Getwd()
+			if err != nil {
+				panic(err)
+			}
+			resolvConfPath = dir + "/testdata/resolv.conf"
+			ctx := context.Background()
+			Expect(cli.Create(ctx, &operatorv1.Installation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Status: operatorv1.InstallationStatus{
+					Variant: operatorv1.TigeraSecureEnterprise,
+				},
+				Spec: operatorv1.InstallationSpec{
+					Variant:               operatorv1.TigeraSecureEnterprise,
+					ClusterManagementType: operatorv1.ClusterManagementTypeManagement,
+				},
+			})).ShouldNot(HaveOccurred())
+			Expect(cli.Create(ctx, &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: render.ElasticsearchStorageClass,
+				},
+			})).ShouldNot(HaveOccurred())
+
+			Expect(cli.Create(ctx, &operatorv1.LogStorage{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "tigera-secure",
+				},
+				Spec: operatorv1.LogStorageSpec{
+					Nodes: &operatorv1.Nodes{
+						Count: int64(1),
+					},
+				},
+			})).ShouldNot(HaveOccurred())
+		})
+		It("tests elasticsearch is setup correctly", func() {
+			r, err := logstorage.NewReconcilerWithShims(cli, scheme, status.New(cli, "log-storage"), operatorv1.ProviderNone, resolvConfPath)
+			Expect(err).ShouldNot(HaveOccurred())
+			ctx := context.Background()
+
+			_, err = r.Reconcile(reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(
+				cli.Get(ctx, client.ObjectKey{Name: render.ECKOperatorName, Namespace: render.ECKOperatorNamespace}, &apps.StatefulSet{}),
+			).ShouldNot(HaveOccurred())
+
+			Expect(
+				cli.Get(ctx, client.ObjectKey{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}, &esalpha1.Elasticsearch{}),
+			).ShouldNot(HaveOccurred())
+
+			Expect(
+				cli.Get(ctx, client.ObjectKey{Name: render.KibanaName, Namespace: render.KibanaNamespace}, &kibanav1alpha1.Kibana{}),
+			).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/controller/logstorage/managed_cluster.go
+++ b/pkg/controller/logstorage/managed_cluster.go
@@ -1,0 +1,35 @@
+// The code in this file manages logstorage for the "Managed" cluster type. It sets up the service required to communicate
+// with the Elasticsearch in the management cluster
+package logstorage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/render"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileManaged sets up the ExternalService required for the other components to communicate with the Elasticsearch
+// in the management cluster. If the LogStorage CR still exists then the old Elasticsearch service likely exists, so an
+// error is returned.
+func (r *ReconcileLogStorage) reconcileManaged(ctx context.Context, network *operatorv1.Installation, reqLogger logr.Logger) (reconcile.Result, error) {
+	if _, err := GetLogStorage(ctx, r.client); err == nil {
+		return reconcile.Result{}, fmt.Errorf("cluster type is Managed but logstorage still exists")
+	} else if !errors.IsNotFound(err) {
+		r.status.SetDegraded("Failed to get LogStorage CR", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	hdler := utils.NewComponentHandler(log, r.client, r.scheme, network)
+	component := render.ElasticsearchManaged(r.localDNS, r.provider)
+	if err := hdler.CreateOrUpdate(ctx, component, r.status); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/logstorage/shim_test.go
+++ b/pkg/controller/logstorage/shim_test.go
@@ -1,0 +1,20 @@
+// This file is here so that we can export a constructor to be used by the tests in the logstorage_test package, but since
+// this is an _test file it will only be available for when running tests.
+package logstorage
+
+import (
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/status"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewReconcilerWithShims(
+	cli client.Client,
+	schema *runtime.Scheme,
+	status *status.StatusManager,
+	provider operatorv1.Provider,
+	resolvConfPath string) (*ReconcileLogStorage, error) {
+
+	return newReconciler(cli, schema, status, resolvConfPath, provider)
+}

--- a/pkg/controller/logstorage/testdata/resolv.conf
+++ b/pkg/controller/logstorage/testdata/resolv.conf
@@ -1,0 +1,3 @@
+nameserver 10.96.0.10
+search tigera-mcm.svc.othername.local svc.othername.local othername.local c.tigera-dev.internal google.internal
+options ndots:5

--- a/pkg/controller/logstorage/unmanaged_cluster.go
+++ b/pkg/controller/logstorage/unmanaged_cluster.go
@@ -1,0 +1,297 @@
+// The code in this file manages logstorage for any cluster that isn't of type "Managed". It handles the creation of
+// Elasticsearch and Kibana.
+package logstorage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cmneckalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
+	esalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
+	kibanaalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1alpha1"
+	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
+	"github.com/go-logr/logr"
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/elasticsearch"
+	esusers "github.com/tigera/operator/pkg/elasticsearch/users"
+	"github.com/tigera/operator/pkg/render"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	finalizer                  = "tigera.io/eck-cleanup"
+	defaultElasticsearchShards = 5
+)
+
+func init() {
+	esusers.AddUser(elasticsearch.User{
+		Username: render.ElasticsearchUserCurator,
+		Roles: []elasticsearch.Role{{
+			Name: render.ElasticsearchUserCurator,
+			Definition: &elasticsearch.RoleDefinition{
+				Cluster: []string{"monitor", "manage_index_templates"},
+				Indices: []elasticsearch.RoleIndex{{
+					Names:      []string{"tigera_secure_ee_*"},
+					Privileges: []string{"all"},
+				}},
+			},
+		}},
+	})
+}
+
+// reconileUnManaged creates Elasticsearch and Kibana based off the configuration in the LogStorage CR.
+func (r *ReconcileLogStorage) reconcileUnmanaged(ctx context.Context, network *operatorv1.Installation, reqLogger logr.Logger) (reconcile.Result, error) {
+	ls, err := GetLogStorage(ctx, r.client)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			r.status.SetDegraded("LogStorage resource not found", "")
+			r.status.OnCRNotFound()
+			return reconcile.Result{}, nil
+		}
+		r.status.SetDegraded("Failed to get LogStorage CR", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	reqLogger.V(2).Info("Loaded config", "config", ls)
+	r.status.OnCRFound()
+
+	if ls.DeletionTimestamp != nil {
+		return r.finalizeDeletion(ctx, ls)
+	}
+
+	if svc, err := r.getElasticsearchService(ctx); err == nil {
+		// if the Elasticsearch service is an ExternalName service, then this was previous a "Managed" cluster and
+		// the service needs to be removed before creating the Elasticsearch resource
+		if svc.Spec.Type == corev1.ServiceTypeExternalName {
+			if err := r.client.Delete(ctx, svc); err != nil {
+				r.status.SetDegraded("Failed to delete external service", err.Error())
+				return reconcile.Result{}, err
+			}
+		}
+	} else if !errors.IsNotFound(err) {
+		r.status.SetDegraded("Failed to retrieve external service", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	if !stringsutil.StringInSlice(finalizer, ls.GetFinalizers()) {
+		ls.SetFinalizers(append(ls.GetFinalizers(), finalizer))
+	}
+
+	// Write back the LogStorage object to update any defaults that were set
+	if err = r.client.Update(ctx, ls); err != nil {
+		r.status.SetDegraded("Failed to update LogStorage with defaults", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	pullSecrets, err := utils.GetNetworkingPullSecrets(network, r.client)
+	if err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Error retrieving pull secrets", err)
+		return reconcile.Result{}, err
+	}
+
+	if err := r.client.Get(ctx, client.ObjectKey{Name: render.ElasticsearchStorageClass}, &storagev1.StorageClass{}); err != nil {
+		r.setDegraded(ctx, reqLogger, ls, fmt.Sprintf("Couldn't find storage class %s, this must be provided", render.ElasticsearchStorageClass), err)
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	esCertSecret := &corev1.Secret{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraElasticsearchCertSecret, Namespace: render.OperatorNamespace()}, esCertSecret); err != nil {
+		if errors.IsNotFound(err) {
+			esCertSecret = nil
+		} else {
+			r.setDegraded(ctx, reqLogger, ls, "Failed to read Elasticsearch cert secret", err)
+			return reconcile.Result{}, err
+		}
+	}
+
+	kibanaCertSecret := &corev1.Secret{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraKibanaCertSecret, Namespace: render.OperatorNamespace()}, kibanaCertSecret); err != nil {
+		if errors.IsNotFound(err) {
+			kibanaCertSecret = nil
+		} else {
+			r.setDegraded(ctx, reqLogger, ls, "Failed to read Kibana cert secret", err)
+			return reconcile.Result{}, err
+		}
+	}
+
+	// The ECK operator requires that we provide it with a secret so it can add certificate information in for its webhooks.
+	// If it's created we don't want to overwrite it as we'll lose the certificate information the ECK operator relies on.
+	createWebhookSecret := false
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.ECKWebhookSecretName, Namespace: render.ECKOperatorNamespace}, &corev1.Secret{}); err != nil {
+		if errors.IsNotFound(err) {
+			createWebhookSecret = true
+		} else {
+			r.setDegraded(ctx, reqLogger, ls, "Failed to read Elasticsearch webhook secret", err)
+			return reconcile.Result{}, err
+		}
+	}
+
+	esClusterConfig := render.NewElasticsearchClusterConfig("cluster", ls.Replicas(), defaultElasticsearchShards)
+
+	reqLogger.V(2).Info("Creating Elasticsearch components")
+	hdler := utils.NewComponentHandler(log, r.client, r.scheme, ls)
+	component, err := render.Elasticsearch(
+		ls,
+		esClusterConfig,
+		esCertSecret,
+		kibanaCertSecret,
+		createWebhookSecret,
+		pullSecrets,
+		r.provider,
+		network.Spec.Registry,
+	)
+	if err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Error rendering LogStorage", err)
+		return reconcile.Result{}, err
+	}
+
+	if err := hdler.CreateOrUpdate(ctx, component, r.status); err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Error creating / updating resource", err)
+		return reconcile.Result{}, err
+	}
+
+	reqLogger.V(2).Info("Checking if Elasticsearch is operational")
+	if isReady, err := r.isElasticsearchReady(ctx); err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Error figuring out if Elasticsearch is operational", err)
+		return reconcile.Result{}, err
+	} else if !isReady {
+		r.setDegraded(ctx, reqLogger, ls, "Waiting for Elasticsearch cluster to be operational", nil)
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	reqLogger.V(2).Info("Checking if Kibana is operational")
+	if isReady, err := r.isKibanaReady(ctx); err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Failed to figure out if Kibana is operational", err)
+		return reconcile.Result{}, err
+	} else if !isReady {
+		r.setDegraded(ctx, reqLogger, ls, "Waiting for Kibana to be operational", nil)
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	reqLogger.V(2).Info("Elasticsearch and Kibana are operational")
+	esPublicCertSecret := &corev1.Secret{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.ElasticsearchPublicCertSecret, Namespace: render.ElasticsearchNamespace}, esPublicCertSecret); err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Failed to read Elasticsearch public cert secret", err)
+		return reconcile.Result{}, err
+	}
+
+	kibanaPublicCertSecret := &corev1.Secret{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}, kibanaPublicCertSecret); err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Failed to read Kibana public cert secret", err)
+		return reconcile.Result{}, err
+	}
+
+	updatedESUserSecrets, err := updatedElasticsearchUserSecrets(ctx, esPublicCertSecret, r.client)
+	if err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Error creating Elasticsearch credentials", err)
+		return reconcile.Result{}, err
+	}
+
+	if err := hdler.CreateOrUpdate(ctx, render.ElasticsearchSecrets(updatedESUserSecrets, esPublicCertSecret, kibanaPublicCertSecret), r.status); err != nil {
+		r.setDegraded(ctx, reqLogger, ls, "Error creating / update resource", err)
+		return reconcile.Result{}, err
+	}
+
+	esSecrets, err := utils.ElasticsearchSecrets(context.Background(), []string{render.ElasticsearchUserCurator}, r.client)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Elasticsearch secrets are not available yet, waiting until they become available")
+			r.status.SetDegraded("Elasticsearch secrets are not available yet, waiting until they become available", err.Error())
+			return reconcile.Result{}, nil
+		}
+		r.status.SetDegraded("Failed to get Elasticsearch credentials", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	curatorComponent := render.ElasticCurator(*ls, esSecrets, pullSecrets, network.Spec.Registry, render.DefaultElasticsearchClusterName)
+	if err := hdler.CreateOrUpdate(ctx, curatorComponent, r.status); err != nil {
+		r.status.SetDegraded("Error creating / updating resource", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	r.status.SetCronJobs([]types.NamespacedName{{Name: render.EsCuratorName, Namespace: render.ElasticsearchNamespace}})
+
+	// Clear the degraded bit if we've reached this far.
+	r.status.ClearDegraded()
+	reqLogger.V(2).Info("Elasticsearch users and secrets created for components needing Elasticsearch access")
+	if err := r.updateStatus(ctx, reqLogger, ls, operatorv1.LogStorageStatusReady); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileLogStorage) getElasticsearch(ctx context.Context) (*esalpha1.Elasticsearch, error) {
+	es := esalpha1.Elasticsearch{}
+	return &es, r.client.Get(ctx, client.ObjectKey{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}, &es)
+}
+
+func (r *ReconcileLogStorage) getElasticsearchService(ctx context.Context) (*corev1.Service, error) {
+	svc := corev1.Service{}
+	return &svc, r.client.Get(ctx, client.ObjectKey{Name: render.ElasticsearchServiceName, Namespace: render.ElasticsearchNamespace}, &svc)
+}
+
+func (r *ReconcileLogStorage) getKibana(ctx context.Context) (*kibanaalpha1.Kibana, error) {
+	kb := kibanaalpha1.Kibana{}
+	return &kb, r.client.Get(ctx, client.ObjectKey{Name: render.KibanaName, Namespace: render.KibanaNamespace}, &kb)
+}
+
+func (r *ReconcileLogStorage) isElasticsearchReady(ctx context.Context) (bool, error) {
+	if es, err := r.getElasticsearch(ctx); err != nil {
+		return false, err
+	} else if es.Status.Phase == "Operational" || es.Status.Phase == esalpha1.ElasticsearchReadyPhase {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (r *ReconcileLogStorage) isKibanaReady(ctx context.Context) (bool, error) {
+	if kb, err := r.getKibana(ctx); err != nil {
+		return false, err
+	} else if kb.Status.AssociationStatus == cmneckalpha1.AssociationEstablished {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// finalizeDeletion makes sure that both Kibana and Elasticsearch are deleted before removing the finalizers on the LogStorage
+// resource. This needs to happen because the eck operator will be deleted when the LogStorage resource is deleted, but
+// the eck operator is needed to delete Elasticsearch and Kibana
+func (r *ReconcileLogStorage) finalizeDeletion(ctx context.Context, ls *operatorv1.LogStorage) (reconcile.Result, error) {
+	// remove Elasticsearch
+	if es, err := r.getElasticsearch(ctx); err == nil {
+		if err := r.client.Delete(ctx, es); err != nil {
+			r.status.SetDegraded("Failed to delete Elasticsearch", err.Error())
+			return reconcile.Result{}, err
+		}
+	} else if !errors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+
+	// remove kibana
+	if kb, err := r.getKibana(ctx); err == nil {
+		if err := r.client.Delete(ctx, kb); err != nil {
+			r.status.SetDegraded("Failed to delete kibana", err.Error())
+			return reconcile.Result{}, err
+		}
+	} else if !errors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+
+	// remove the finalizer now that Elasticsearch and Kibana have been deleted
+	ls.SetFinalizers(stringsutil.RemoveStringInSlice(finalizer, ls.GetFinalizers()))
+	if err := r.client.Update(ctx, ls); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -78,6 +78,13 @@ func AddConfigMapWatch(c controller.Controller, name, namespace string) error {
 	return addNamespacedWatch(c, cm)
 }
 
+func AddServiceWatch(c controller.Controller, name, namespace string) error {
+	return addNamespacedWatch(c, &v1.Service{
+		TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "V1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	})
+}
+
 // addWatch creates a watch on the given object. If a name and namespace are provided, then it will
 // use predicates to only return matching objects. If they are not, then all events of the provided kind
 // will be generated.

--- a/pkg/render/elasticsearch_managed.go
+++ b/pkg/render/elasticsearch_managed.go
@@ -1,0 +1,50 @@
+// The code in this file renders the necessary components for a managed cluster to be able to communicate with the elasticsearch
+// in it's management cluster
+package render
+
+import (
+	"fmt"
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const ElasticsearchServiceName = "tigera-secure-es-http"
+
+func ElasticsearchManaged(clusterDNS string, provider operatorv1.Provider) Component {
+	return &elasticsearchManaged{
+		clusterDNS: clusterDNS,
+		provider:   provider,
+	}
+}
+
+type elasticsearchManaged struct {
+	clusterDNS string
+	provider   operatorv1.Provider
+}
+
+func (es elasticsearchManaged) Objects() []runtime.Object {
+	return []runtime.Object{
+		createNamespace(ElasticsearchNamespace, es.provider == operatorv1.ProviderOpenShift),
+		es.externalService(),
+	}
+}
+
+func (es elasticsearchManaged) Ready() bool {
+	return true
+}
+
+func (es elasticsearchManaged) externalService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ElasticsearchServiceName,
+			Namespace: ElasticsearchNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: fmt.Sprintf("%s.%s.%s", GuardianServiceName, GuardianNamespace, es.clusterDNS),
+		},
+	}
+}

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -20,6 +20,7 @@ const (
 	GuardianClusterRoleName        = GuardianName
 	GuardianClusterRoleBindingName = GuardianName
 	GuardianDeploymentName         = GuardianName
+	GuardianServiceName            = "tigera-guardian"
 	GuardianConfigMapName          = "tigera-guardian-config"
 	GuardianVolumeName             = "tigera-guardian-certs"
 	GuardianSecretName             = "tigera-managed-cluster-connection"
@@ -56,6 +57,7 @@ func (c *GuardianComponent) Objects() []runtime.Object {
 		c.clusterRole(),
 		c.clusterRoleBinding(),
 		c.deployment(),
+		c.service(),
 		c.configMap(),
 		copySecrets(GuardianNamespace, c.tunnelSecret)[0],
 	}
@@ -63,6 +65,28 @@ func (c *GuardianComponent) Objects() []runtime.Object {
 
 func (c *GuardianComponent) Ready() bool {
 	return true
+}
+
+func (c *GuardianComponent) service() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GuardianServiceName,
+			Namespace: GuardianNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"k8s-app": GuardianName,
+			},
+			Ports: []corev1.ServicePort{{
+				Port: 9200,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8080,
+				},
+				Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
 }
 
 func (c *GuardianComponent) serviceAccount() runtime.Object {

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Rendering tests", func() {
 			{name: render.GuardianClusterRoleName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.GuardianClusterRoleBindingName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: render.GuardianDeploymentName, ns: render.GuardianNamespace, group: "apps", version: "v1", kind: "Deployment"},
+			{name: render.GuardianServiceName, ns: render.GuardianNamespace, group: "", version: "", kind: ""},
 			{name: render.GuardianConfigMapName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "ConfigMap"},
 			{name: render.GuardianSecretName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
 		}


### PR DESCRIPTION
…ster type

This commit modifies the logstorage controller as follows:
- Move "unmanaged" cluster controller logic into separate file from logstorage_controller
- Create "managed" cluster controller logic in separate file from logstorage_controller
- Check if cluster type is managed and run managed or non managed cluster logic accordingly
- Create ExternalName service if cluster type is managed
- Create elasticsearch components if cluster type is non managed (removing ExternalName service first if necessary)
- Refactor logstorage creation logic so it's not so tightly coupled with the manager or controller.Controller instance.
- Add tests for LogStorage controller