### PR TITLE
Add CLUSTER_NAME env for intrusion installer

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -159,7 +159,8 @@ func (c *intrusionDetectionComponent) intrusionDetectionJobContainer() v1.Contai
 			},
 			{
 				Name:  "KB_CA_CERT",
-				Value: KibanaDefaultCertPath},
+				Value: KibanaDefaultCertPath,
+			},
 			{
 				Name:  "CLUSTER_NAME",
 				Value: c.esClusterConfig.ClusterName(),


### PR DESCRIPTION
CLUSTER_NAME env variable is used in the latest version of install.py. This commit sets it explicitly for operator based installations. In future tickets we will start setting this value based on the (MCM) cluster name.