### PR TITLE
Disable controller elasticsearchconfiguration for managed clusters

### DIFF
--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -177,7 +177,11 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 
 	enabledControllers := []string{"node"}
 	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
-		enabledControllers = append(enabledControllers, "service", "elasticsearchconfiguration")
+		enabledControllers = append(enabledControllers, "service")
+
+		if c.cr.Spec.ClusterManagementType != operator.ClusterManagementTypeManaged {
+			enabledControllers = append(enabledControllers, "elasticsearchconfiguration")
+		}
 
 		if c.cr.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
 			enabledControllers = append(enabledControllers, "managedcluster")


### PR DESCRIPTION
This isn't supposed to run in managed clusters as the management cluster is taking care of the elasticsearch configuration