### PR TITLE
Use 1/3 of available memory for JVM Heap, max 26GiB

### DIFF
--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -242,6 +242,12 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 // Important note: Following Elastic ECK docs, the recommendation is to set the Java heap size
 // to half the size of RAM allocated to the Pod:
 // https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html#k8s-compute-resources-elasticsearch
+//
+// This recommendation does not consider space for machine learning however - we're using the
+// default limit of 30% of node memory there, so we adjust accordingly.
+//
+// Finally limit the value to 26GiB to encourage zero-based compressed oops:
+// https://www.elastic.co/blog/a-heap-of-trouble
 func memoryQuantityToJVMHeapSize(q *resource.Quantity) string {
 	// Get the Quantity's raw number with any scale factor applied (based any unit when it was parsed)
 	// e.g.
@@ -250,8 +256,8 @@ func memoryQuantityToJVMHeapSize(q *resource.Quantity) string {
 	// "1000" is parsed as a Quantity with value 1000, scale factor 0, and returns 1000
 	rawMemQuantity := q.AsDec()
 
-	// Next cut the raw number by half (following Elastic recommendation)
-	divisor := inf.NewDec(2, 0)
+	// Use one third of that for the JVM heap.
+	divisor := inf.NewDec(3, 0)
 	halvedQuantity := new(inf.Dec).QuoRound(rawMemQuantity, divisor, 0, inf.RoundFloor)
 
 	// The remaining operations below perform validation and possible modification of the
@@ -273,7 +279,13 @@ func memoryQuantityToJVMHeapSize(q *resource.Quantity) string {
 		newRawMemQuantity = minLimit.UnscaledBig().Int64()
 	}
 
-	// Note: Because we roumd to the nearest mulitple of 1024 above and then use BinarySI format below,
+	// Limit the JVM heap to 26GiB.
+	maxLimit := inf.NewDec(27917287424, 0)
+	if roundedToNearest.Cmp(maxLimit) > 0 {
+		newRawMemQuantity = maxLimit.UnscaledBig().Int64()
+	}
+
+	// Note: Because we round to the nearest multiple of 1024 above and then use BinarySI format below,
 	// we will always get a binary unit (e.g. Ki, Mi, Gi). However, depending on what the raw number is
 	// the Quantity internal formatter might not use the most intuitive unit.
 	//

--- a/pkg/render/elasticsearch_internal_test.go
+++ b/pkg/render/elasticsearch_internal_test.go
@@ -15,24 +15,23 @@ func Test_convertQuantityJVMHeapSize(t *testing.T) {
 		args args
 		want string
 	}{
-		{name: "Conversion from Gi to G", args: args{q: resource.MustParse("2Gi")}, want: "1G"},
-		{name: "Conversion from Gi to M", args: args{q: resource.MustParse("3Gi")}, want: "1536M"},
-		{name: "Conversion from Mi to M", args: args{q: resource.MustParse("650Mi")}, want: "325M"},
-		{name: "Conversion from Mi to K", args: args{q: resource.MustParse("5Mi")}, want: "2560K"},
-		{name: "Conversion from Ki to K", args: args{q: resource.MustParse("2500000Ki")}, want: "1250000K"},
-		{name: "Conversion from G to K (with rounding)", args: args{q: resource.MustParse("2G")}, want: "976562K"},
-		{name: "Conversion from M to K (with rounding)", args: args{q: resource.MustParse("13M")}, want: "6347K"},
+		{name: "Conversion from Gi to G", args: args{q: resource.MustParse("3Gi")}, want: "1G"},
+		{name: "Conversion from Gi to K (with rounding)", args: args{q: resource.MustParse("4Gi")}, want: "1398101K"},
+		{name: "Conversion from Mi to M", args: args{q: resource.MustParse("975Mi")}, want: "325M"},
+		{name: "Conversion from Mi to K (with rounding)", args: args{q: resource.MustParse("10Mi")}, want: "3413K"},
+		{name: "Conversion from Ki to K", args: args{q: resource.MustParse("2400000Ki")}, want: "800000K"},
+		{name: "Conversion from G to K (with rounding)", args: args{q: resource.MustParse("4G")}, want: "1302083K"},
+		{name: "Conversion from M to K (with rounding)", args: args{q: resource.MustParse("13M")}, want: "4231K"},
 		{name: "Conversion from k is below minimum limit (2 megabytes)", args: args{q: resource.MustParse("5k")}, want: "2M"},
-		// Below example is 2Gi
-		{name: "Conversion from raw number equivalent to Gi to G", args: args{q: resource.MustParse("2147483648")}, want: "1G"},
-		// Below example is 5Gi, which ends up translate to M (not G) because using G would result in decimal value
-		{name: "Conversion from raw number equivalent to Gi to M", args: args{q: resource.MustParse("5368709120")}, want: "2560M"},
-		// Below example is 40Mi
-		{name: "Conversion from raw number equivalent to Mi to M", args: args{q: resource.MustParse("41943040")}, want: "20M"},
+		{name: "Conversion from Gi is above maximum limit (26 gigabytes)", args: args{q: resource.MustParse("96Gi")}, want: "26G"},
+		// Below example is 3Gi
+		{name: "Conversion from raw number equivalent to Gi to G", args: args{q: resource.MustParse("3221225472")}, want: "1G"},
+		// Below example is 5Gi, which ends up translate to K (not G) because using G would result in decimal value
+		{name: "Conversion from raw number equivalent to Gi to M", args: args{q: resource.MustParse("5368709120")}, want: "1747626K"},
 		// Below example is 20Mi
-		{name: "Conversion from raw number equivalent to Mi to K", args: args{q: resource.MustParse("20097152")}, want: "9813K"},
+		{name: "Conversion from raw number equivalent to Mi to K", args: args{q: resource.MustParse("20971520")}, want: "6826K"},
 		{name: "Conversion from raw number is below minimum limit (2 megabytes)", args: args{q: resource.MustParse("2000")}, want: "2M"},
-		{name: "Conversion from raw number is below minimum limit (2 megabytes)", args: args{q: resource.MustParse("500000")}, want: "2M"},
+		{name: "Conversion from raw number is above maximum limit (26 gigabytes)", args: args{q: resource.MustParse("500000000000")}, want: "26G"},
 		{name: "Conversion from decimal is below minimum limit (2 megabytes)", args: args{q: resource.MustParse("5.4")}, want: "2M"},
 		{name: "Conversion from Mi is below minimum limit (2 megabytes)", args: args{q: resource.MustParse("1Mi")}, want: "2M"},
 	}


### PR DESCRIPTION
Approximate memory budget is 33% JVM heap, 30% ML jobs, 37% file cache and misc.

26GiB limit is to guarantee zero-based compressed oops.