### PR TITLE
Update manager cert for macOS 10.15

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -46,6 +46,7 @@ func APIServer(registry string, tlsKeyPair *corev1.Secret, pullSecrets []*corev1
 			APIServerTLSSecretName,
 			APIServerSecretKeyName,
 			APIServerSecretCertName,
+			DefaultCertificateDuration,
 			nil,
 			apiServiceHostname,
 		)

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -62,6 +62,7 @@ func Compliance(
 			ComplianceServerCertSecret,
 			"tls.key",
 			"tls.crt",
+			DefaultCertificateDuration,
 			nil, "compliance.tigera-compliance.svc",
 		)
 		if err != nil {

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -60,6 +60,7 @@ func Elasticsearch(
 			TigeraElasticsearchCertSecret,
 			"tls.key",
 			"tls.crt",
+			DefaultCertificateDuration,
 			nil, ElasticsearchHTTPURL,
 		)
 		if err != nil {
@@ -74,6 +75,7 @@ func Elasticsearch(
 			TigeraKibanaCertSecret,
 			"tls.key",
 			"tls.crt",
+			DefaultCertificateDuration,
 			nil, KibanaHTTPURL,
 		)
 		if err != nil {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -64,6 +64,7 @@ func Manager(
 			ManagerTLSSecretName,
 			ManagerSecretKeyName,
 			ManagerSecretCertName,
+			825*24*time.Hour, // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
 			nil,
 		)
 		if err != nil {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -145,6 +145,7 @@ func createTLS() (*TyphaNodeTLS, error) {
 		NodeTLSSecretName,
 		TLSSecretKeyName,
 		TLSSecretCertName,
+		DefaultCertificateDuration,
 		[]crypto.CertificateExtensionFunc{setClientAuth},
 		"typha-client")
 	if err != nil {
@@ -158,6 +159,7 @@ func createTLS() (*TyphaNodeTLS, error) {
 		TyphaTLSSecretName,
 		TLSSecretKeyName,
 		TLSSecretCertName,
+		DefaultCertificateDuration,
 		[]crypto.CertificateExtensionFunc{setServerAuth},
 		"typha-server")
 	if err != nil {


### PR DESCRIPTION
Specify a cert expiration of 825 days for the certificate for the manager so macOS 10.15 will allow it. https://support.apple.com/en-us/HT210176