### PR TITLE
Update kube-controllers clusterrole to manage hostendpoints

### DIFF
--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -101,6 +101,12 @@ func (c *kubeControllersComponent) controllersRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "create", "update"},
 			},
 			{
+				// Needs to manage hostendpoints.
+				APIGroups: []string{"crd.projectcalico.org"},
+				Resources: []string{"hostendpoints"},
+				Verbs:     []string{"get", "list", "create", "update", "delete"},
+			},
+			{
 				// Needs to manipulate kubecontrollersconfiguration, which contains
 				// its config.  It creates a default if none exists, and updates status
 				// as well.

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -135,12 +135,6 @@ func (c *kubeControllersComponent) controllersRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"watch", "list", "get"},
 			},
 			{
-				// Needs access to update clusterinformations.
-				APIGroups: []string{"crd.projectcalico.org"},
-				Resources: []string{"clusterinformations"},
-				Verbs:     []string{"get", "create", "update"},
-			},
-			{
 				// calico-kube-controllers requires tiers create
 				APIGroups: []string{"crd.projectcalico.org"},
 				Resources: []string{"tiers"},


### PR DESCRIPTION
kube-controllers now manages hostendpoints. See https://github.com/projectcalico/kube-controllers/pull/458