### PR TITLE
Create Voltron tunnel secret in Operator namespace

### DIFF
--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -220,8 +220,8 @@ func copyImagePullSecrets(pullSecrets []*v1.Secret, ns string) []runtime.Object 
 	return secrets
 }
 
-func copySecrets(ns string, oSecrets ...*v1.Secret) []runtime.Object {
-	var secrets []runtime.Object
+func copySecrets(ns string, oSecrets ...*v1.Secret) []*v1.Secret {
+	var secrets []*v1.Secret
 	for _, s := range oSecrets {
 		x := s.DeepCopy()
 		x.ObjectMeta = metav1.ObjectMeta{Name: s.Name, Namespace: ns}
@@ -285,4 +285,12 @@ func securityContext() *v1.SecurityContext {
 		RunAsNonRoot:             &runAsNonRoot,
 		AllowPrivilegeEscalation: &allowPriviledgeEscalation,
 	}
+}
+
+func secretsToRuntimeObjects(secrets ...*v1.Secret) []runtime.Object {
+	objs := make([]runtime.Object, len(secrets))
+	for i, secret := range secrets {
+		objs[i] = secret
+	}
+	return objs
 }

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -16,6 +16,7 @@ package render
 
 import (
 	"fmt"
+
 	ocsv1 "github.com/openshift/api/security/v1"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	appsv1 "k8s.io/api/apps/v1"
@@ -107,7 +108,7 @@ func (c *complianceComponent) Objects() []runtime.Object {
 		complianceObjs = append(complianceObjs, c.complianceBenchmarkerSecurityContextConstraints())
 	}
 
-	complianceObjs = append(complianceObjs, copySecrets(ComplianceNamespace, c.esSecrets...)...)
+	complianceObjs = append(complianceObjs, secretsToRuntimeObjects(copySecrets(ComplianceNamespace, c.esSecrets...)...)...)
 
 	return complianceObjs
 }

--- a/pkg/render/elastic_curator.go
+++ b/pkg/render/elastic_curator.go
@@ -64,8 +64,7 @@ func (ec *elasticCuratorComponent) Objects() []runtime.Object {
 		ec.cronJob(),
 	}
 	objs = append(objs, copyImagePullSecrets(ec.pullSecrets, ElasticsearchNamespace)...)
-	return append(objs, copySecrets(ElasticsearchNamespace, ec.esSecrets...)...)
-
+	return append(objs, secretsToRuntimeObjects(copySecrets(ElasticsearchNamespace, ec.esSecrets...)...)...)
 }
 
 func (ec elasticCuratorComponent) cronJob() *batch.CronJob {

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"fmt"
+
 	cmneckalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1alpha1"
 	esalpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1alpha1"
 	kibanav1alpha1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1alpha1"
@@ -79,8 +80,8 @@ func Elasticsearch(
 		kibanaCertSecrets = []runtime.Object{kibanaCertSecret}
 	}
 
-	esCertSecrets = append(esCertSecrets, copySecrets(ElasticsearchNamespace, esCertSecret)...)
-	kibanaCertSecrets = append(kibanaCertSecrets, copySecrets(KibanaNamespace, kibanaCertSecret)...)
+	esCertSecrets = append(esCertSecrets, secretsToRuntimeObjects(copySecrets(ElasticsearchNamespace, esCertSecret)...)...)
+	kibanaCertSecrets = append(kibanaCertSecrets, secretsToRuntimeObjects(copySecrets(KibanaNamespace, kibanaCertSecret)...)...)
 	return &elasticsearchComponent{
 		logStorage:          logStorage,
 		clusterConfig:       clusterConfig,
@@ -109,7 +110,7 @@ func (es *elasticsearchComponent) Objects() []runtime.Object {
 	objs = append(objs, es.eckOperator()...)
 	objs = append(objs, createNamespace(ElasticsearchNamespace, es.provider == operatorv1.ProviderOpenShift))
 
-	objs = append(objs, copySecrets(ElasticsearchNamespace, es.pullSecrets...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(ElasticsearchNamespace, es.pullSecrets...)...)...)
 	objs = append(objs, es.esCertSecrets...)
 	objs = append(objs, es.clusterConfig.ConfigMap())
 
@@ -214,7 +215,7 @@ func (es elasticsearchComponent) eckOperator() []runtime.Object {
 		objs = append(objs, es.eckOperatorClusterAdminClusterRoleBinding())
 	}
 
-	objs = append(objs, copySecrets(ECKOperatorNamespace, es.pullSecrets...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(ECKOperatorNamespace, es.pullSecrets...)...)...)
 	if es.createWebhookSecret {
 		objs = append(objs, es.eckOperatorWebhookSecret())
 	}
@@ -424,7 +425,7 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *apps.StatefulSet {
 // Create resources needed to run a Kibana cluster (namespace, Kibana resource, secrets...)
 func (es elasticsearchComponent) kibana() []runtime.Object {
 	objs := []runtime.Object{createNamespace(KibanaNamespace, false)}
-	objs = append(objs, copySecrets(KibanaNamespace, es.pullSecrets...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(KibanaNamespace, es.pullSecrets...)...)...)
 	objs = append(objs, es.kibanaCertSecrets...)
 	objs = append(objs, es.kibanaCR())
 	return objs

--- a/pkg/render/elasticsearch_secrets.go
+++ b/pkg/render/elasticsearch_secrets.go
@@ -38,17 +38,8 @@ func ElasticsearchSecrets(updatedESUserSecrets []*corev1.Secret, esPublicCertSec
 
 func (es elasticsearchSecrets) Objects() []runtime.Object {
 	var objs []runtime.Object
-	objs = append(objs, convertSecretsToRuntime(es.updatedESUserSecrets)...)
-	objs = append(objs, copySecrets(OperatorNamespace(), es.esPublicCertSecret, es.kibanaPublicCertSecret)...)
-	return objs
-}
-
-func convertSecretsToRuntime(secrets []*corev1.Secret) []runtime.Object {
-	var objs []runtime.Object
-	for _, secret := range secrets {
-		objs = append(objs, secret)
-	}
-
+	objs = append(objs, secretsToRuntimeObjects(es.updatedESUserSecrets...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(OperatorNamespace(), es.esPublicCertSecret, es.kibanaPublicCertSecret)...)...)
 	return objs
 }
 

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -120,7 +120,7 @@ func (c *fluentdComponent) Objects() []runtime.Object {
 			c.eksLogForwarderDeployment())
 	}
 
-	objs = append(objs, copySecrets(LogCollectorNamespace, c.esSecrets...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(LogCollectorNamespace, c.esSecrets...)...)...)
 	objs = append(objs, c.daemonset())
 
 	return objs

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -62,8 +62,8 @@ type intrusionDetectionComponent struct {
 func (c *intrusionDetectionComponent) Objects() []runtime.Object {
 	objs := []runtime.Object{createNamespace(IntrusionDetectionNamespace, c.openshift)}
 	objs = append(objs, copyImagePullSecrets(c.pullSecrets, IntrusionDetectionNamespace)...)
-	objs = append(objs, copySecrets(IntrusionDetectionNamespace, c.esSecrets...)...)
-	objs = append(objs, copySecrets(IntrusionDetectionNamespace, c.kibanaCertSecret)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(IntrusionDetectionNamespace, c.esSecrets...)...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(IntrusionDetectionNamespace, c.kibanaCertSecret)...)...)
 
 	return append(objs,
 		c.intrusionDetectionServiceAccount(),

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -87,12 +87,13 @@ func Manager(
 
 	var tunnelSecrets []*corev1.Secret
 	if management {
-		// If there is no secret, we should create one.
+		// If there is no secret create one and add it to the operator namespace.
 		if tunnelSecret == nil {
-			tunnelSecrets = []*corev1.Secret{voltronTunnelSecret()}
-		} else {
-			tunnelSecrets = []*corev1.Secret{tunnelSecret}
+			tunnelSecret = voltronTunnelSecret()
+			tunnelSecrets = append(tunnelSecrets, tunnelSecret)
 		}
+
+		tunnelSecrets = append(tunnelSecrets, copySecrets(ManagerNamespace, tunnelSecret)...)
 	}
 	return &managerComponent{
 		cr:              cr,
@@ -148,9 +149,9 @@ func (c *managerComponent) Objects() []runtime.Object {
 	if c.openshift {
 		objs = append(objs, c.securityContextConstraints())
 	}
-	objs = append(objs, copySecrets(ManagerNamespace, c.esSecrets...)...)
-	objs = append(objs, copySecrets(ManagerNamespace, c.kibanaSecrets...)...)
-	objs = append(objs, copySecrets(ManagerNamespace, c.tunnelSecrets...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(ManagerNamespace, c.esSecrets...)...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(ManagerNamespace, c.kibanaSecrets...)...)...)
+	objs = append(objs, secretsToRuntimeObjects(c.tunnelSecrets...)...)
 	if c.oidcConfig != nil {
 		objs = append(objs, copyConfigMaps(ManagerNamespace, c.oidcConfig)...)
 	}
@@ -473,7 +474,7 @@ func voltronTunnelSecret() *v1.Secret {
 		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      VoltronTunnelSecretName,
-			Namespace: ManagerNamespace,
+			Namespace: OperatorNamespace(),
 		},
 		Data: map[string][]byte{
 			"cert": []byte(cert),

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	It("should render all resources for a default configuration", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(13))
+		Expect(len(resources)).To(Equal(14))
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -77,6 +77,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Service"},
 			{name: "tigera-ui-user", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: render.VoltronTunnelSecretName, ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Deployment"},
 		}
@@ -107,12 +108,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				}
 			}
 			resources := renderObjects(instance, nil)
-			Expect(len(resources)).To(Equal(13))
+			Expect(len(resources)).To(Equal(14))
 
 			// Should render the correct resource based on test case.
 			Expect(GetResource(resources, "tigera-manager", "tigera-manager", "", "v1", "Deployment")).ToNot(BeNil())
 
-			d := resources[12].(*v1.Deployment)
+			d := resources[13].(*v1.Deployment)
 
 			Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(3))
 			Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-manager"))
@@ -133,10 +134,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 		// Should render the correct resource based on test case.
 		resources := renderObjects(instance, oidcConfig)
-		Expect(len(resources)).To(Equal(14))
+		Expect(len(resources)).To(Equal(15))
 
 		Expect(GetResource(resources, render.ManagerOIDCConfig, "tigera-manager", "", "v1", "ConfigMap")).ToNot(BeNil())
-		d := resources[13].(*v1.Deployment)
+		d := resources[14].(*v1.Deployment)
 
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
 
@@ -161,8 +162,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		// Should render the correct resource based on test case.
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(13))
-		d := resources[12].(*v1.Deployment)
+		Expect(len(resources)).To(Equal(14))
+		d := resources[13].(*v1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
 		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(4))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
@@ -171,19 +172,19 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	It("should render multicluster settings properly", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(13))
+		Expect(len(resources)).To(Equal(14))
 
 		By("creating a valid self-signed cert")
 		// Use the x509 package to validate that the cert was signed with the privatekey
-		voltronSecret := resources[11].(*corev1.Secret)
-		validateSecret(voltronSecret)
+		validateSecret(resources[11].(*corev1.Secret))
+		validateSecret(resources[12].(*corev1.Secret))
 
 		By("configuring the manager deployment")
-		manager := resources[12].(*v1.Deployment).Spec.Template.Spec.Containers[0]
+		manager := resources[13].(*v1.Deployment).Spec.Template.Spec.Containers[0]
 		Expect(manager.Name).To(Equal("tigera-manager"))
 		ExpectEnv(manager.Env, "ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
 
-		voltron := resources[12].(*v1.Deployment).Spec.Template.Spec.Containers[2]
+		voltron := resources[13].(*v1.Deployment).Spec.Template.Spec.Containers[2]
 		Expect(voltron.Name).To(Equal("tigera-voltron"))
 		ExpectEnv(voltron.Env, "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
 	})


### PR DESCRIPTION
The voltron tls secret wasn't being created in the operator namespace, which meant that every time the manager reconciled it would recreate the secret and break the tunnel to the managed clusters.

I've refactored the copySecrets to return an array of secrets instead of runtime objects so that you can still refer to the returned array as secrets, instead of having to convert the back. This was needed for the annotation to be generated.