### PR TITLE
Create sa and rbac for managed cluster's compliance server, so it can…

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -124,17 +124,24 @@ func (c *complianceComponent) Objects() []runtime.Object {
 		c.complianceGlobalReportNetworkAccess(),
 		c.complianceGlobalReportPolicyAudit(),
 		c.complianceGlobalReportCISBenchmark(),
+
+		// We always need a sa and crb, whether a deployment of compliance-server is present or not.
+		// These two are used for rbac checks for managed clusters.
+		c.complianceServerServiceAccount(),
+		c.complianceServerClusterRoleBinding(),
 	)
 
 	// Compliance server is only for Standalone or Management clusters
 	if c.installation.Spec.ClusterManagementType != operatorv1.ClusterManagementTypeManaged {
 		complianceObjs = append(complianceObjs, secretsToRuntimeObjects(c.complianceServerCertSecrets...)...)
 		complianceObjs = append(complianceObjs,
-			c.complianceServerServiceAccount(),
 			c.complianceServerClusterRole(),
-			c.complianceServerClusterRoleBinding(),
 			c.complianceServerService(),
 			c.complianceServerDeployment(),
+		)
+	} else {
+		complianceObjs = append(complianceObjs,
+			c.complianceServerManagedClusterRole(),
 		)
 	}
 
@@ -442,6 +449,25 @@ func (c *complianceComponent) complianceServerClusterRole() *rbacv1.ClusterRole 
 				APIGroups: []string{"authentication.k8s.io"},
 				Resources: []string{"tokenreviews"},
 				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
+			},
+		},
+	}
+}
+
+func (c *complianceComponent) complianceServerManagedClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"globalreporttypes", "globalreports"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{"authorization.k8s.io"},

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -68,11 +68,11 @@ var _ = Describe("compliance rendering tests", func() {
 				{"network-access", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"policy-audit", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"},
+				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
+				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
 				{render.ComplianceServerCertSecret, "tigera-operator", "", "v1", "Secret"},
 				{render.ComplianceServerCertSecret, "tigera-compliance", "", "v1", "Secret"},
-				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRole"},
-				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
 				{"compliance", ns, "", "v1", "Service"},
 				{"compliance-server", ns, "apps", "v1", "Deployment"},
 			}
@@ -135,6 +135,9 @@ var _ = Describe("compliance rendering tests", func() {
 				{"network-access", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"policy-audit", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"},
+				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
+				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
+				{"tigera-compliance-server", "", rbac, "v1", "ClusterRole"},
 			}
 
 			Expect(len(resources)).To(Equal(len(expectedResources)))


### PR DESCRIPTION
…… (#365)

* Create sa and rbac for managed cluster's compliance server, so it can check rbac

* Add extra rbac role. Move compliance-server resources out of else{}

* Improved explanation in comment