### PR TITLE
(SAAS-664) Make sure Elasticsearch / Kibana are cleaned up after LogStorage CR is deleted for all cluster types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.10.1-0.20190910171846-947a464dbe96
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 
 	github.com/tigera/api v0.0.0-20200117234535-b3d9372ce711
 	gopkg.in/inf.v0 v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50/go.mod h1:1pdIZTAHUz+HDKDVZ++5xg/duPlhKAIzw9qy42CWYp4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -21,19 +21,25 @@ import (
 	"os"
 	"regexp"
 
+	apps "k8s.io/api/apps/v1"
+
+	"github.com/elastic/cloud-on-k8s/operators/pkg/utils/stringsutil"
+
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	esalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
-	kibanaalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
+
+	kibanaalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -134,17 +140,21 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return fmt.Errorf("log-storage-controller failed to watch Network resource: %v", err)
 	}
 
-	if err = c.Watch(&source.Kind{Type: &esalpha1.Elasticsearch{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &operatorv1.LogStorage{},
-	}); err != nil {
+	if err = c.Watch(&source.Kind{Type: &apps.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKOperatorName},
+	}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("log-storage-controller failed to watch StatefulSet resource: %v", err)
+	}
+
+	if err = c.Watch(&source.Kind{Type: &esalpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.ElasticsearchName},
+	}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-controller failed to watch Elasticsearch resource: %v", err)
 	}
 
