### PR TITLE
Watch elasticsearch config map in logstorage controller

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -163,6 +163,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 	}
 
+	if err = utils.AddConfigMapWatch(c, render.ElasticsearchConfigMapName, render.OperatorNamespace()); err != nil {
+		return fmt.Errorf("log-storage-controller failed to watch the ConfigMap resource: %v", err)
+	}
+
 	if err := utils.AddServiceWatch(c, render.ElasticsearchServiceName, render.ElasticsearchNamespace); err != nil {
 		return fmt.Errorf("log-storage-controller failed to watch the Service resource: %v", err)
 	}


### PR DESCRIPTION
This watch is to make sure we recreate or revert changes to the elasticsearch config map that the logstorage controller makes