### PR TITLE
Give API server GlobalAlertTemplate permissions, add GlobalAlertTempl…

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -288,6 +288,7 @@ func (c *apiServerComponent) apiServiceAccountClusterRole() *rbacv1.ClusterRole 
 					"globalnetworksets",
 					"networksets",
 					"globalalerts",
+					"globalalerttemplates",
 					"globalthreatfeeds",
 					"globalreporttypes",
 					"globalreports",
@@ -655,7 +656,7 @@ func (c *apiServerComponent) k8sRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-tier-getter",
+			Name: "tigera-tier-getter",
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "ClusterRole",
@@ -664,8 +665,8 @@ func (c *apiServerComponent) k8sRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 		Subjects: []rbacv1.Subject{
 			{
-				Kind:      "User",
-				Name:      "system:kube-controller-manager",
+				Kind:     "User",
+				Name:     "system:kube-controller-manager",
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},

--- a/pkg/render/crds.go
+++ b/pkg/render/crds.go
@@ -184,6 +184,14 @@ func tigeraSecureCRDs() []runtime.Object {
 		{
 			scope: apiextensions.ClusterScoped,
 			names: apiextensions.CustomResourceDefinitionNames{
+				Plural:   "globalalerttemplates",
+				Singular: "globalalerttemplate",
+				Kind:     "GlobalAlertTemplate",
+			},
+		},
+		{
+			scope: apiextensions.ClusterScoped,
+			names: apiextensions.CustomResourceDefinitionNames{
 				Plural:   "globalreports",
 				Singular: "globalreport",
 				Kind:     "GlobalReport",

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Rendering tests", func() {
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		c, err := render.Calico(instance, nil, typhaNodeTLS, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico})
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
-		Expect(componentCount(c.Render())).To(Equal((37 + 1 + 1 + 11)))
+		Expect(componentCount(c.Render())).To(Equal((37 + 1 + 1 + 12)))
 	})
 })
 


### PR DESCRIPTION
…ate crd

It's possible this fixes some serious issues with resource lifecycles, where pods aren't delete when deployments are deleted / the operator lock file isn't deleted when the operator is deleted. It may be that the kube controller is just too tied up with a back log of errors