### PR TITLE
dont panic on unexpected genversion data

### DIFF
--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -82,12 +82,15 @@ func readComponents(versionsPath string) (Components, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := make(map[string]Components)
+
+	c := struct {
+		Components Components
+	}{}
 	if err := yaml.Unmarshal(f, &c); err != nil {
 		return nil, err
 	}
 
-	return c["components"], nil
+	return c.Components, nil
 }
 
 func render(tplFile string, vz Components) error {


### PR DESCRIPTION
hashreleases pass a `versions.yml` that includes a toplevel `title` key which causes a panic because it doesn't match `map[string]Component`. this pr unmarshales into the correct type, discarding the additional data.