### PR TITLE
Use new kube controller to create ManagedCluster es configuration

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -14,7 +14,7 @@ const (
 	// Overrides for Calico.
 	VersionTigeraNode            = "v2.6.0-0.dev-175-g3f547b6"
 	VersionTigeraTypha           = "v2.6.0-0.dev-104-g6c51073"
-	VersionTigeraKubeControllers = "v2.6.0-0.dev-86-g506e244-dirty"
+	VersionTigeraKubeControllers = "v2.7.0-0.dev-65-ge9f3e26"
 
 	// API server images.
 	VersionAPIServer   = "v2.7.0-0.dev-28-g95b7ffeb"

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -16,8 +16,10 @@ package render_test
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/components"
 	v1 "k8s.io/api/core/v1"
 
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
@@ -90,6 +92,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		// The Deployment should have the correct configuration.
 		ds := resources[3].(*apps.Deployment)
 
-		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:v2.6.0-0.dev-86-g506e244-dirty"))
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.VersionTigeraKubeControllers))
 	})
 })


### PR DESCRIPTION
Update to use the new kube controller that will create the es resources in a managed cluster when it connects.