### PR TITLE
[cherry-pick] custom FlexVolume path (#417)

### DIFF
--- a/deploy/crds/operator_v1_installation_crd.yaml
+++ b/deploy/crds/operator_v1_installation_crd.yaml
@@ -149,6 +149,12 @@ spec:
                 will be used.  Image format:    `<registry>/<imagePath>/<imageName>:<tag-name>`  This
                 option allows configuring the `<imagePath>` portion of the above format.'
               type: string
+            flexVolumePath:
+              description: FlexVolumePath optionally specifies a custom path for FlexVolume.
+                If not specified, FlexVolume will be enabled by default. If set to
+                'None', FlexVolume will be disabled. The default is based on the k8s
+                provider.
+              type: string
             imagePullSecrets:
               description: ImagePullSecrets is an array of references to container
                 registry pull secrets to use. These are applied to all images to be

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -72,6 +72,12 @@ type InstallationSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Standalone,Management,Managed
 	ClusterManagementType ClusterManagementType `json:"clusterManagementType,omitempty"`
+
+	// FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be
+	// enabled by default. If set to 'None', FlexVolume will be disabled. The default is based on the
+	// kubernetesProvider.
+	// +optional
+	FlexVolumePath string `json:"flexVolumePath,omitempty"`
 }
 
 // Provider represents a particular provider or flavor of Kubernetes. Valid options

--- a/pkg/apis/operator/v1/zz_generated.openapi.go
+++ b/pkg/apis/operator/v1/zz_generated.openapi.go
@@ -335,6 +335,13 @@ func schema_pkg_apis_operator_v1_InstallationSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"flexVolumePath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be enabled by default. If set to 'None', FlexVolume will be disabled. The default is based on the k8s provider.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -322,6 +322,21 @@ func fillDefaults(instance *operator.Installation) error {
 		}
 	}
 
+	// If not specified by the user, set the flex volume plugin location based on platform.
+	if len(instance.Spec.FlexVolumePath) == 0 {
+		if instance.Spec.KubernetesProvider == operator.ProviderOpenShift {
+			// In OpenShift 4.x, the location for flexvolume plugins has changed.
+			// See: https://bugzilla.redhat.com/show_bug.cgi?id=1667606#c5
+			instance.Spec.FlexVolumePath = "/etc/kubernetes/kubelet-plugins/volume/exec/"
+		} else if instance.Spec.KubernetesProvider == operator.ProviderGKE {
+			instance.Spec.FlexVolumePath = "/home/kubernetes/flexvolume/"
+		} else if instance.Spec.KubernetesProvider == operator.ProviderAKS {
+			instance.Spec.FlexVolumePath = "/etc/kubernetes/volumeplugins/"
+		} else {
+			instance.Spec.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -105,6 +105,7 @@ var _ = Describe("Defaulting logic tests", func() {
 						FirstFound: &false_,
 					},
 				},
+				FlexVolumePath: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
 			},
 		}
 		instanceCopy := instance.DeepCopyObject().(*operator.Installation)
@@ -171,7 +172,8 @@ var _ = Describe("Defaulting logic tests", func() {
 						{CIDR: "10.0.0.0/8"},
 					},
 				},
-			}),
+			},
+		),
 		table.Entry("CIDR specified from OS config and Calico config",
 			&operator.Installation{
 				Spec: operator.InstallationSpec{
@@ -189,6 +191,36 @@ var _ = Describe("Defaulting logic tests", func() {
 						{CIDR: "10.0.0.0/8"},
 					},
 				},
-			}),
+			},
+		),
+	)
+
+	table.DescribeTable("Test different values for FlexVolumePath",
+		func(i *operator.Installation, expectedFlexVolumePath string) {
+			Expect(fillDefaults(i)).To(BeNil())
+			Expect(i.Spec.FlexVolumePath).To(Equal(expectedFlexVolumePath))
+		},
+
+		table.Entry("FlexVolumePath set to None",
+			&operator.Installation{
+				Spec: operator.InstallationSpec{
+					FlexVolumePath: "None",
+				},
+			}, "None",
+		),
+
+		table.Entry("FlexVolumePath left empty (default)",
+			&operator.Installation{
+				Spec: operator.InstallationSpec{},
+			}, "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
+		),
+
+		table.Entry("FlexVolumePath set to a custom path",
+			&operator.Installation{
+				Spec: operator.InstallationSpec{
+					FlexVolumePath: "/foo/bar/",
+				},
+			}, "/foo/bar/",
+		),
 	)
 })

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -17,6 +17,7 @@ package installation
 import (
 	"fmt"
 	"net"
+	"path"
 	"strings"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
@@ -135,6 +136,11 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 				return err
 			}
 		}
+	}
+
+	if instance.Spec.FlexVolumePath != "None" && !path.IsAbs(instance.Spec.FlexVolumePath) {
+		return fmt.Errorf("Installation spec.FlexVolumePath '%s' is not an absolute path",
+			instance.Spec.FlexVolumePath)
 	}
 
 	return nil

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -27,7 +27,8 @@ var _ = Describe("Installation validation tests", func() {
 	BeforeEach(func() {
 		instance = &operator.Installation{
 			Spec: operator.InstallationSpec{
-				CalicoNetwork: &operator.CalicoNetworkSpec{},
+				CalicoNetwork:  &operator.CalicoNetworkSpec{},
+				FlexVolumePath: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
 			},
 		}
 	})
@@ -81,4 +82,9 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should not allow a relative path in FlexVolumePath", func() {
+		instance.Spec.FlexVolumePath = "foo/bar/baz"
+		err := validateCustomResource(instance)
+		Expect(err).To(HaveOccurred())
+	})
 })

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -786,37 +786,6 @@ var _ = Describe("Node rendering tests", func() {
 			}),
 	)
 
