### PR TITLE
Don't overwrite resources in the status manager

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/tigera/operator/pkg/controller/installation"
-	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
 
@@ -143,7 +142,7 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 		tunnelSecret,
 	)
 
-	if err := ch.CreateOrUpdate(ctx, component, &status.StatusManager{}); err != nil {
+	if err := ch.CreateOrUpdate(ctx, component, nil); err != nil {
 		return result, err
 	}
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -459,8 +459,8 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 
 	// TODO: We handle too many components in this controller at the moment. Once we are done consolidating,
 	// we can have the CreateOrUpdate logic handle this for us.
-	r.status.SetDaemonsets([]types.NamespacedName{{Name: "calico-node", Namespace: "calico-system"}})
-	r.status.SetDeployments([]types.NamespacedName{{Name: "calico-kube-controllers", Namespace: "calico-system"}})
+	r.status.AddDaemonsets([]types.NamespacedName{{Name: "calico-node", Namespace: "calico-system"}})
+	r.status.AddDeployments([]types.NamespacedName{{Name: "calico-kube-controllers", Namespace: "calico-system"}})
 
 	// We have successfully reconciled the Calico installation.
 	if instance.Spec.KubernetesProvider == operator.ProviderOpenShift {

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -157,7 +157,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch all the secrets created by this controller so we can regenerate any that are deleted
 	for _, secretName := range []string{
 		render.TigeraElasticsearchCertSecret, render.TigeraKibanaCertSecret,
-		render.ECKWebhookSecretName, render.ElasticsearchCuratorUserSecret} {
+		render.ECKWebhookSecretName} {
 		if err = utils.AddSecretsWatch(c, secretName, render.OperatorNamespace()); err != nil {
 			return fmt.Errorf("log-storage-controller failed to watch the Secret resource: %v", err)
 		}

--- a/pkg/controller/logstorage/unmanaged_cluster.go
+++ b/pkg/controller/logstorage/unmanaged_cluster.go
@@ -192,7 +192,7 @@ func (r *ReconcileLogStorage) reconcileUnmanaged(ctx context.Context, network *o
 		return reconcile.Result{}, err
 	}
 
-	r.status.SetCronJobs([]types.NamespacedName{{Name: render.EsCuratorName, Namespace: render.ElasticsearchNamespace}})
+	r.status.AddCronJobs([]types.NamespacedName{{Name: render.EsCuratorName, Namespace: render.ElasticsearchNamespace}})
 
 	// Clear the degraded bit if we've reached this far.
 	r.status.ClearDegraded()

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -129,9 +129,9 @@ func (c componentHandler) CreateOrUpdate(ctx context.Context, component render.C
 		continue
 	}
 	if status != nil {
-		status.SetDaemonsets(daemonSets)
-		status.SetDeployments(deployments)
-		status.SetStatefulSets(statefulsets)
+		status.AddDaemonsets(daemonSets)
+		status.AddDeployments(deployments)
+		status.AddStatefulSets(statefulsets)
 	}
 	cmpLog.Info("Done reconciling component")
 	return nil


### PR DESCRIPTION
If a controller calls CreateOrUpdate multiple times then the deployments, daemonsets, cronjobs, and statefulsets are overwritten which each call. This means that when syncState runs there may or may not be one of the resources required for the status manager to know if it should update the status (the status manager requires that it has one of the four previously mentioned resources to update the status)

This is particularily a problem for the logstorage resource, as it calls CreateOrUpdate multiple times, and not always with one of the four previously mentioned resources.

This commit modifies the Set<Resource> methods so that it adds stored resources to the status manager if those resources aren't already in there, instead of replacing the resources.

I've also reverted the previous change to watch the curator secret, as it was actually already being watched through watching all the secrets with the "tigera-elasticsearch-user" label