### PR TITLE
removing tech preview annotations for cnx policy recommendation 

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -3,7 +3,6 @@ package render
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -33,16 +32,6 @@ const (
 	ElasticsearchUserManager = "tigera-ee-manager"
 	tlsSecretHashAnnotation  = "hash.operator.tigera.io/tls-secret"
 	oidcConfigHashAnnotation = "hash.operator.tigera.io/oidc-config"
-)
-
-const (
-	// Use this annotation to enable the Policy Recommendation tech preview feature.
-	// "tech-preview.operator.tigera.io/policy-recommendation: Enabled"
-	techPreviewFeaturePolicyRecommendationAnnotation = "tech-preview.operator.tigera.io/policy-recommendation"
-
-	// The lower case of the value that we look for to enable a tech preview feature.
-	// The feature is disabled for all other values.
-	techPreviewEnabledValue = "enabled"
 )
 
 // ManagementClusterConnection configuration constants
@@ -342,7 +331,7 @@ func (c *managerComponent) managerEnvVars() []v1.EnvVar {
 		{Name: "CNX_ENABLE_ERROR_TRACKING", Value: "false"},
 		{Name: "CNX_ALP_SUPPORT", Value: "true"},
 		{Name: "CNX_CLUSTER_NAME", Value: "cluster"},
-		{Name: "CNX_POLICY_RECOMMENDATION_SUPPORT", Value: c.policyRecommendationSupport()},
+		{Name: "CNX_POLICY_RECOMMENDATION_SUPPORT", Value: "true"},
 		{Name: "ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.management)},
 	}
 
@@ -806,15 +795,6 @@ func (c *managerComponent) getTLSObjects() []runtime.Object {
 	}
 
 	return objs
-}
-
-func (c *managerComponent) policyRecommendationSupport() string {
-	supported := "false"
-	a := c.cr.GetObjectMeta().GetAnnotations()
-	if val, ok := a[techPreviewFeaturePolicyRecommendationAnnotation]; ok && strings.ToLower(val) == techPreviewEnabledValue {
-		supported = "true"
-	}
-	return supported
 }
 
 func (c *managerComponent) globalAlertTemplates() []runtime.Object {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -89,38 +89,19 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 	})
 
-	It("should handle tech preview annotation and render manager", func() {
-		testCaseValues := []struct {
-			annotationValue   string
-			envValue          string
-			includeAnnotation bool
-		}{
-			{annotationValue: "Enabled", envValue: "true", includeAnnotation: true},
-			{annotationValue: "enabled", envValue: "true", includeAnnotation: true},
-			{annotationValue: "somethingelse", envValue: "false", includeAnnotation: true},
-			{annotationValue: "", envValue: "false", includeAnnotation: false},
-		}
-		i := 0
-		for _, tcValues := range testCaseValues {
-			if tcValues.includeAnnotation {
-				instance.ObjectMeta.Annotations = map[string]string{
-					"tech-preview.operator.tigera.io/policy-recommendation": tcValues.annotationValue,
-				}
-			}
-			resources := renderObjects(instance, nil)
-			Expect(len(resources)).To(Equal(22))
+	It("should ensure cnx policy recommendation support is always set to true", func() {
+		resources := renderObjects(instance, nil)
+		Expect(len(resources)).To(Equal(22))
 
-			// Should render the correct resource based on test case.
-			Expect(GetResource(resources, "tigera-manager", "tigera-manager", "", "v1", "Deployment")).ToNot(BeNil())
+		// Should render the correct resource based on test case.
+		Expect(GetResource(resources, "tigera-manager", "tigera-manager", "", "v1", "Deployment")).ToNot(BeNil())
 
-			d := resources[13].(*v1.Deployment)
+		d := resources[13].(*v1.Deployment)
 
-			Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(3))
-			Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-manager"))
-			Expect(d.Spec.Template.Spec.Containers[0].Env[8].Name).To(Equal("CNX_POLICY_RECOMMENDATION_SUPPORT"))
-			Expect(d.Spec.Template.Spec.Containers[0].Env[8].Value).To(Equal(tcValues.envValue))
-			i++
-		}
+		Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(3))
+		Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-manager"))
+		Expect(d.Spec.Template.Spec.Containers[0].Env[8].Name).To(Equal("CNX_POLICY_RECOMMENDATION_SUPPORT"))
+		Expect(d.Spec.Template.Spec.Containers[0].Env[8].Value).To(Equal("true"))
 	})
 
 	It("should render OIDC configmaps given OIDC configuration", func() {


### PR DESCRIPTION
This PR contains below changes, related issue [CNX-11191](https://tigera.atlassian.net/browse/CNX-11191)

- removes tech preview annotations for `policy-recommendation`
- sets `CNX_POLICY_RECOMMENDATION_SUPPORT` to be `true` always (hardcoded)
- ensures that `CNX_POLICY_RECOMMENDATION_SUPPORT=true` with test case, removing older test case which checks if the tech preview annotations working fine