-	It("should not export FELIX_PROMETHEUSREPORTERPORT if NodeMetricsPort is nil", func() {
-		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
-		defaultInstance.Spec.NodeMetricsPort = nil
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(5))
-
-		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
-		Expect(dsResource).ToNot(BeNil())
-
-		notExpectedEnvVar := v1.EnvVar{Name: "FELIX_PROMETHEUSREPORTERPORT"}
-		ds := dsResource.(*apps.DaemonSet)
-		Expect(ds.Spec.Template.Spec.Containers[0].Env).ToNot(ContainElement(notExpectedEnvVar))
-	})
-
-	It("should export FELIX_PROMETHEUSREPORTERPORT with a custom value if NodeMetricsPort is set", func() {
-		var nodeMetricsPort int32 = 1234
-		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
-		defaultInstance.Spec.NodeMetricsPort = &nodeMetricsPort
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(6))
-
-		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
-		Expect(dsResource).ToNot(BeNil())
-
-		expectedEnvVar := v1.EnvVar{Name: "FELIX_PROMETHEUSREPORTERPORT", Value: "1234"}
-		ds := dsResource.(*apps.DaemonSet)
-		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ContainElement(expectedEnvVar))
-	})
-
 	It("should not render a FlexVolume container if FlexVolumePath is set to None", func() {
 		defaultInstance.Spec.FlexVolumePath = "None"
 		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Node rendering tests", func() {
 	})
 
 	It("should render all resources for a default configuration", func() {
+		defaultInstance.Spec.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(5))
@@ -87,8 +88,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/%s", render.CNIImageName)))
 
 		// Verify the Flex volume container image.
-
-		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("docker.io/%s", render.FlexVolumeImageName)))
+		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("docker.io/%s@%s", components.ComponentFlexVolume.Image, components.ComponentFlexVolume.Digest)))
 
 		optional := true
 		// Verify env
@@ -320,6 +320,7 @@ var _ = Describe("Node rendering tests", func() {
 	})
 
 	It("should render all resources when running on openshift", func() {
+		defaultInstance.Spec.FlexVolumePath = "/etc/kubernetes/kubelet-plugins/volume/exec/"
 		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(5))
@@ -784,6 +785,50 @@ var _ = Describe("Node rendering tests", func() {
 				"CALICO_IPV4POOL_NODE_SELECTOR": "has(thiskey)",
 			}),
 	)
+
+	It("should not export FELIX_PROMETHEUSREPORTERPORT if NodeMetricsPort is nil", func() {
+		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
+		defaultInstance.Spec.NodeMetricsPort = nil
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(5))
+
+		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+		Expect(dsResource).ToNot(BeNil())
+
+		notExpectedEnvVar := v1.EnvVar{Name: "FELIX_PROMETHEUSREPORTERPORT"}
+		ds := dsResource.(*apps.DaemonSet)
+		Expect(ds.Spec.Template.Spec.Containers[0].Env).ToNot(ContainElement(notExpectedEnvVar))
+	})
+
+	It("should export FELIX_PROMETHEUSREPORTERPORT with a custom value if NodeMetricsPort is set", func() {
+		var nodeMetricsPort int32 = 1234
+		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
+		defaultInstance.Spec.NodeMetricsPort = &nodeMetricsPort
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(6))
+
+		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+		Expect(dsResource).ToNot(BeNil())
+
+		expectedEnvVar := v1.EnvVar{Name: "FELIX_PROMETHEUSREPORTERPORT", Value: "1234"}
+		ds := dsResource.(*apps.DaemonSet)
+		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ContainElement(expectedEnvVar))
+	})
+
+	It("should not render a FlexVolume container if FlexVolumePath is set to None", func() {
+		defaultInstance.Spec.FlexVolumePath = "None"
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(5))
+
+		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+		Expect(dsResource).ToNot(BeNil())
+		ds := dsResource.(*apps.DaemonSet)
+		Expect(ds).ToNot(BeNil())
+		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver")).To(BeNil())
+	})
 })
 
 // verifyProbes asserts the expected node liveness and readiness probe.

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/%s", render.CNIImageName)))
 
 		// Verify the Flex volume container image.
-		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("docker.io/%s@%s", components.ComponentFlexVolume.Image, components.ComponentFlexVolume.Digest)))
+		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(HavePrefix("docker.io/calico/pod2daemon-flexvol"))
 
 		optional := true
 		// Verify env
@@ -789,7 +789,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should not render a FlexVolume container if FlexVolumePath is set to None", func() {
 		defaultInstance.Spec.FlexVolumePath = "None"
 		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
-		resources, _ := component.Objects()
+		resources := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
 		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")


### PR DESCRIPTION
* WIP: custom FlexVolume path

* Erik's code review

* Make gen-files

* Add render UT for when FlexVolumePath is set to None

* Move FlexVolumePath out of CalicoNetwork

* Check if a user specified FlexVolumePath is valid

* Fix

* Fix (2)

* Regex for absolute path, move validation to validation.go

* Fix

* Move check for relative path to validation{_test}.go

* Fixes for field validation

* Fix missing FlexVolumePath parameter in validation_test.go

* Fix comment