### PR TITLE
adding DNS logs to flow to splunk

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -413,6 +413,7 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 					}},
 				corev1.EnvVar{Name: "SPLUNK_FLOW_LOG", Value: "true"},
 				corev1.EnvVar{Name: "SPLUNK_AUDIT_LOG", Value: "true"},
+				corev1.EnvVar{Name: "SPLUNK_DNS_LOG", Value: "true"},
 				corev1.EnvVar{Name: "SPLUNK_HEC_HOST", Value: host},
 				corev1.EnvVar{Name: "SPLUNK_HEC_PORT", Value: port},
 				corev1.EnvVar{Name: "SPLUNK_PROTOCOL", Value: proto},

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -269,6 +269,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}{
 			{"SPLUNK_FLOW_LOG", "true", "", ""},
 			{"SPLUNK_AUDIT_LOG", "true", "", ""},
+			{"SPLUNK_DNS_LOG", "true", "", ""},
 			{"SPLUNK_HEC_HOST", "1.2.3.4", "", ""},
 			{"SPLUNK_HEC_PORT", "8088", "", ""},
 			{"SPLUNK_PROTOCOL", "https", "", ""},
@@ -336,6 +337,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}{
 			{"SPLUNK_FLOW_LOG", "true", "", ""},
 			{"SPLUNK_AUDIT_LOG", "true", "", ""},
+			{"SPLUNK_DNS_LOG", "true", "", ""},
 			{"SPLUNK_HEC_HOST", "1.2.3.4", "", ""},
 			{"SPLUNK_HEC_PORT", "8088", "", ""},
 			{"SPLUNK_PROTOCOL", "https", "", ""},


### PR DESCRIPTION
adding `SPLUNK_DNS_LOG` variable in fluentd render so that DNS logs can flow to splunk 