### PR TITLE
Change render.Component.Objects() to return two object slices

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -73,18 +73,15 @@ func (c componentHandler) CreateOrUpdate(ctx context.Context, component render.C
 	statefulsets := []types.NamespacedName{}
 	objsToCreate, objsToDelete := component.Objects()
 
-	var err error
-	var key client.ObjectKey
-
 	for _, obj := range objsToCreate {
 		// Set CR instance as the owner and controller.
-		if err = controllerutil.SetControllerReference(c.cr, obj.(metav1.ObjectMetaAccessor).GetObjectMeta(), c.scheme); err != nil {
+		if err := controllerutil.SetControllerReference(c.cr, obj.(metav1.ObjectMetaAccessor).GetObjectMeta(), c.scheme); err != nil {
 			return err
 		}
 
 		logCtx := ContextLoggerForResource(c.log, obj)
 		var old runtime.Object = obj.DeepCopyObject()
-		key, err = client.ObjectKeyFromObject(obj)
+		key, err := client.ObjectKeyFromObject(obj)
 		if err != nil {
 			return err
 		}
@@ -160,7 +157,7 @@ func (c componentHandler) CreateOrUpdate(ctx context.Context, component render.C
 			return err
 		}
 
-		key, err = client.ObjectKeyFromObject(obj)
+		key, err := client.ObjectKeyFromObject(obj)
 		switch obj.(type) {
 		case *apps.Deployment:
 			status.RemoveDeployments(key)

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -160,7 +160,7 @@ func (c componentHandler) CreateOrUpdate(ctx context.Context, component render.C
 			return err
 		}
 
-		key, err := client.ObjectKeyFromObject(obj)
+		key, err = client.ObjectKeyFromObject(obj)
 		switch obj.(type) {
 		case *apps.Deployment:
 			status.RemoveDeployments(key)

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -71,7 +71,9 @@ func (c componentHandler) CreateOrUpdate(ctx context.Context, component render.C
 	daemonSets := []types.NamespacedName{}
 	deployments := []types.NamespacedName{}
 	statefulsets := []types.NamespacedName{}
-	for _, obj := range component.Objects() {
+	objsToCreate, _ := component.Objects()
+
+	for _, obj := range objsToCreate {
 		// Set CR instance as the owner and controller.
 		if err := controllerutil.SetControllerReference(c.cr, obj.(metav1.ObjectMetaAccessor).GetObjectMeta(), c.scheme); err != nil {
 			return err

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -73,16 +73,18 @@ func (c componentHandler) CreateOrUpdate(ctx context.Context, component render.C
 	statefulsets := []types.NamespacedName{}
 	objsToCreate, objsToDelete := component.Objects()
 
+	var err error
+	var key client.ObjectKey
+
 	for _, obj := range objsToCreate {
 		// Set CR instance as the owner and controller.
-		if err := controllerutil.SetControllerReference(c.cr, obj.(metav1.ObjectMetaAccessor).GetObjectMeta(), c.scheme); err != nil {
+		if err = controllerutil.SetControllerReference(c.cr, obj.(metav1.ObjectMetaAccessor).GetObjectMeta(), c.scheme); err != nil {
 			return err
 		}
 
 		logCtx := ContextLoggerForResource(c.log, obj)
 		var old runtime.Object = obj.DeepCopyObject()
-		var key client.ObjectKey
-		key, err := client.ObjectKeyFromObject(obj)
+		key, err = client.ObjectKeyFromObject(obj)
 		if err != nil {
 			return err
 		}
@@ -156,6 +158,16 @@ func (c componentHandler) CreateOrUpdate(ctx context.Context, component render.C
 			logCtx := ContextLoggerForResource(c.log, obj)
 			logCtx.Error(err, "Error deleting object %v", obj)
 			return err
+		}
+
+		key, err := client.ObjectKeyFromObject(obj)
+		switch obj.(type) {
+		case *apps.Deployment:
+			status.RemoveDeployments(key)
+		case *apps.DaemonSet:
+			status.RemoveDaemonsets(key)
+		case *apps.StatefulSet:
+			status.RemoveStatefulSets(key)
 		}
 	}
 

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -80,7 +80,7 @@ type apiServerComponent struct {
 	openshift    bool
 }
 
-func (c *apiServerComponent) Objects() []runtime.Object {
+func (c *apiServerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		createNamespace(APIServerNamespace, c.openshift),
 	}
@@ -113,7 +113,7 @@ func (c *apiServerComponent) Objects() []runtime.Object {
 		c.tigeraNetworkAdminClusterRole(),
 	)
 
-	return objs
+	return objs, nil
 }
 
 func (c *apiServerComponent) Ready() bool {

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -47,7 +47,7 @@ var _ = Describe("API server rendering tests", func() {
 		component, err := render.APIServer(instance, nil, nil, openshift)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 
-		resources := component.Objects()
+		resources, _ := component.Objects()
 
 		// Should render the correct resources.
 		// - 1 namespace
@@ -209,7 +209,7 @@ var _ = Describe("API server rendering tests", func() {
 	It("should render an API server with custom configuration", func() {
 		component, err := render.APIServer(instance, nil, nil, openshift)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 
 		// Should render the correct resources.
 		// Expect same number as above
@@ -224,7 +224,7 @@ var _ = Describe("API server rendering tests", func() {
 	It("should render needed resources for k8s kube-controller", func() {
 		component, err := render.APIServer(instance, nil, nil, openshift)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 
 		Expect(len(resources)).To(Equal(20))
 

--- a/pkg/render/aws-securitygroup-setup.go
+++ b/pkg/render/aws-securitygroup-setup.go
@@ -39,13 +39,13 @@ type awsSGSetupComponent struct {
 	initImageVersion string
 }
 
-func (c *awsSGSetupComponent) Objects() []runtime.Object {
+func (c *awsSGSetupComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	return []runtime.Object{
 		c.serviceAccount(),
 		c.role(),
 		c.roleBinding(),
 		c.setupJob(),
-	}
+	}, nil
 }
 
 func (c *awsSGSetupComponent) Ready() bool {

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -92,7 +92,7 @@ type complianceComponent struct {
 	openshift                   bool
 }
 
-func (c *complianceComponent) Objects() []runtime.Object {
+func (c *complianceComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	complianceObjs := append(
 		[]runtime.Object{createNamespace(ComplianceNamespace, c.openshift)},
 		copyImagePullSecrets(c.pullSecrets, ComplianceNamespace)...,
@@ -144,7 +144,7 @@ func (c *complianceComponent) Objects() []runtime.Object {
 
 	complianceObjs = append(complianceObjs, secretsToRuntimeObjects(copySecrets(ComplianceNamespace, c.esSecrets...)...)...)
 
-	return complianceObjs
+	return complianceObjs, nil
 }
 
 func (c *complianceComponent) Ready() bool {

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -33,7 +33,7 @@ var _ = Describe("compliance rendering tests", func() {
 				},
 			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1), nil, notOpenshift)
 			Expect(err).ShouldNot(HaveOccurred())
-			resources := component.Objects()
+			resources, _ := component.Objects()
 
 			ns := "tigera-compliance"
 			rbac := "rbac.authorization.k8s.io"
@@ -100,7 +100,7 @@ var _ = Describe("compliance rendering tests", func() {
 				},
 			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1), nil, notOpenshift)
 			Expect(err).ShouldNot(HaveOccurred())
-			resources := component.Objects()
+			resources, _ := component.Objects()
 
 			ns := "tigera-compliance"
 			rbac := "rbac.authorization.k8s.io"

--- a/pkg/render/configmap.go
+++ b/pkg/render/configmap.go
@@ -27,12 +27,12 @@ type configMapComponent struct {
 	configMaps []*corev1.ConfigMap
 }
 
-func (c *configMapComponent) Objects() []runtime.Object {
+func (c *configMapComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{}
 	for _, cm := range c.configMaps {
 		objs = append(objs, cm)
 	}
-	return objs
+	return objs, nil
 }
 
 func (c *configMapComponent) Ready() bool {

--- a/pkg/render/crds.go
+++ b/pkg/render/crds.go
@@ -31,12 +31,12 @@ type crdComponent struct {
 	cr *operator.Installation
 }
 
-func (c *crdComponent) Objects() []runtime.Object {
+func (c *crdComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	crds := c.calicoCRDs()
 	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
 		crds = append(crds, tigeraSecureCRDs()...)
 	}
-	return crds
+	return crds, nil
 }
 
 func (c *crdComponent) Ready() bool {

--- a/pkg/render/elastic_curator.go
+++ b/pkg/render/elastic_curator.go
@@ -73,12 +73,13 @@ type elasticCuratorComponent struct {
 	clusterName string
 }
 
-func (ec *elasticCuratorComponent) Objects() []runtime.Object {
+func (ec *elasticCuratorComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		ec.cronJob(),
 	}
 	objs = append(objs, copyImagePullSecrets(ec.pullSecrets, ElasticsearchNamespace)...)
-	return append(objs, secretsToRuntimeObjects(copySecrets(ElasticsearchNamespace, ec.esSecrets...)...)...)
+	objs = append(objs, secretsToRuntimeObjects(copySecrets(ElasticsearchNamespace, ec.esSecrets...)...)...)
+	return objs, nil
 }
 
 func (ec elasticCuratorComponent) cronJob() *batch.CronJob {

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -123,7 +123,7 @@ type elasticsearchComponent struct {
 	registry            string
 }
 
-func (es *elasticsearchComponent) Objects() []runtime.Object {
+func (es *elasticsearchComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	var objs []runtime.Object
 	objs = append(objs, es.eckOperator()...)
 	objs = append(objs, createNamespace(ElasticsearchNamespace, es.provider == operatorv1.ProviderOpenShift))
@@ -135,7 +135,7 @@ func (es *elasticsearchComponent) Objects() []runtime.Object {
 	objs = append(objs, es.elasticsearchCluster())
 	objs = append(objs, es.kibana()...)
 
-	return objs
+	return objs, nil
 }
 
 func (es *elasticsearchComponent) Ready() bool {

--- a/pkg/render/elasticsearch_managed.go
+++ b/pkg/render/elasticsearch_managed.go
@@ -39,11 +39,11 @@ type elasticsearchManaged struct {
 	provider   operatorv1.Provider
 }
 
-func (es elasticsearchManaged) Objects() []runtime.Object {
+func (es elasticsearchManaged) Objects() ([]runtime.Object, []runtime.Object) {
 	return []runtime.Object{
 		createNamespace(ElasticsearchNamespace, es.provider == operatorv1.ProviderOpenShift),
 		es.externalService(),
-	}
+	}, nil
 }
 
 func (es elasticsearchManaged) Ready() bool {

--- a/pkg/render/elasticsearch_secrets.go
+++ b/pkg/render/elasticsearch_secrets.go
@@ -34,10 +34,10 @@ func ElasticsearchSecrets(esPublicCertSecret *corev1.Secret, kibanaPublicCertSec
 	}
 }
 
-func (es elasticsearchSecrets) Objects() []runtime.Object {
+func (es elasticsearchSecrets) Objects() ([]runtime.Object, []runtime.Object) {
 	var objs []runtime.Object
 	objs = append(objs, secretsToRuntimeObjects(copySecrets(OperatorNamespace(), es.esPublicCertSecret, es.kibanaPublicCertSecret)...)...)
-	return objs
+	return objs, nil
 }
 
 func (es elasticsearchSecrets) Ready() bool {

--- a/pkg/render/elasticsearch_test.go
+++ b/pkg/render/elasticsearch_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		component, err := render.Elasticsearch(logStorage, esConfig, nil, nil, false, nil, operator.ProviderNone, "docker.elastic.co/eck/")
 		Expect(err).NotTo(HaveOccurred())
 
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {
@@ -113,7 +113,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		component, err := render.Elasticsearch(logStorage, esConfig, nil, nil, false,
 			[]*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "pull-secret"}}}, operator.ProviderNone, "docker.elastic.co/eck/")
 		Expect(err).NotTo(HaveOccurred())
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {
@@ -147,7 +147,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 		component, err := render.Elasticsearch(logStorage, esConfig, nil, nil, false, nil, operator.ProviderOpenShift, "docker.elastic.co/eck/")
 		Expect(err).NotTo(HaveOccurred())
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {
@@ -181,7 +181,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		}
 		component, err := render.Elasticsearch(logStorage, esConfig, nil, nil, true, nil, operator.ProviderOpenShift, "docker.elastic.co/eck/")
 		Expect(err).NotTo(HaveOccurred())
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {
@@ -214,7 +214,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			{"tigera-secure", "tigera-kibana", "", "", ""},
 		}
 		Expect(err).NotTo(HaveOccurred())
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -101,7 +101,7 @@ type fluentdComponent struct {
 	installation    *operatorv1.Installation
 }
 
-func (c *fluentdComponent) Objects() []runtime.Object {
+func (c *fluentdComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	var objs []runtime.Object
 	objs = append(objs,
 		createNamespace(
@@ -123,7 +123,7 @@ func (c *fluentdComponent) Objects() []runtime.Object {
 	objs = append(objs, secretsToRuntimeObjects(copySecrets(LogCollectorNamespace, c.esSecrets...)...)...)
 	objs = append(objs, c.daemonset())
 
-	return objs
+	return objs, nil
 }
 
 func (c *fluentdComponent) Ready() bool {

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 	It("should render all resources for a default configuration", func() {
 		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, filters, eksConfig, nil, installation)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(2))
 
 		// Should render the correct resources.
@@ -84,7 +84,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			},
 		}
 		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, filters, eksConfig, nil, installation)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(3))
 
 		// Should render the correct resources.
@@ -150,7 +150,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			},
 		}
 		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, filters, eksConfig, nil, installation)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(2))
 
 		// Should render the correct resources.
@@ -218,7 +218,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			Flow: "flow-filter",
 		}
 		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, filters, eksConfig, nil, installation)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(3))
 
 		// Should render the correct resources.
@@ -263,7 +263,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			},
 		}
 		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, filters, eksConfig, nil, installation)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
 		// Should render the correct resources.

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -64,7 +64,7 @@ type GuardianComponent struct {
 	tunnelSecret *corev1.Secret
 }
 
-func (c *GuardianComponent) Objects() []runtime.Object {
+func (c *GuardianComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	return []runtime.Object{
 		createNamespace(GuardianNamespace, c.openshift),
 		c.serviceAccount(),
@@ -73,7 +73,7 @@ func (c *GuardianComponent) Objects() []runtime.Object {
 		c.deployment(),
 		c.service(),
 		copySecrets(GuardianNamespace, c.tunnelSecret)[0],
-	}
+	}, nil
 }
 
 func (c *GuardianComponent) Ready() bool {

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Rendering tests", func() {
 			"my-reg/",
 			secret,
 		)
-		resources = g.Objects()
+		resources, _ = g.Objects()
 	})
 
 	It("should render all resources for a managed cluster", func() {

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -60,21 +60,20 @@ type intrusionDetectionComponent struct {
 	openshift        bool
 }
 
-func (c *intrusionDetectionComponent) Objects() []runtime.Object {
+func (c *intrusionDetectionComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{createNamespace(IntrusionDetectionNamespace, c.openshift)}
 	objs = append(objs, copyImagePullSecrets(c.pullSecrets, IntrusionDetectionNamespace)...)
 	objs = append(objs, secretsToRuntimeObjects(copySecrets(IntrusionDetectionNamespace, c.esSecrets...)...)...)
 	objs = append(objs, secretsToRuntimeObjects(copySecrets(IntrusionDetectionNamespace, c.kibanaCertSecret)...)...)
-
-	return append(objs,
-		c.intrusionDetectionServiceAccount(),
+	objs = append(objs, c.intrusionDetectionServiceAccount(),
 		c.intrusionDetectionClusterRole(),
 		c.intrusionDetectionClusterRoleBinding(),
 		c.intrusionDetectionRole(),
 		c.intrusionDetectionRoleBinding(),
 		c.intrusionDetectionDeployment(),
-		c.intrusionDetectionElasticsearchJob(),
-	)
+		c.intrusionDetectionElasticsearchJob())
+
+	return objs, nil
 }
 
 func (c *intrusionDetectionComponent) Ready() bool {

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		esConfigMap := render.NewElasticsearchClusterConfig("clusterTestName", 1, 1)
 
 		component := render.IntrusionDetection(nil, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}}, "testregistry.com/", esConfigMap, nil, notOpenshift)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(9))
 
 		// Should render the correct resources.

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -39,13 +39,13 @@ type kubeControllersComponent struct {
 	cr *operator.Installation
 }
 
-func (c *kubeControllersComponent) Objects() []runtime.Object {
+func (c *kubeControllersComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	return []runtime.Object{
 		c.controllersServiceAccount(),
 		c.controllersRole(),
 		c.controllersRoleBinding(),
 		c.controllersDeployment(),
-	}
+	}, nil
 }
 
 func (c *kubeControllersComponent) Ready() bool {

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -46,7 +46,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 	It("should render all resources for a custom configuration", func() {
 		component := render.KubeControllers(instance)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(4))
 
 		// Should render the correct resources.
@@ -80,7 +80,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 
 		component := render.KubeControllers(instance)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(4))
 
 		// Should render the correct resources.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -135,7 +135,7 @@ type managerComponent struct {
 	tunnelSecrets []*corev1.Secret
 }
 
-func (c *managerComponent) Objects() []runtime.Object {
+func (c *managerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		createNamespace(ManagerNamespace, c.openshift),
 	}
@@ -166,7 +166,7 @@ func (c *managerComponent) Objects() []runtime.Object {
 	objs = append(objs, c.managerDeployment())
 	objs = append(objs, c.globalAlertTemplates()...)
 
-	return objs
+	return objs, nil
 }
 
 func (c *managerComponent) Ready() bool {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -236,6 +236,6 @@ func renderObjects(instance *operator.Manager, oidcConfig *corev1.ConfigMap) []r
 		true,
 		nil)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
-	resources := component.Objects()
+	resources, _ := component.Objects()
 	return resources
 }

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -41,7 +41,7 @@ type namespaceComponent struct {
 	pullSecrets []*corev1.Secret
 }
 
-func (c *namespaceComponent) Objects() []runtime.Object {
+func (c *namespaceComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	ns := []runtime.Object{
 		createNamespace(common.CalicoNamespace, c.openshift),
 	}
@@ -55,7 +55,7 @@ func (c *namespaceComponent) Objects() []runtime.Object {
 			ns = append(ns, copyImagePullSecrets(c.pullSecrets, TigeraPrometheusNamespace)...)
 		}
 	}
-	return ns
+	return ns, nil
 }
 
 func (c *namespaceComponent) Ready() bool {

--- a/pkg/render/namespaces_test.go
+++ b/pkg/render/namespaces_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Namespace rendering tests", func() {
 
 	It("should render a namespace", func() {
 		component := render.Namespaces(instance, notOpenshift, nil)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(1))
 		ExpectResource(resources[0], "calico-system", "", "", "v1", "Namespace")
 		meta := resources[0].(metav1.ObjectMetaAccessor).GetObjectMeta()
@@ -49,7 +49,7 @@ var _ = Describe("Namespace rendering tests", func() {
 		// We expect calico-system and tigera-prometheus.
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		component := render.Namespaces(instance, notOpenshift, nil)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(2))
 		ExpectResource(resources[0], "calico-system", "", "", "v1", "Namespace")
 		meta := resources[0].(metav1.ObjectMetaAccessor).GetObjectMeta()
@@ -66,7 +66,7 @@ var _ = Describe("Namespace rendering tests", func() {
 
 	It("should render a namespace for openshift", func() {
 		component := render.Namespaces(instance, openshift, nil)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(1))
 		ExpectResource(resources[0], "calico-system", "", "", "v1", "Namespace")
 		meta := resources[0].(metav1.ObjectMetaAccessor).GetObjectMeta()

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -55,7 +55,7 @@ type nodeComponent struct {
 	migrationNeeded bool
 }
 
-func (c *nodeComponent) Objects() []runtime.Object {
+func (c *nodeComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		c.nodeServiceAccount(),
 		c.nodeRole(),
@@ -80,7 +80,7 @@ func (c *nodeComponent) Objects() []runtime.Object {
 
 	objs = append(objs, c.nodeDaemonset())
 
-	return objs
+	return objs, nil
 }
 
 func (c *nodeComponent) Ready() bool {

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should render all resources for a default configuration", func() {
 		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
 		// Should render the correct resources.
@@ -230,7 +230,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should render all resources for a default configuration using TigeraSecureEnterprise", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
 		// Should render the correct resources.
@@ -321,7 +321,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should render all resources when running on openshift", func() {
 		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
 		// Should render the correct resources.
@@ -439,7 +439,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should render all resources when variant is TigeraSecureEnterprise and running on openshift", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
 		// Should render the correct resources.
@@ -538,7 +538,7 @@ var _ = Describe("Node rendering tests", func() {
 			"template-1.yaml": "dataforTemplate1 that is not used here",
 		}
 		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, bt, typhaNodeTLS, false)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
 		// Should render the correct resources.
@@ -583,7 +583,7 @@ var _ = Describe("Node rendering tests", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.CanReach = "1.1.1.1"
 			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-			resources := component.Objects()
+			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
 			dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -598,7 +598,7 @@ var _ = Describe("Node rendering tests", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.Interface = "eth*"
 			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-			resources := component.Objects()
+			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
 			dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -613,7 +613,7 @@ var _ = Describe("Node rendering tests", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.SkipInterface = "eth*"
 			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-			resources := component.Objects()
+			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
 			dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -627,7 +627,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should include updates needed for the core upgrade", func() {
 		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, true)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5), fmt.Sprintf("resources are %v", resources))
 
 		// Should render the correct resources.
@@ -662,7 +662,7 @@ var _ = Describe("Node rendering tests", func() {
 			// Provider does not matter for IPPool configuration
 			defaultInstance.Spec.CalicoNetwork.IPPools = []operator.IPPool{pool}
 			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-			resources := component.Objects()
+			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
 			dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")

--- a/pkg/render/priority_class.go
+++ b/pkg/render/priority_class.go
@@ -32,8 +32,8 @@ func PriorityClassDefinitions(cr *operator.Installation) Component {
 type priorityClassComponent struct {
 }
 
-func (c *priorityClassComponent) Objects() []runtime.Object {
-	return []runtime.Object{c.calicoPriority()}
+func (c *priorityClassComponent) Objects() ([]runtime.Object, []runtime.Object) {
+	return []runtime.Object{c.calicoPriority()}, nil
 }
 
 func (c *priorityClassComponent) Ready() bool {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -41,7 +41,7 @@ var (
 type Component interface {
 	// Objects returns the lists of objects in this component that should be created and/or deleted during
 	// rendering.
-	Objects() ([]runtime.Object, []runtime.Object)
+	Objects() (objsToCreate, objsToDelete []runtime.Object)
 
 	// Ready returns true if the component is ready to be created.
 	Ready() bool

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -39,8 +39,9 @@ var (
 )
 
 type Component interface {
-	// Objects returns all objects this component contains.
-	Objects() []runtime.Object
+	// Objects returns the lists of objects in this component that should be created and/or deleted during
+	// rendering.
+	Objects() ([]runtime.Object, []runtime.Object)
 
 	// Ready returns true if the component is ready to be created.
 	Ready() bool

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -85,7 +85,8 @@ var _ = Describe("Rendering tests", func() {
 func componentCount(components []render.Component) int {
 	count := 0
 	for _, c := range components {
-		count += len(c.Objects())
+		objsToCreate, _ := c.Objects()
+		count += len(objsToCreate)
 	}
 	return count
 }

--- a/pkg/render/secrets.go
+++ b/pkg/render/secrets.go
@@ -27,12 +27,12 @@ type secretsComponent struct {
 	secrets []*corev1.Secret
 }
 
-func (c *secretsComponent) Objects() []runtime.Object {
+func (c *secretsComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{}
 	for _, s := range c.secrets {
 		objs = append(objs, s)
 	}
-	return objs
+	return objs, nil
 }
 
 func (c *secretsComponent) Ready() bool {

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -54,7 +54,7 @@ type typhaComponent struct {
 	namespaceMigration bool
 }
 
-func (c *typhaComponent) Objects() []runtime.Object {
+func (c *typhaComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	return []runtime.Object{
 		c.typhaServiceAccount(),
 		c.typhaRole(),
@@ -62,7 +62,7 @@ func (c *typhaComponent) Objects() []runtime.Object {
 		c.typhaDeployment(),
 		c.typhaService(),
 		c.typhaPodDisruptionBudget(),
-	}
+	}, nil
 }
 
 func (c *typhaComponent) typhaPodDisruptionBudget() *policyv1beta1.PodDisruptionBudget {
@@ -450,7 +450,7 @@ func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
 	}
 	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
 		extraTyphaEnv := []v1.EnvVar{
-		// When we add AWS integration then we need Security group stuff here
+			// When we add AWS integration then we need Security group stuff here
 		}
 		typhaEnv = append(typhaEnv, extraTyphaEnv...)
 	}

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Typha rendering tests", func() {
 
 	It("should render all resources for a default configuration", func() {
 		component := render.Typha(installation, provider, typhaNodeTLS, false)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
 		// Should render the correct resources.
@@ -79,7 +79,7 @@ var _ = Describe("Typha rendering tests", func() {
 
 	It("should include updates needed for migration of core components from kube-system namespace", func() {
 		component := render.Typha(installation, provider, typhaNodeTLS, true)
-		resources := component.Objects()
+		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
 		dResource := GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")


### PR DESCRIPTION
The goal of this change is to allow methods in the render package to return a list of objects to be deleted in addition to the list of objects rendered. This has become necessary in a couple cases where a user specified parameter removes the need for a component or service. For example, when the user sets (the soon-to-be-introduced) nodeMetricsPort to nil, we should return that service for deletion.