### PR TITLE
Include RBAC for accessing configmaps

### DIFF
--- a/config/calico_versions.yml
+++ b/config/calico_versions.yml
@@ -1,11 +1,11 @@
 components:
   typha:
-    version: v3.12.0
+    version: v3.13.0
   calico/node:
-    version: v3.12.0
+    version: v3.13.0
   calico/cni:
-    version: v3.12.0
+    version: v3.13.0
   calico/kube-controllers:
-    version: v3.12.0
+    version: v3.13.0
   flexvol:
-    version: v3.12.0
+    version: v3.13.0

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -183,6 +183,12 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"patch"},
 			},
 			{
+				// Calico needs to query configmaps for pool auto-detection on kubeadm.
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"get"},
+			},
+			{
 				// For monitoring Calico-specific configuration.
 				APIGroups: []string{"crd.projectcalico.org"},
 				Resources: []string{


### PR DESCRIPTION
We forgot to update the RBAc in order to enable auto-detection on
kubeadm.

In reality, the operator doesn't currently use this auto-detection, but
node still needs it anyway in order to query the configmap, else it
crashes.