### PR TITLE
calico-node clusterrole: add secrets permissions

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -153,6 +153,12 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"watch", "list", "get"},
 			},
 			{
+				// Used when configuring bgp password in bgppeer
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"watch", "list", "get"},
+			},
+			{
 				// Some information is stored on the node status.
 				APIGroups: []string{""},
 				Resources: []string{"nodes/status"},


### PR DESCRIPTION
Such secrets permissions are needed to properly configure bgp password
in bgppeers