-	if err = c.Watch(&source.Kind{Type: &kibanaalpha1.Kibana{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &operatorv1.LogStorage{},
-	}); err != nil {
+	if err = c.Watch(&source.Kind{Type: &kibanaalpha1.Kibana{
+		ObjectMeta: metav1.ObjectMeta{Namespace: render.KibanaNamespace, Name: render.KibanaName},
+	}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-controller failed to watch Kibana resource: %v", err)
 	}
 
@@ -257,6 +267,21 @@ func (r *ReconcileLogStorage) Reconcile(request reconcile.Request) (reconcile.Re
 
 	ctx := context.Background()
 
+	// Try to retrieve the LogStorage resource to see if we need to clean up after it's been marked for deletion
+	if ls, err := GetLogStorage(ctx, r.client); err != nil {
+		if !errors.IsNotFound(err) {
+			r.status.SetDegraded("Failed to get LogStorage CR", err.Error())
+			return reconcile.Result{}, err
+		}
+	} else if ls.DeletionTimestamp != nil {
+		if err := r.finalizeDeletion(ctx, ls); err != nil {
+			r.setDegraded(ctx, reqLogger, ls, "Finalizing deletion of LogStorage before continuing", err)
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
 	network, err := installation.GetInstallation(context.Background(), r.client, r.provider)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -297,6 +322,59 @@ func (r *ReconcileLogStorage) updateStatus(ctx context.Context, reqLogger logr.L
 	if err := r.client.Status().Update(ctx, ls); err != nil {
 		reqLogger.Error(err, fmt.Sprintf("Error updating the log-storage status %s", state))
 		r.status.SetDegraded(fmt.Sprintf("Error updating the log-storage status %s", state), err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// finalizeDeletion makes sure that both Kibana and Elasticsearch are deleted before removing the finalizer on the LogStorage
+// resource. This needs to happen because the ECK operator will be deleted when the LogStorage resource is deleted, but
+// the ECK operator is needed to delete Elasticsearch and Kibana.
+func (r *ReconcileLogStorage) finalizeDeletion(ctx context.Context, ls *operatorv1.LogStorage) error {
+	log.Info("Finalizing LogStorage deletion")
+	// if both Elasticsearch and Kibana are already deleted then this stays true and we'll remove the LogStorage CR
+	// finalizer. We want to wait until the ECK operator has completely removed Elasticsearch before allowing the
+	// LogStorage CR to be deleted
+	removeFinalizer := true
+
+	// Delete Elasticsearch
+	if es, err := r.getElasticsearch(ctx); err == nil {
+		// If the DeletionTimestamp is set then we're just waiting for the ECK operator to finish deleting Elasticsearch
+		if es.DeletionTimestamp == nil {
+			log.Info("Deleting Elasticsearch")
+			if err := r.client.Delete(ctx, es); err != nil {
+				return err
+			}
+		}
+		removeFinalizer = false
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	// Delete Kibana
+	if kb, err := r.getKibana(ctx); err == nil {
+		// If the DeletionTimestamp is set then we're just waiting for the ECK operator to finish deleting Kibana
+		if kb.DeletionTimestamp == nil {
+			log.Info("Deleting Kibana")
+			if err := r.client.Delete(ctx, kb); err != nil {
+				return err
+			}
+		}
+		removeFinalizer = false
+	} else if !errors.IsNotFound(err) {
+		return err
+	}
+
+	if !removeFinalizer {
+		log.Info("Waiting for Elasticsearch and Kibana deletion to complete before removing finalizers from LogStorage")
+		return nil
+	}
+
+	// remove the finalizer now that Elasticsearch and Kibana have been deleted
+	log.Info("Removing finalizers from LogStorage")
+	ls.SetFinalizers(stringsutil.RemoveStringInSlice(finalizer, ls.GetFinalizers()))
+	if err := r.client.Update(ctx, ls); err != nil {
 		return err
 	}
 

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -17,158 +17,427 @@ package logstorage_test
 import (
 	"context"
 	"os"
+	"time"
 
-	esalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
-	kibanav1alpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/tigera/operator/pkg/apis"
-	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/logstorage"
 	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
-	apps "k8s.io/api/apps/v1"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stretchr/testify/mock"
+
+	cmneckalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/common/v1alpha1"
+	esalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
+	kibanaalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/kibana/v1alpha1"
+
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1beta "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = Describe("Log storage controller", func() {
-	var (
-		scheme *runtime.Scheme
-	)
-	BeforeEach(func() {
-		scheme = runtime.NewScheme()
-		Expect(apis.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-		Expect(storagev1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-		Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-	})
-	Context("Managed Cluster", func() {
+var (
+	eckOperatorObjKey = client.ObjectKey{Name: render.ECKOperatorName, Namespace: render.ECKOperatorNamespace}
+	esObjKey          = client.ObjectKey{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}
+	kbObjKey          = client.ObjectKey{Name: render.KibanaName, Namespace: render.KibanaNamespace}
+	curatorObjKey     = types.NamespacedName{Namespace: render.ElasticsearchNamespace, Name: render.EsCuratorName}
+
+	esPublicCertObjMeta     = metav1.ObjectMeta{Name: render.ElasticsearchPublicCertSecret, Namespace: render.ElasticsearchNamespace}
+	kbPublicCertObjMeta     = metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}
+	curatorUsrSecretObjMeta = metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: render.OperatorNamespace()}
+)
+
+var _ = Describe("LogStorage controller", func() {
+	Context("Reconcile", func() {
 		var (
-			cli            client.Client
-			resolvConfPath string
+			cli        client.Client
+			mockStatus *status.MockStatus
+			scheme     *runtime.Scheme
 		)
+
 		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(apis.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(storagev1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(batchv1beta.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+
 			cli = fake.NewFakeClientWithScheme(scheme)
-			dir, err := os.Getwd()
-			if err != nil {
-				panic(err)
-			}
-			resolvConfPath = dir + "/testdata/resolv.conf"
-			ctx := context.Background()
-			Expect(cli.Create(ctx, &operatorv1.Installation{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
-				Status: operatorv1.InstallationStatus{
-					Variant: operatorv1.TigeraSecureEnterprise,
-				},
-				Spec: operatorv1.InstallationSpec{
-					Variant:               operatorv1.TigeraSecureEnterprise,
-					ClusterManagementType: operatorv1.ClusterManagementTypeManaged,
-				},
-			})).ShouldNot(HaveOccurred())
 		})
-		It("tests that the ExternalService is setup", func() {
-			r, err := logstorage.NewReconcilerWithShims(cli, scheme, status.New(cli, "log-storage"), operatorv1.ProviderNone, resolvConfPath)
-			Expect(err).ShouldNot(HaveOccurred())
-			ctx := context.Background()
 
-			_, err = r.Reconcile(reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			svc := &corev1.Service{}
-			Expect(
-				cli.Get(ctx, client.ObjectKey{Name: render.ElasticsearchServiceName, Namespace: render.ElasticsearchNamespace}, svc),
-			).ShouldNot(HaveOccurred())
-
-			Expect(svc.Spec.ExternalName).Should(Equal("tigera-guardian.tigera-guardian.svc.othername.local"))
-			Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
-		})
-		It("tests an error is returned if the LogStorage resource exists", func() {
-			r, err := logstorage.NewReconcilerWithShims(cli, scheme, status.New(cli, "log-storage"), operatorv1.ProviderNone, resolvConfPath)
-			Expect(err).ShouldNot(HaveOccurred())
-			ctx := context.Background()
-
-			Expect(cli.Create(ctx, &operatorv1.LogStorage{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "tigera-secure",
-				},
-			})).ShouldNot(HaveOccurred())
-
-			_, err = r.Reconcile(reconcile.Request{})
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(Equal("cluster type is Managed but logstorage still exists"))
-		})
-	})
-	Context("Non managed cluster", func() {
-		var (
-			cli            client.Client
-			resolvConfPath string
-		)
-		BeforeEach(func() {
-			cli = fake.NewFakeClientWithScheme(scheme)
-			dir, err := os.Getwd()
-			if err != nil {
-				panic(err)
-			}
-			resolvConfPath = dir + "/testdata/resolv.conf"
-			ctx := context.Background()
-			Expect(cli.Create(ctx, &operatorv1.Installation{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-				},
-				Status: operatorv1.InstallationStatus{
-					Variant: operatorv1.TigeraSecureEnterprise,
-				},
-				Spec: operatorv1.InstallationSpec{
-					Variant:               operatorv1.TigeraSecureEnterprise,
-					ClusterManagementType: operatorv1.ClusterManagementTypeManagement,
-				},
-			})).ShouldNot(HaveOccurred())
-			Expect(cli.Create(ctx, &storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: render.ElasticsearchStorageClass,
-				},
-			})).ShouldNot(HaveOccurred())
-
-			Expect(cli.Create(ctx, &operatorv1.LogStorage{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "tigera-secure",
-				},
-				Spec: operatorv1.LogStorageSpec{
-					Nodes: &operatorv1.Nodes{
-						Count: int64(1),
+		Context("Managed Cluster", func() {
+			BeforeEach(func() {
+				ctx := context.Background()
+				Expect(cli.Create(ctx, &operatorv1.Installation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
 					},
-				},
-			})).ShouldNot(HaveOccurred())
+					Status: operatorv1.InstallationStatus{
+						Variant: operatorv1.TigeraSecureEnterprise,
+					},
+					Spec: operatorv1.InstallationSpec{
+						Variant:               operatorv1.TigeraSecureEnterprise,
+						ClusterManagementType: operatorv1.ClusterManagementTypeManaged,
+					},
+				})).ShouldNot(HaveOccurred())
+
+				mockStatus = &status.MockStatus{}
+				mockStatus.On("Run").Return()
+			})
+			Context("ExternalService is correctly setup", func() {
+				BeforeEach(func() {
+					mockStatus.On("AddDaemonsets", mock.Anything).Return()
+					mockStatus.On("AddDeployments", mock.Anything).Return()
+					mockStatus.On("AddStatefulSets", mock.Anything).Return()
+				})
+				It("tests that the ExternalService is setup with the default service name", func() {
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, "")
+					Expect(err).ShouldNot(HaveOccurred())
+					ctx := context.Background()
+
+					_, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+
+					svc := &corev1.Service{}
+					Expect(
+						cli.Get(ctx, client.ObjectKey{Name: render.ElasticsearchServiceName, Namespace: render.ElasticsearchNamespace}, svc),
+					).ShouldNot(HaveOccurred())
+
+					Expect(svc.Spec.ExternalName).Should(Equal("tigera-guardian.tigera-guardian.svc.cluster.local"))
+					Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
+				})
+				It("tests that the ExternalService is setup with the url parsed from the given resolv.conf", func() {
+					dir, err := os.Getwd()
+					if err != nil {
+						panic(err)
+					}
+					resolvConfPath := dir + "/testdata/resolv.conf"
+
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, resolvConfPath)
+					Expect(err).ShouldNot(HaveOccurred())
+					ctx := context.Background()
+
+					_, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+
+					svc := &corev1.Service{}
+					Expect(
+						cli.Get(ctx, client.ObjectKey{Name: render.ElasticsearchServiceName, Namespace: render.ElasticsearchNamespace}, svc),
+					).ShouldNot(HaveOccurred())
+
+					Expect(svc.Spec.ExternalName).Should(Equal("tigera-guardian.tigera-guardian.svc.othername.local"))
+					Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
+				})
+			})
+
+			Context("LogStorage exists", func() {
+				BeforeEach(func() {
+					setUpLogStorageComponents(cli)
+				})
+
+				It("returns an error if the LogStorage resource exists and is not marked for deletion", func() {
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, "")
+					Expect(err).ShouldNot(HaveOccurred())
+
+					result, err := r.Reconcile(reconcile.Request{})
+					Expect(result).Should(Equal(reconcile.Result{}))
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(Equal("cluster type is Managed but logstorage still exists"))
+
+					mockStatus.AssertExpectations(GinkgoT())
+				})
+
+				It("finalises the deletion of the LogStorage CR when marked for deletion and continues without error", func() {
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, "")
+					Expect(err).ShouldNot(HaveOccurred())
+
+					ls := &operatorv1.LogStorage{}
+					Expect(cli.Get(context.Background(), utils.DefaultTSEEInstanceKey, ls)).ShouldNot(HaveOccurred())
+
+					now := metav1.Now()
+					ls.DeletionTimestamp = &now
+					ls.SetFinalizers([]string{"tigera.io/eck-cleanup"})
+					Expect(cli.Update(context.Background(), ls)).ShouldNot(HaveOccurred())
+
+					result, err := r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					By("expecting not to find the tigera-secure Elasticsearch or Kibana resources")
+					err = cli.Get(context.Background(), esObjKey, &esalpha1.Elasticsearch{})
+					Expect(errors.IsNotFound(err)).Should(BeTrue())
+					err = cli.Get(context.Background(), kbObjKey, &kibanaalpha1.Kibana{})
+					Expect(errors.IsNotFound(err)).Should(BeTrue())
+
+					// The LogStorage CR should still contain the finalizer, as we wait for ES and KB to finish deleting
+					By("waiting for the Elasticsearch and Kibana resources to be deleted")
+					ls = &operatorv1.LogStorage{}
+					Expect(cli.Get(context.Background(), utils.DefaultTSEEInstanceKey, ls)).ShouldNot(HaveOccurred())
+					Expect(ls.Finalizers).Should(ContainElement("tigera.io/eck-cleanup"))
+
+					result, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					By("expecting not to find the eck-cleanup finalizer in the LogStorage CR anymore")
+					ls = &operatorv1.LogStorage{}
+					Expect(cli.Get(context.Background(), utils.DefaultTSEEInstanceKey, ls)).ShouldNot(HaveOccurred())
+					Expect(ls.Finalizers).ShouldNot(ContainElement("tigera.io/eck-cleanup"))
+
+					mockStatus.AssertExpectations(GinkgoT())
+				})
+			})
+
 		})
-		It("tests elasticsearch is setup correctly", func() {
-			r, err := logstorage.NewReconcilerWithShims(cli, scheme, status.New(cli, "log-storage"), operatorv1.ProviderNone, resolvConfPath)
-			Expect(err).ShouldNot(HaveOccurred())
-			ctx := context.Background()
+		Context("Unmanaged cluster", func() {
+			Context("successful LogStorage Reconcile", func() {
+				var mockStatus *status.MockStatus
 
-			_, err = r.Reconcile(reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
+				BeforeEach(func() {
+					ctx := context.Background()
+					Expect(cli.Create(ctx, &operatorv1.Installation{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Status: operatorv1.InstallationStatus{
+							Variant: operatorv1.TigeraSecureEnterprise,
+						},
+						Spec: operatorv1.InstallationSpec{
+							Variant:               operatorv1.TigeraSecureEnterprise,
+							ClusterManagementType: operatorv1.ClusterManagementTypeManagement,
+						},
+					})).ShouldNot(HaveOccurred())
 
-			Expect(
-				cli.Get(ctx, client.ObjectKey{Name: render.ECKOperatorName, Namespace: render.ECKOperatorNamespace}, &apps.StatefulSet{}),
-			).ShouldNot(HaveOccurred())
+					mockStatus = &status.MockStatus{}
+					mockStatus.On("Run").Return()
+					mockStatus.On("AddDaemonsets", mock.Anything)
+					mockStatus.On("AddDeployments", mock.Anything)
+					mockStatus.On("AddStatefulSets", mock.Anything)
+					mockStatus.On("AddCronJobs", mock.Anything)
+					mockStatus.On("OnCRFound").Return()
+				})
+				It("test LogStorage reconciles successfully", func() {
+					ctx := context.Background()
+					Expect(cli.Create(ctx, &storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: render.ElasticsearchStorageClass,
+						},
+					})).ShouldNot(HaveOccurred())
 
-			Expect(
-				cli.Get(ctx, client.ObjectKey{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}, &esalpha1.Elasticsearch{}),
-			).ShouldNot(HaveOccurred())
+					Expect(cli.Create(ctx, &operatorv1.LogStorage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "tigera-secure",
+						},
+						Spec: operatorv1.LogStorageSpec{
+							Nodes: &operatorv1.Nodes{
+								Count: int64(1),
+							},
+						},
+					})).ShouldNot(HaveOccurred())
 
-			Expect(
-				cli.Get(ctx, client.ObjectKey{Name: render.KibanaName, Namespace: render.KibanaNamespace}, &kibanav1alpha1.Kibana{}),
-			).ShouldNot(HaveOccurred())
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, "")
+					Expect(err).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
+					result, err := r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					// Expect to be waiting for Elasticsearch and Kibana to be functional
+					Expect(result).Should(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+
+					By("asserting the finalizers have been set on the LogStorage CR")
+					ls := &operatorv1.LogStorage{}
+					Expect(cli.Get(context.Background(), types.NamespacedName{Name: "tigera-secure"}, ls)).ShouldNot(HaveOccurred())
+					Expect(ls.Finalizers).Should(ContainElement("tigera.io/eck-cleanup"))
+
+					Expect(cli.Get(ctx, eckOperatorObjKey, &appsv1.StatefulSet{})).ShouldNot(HaveOccurred())
+
+					es := &esalpha1.Elasticsearch{}
+					Expect(cli.Get(ctx, esObjKey, es)).ShouldNot(HaveOccurred())
+
+					es.Status.Phase = esalpha1.ElasticsearchOperationalPhase
+					Expect(cli.Update(ctx, es)).ShouldNot(HaveOccurred())
+
+					kb := &kibanaalpha1.Kibana{}
+					Expect(cli.Get(ctx, kbObjKey, kb)).ShouldNot(HaveOccurred())
+
+					kb.Status.AssociationStatus = cmneckalpha1.AssociationEstablished
+					Expect(cli.Update(ctx, kb)).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: esPublicCertObjMeta})).ShouldNot(HaveOccurred())
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: kbPublicCertObjMeta})).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Elasticsearch secrets are not available yet, waiting until they become available", "secrets \"tigera-ee-curator-elasticsearch-access\" not found").Return()
+					result, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					// Expect to be waiting for curator secret
+					Expect(result).Should(Equal(reconcile.Result{}))
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: curatorUsrSecretObjMeta})).ShouldNot(HaveOccurred())
+
+					mockStatus.On("ClearDegraded")
+					result, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					By("confirming curator job is created")
+					Expect(cli.Get(ctx, curatorObjKey, &batchv1beta.CronJob{})).ShouldNot(HaveOccurred())
+
+					mockStatus.AssertExpectations(GinkgoT())
+				})
+			})
+
+			Context("LogStorage CR deleted", func() {
+				var mockStatus *status.MockStatus
+
+				BeforeEach(func() {
+					ctx := context.Background()
+
+					Expect(cli.Create(ctx, &operatorv1.Installation{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "default",
+						},
+						Status: operatorv1.InstallationStatus{
+							Variant: operatorv1.TigeraSecureEnterprise,
+						},
+						Spec: operatorv1.InstallationSpec{
+							Variant:               operatorv1.TigeraSecureEnterprise,
+							ClusterManagementType: operatorv1.ClusterManagementTypeManagement,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					setUpLogStorageComponents(cli)
+
+					mockStatus = &status.MockStatus{}
+					mockStatus.On("Run").Return()
+					mockStatus.On("AddDaemonsets", mock.Anything)
+					mockStatus.On("AddDeployments", mock.Anything)
+					mockStatus.On("AddStatefulSets", mock.Anything)
+					mockStatus.On("AddCronJobs", mock.Anything)
+					mockStatus.On("ClearDegraded", mock.Anything)
+					mockStatus.On("OnCRFound").Return()
+				})
+
+				It("deletes Elasticsearch and Kibana then removes the finalizers on the LogStorage CR", func() {
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, "")
+					Expect(err).ShouldNot(HaveOccurred())
+
+					By("making sure LogStorage has successfully reconciled")
+					result, err := r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					ls := &operatorv1.LogStorage{}
+					Expect(cli.Get(context.Background(), utils.DefaultTSEEInstanceKey, ls)).ShouldNot(HaveOccurred())
+
+					By("setting the DeletionTimestamp on the LogStorage CR")
+					// The fake library does seem to respect finalizers when Delete is called, so we need to manually set the
+					// DeletionTimestamp.
+					now := metav1.Now()
+					ls.DeletionTimestamp = &now
+					Expect(cli.Update(context.Background(), ls)).ShouldNot(HaveOccurred())
+
+					result, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					By("expecting not to find the tigera-secure Elasticsearch or Kibana resources")
+					err = cli.Get(context.Background(), esObjKey, &esalpha1.Elasticsearch{})
+					Expect(errors.IsNotFound(err)).Should(BeTrue())
+					err = cli.Get(context.Background(), kbObjKey, &kibanaalpha1.Kibana{})
+					Expect(errors.IsNotFound(err)).Should(BeTrue())
+
+					// The LogStorage CR should still contain the finalizer, as we wait for ES and KB to finish deleting
+					By("waiting for the Elasticsearch and Kibana resources to be deleted")
+					ls = &operatorv1.LogStorage{}
+					Expect(cli.Get(context.Background(), utils.DefaultTSEEInstanceKey, ls)).ShouldNot(HaveOccurred())
+					Expect(ls.Finalizers).Should(ContainElement("tigera.io/eck-cleanup"))
+
+					result, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					By("expecting not to find the eck-cleanup finalizer in the LogStorage CR anymore")
+					ls = &operatorv1.LogStorage{}
+					Expect(cli.Get(context.Background(), utils.DefaultTSEEInstanceKey, ls)).ShouldNot(HaveOccurred())
+					Expect(ls.Finalizers).ShouldNot(ContainElement("tigera.io/eck-cleanup"))
+
+					mockStatus.AssertExpectations(GinkgoT())
+				})
+			})
 		})
 	})
 })
