### PR TITLE
[Cherry Pick] Increase eck operator memory to prevent OCP OOMKILL

### DIFF
--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -379,7 +379,7 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *apps.StatefulSet {
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
 								"cpu":    resource.MustParse("1"),
-								"memory": resource.MustParse("100Mi"),
+								"memory": resource.MustParse("150Mi"),
 							},
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),


### PR DESCRIPTION
The memory limit was just a little to low

Original commit https://github.com/tigera/operator/commit/cfc1b956191485ceb97a4e40a91d13c32ab9e981