### PR TITLE
set image tags to release-v2.7

### DIFF
--- a/pkg/components/versions.go
+++ b/pkg/components/versions.go
@@ -26,41 +26,41 @@ const (
 // This section contains images used when installing Tigera Secure.
 const (
 	// Overrides for Calico.
-	VersionTigeraNode            = "v2.7.0"
-	VersionTigeraTypha           = "v2.7.0"
-	VersionTigeraKubeControllers = "v2.7.0"
+	VersionTigeraNode            = "release-v2.7"
+	VersionTigeraTypha           = "release-v2.7"
+	VersionTigeraKubeControllers = "release-v2.7"
 
 	// API server images.
-	VersionAPIServer   = "v2.7.0"
-	VersionQueryServer = "v2.7.0"
+	VersionAPIServer   = "release-v2.7"
+	VersionQueryServer = "release-v2.7"
 
 	// Logging
-	VersionFluentd = "v2.7.0"
+	VersionFluentd = "release-v2.7"
 
 	// Compliance images.
-	VersionComplianceController  = "v2.7.0"
-	VersionComplianceReporter    = "v2.7.0"
-	VersionComplianceServer      = "v2.7.0"
-	VersionComplianceSnapshotter = "v2.7.0"
-	VersionComplianceBenchmarker = "v2.7.0"
+	VersionComplianceController  = "release-v2.7"
+	VersionComplianceReporter    = "release-v2.7"
+	VersionComplianceServer      = "release-v2.7"
+	VersionComplianceSnapshotter = "release-v2.7"
+	VersionComplianceBenchmarker = "release-v2.7"
 
 	// Intrusion detection images.
-	VersionIntrusionDetectionController   = "v2.7.0"
-	VersionIntrusionDetectionJobInstaller = "v2.7.0"
+	VersionIntrusionDetectionController   = "release-v2.7"
+	VersionIntrusionDetectionJobInstaller = "release-v2.7"
 
 	// Manager images.
-	VersionManager        = "v2.7.0"
-	VersionManagerProxy   = "v2.7.0"
-	VersionManagerEsProxy = "v2.7.0"
+	VersionManager        = "release-v2.7"
+	VersionManagerProxy   = "release-v2.7"
+	VersionManagerEsProxy = "release-v2.7"
 
 	// ECK Elasticsearch images
 	VersionECKOperator      = "0.9.0"
 	VersionECKElasticsearch = "7.3.2"
 	VersionECKKibana        = "7.3.2"
-	VersionEsCurator        = "v2.7.0"
+	VersionEsCurator        = "release-v2.7"
 
 	VersionKibana = "7.3"
 
 	// Multicluster tunnel image.
-	VersionGuardian = "v2.7.0"
+	VersionGuardian = "release-v2.7"
 )

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -246,7 +246,7 @@ var _ = Describe("Node rendering tests", func() {
 
 		// The DaemonSet should have the correct configuration.
 		ds := dsResource.(*apps.DaemonSet)
-		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(render.TigeraRegistry + "tigera/cnx-node:v2.7.0"))
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(render.TigeraRegistry + "tigera/cnx-node:release-v2.7"))
 		ExpectEnv(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env, "CNI_NET_DIR", "/etc/cni/net.d")
 
 		optional := true
@@ -455,7 +455,7 @@ var _ = Describe("Node rendering tests", func() {
 
 		// The DaemonSet should have the correct configuration.
 		ds := dsResource.(*apps.DaemonSet)
-		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(render.TigeraRegistry + "tigera/cnx-node:v2.7.0"))
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(render.TigeraRegistry + "tigera/cnx-node:release-v2.7"))
 
 		ExpectEnv(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env, "CNI_NET_DIR", "/var/run/multus/cni/net.d")
 


### PR DESCRIPTION
Since hash releases are unreliable at the moment, let's have a fall-back for installing latest Tigera images. Note leaving Calico components (e.g. CNI) pinned to v3.12.0 for time being.