+
+func setUpLogStorageComponents(cli client.Client) {
+	ctx := context.Background()
+	Expect(cli.Create(ctx, &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: render.ElasticsearchStorageClass,
+		},
+	})).ShouldNot(HaveOccurred())
+
+	ls := &operatorv1.LogStorage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tigera-secure",
+		},
+		Spec: operatorv1.LogStorageSpec{
+			Nodes: &operatorv1.Nodes{
+				Count: int64(1),
+			},
+		},
+	}
+
+	Expect(cli.Create(ctx, ls)).ShouldNot(HaveOccurred())
+
+	By("creating all the components needed for LogStorage to be available")
+	component, err := render.Elasticsearch(
+		ls,
+		render.NewElasticsearchClusterConfig("cluster", 1, 1),
+		&corev1.Secret{ObjectMeta: esPublicCertObjMeta},
+		&corev1.Secret{ObjectMeta: kbPublicCertObjMeta},
+		false,
+		[]*corev1.Secret{},
+		operatorv1.ProviderNone,
+		"test-registry/",
+	)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	createObj, _ := component.Objects()
+	for _, obj := range createObj {
+		switch obj.(type) {
+		case *esalpha1.Elasticsearch:
+			By("setting the Elasticsearch status to operational so we pass the Elasticsearch ready check")
+			es := obj.(*esalpha1.Elasticsearch)
+			es.Status.Phase = esalpha1.ElasticsearchOperationalPhase
+			obj = es
+
+		case *kibanaalpha1.Kibana:
+			By("setting the Kibana status to operational so we pass the Kibana ready check")
+			kb := obj.(*kibanaalpha1.Kibana)
+			kb.Status.AssociationStatus = cmneckalpha1.AssociationEstablished
+			obj = kb
+		}
+		Expect(cli.Create(ctx, obj)).ShouldNot(HaveOccurred())
+	}
+
+	Expect(
+		cli.Create(ctx, &corev1.Secret{
+			ObjectMeta: curatorUsrSecretObjMeta,
+		}),
+	).ShouldNot(HaveOccurred())
+}

