### PR TITLE
Change RBAC resources to match es-proxy

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -653,7 +653,7 @@ func (c *managerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			// Access to flow logs, audit logs, and statistics
 			{
 				APIGroups: []string{"lma.tigera.io"},
-				Resources: []string{"index"},
+				Resources: []string{"*"},
 				ResourceNames: []string{
 					"flows", "audit*", "events", "dns",
 				},
@@ -739,7 +739,7 @@ func (c *managerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 			// Access to flow logs, audit logs, and statistics
 			{
 				APIGroups: []string{"lma.tigera.io"},
-				Resources: []string{"index"},
+				Resources: []string{"*"},
 				ResourceNames: []string{
 					"flows", "audit*", "events", "dns",
 				},


### PR DESCRIPTION
In 2.7 we will have MCM support. Elasticsearch indices from each cluster will be centralized in the management cluster. The RBAC can now be used more fine-grained by granting index permissions per cluster. The default cluster name for enterprise installations is "cluster". By default (for now) we grant permission to each cluster with the default roles that we set in the Quickstart guide. These changes have no impact on standard/standalone installations.

After PR's have been merged in other repo's and before cutting release 2.7, the ui-user resource will be changed to "cluster", which grants access to to the data in the indexes belonging to cluster "cluster" (Standalone and management cluster)