### PR TITLE
(SAAS-642) Generate certificate for compliance server and use it in v…

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -74,15 +74,16 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return fmt.Errorf("manager-controller failed to watch compliance resource: %v", err)
 	}
 
-	for _, secretName := range []string{
-		render.ManagerTLSSecretName,
-		render.ElasticsearchPublicCertSecret,
-		render.ElasticsearchManagerUserSecret,
-		render.KibanaPublicCertSecret,
-		render.VoltronTunnelSecretName,
-	} {
-		if err = utils.AddSecretsWatch(c, secretName, render.OperatorNamespace()); err != nil {
-			return fmt.Errorf("manager-controller failed to watch Secret resource %s: %v", secretName, err)
+	// Watch the given secrets in each both the manager and operator namespaces
+	for _, namespace := range []string{render.OperatorNamespace(), render.ManagerNamespace} {
+		for _, secretName := range []string{
+			render.ManagerTLSSecretName, render.ElasticsearchPublicCertSecret,
+			render.ElasticsearchManagerUserSecret, render.KibanaPublicCertSecret,
+			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret,
+		} {
+			if err = utils.AddSecretsWatch(c, secretName, namespace); err != nil {
+				return fmt.Errorf("compliance-controller failed to watch the secret '%s' in '%s' namespace: %v", secretName, namespace, err)
+			}
 		}
 	}
 
@@ -251,6 +252,21 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
+	complianceServerCertSecret, err := utils.ValidateCertPair(r.client,
+		render.ComplianceServerCertSecret,
+		render.ComplianceServerCertName,
+		render.ComplianceServerKeyName,
+	)
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("failed to retrieve %s", render.ComplianceServerCertSecret))
+		r.status.SetDegraded(fmt.Sprintf("Failed to retrieve %s", render.ComplianceServerCertSecret), err.Error())
+		return reconcile.Result{}, err
+	} else if complianceServerCertSecret == nil {
+		reqLogger.Info(fmt.Sprintf("Waiting for secret '%s' to become available", render.ComplianceServerCertSecret))
+		r.status.SetDegraded(fmt.Sprintf("Waiting for secret '%s' to become available", render.ComplianceServerCertSecret), "")
+		return reconcile.Result{}, nil
+	}
+
 	oidcConfig, err := getOIDCConfig(ctx, r.client)
 	if err != nil {
 		r.status.SetDegraded("OIDC configuration not available, waiting to become available", err.Error())
@@ -286,6 +302,7 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		instance,
 		esSecrets,
 		[]*corev1.Secret{kibanaPublicCertSecret},
+		complianceServerCertSecret,
 		esClusterConfig,
 		tlsSecret,
 		pullSecrets,

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -39,30 +39,56 @@ const (
 	ElasticsearchComplianceSnapshotterUserSecret = "tigera-ee-compliance-snapshotter-elasticsearch-access"
 	ElasticsearchComplianceServerUserSecret      = "tigera-ee-compliance-server-elasticsearch-access"
 	ElasticsearchCuratorUserSecret               = "tigera-ee-curator-elasticsearch-access"
+
+	ComplianceServerCertSecret = "tigera-compliance-server-tls"
+	ComplianceServerCertName   = "tls.crt"
+	ComplianceServerKeyName    = "tls.key"
+
+	complianceServerTLSHashAnnotation = "hash.operator.tigera.io/tls-certificate"
 )
 
 func Compliance(
 	esSecrets []*corev1.Secret,
 	installation *operatorv1.Installation,
+	complianceServerCertSecret *corev1.Secret,
 	esClusterConfig *ElasticsearchClusterConfig,
 	pullSecrets []*corev1.Secret,
 	openshift bool,
-) Component {
-	return &complianceComponent{
-		esSecrets:       esSecrets,
-		installation:    installation,
-		esClusterConfig: esClusterConfig,
-		pullSecrets:     pullSecrets,
-		openshift:       openshift,
+) (Component, error) {
+	var complianceServerCertSecrets []*corev1.Secret
+	if complianceServerCertSecret == nil {
+		var err error
+		complianceServerCertSecret, err = createOperatorTLSSecret(nil,
+			ComplianceServerCertSecret,
+			"tls.key",
+			"tls.crt",
+			nil, "compliance.tigera-compliance.svc",
+		)
+		if err != nil {
+			return nil, err
+		}
+		complianceServerCertSecrets = []*corev1.Secret{complianceServerCertSecret}
 	}
+
+	complianceServerCertSecrets = append(complianceServerCertSecrets, copySecrets(ComplianceNamespace, complianceServerCertSecret)...)
+
+	return &complianceComponent{
+		esSecrets:                   esSecrets,
+		installation:                installation,
+		esClusterConfig:             esClusterConfig,
+		pullSecrets:                 pullSecrets,
+		complianceServerCertSecrets: complianceServerCertSecrets,
+		openshift:                   openshift,
+	}, nil
 }
 
 type complianceComponent struct {
-	esSecrets       []*corev1.Secret
-	installation    *operatorv1.Installation
-	esClusterConfig *ElasticsearchClusterConfig
-	pullSecrets     []*corev1.Secret
-	openshift       bool
+	esSecrets                   []*corev1.Secret
+	installation                *operatorv1.Installation
+	esClusterConfig             *ElasticsearchClusterConfig
+	pullSecrets                 []*corev1.Secret
+	complianceServerCertSecrets []*corev1.Secret
+	openshift                   bool
 }
 
 func (c *complianceComponent) Objects() []runtime.Object {
@@ -101,6 +127,7 @@ func (c *complianceComponent) Objects() []runtime.Object {
 
 	// Compliance server is only for Standalone or Management clusters
 	if c.installation.Spec.ClusterManagementType != operatorv1.ClusterManagementTypeManaged {
+		complianceObjs = append(complianceObjs, secretsToRuntimeObjects(c.complianceServerCertSecrets...)...)
 		complianceObjs = append(complianceObjs,
 			c.complianceServerServiceAccount(),
 			c.complianceServerClusterRole(),
@@ -464,7 +491,7 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 		{Name: "LOG_LEVEL", Value: "info"},
 		{Name: "TIGERA_COMPLIANCE_JOB_NAMESPACE", Value: ComplianceNamespace},
 	}
-
+	defaultMode := int32(420)
 	return ElasticsearchDecorateAnnotations(&appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -486,6 +513,9 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 					Namespace: ComplianceNamespace,
 					Labels: map[string]string{
 						"k8s-app": "compliance-server",
+					},
+					Annotations: map[string]string{
+						complianceServerTLSHashAnnotation: AnnotationHash(c.complianceServerCertSecrets[0].Data),
 					},
 				},
 				Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
@@ -527,8 +557,32 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 								PeriodSeconds:       10,
 								FailureThreshold:    5,
 							},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "cert",
+								MountPath: "/code/apiserver.local.config/certificates",
+								ReadOnly:  true,
+							}},
 						}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceServerUserSecret),
 					},