--- a/pkg/controller/status/mock.go
+++ b/pkg/controller/status/mock.go
@@ -1,0 +1,74 @@
+package status
+
+import (
+	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type MockStatus struct {
+	mock.Mock
+}
+
+func (m *MockStatus) Run() {
+	m.Called()
+}
+
+func (m *MockStatus) OnCRFound() {
+	m.Called()
+}
+
+func (m *MockStatus) OnCRNotFound() {
+	m.Called()
+}
+
+func (m *MockStatus) AddDaemonsets(dss []types.NamespacedName) {
+	m.Called(dss)
+}
+
+func (m *MockStatus) AddDeployments(deps []types.NamespacedName) {
+	m.Called(deps)
+}
+
+func (m *MockStatus) AddStatefulSets(sss []types.NamespacedName) {
+	m.Called(sss)
+}
+
+func (m *MockStatus) AddCronJobs(cjs []types.NamespacedName) {
+	m.Called(cjs)
+}
+
+func (m *MockStatus) RemoveDaemonsets(dss ...types.NamespacedName) {
+	m.Called(dss)
+}
+
+func (m *MockStatus) RemoveDeployments(dps ...types.NamespacedName) {
+	m.Called(dps)
+}
+
+func (m *MockStatus) RemoveStatefulSets(sss ...types.NamespacedName) {
+	m.Called(sss)
+}
+
+func (m *MockStatus) RemoveCronJobs(cjs ...types.NamespacedName) {
+	m.Called(cjs)
+}
+
+func (m *MockStatus) SetDegraded(reason, msg string) {
+	m.Called(reason, msg)
+}
+
+func (m *MockStatus) ClearDegraded() {
+	m.Called()
+}
+
+func (m *MockStatus) IsAvailable() bool {
+	return m.Called().Bool(0)
+}
+
+func (m MockStatus) IsProgressing() bool {
+	return m.Called().Bool(0)
+}
+
+func (m *MockStatus) IsDegraded() bool {
+	return m.Called().Bool(0)
+}


### PR DESCRIPTION
If the cluster type was Managed, then the code path that cleans up Elasticsearch and Kibana before removing the finalizers on the LogStorage CR wasn't followed.

This commit also does the following:

- Update the Elasticsearch and Kibana watches to not use EnqueueRequestForOwner (so that we can tell when we're reconciling for elasticsearch or kibana)
- Add a watch for the ECK statefulset