### PR TITLE
SAAS-663 Add tigerastatus for managed cluster

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -17,6 +17,7 @@ package clusterconnection
 import (
 	"context"
 	"fmt"
+	"github.com/tigera/operator/pkg/controller/status"
 
 	"github.com/tigera/operator/pkg/controller/installation"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -36,9 +37,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("clusterconnection_controller")
-
 const controllerName = "clusterconnection-controller"
+
+var log = logf.Log.WithName(controllerName)
 
 // Add creates a new ManagementClusterConnection Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and start it when the Manager is started. This controller is meant only for enterprise users.
@@ -52,11 +53,14 @@ func Add(mgr manager.Manager, p operatorv1.Provider, enterpriseEnabled bool) err
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, p operatorv1.Provider) reconcile.Reconciler {
-	return &ReconcileConnection{
+	c := &ReconcileConnection{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Provider: p,
+		Status:   status.New(mgr.GetClient(), "management-cluster-connection"),
 	}
+	c.Status.Run()
+	return c
 }
 
 // add adds a new controller to mgr with r as the reconcile.Reconciler
@@ -93,6 +97,13 @@ type ReconcileConnection struct {
 	Client   client.Client
 	Scheme   *runtime.Scheme
 	Provider operatorv1.Provider
+	Status   status.StatusManager
+}
+
+func GetClusterConnection(ctx context.Context, cli client.Client) (*operatorv1.ManagementClusterConnection, error) {
+	mcc := &operatorv1.ManagementClusterConnection{}
+	err := cli.Get(ctx, utils.DefaultTSEEInstanceKey, mcc)
+	return mcc, err
 }
 
 // Reconcile reads that state of the cluster for a ManagementClusterConnection object and makes changes based on the
@@ -105,15 +116,13 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 	ctx := context.Background()
 	result := reconcile.Result{}
 
-	instl, err := installation.GetInstallation(context.Background(), r.Client, r.Provider)
+	instl, err := installation.GetInstallation(ctx, r.Client, r.Provider)
 	if err != nil {
 		return result, err
 	}
 
 	// Fetch the managementClusterConnection.
-	mcc := &operatorv1.ManagementClusterConnection{}
-	err = r.Client.Get(ctx, utils.DefaultTSEEInstanceKey, mcc)
-
+	mcc, err := GetClusterConnection(ctx, r.Client)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// If the resource is not found, we will not return an error. Instead, the watch on the resource will
@@ -121,10 +130,14 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 			if instl.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManaged {
 				log.Error(err, "ManagementClusterConnection is a necessary resource for Managed clusters")
 			}
+			r.Status.OnCRNotFound()
 			return result, nil
 		}
+		r.Status.SetDegraded("Error querying ManagementClusterConnection", err.Error())
 		return result, err
 	}
+	log.V(2).Info("Loaded ManagementClusterConnection config", "config", mcc)
+	r.Status.OnCRFound()
 
 	if instl.Spec.ClusterManagementType != operatorv1.ClusterManagementTypeManaged {
 		log.Info(fmt.Sprintf("Setting up management cluster connection, even though clusterType != %v",
@@ -134,6 +147,7 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 	pullSecrets, err := utils.GetNetworkingPullSecrets(instl, r.Client)
 	if err != nil {
 		log.Error(err, "Error with Pull secrets")
+		r.Status.SetDegraded("Error with Pull secrets", err.Error())
 		return result, err
 	}
 
@@ -141,6 +155,7 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 	tunnelSecret := &corev1.Secret{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: render.GuardianSecretName, Namespace: render.OperatorNamespace()}, tunnelSecret)
 	if err != nil {
+		r.Status.SetDegraded("Error copying secrets to the guardian namespace", err.Error())
 		if !errors.IsNotFound(err) {
 			return result, nil
 		}
@@ -156,9 +171,13 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 		tunnelSecret,
 	)
 
-	if err := ch.CreateOrUpdate(ctx, component, nil); err != nil {
+	if err := ch.CreateOrUpdate(ctx, component, r.Status); err != nil {
+		r.Status.SetDegraded("Error creating or updating resource", err.Error())
 		return result, err
 	}
+
+	// Clear the degraded bit if we've reached this far.
+	r.Status.ClearDegraded()
 
 	//We should create the Guardian deployment.
 	return result, nil

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -48,16 +48,17 @@ func Add(mgr manager.Manager, p operatorv1.Provider, enterpriseEnabled bool) err
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, p))
+	statusManager := status.New(mgr.GetClient(), "management-cluster-connection")
+	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme(), statusManager, p))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, p operatorv1.Provider) reconcile.Reconciler {
+func newReconciler(cli client.Client, schema *runtime.Scheme, statusMgr status.StatusManager, p operatorv1.Provider) reconcile.Reconciler {
 	c := &ReconcileConnection{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
+		Client:   cli,
+		Scheme:   schema,
 		Provider: p,
-		status:   status.New(mgr.GetClient(), "management-cluster-connection"),
+		status:   statusMgr,
 	}
 	c.status.Run()
 	return c

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -16,6 +16,7 @@ package clusterconnection_test
 
 import (
 	"context"
+	"github.com/tigera/operator/pkg/controller/status"
 
 	"github.com/tigera/operator/pkg/controller/clusterconnection"
 	"github.com/tigera/operator/pkg/render"
@@ -60,6 +61,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 			Client:   c,
 			Scheme:   scheme,
 			Provider: operatorv1.ProviderNone,
+			Status:	status.New(c, "management-cluster-connection"),
 		}
 		dpl = &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -61,7 +61,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 			Client:   c,
 			Scheme:   scheme,
 			Provider: operatorv1.ProviderNone,
-			Status:	status.New(c, "management-cluster-connection"),
+			status:	status.New(c, "management-cluster-connection"),
 		}
 		dpl = &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},

