### PR TITLE
Revert custom image name for guardian image

### DIFF
--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -248,8 +248,7 @@ func (c *GuardianComponent) container() []v1.Container {
 	return []corev1.Container{
 		{
 			Name:            GuardianDeploymentName,
-			Image:           "gcr.io/tigera-dev/experimental/brianmcmahon/tigera/guardian:latest",
-			ImagePullPolicy: "Always",
+			Image:           constructImage(GuardianImageName, c.registry),
 			Env: []corev1.EnvVar{
 				{
 					Name:      "GUARDIAN_PORT",

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -3,10 +3,12 @@ package render_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -31,14 +33,13 @@ var _ = Describe("Rendering tests", func() {
 			addr,
 			[]*corev1.Secret{},
 			false,
-			"my-reg",
+			"my-reg/",
 			secret,
 		)
 		resources = g.Objects()
 	})
 
 	It("should render all resources for a managed cluster", func() {
-
 		expectedResources := []struct {
 			name    string
 			ns      string
@@ -59,6 +60,9 @@ var _ = Describe("Rendering tests", func() {
 		for i, expectedRes := range expectedResources {
 			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
+
+		deployment := resources[4].(*appsv1.Deployment)
+		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("my-reg/tigera/guardian:" + components.VersionGuardian))
 	})
 
 })

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -20,9 +20,12 @@ import (
 	"encoding/pem"
 	"time"
 
+	"github.com/tigera/operator/pkg/components"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/library-go/pkg/crypto"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,6 +87,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 			i++
 		}
+
+		deployment := resources[13].(*appsv1.Deployment)
+		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/cnx-manager:" + components.VersionManager))
+		Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/es-proxy:" + components.VersionManagerEsProxy))
+		Expect(deployment.Spec.Template.Spec.Containers[2].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/voltron:" + components.VersionManagerProxy))
 	})
 
 	It("should ensure cnx policy recommendation support is always set to true", func() {


### PR DESCRIPTION
Also added tests for the voltron and guardian image to make sure custom images don't go through again