### PR TITLE
Request memory for Curator

### DIFF
--- a/pkg/render/elastic_curator.go
+++ b/pkg/render/elastic_curator.go
@@ -119,6 +119,14 @@ func (ec elasticCuratorComponent) cronJob() *batch.CronJob {
 									Image:         constructImage(EsCuratorImageName, ec.registry),
 									Env:           ec.envVars(),
 									LivenessProbe: elasticCuratorLivenessProbe,
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											"memory": resource.MustParse("192Mi"),
+										},
+										Requests: corev1.ResourceList{
+											"memory":  resource.MustParse("128Mi"),
+										},
+									},
 									SecurityContext: &v1.SecurityContext{
 										RunAsNonRoot:             &f,
 										AllowPrivilegeEscalation: &f,


### PR DESCRIPTION
Curator running (but not deleting anything) in my cluster requires more than 48MB and less than 64MB.  I've doubled this for the sake of paranoia and to give it a chance to actually delete indices.