--- a/pkg/controller/clusterconnection/shim_test.go
+++ b/pkg/controller/clusterconnection/shim_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is here so that we can export a constructor to be used by the tests in the clusterconnection_test package, but since
+// this is an _test file it will only be available for when running tests.
+
+package clusterconnection
+
+import (
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/status"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func NewReconcilerWithShims(cli client.Client, schema *runtime.Scheme, status status.StatusManager, provider operatorv1.Provider) reconcile.Reconciler {
+
+	return newReconciler(cli, schema, status, provider)
+}

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -153,6 +153,14 @@ func (m *statusManager) OnCRNotFound() {
 	m.clearProgressing()
 	m.lock.Lock()
 	defer m.lock.Unlock()
+	// Remove status displayed for CR, if CR was available earlier but not now.
+	if m.enabled {
+		ts := &operator.TigeraStatus{ObjectMeta: metav1.ObjectMeta{Name: m.component}}
+		err := m.client.Delete(context.TODO(), ts)
+		if err != nil {
+			log.WithValues("error", err).Info("Failed to remove TigeraStatus", m.component)
+		}
+	}
 	m.enabled = false
 	m.progressing = []string{}
 	m.failing = []string{}

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -28,6 +28,7 @@ import (
 	batch "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,6 +107,9 @@ func (m *statusManager) Run() {
 		// Loop forever, periodically checking dependent objects for their state.
 		for {
 			if !m.syncState() {
+				if !m.enabled {
+					m.crCleanup()
+				}
 				// Waiting to be in sync.
 				time.Sleep(5 * time.Second)
 				continue
@@ -131,6 +135,10 @@ func (m *statusManager) Run() {
 				m.clearDegraded()
 			}
 
+			if !m.enabled {
+				m.crCleanup()
+			}
+
 			time.Sleep(5 * time.Second)
 		}
 	}()
@@ -153,14 +161,6 @@ func (m *statusManager) OnCRNotFound() {
 	m.clearProgressing()
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	// Remove status displayed for CR, if CR was available earlier but not now.
-	if m.enabled {
-		ts := &operator.TigeraStatus{ObjectMeta: metav1.ObjectMeta{Name: m.component}}
-		err := m.client.Delete(context.TODO(), ts)
-		if err != nil {
-			log.WithValues("error", err).Info("Failed to remove TigeraStatus", m.component)
-		}
-	}
 	m.enabled = false
 	m.progressing = []string{}
 	m.failing = []string{}
@@ -309,6 +309,7 @@ func (m *statusManager) syncState() bool {
 	defer m.lock.Unlock()
 	progressing := []string{}
 	failing := []string{}
+
 	// For each daemonset, check its rollout status.
 	for _, dsnn := range m.daemonsets {
 		ds := &appsv1.DaemonSet{}
@@ -413,6 +414,15 @@ func (m *statusManager) syncState() bool {
 	// we're not yet ready to report status. However, if we've been given an explicit degraded state, then
 	// we should report it.
 	return m.explicitDegradedReason != ""
+}
+
+// crCleanup removes the status displayed for CR in the TigeraStatus
+func (m *statusManager) crCleanup() {
+	ts := &operator.TigeraStatus{ObjectMeta: metav1.ObjectMeta{Name: m.component}}
+	err := m.client.Delete(context.TODO(), ts)
+	if err != nil && !apierrs.IsNotFound(err) {
+		log.WithValues("error", err).Info("Failed to remove TigeraStatus", m.component)
+	}
 }
 
 // podsFailing takes a selector and returns if any of the pods that match it are failing. Failing pods are defined


### PR DESCRIPTION
- Remove the status if related CR is not found.
- Add a new status `management-cluster-connection` to managed cluster that will let the user know if its connected to management cluster