### PR TITLE
Add toggle for FlexVol init container

### DIFF
--- a/deploy/crds/operator_v1_installation_crd.yaml
+++ b/deploy/crds/operator_v1_installation_crd.yaml
@@ -81,6 +81,9 @@ spec:
                     for pods on the Calico network. Default: 1410'
                   format: int32
                   type: integer
+                flexVolInitContainerEnabled:
+                  description: 'Enable or disable the FlexVol init container. Default: enabled'
+                  type: bool
                 nodeAddressAutodetectionV4:
                   description: NodeAddressAutodetectionV4 specifies an approach to
                     automatically detect node IPv4 addresses. If not specified, will

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -99,7 +99,7 @@ const (
 	ClusterManagementTypeManaged    ClusterManagementType = "Managed"
 )
 
-// CalicoNetwork specifies configuration options for Calico provided pod networking.
+// CalicoNetworkSpec specifies configuration options for Calico provided pod networking.
 type CalicoNetworkSpec struct {
 	// IPPools contains a list of IP pools to use for allocating pod IP addresses. At most one IP pool
 	// may be specified. If omitted, a single pool will be configured when needed.
@@ -120,6 +120,11 @@ type CalicoNetworkSpec struct {
 	// IPv6 addresses will not be auto-detected.
 	// +optional
 	NodeAddressAutodetectionV6 *NodeAddressAutodetection `json:"nodeAddressAutodetectionV6,omitempty"`
+
+	// FlexVolInitContainerEnabled allows the toggling on/off of the FlexVol init container. If not specified,
+	// FlexVol will be enabled by default.
+	// +optional
+	FlexVolInitContainerEnabled *bool `json:"flexVolInitContainerEnabled,omitempty"`
 }
 
 // NodeAddressAutodetection provides configuration options for auto-detecting node addresses. At most one option

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -190,6 +190,11 @@ func (in *CalicoNetworkSpec) DeepCopyInto(out *CalicoNetworkSpec) {
 		*out = new(NodeAddressAutodetection)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.FlexVolInitContainerEnabled != nil {
+		in, out := &in.FlexVolInitContainerEnabled, &out.FlexVolInitContainerEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -272,6 +272,10 @@ func fillDefaults(instance *operator.Installation) error {
 			}
 		}
 
+		if instance.Spec.CalicoNetwork.FlexVolInitContainerEnabled == nil {
+			*instance.Spec.CalicoNetwork.FlexVolInitContainerEnabled = true
+		}
+
 		v4pool = render.GetIPv4Pool(instance.Spec.CalicoNetwork)
 		v6pool = render.GetIPv6Pool(instance.Spec.CalicoNetwork)
 

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -90,6 +90,9 @@ var _ = Describe("Testing core-controller installation", func() {
 				Expect(i.Spec.CalicoNetwork.IPPools).To(HaveLen(0))
 				return
 			}
+			if caliconet.FlexVolInitContainerEnabled == nil {
+				Expect(i.Spec.CalicoNetwork.FlexVolInitContainerEnabled).To(BeTrue())
+			}
 			Expect(i.Spec.CalicoNetwork.IPPools).To(HaveLen(1))
 			pool := i.Spec.CalicoNetwork.IPPools[0]
 			pExpect := calicoNet.IPPools[0]

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(*v4pool.BlockSize).To(Equal(int32(26)))
 		v6pool := render.GetIPv6Pool(instance.Spec.CalicoNetwork)
 		Expect(v6pool).To(BeNil())
+		Expect(instance.Spec.CalicoNetwork.FlexVolInitContainerEnabled).To(BeTrue())
 	})
 
 	It("should properly fill defaults on an empty TigeraSecureEnterprise instance", func() {
@@ -53,6 +54,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(*v4pool.BlockSize).To(Equal(int32(26)))
 		v6pool := render.GetIPv6Pool(instance.Spec.CalicoNetwork)
 		Expect(v6pool).To(BeNil())
+		Expect(instance.Spec.CalicoNetwork.FlexVolInitContainerEnabled).To(BeTrue())
 	})
 
 	It("should error if CalicoNetwork is provided on EKS", func() {
@@ -158,6 +160,7 @@ var _ = Describe("Defaulting logic tests", func() {
 				Expect(v4pool.NodeSelector).ToNot(BeEmpty(), "NodeSelector should be set on pool %v", v4pool)
 				v6pool := render.GetIPv6Pool(i.Spec.CalicoNetwork)
 				Expect(v6pool).To(BeNil())
+				Expect(i.Spec.CalicoNetwork.FlexVolInitContainerEnabled).To(BeTrue())
 			}
 		},
 


### PR DESCRIPTION
Adds a configurable parameter to `CalicoNetworkSpec` to allow for the enabling/disabling (default: enabled) of the flexvol init container.