+					Volumes: []corev1.Volume{{
+						Name: "cert",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								DefaultMode: &defaultMode,
+								SecretName:  ComplianceServerCertSecret,
+								Items: []corev1.KeyToPath{
+									{
+										Key:  "tls.crt",
+										Path: "apiserver.crt",
+									},
+									{
+										Key:  "tls.key",
+										Path: "apiserver.key",
+									},
+								},
+							},
+						},
+					}},
 				}),
 			},
 		},

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -25,13 +25,14 @@ import (
 var _ = Describe("compliance rendering tests", func() {
 	Context("Standalone cluster", func() {
 		It("should render all resources for a default configuration", func() {
-			component := render.Compliance(nil, &operatorv1.Installation{
+			component, err := render.Compliance(nil, &operatorv1.Installation{
 				Spec: operatorv1.InstallationSpec{
 					KubernetesProvider:    operatorv1.ProviderNone,
 					Registry:              "testregistry.com/",
 					ClusterManagementType: operatorv1.ClusterManagementTypeStandalone,
 				},
-			}, render.NewElasticsearchClusterConfig("cluster", 1, 1), nil, notOpenshift)
+			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1), nil, notOpenshift)
+			Expect(err).ShouldNot(HaveOccurred())
 			resources := component.Objects()
 
 			ns := "tigera-compliance"
@@ -67,6 +68,8 @@ var _ = Describe("compliance rendering tests", func() {
 				{"network-access", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"policy-audit", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"},
+				{render.ComplianceServerCertSecret, "tigera-operator", "", "v1", "Secret"},
+				{render.ComplianceServerCertSecret, "tigera-compliance", "", "v1", "Secret"},
 				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRole"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
@@ -89,13 +92,14 @@ var _ = Describe("compliance rendering tests", func() {
 
 	Context("ManagedCluster", func() {
 		It("should render all resources for a default configuration", func() {
-			component := render.Compliance(nil, &operatorv1.Installation{
+			component, err := render.Compliance(nil, &operatorv1.Installation{
 				Spec: operatorv1.InstallationSpec{
 					KubernetesProvider:    operatorv1.ProviderNone,
 					Registry:              "testregistry.com/",
 					ClusterManagementType: operatorv1.ClusterManagementTypeManaged,
 				},
-			}, render.NewElasticsearchClusterConfig("cluster", 1, 1), nil, notOpenshift)
+			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1), nil, notOpenshift)
+			Expect(err).ShouldNot(HaveOccurred())
 			resources := component.Objects()
 
 			ns := "tigera-compliance"

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -58,7 +58,6 @@ func (c *GuardianComponent) Objects() []runtime.Object {
 		c.clusterRoleBinding(),
 		c.deployment(),
 		c.service(),
-		c.configMap(),
 		copySecrets(GuardianNamespace, c.tunnelSecret)[0],
 	}
 }
@@ -93,43 +92,6 @@ func (c *GuardianComponent) serviceAccount() runtime.Object {
 	return &v1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: GuardianServiceAccountName, Namespace: GuardianNamespace},
-	}
-}
-
-func (c *GuardianComponent) configMap() runtime.Object {
-	return &v1.ConfigMap{
-		TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: GuardianConfigMapName, Namespace: GuardianNamespace},
-		Data: map[string]string{
-			// Server port for Guardian
-			"tigera-guardian.port": "9443",
-			// Logging level
-			"tigera-guardian.log-level": "INFO",
-			// Proxy targets
-			"tigera-guardian.proxy-targets": `[
-				{
-					"path": "/api/",
-					"url": "https://kubernetes.default",
-					"tokenPath": "/var/run/secrets/kubernetes.io/serviceaccount/token",
-					"caBundlePath": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-				},
-				{
-					"path": "/apis/",
-					"url": "https://kubernetes.default",
-					"tokenPath": "/var/run/secrets/kubernetes.io/serviceaccount/token",
-					"caBundlePath": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-				},
-				{
-					"path": "/tigera-elasticsearch/",
-					"url": "https://tigera-manager.tigera-manager.svc:9443"
-				},
-				{
-					"path": "/compliance/",
-					"url": "https://compliance.tigera-compliance.svc"
-				}]`,
-			// This tells Guardian how to reach Voltron
-			"tigera-guardian.voltron-url": c.url,
-		},
 	}
 }
 
@@ -247,25 +209,12 @@ func (c *GuardianComponent) volumes() []v1.Volume {
 func (c *GuardianComponent) container() []v1.Container {
 	return []corev1.Container{
 		{
-			Name:            GuardianDeploymentName,
-			Image:           constructImage(GuardianImageName, c.registry),
+			Name:  GuardianDeploymentName,
+			Image: constructImage(GuardianImageName, c.registry),
 			Env: []corev1.EnvVar{
-				{
-					Name:      "GUARDIAN_PORT",
-					ValueFrom: envVarSourceFromConfigmap(GuardianConfigMapName, "tigera-guardian.port"),
-				},
-				{
-					Name:      "GUARDIAN_LOGLEVEL",
-					ValueFrom: envVarSourceFromConfigmap(GuardianConfigMapName, "tigera-guardian.log-level"),
-				},
-				{
-					Name:      "GUARDIAN_PROXY_TARGETS",
-					ValueFrom: envVarSourceFromConfigmap(GuardianConfigMapName, "tigera-guardian.proxy-targets"),
-				},
-				{
-					Name:      "GUARDIAN_VOLTRON_URL",
-					ValueFrom: envVarSourceFromConfigmap(GuardianConfigMapName, "tigera-guardian.voltron-url"),
-				},
+				{Name: "GUARDIAN_PORT", Value: "9443"},
+				{Name: "GUARDIAN_LOGLEVEL", Value: "INFO"},
+				{Name: "GUARDIAN_VOLTRON_URL", Value: c.url},
 			},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      GuardianVolumeName,

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Rendering tests", func() {
 			{name: render.GuardianClusterRoleBindingName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: render.GuardianDeploymentName, ns: render.GuardianNamespace, group: "apps", version: "v1", kind: "Deployment"},
 			{name: render.GuardianServiceName, ns: render.GuardianNamespace, group: "", version: "", kind: ""},
-			{name: render.GuardianConfigMapName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "ConfigMap"},
 			{name: render.GuardianSecretName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
 		}
 		Expect(len(resources)).To(Equal(len(expectedResources)))

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	It("should render all resources for a default configuration", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(22))
+		Expect(len(resources)).To(Equal(23))
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -77,6 +77,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Service"},
 			{name: "tigera-ui-user", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: render.ComplianceServerCertSecret, ns: "tigera-manager", group: "", version: "", kind: ""},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Deployment"},
@@ -88,7 +89,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			i++
 		}
 
-		deployment := resources[13].(*appsv1.Deployment)
+		deployment := resources[14].(*appsv1.Deployment)
 		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/cnx-manager:" + components.VersionManager))
 		Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/es-proxy:" + components.VersionManagerEsProxy))
 		Expect(deployment.Spec.Template.Spec.Containers[2].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/voltron:" + components.VersionManagerProxy))
@@ -96,12 +97,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	It("should ensure cnx policy recommendation support is always set to true", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(22))
+		Expect(len(resources)).To(Equal(23))
 
 		// Should render the correct resource based on test case.
 		Expect(GetResource(resources, "tigera-manager", "tigera-manager", "", "v1", "Deployment")).ToNot(BeNil())
 
-		d := resources[13].(*v1.Deployment)
+		d := resources[14].(*v1.Deployment)
 
 		Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(3))
 		Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-manager"))
@@ -120,10 +121,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 		// Should render the correct resource based on test case.
 		resources := renderObjects(instance, oidcConfig)
-		Expect(len(resources)).To(Equal(23))
+		Expect(len(resources)).To(Equal(24))
 
 		Expect(GetResource(resources, render.ManagerOIDCConfig, "tigera-manager", "", "v1", "ConfigMap")).ToNot(BeNil())
-		d := resources[14].(*v1.Deployment)
+		d := resources[15].(*v1.Deployment)
 
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
 
@@ -134,9 +135,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(render.ManagerOIDCConfig))
 		Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal(render.ManagerOIDCJwksURI))
 
-		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(5))
-		Expect(d.Spec.Template.Spec.Volumes[3].Name).To(Equal(render.ManagerOIDCConfig))
-		Expect(d.Spec.Template.Spec.Volumes[3].ConfigMap.Name).To(Equal(render.ManagerOIDCConfig))
+		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(6))
+		Expect(d.Spec.Template.Spec.Volumes[4].Name).To(Equal(render.ManagerOIDCConfig))
+		Expect(d.Spec.Template.Spec.Volumes[4].ConfigMap.Name).To(Equal(render.ManagerOIDCConfig))
 	})
 
 	It("should set OIDC Authority environment when auth-type is OIDC", func() {
@@ -148,29 +149,29 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		// Should render the correct resource based on test case.
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(22))
-		d := resources[13].(*v1.Deployment)
+		Expect(len(resources)).To(Equal(23))
+		d := resources[14].(*v1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
-		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(4))
+		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(5))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
 		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
 	})
 
 	It("should render multicluster settings properly", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(22))
+		Expect(len(resources)).To(Equal(23))
 
 		By("creating a valid self-signed cert")
 		// Use the x509 package to validate that the cert was signed with the privatekey
-		validateSecret(resources[11].(*corev1.Secret))
 		validateSecret(resources[12].(*corev1.Secret))
+		validateSecret(resources[13].(*corev1.Secret))
 
 		By("configuring the manager deployment")
-		manager := resources[13].(*v1.Deployment).Spec.Template.Spec.Containers[0]
+		manager := resources[14].(*v1.Deployment).Spec.Template.Spec.Containers[0]
 		Expect(manager.Name).To(Equal("tigera-manager"))
 		ExpectEnv(manager.Env, "ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
 
-		voltron := resources[13].(*v1.Deployment).Spec.Template.Spec.Containers[2]
+		voltron := resources[14].(*v1.Deployment).Spec.Template.Spec.Containers[2]
 		Expect(voltron.Name).To(Equal("tigera-voltron"))
 		ExpectEnv(voltron.Env, "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
 	})
@@ -218,6 +219,16 @@ func renderObjects(instance *operator.Manager, oidcConfig *corev1.ConfigMap) []r
 	component, err := render.Manager(instance,
 		nil,
 		nil,
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ComplianceServerCertSecret,
+				Namespace: render.OperatorNamespace(),
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("crt"),
+				"tls.key": []byte("crt"),
+			},
+		},
 		esConfigMap,
 		nil,
 		nil,


### PR DESCRIPTION
…oltron

Previously the compliance server was generating it's own certificate (within the code) if one wasn't provided. This PR generates that certificate, stores in a secret and mounts it to the compliance server.

Furthermore, we mount that secret to voltron so we can verify the certificate when voltron proxies requests to compliance.

Other changes in this PR:
- Remove configmap for guardian (we aren't allowing the proxy targets to be configurable and now it just doesn't seem needed for the other variables)