### PR TITLE
(CNX-11672) Increase eck operator memory to prevent OCP OOMKILL

### DIFF
--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -549,7 +549,7 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *apps.StatefulSet {
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
 								"cpu":    resource.MustParse("1"),
-								"memory": resource.MustParse("100Mi"),
+								"memory": resource.MustParse("150Mi"),
 							},
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),


### PR DESCRIPTION
The memory limit was just a little to low