### PR TITLE
update prometheus and calico-system namespace creation

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -18,4 +18,6 @@ const (
 	CalicoNamespace     = "calico-system"
 	TyphaDeploymentName = "calico-typha"
 	NodeDaemonSetName   = "calico-node"
+
+	TigeraPrometheusNamespace = "tigera-prometheus"
 )

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -114,6 +114,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return fmt.Errorf("manager-controller failed to watch Network resource: %v", err)
 	}
 
+	if err = utils.AddNamespaceWatch(c, common.TigeraPrometheusNamespace); err != nil {
+		return fmt.Errorf("manager-controller failed to watch the '%s' namespace: %v", common.TigeraPrometheusNamespace, err)
+	}
+
 	return nil
 }
 

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/compliance"
 	"github.com/tigera/operator/pkg/controller/installation"
 	"github.com/tigera/operator/pkg/controller/status"
@@ -213,6 +214,17 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 	if compliance.Status.State != operatorv1.ComplianceStatusReady {
 		r.status.SetDegraded("Compliance is not ready", fmt.Sprintf("compliance status: %s", compliance.Status.State))
 		return reconcile.Result{}, nil
+	}
+
+	// check that prometheus is running
+	ns := &corev1.Namespace{}
+	if err = r.client.Get(ctx, client.ObjectKey{Name: common.TigeraPrometheusNamespace}, ns); err != nil {
+		if errors.IsNotFound(err) {
+			r.status.SetDegraded("tigera-prometheus namespace does not exist", "Dependency on tigera-prometheus not satisfied")
+		} else {
+			r.status.SetDegraded("Error querying prometheus", err.Error())
+		}
+		return reconcile.Result{}, err
 	}
 
 	// Check that if the manager certpair secret exists that it is valid (has key and cert fields)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -76,6 +76,16 @@ func AddComplianceWatch(c controller.Controller) error {
 	return c.Watch(&source.Kind{Type: &operatorv1.Compliance{}}, &handler.EnqueueRequestForObject{})
 }
 
+func AddNamespaceWatch(c controller.Controller, name string) error {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	return c.Watch(&source.Kind{Type: ns}, &handler.EnqueueRequestForObject{})
+}
+
 type MetaMatch func(metav1.ObjectMeta) bool
 
 func AddSecretsWatch(c controller.Controller, name, namespace string, metaMatches ...MetaMatch) error {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -140,6 +141,13 @@ func (c *managerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 		createNamespace(ManagerNamespace, c.openshift),
 	}
 	objs = append(objs, copyImagePullSecrets(c.pullSecrets, ManagerNamespace)...)
+
+	// TODO: move copying of imagePullSecrets for prometheus into a dedicated prometheus controller
+	// once one is introduced.
+	// note that the TigeraPrometheusNamespace is not created by the operator but rather a dependency
+	// (as is all prometheus resources).
+	objs = append(objs, copyImagePullSecrets(c.pullSecrets, common.TigeraPrometheusNamespace)...)
+
 	objs = append(objs,
 		c.managerServiceAccount(),
 		c.managerClusterRole(),
@@ -354,7 +362,7 @@ func (c *managerComponent) managerProxyProbe() *v1.Probe {
 // managerEnvVars returns the envvars for the manager container.
 func (c *managerComponent) managerEnvVars() []v1.EnvVar {
 	envs := []v1.EnvVar{
-		{Name: "CNX_PROMETHEUS_API_URL", Value: fmt.Sprintf("/api/v1/namespaces/%s/services/calico-node-prometheus:9090/proxy/api/v1", TigeraPrometheusNamespace)},
+		{Name: "CNX_PROMETHEUS_API_URL", Value: fmt.Sprintf("/api/v1/namespaces/%s/services/calico-node-prometheus:9090/proxy/api/v1", common.TigeraPrometheusNamespace)},
 		{Name: "CNX_COMPLIANCE_REPORTS_API_URL", Value: "/compliance/reports"},
 		{Name: "CNX_QUERY_API_URL", Value: "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy"},
 		{Name: "CNX_ELASTICSEARCH_API_URL", Value: "/tigera-elasticsearch"},
@@ -660,5 +668,3 @@ func (c *managerComponent) getTLSObjects() []runtime.Object {
 
 	return objs
 }
-
-

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -23,10 +23,6 @@ import (
 	"github.com/tigera/operator/pkg/common"
 )
 
-const (
-	TigeraPrometheusNamespace = "tigera-prometheus"
-)
-
 func Namespaces(cr *operator.Installation, openshift bool, pullSecrets []*corev1.Secret) Component {
 	return &namespaceComponent{
 		cr:          cr,
@@ -49,12 +45,6 @@ func (c *namespaceComponent) Objects() ([]runtime.Object, []runtime.Object) {
 		ns = append(ns, copyImagePullSecrets(c.pullSecrets, common.CalicoNamespace)...)
 	}
 
-	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
-		ns = append(ns, createNamespace(TigeraPrometheusNamespace, c.openshift))
-		if len(c.pullSecrets) > 0 {
-			ns = append(ns, copyImagePullSecrets(c.pullSecrets, TigeraPrometheusNamespace)...)
-		}
-	}
 	return ns, nil
 }
 

--- a/pkg/render/namespaces_test.go
+++ b/pkg/render/namespaces_test.go
@@ -45,25 +45,6 @@ var _ = Describe("Namespace rendering tests", func() {
 		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
 	})
 
-	It("should render an additional namespace if this is Tigera Secure", func() {
-		// We expect calico-system and tigera-prometheus.
-		instance.Spec.Variant = operator.TigeraSecureEnterprise
-		component := render.Namespaces(instance, notOpenshift, nil)
-		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(2))
-		ExpectResource(resources[0], "calico-system", "", "", "v1", "Namespace")
-		meta := resources[0].(metav1.ObjectMetaAccessor).GetObjectMeta()
-		Expect(meta.GetLabels()["name"]).To(Equal("calico-system"))
-		Expect(meta.GetLabels()).NotTo(ContainElement("openshift.io/run-level"))
-		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
-
-		ExpectResource(resources[1], "tigera-prometheus", "", "", "v1", "Namespace")
-		meta = resources[1].(metav1.ObjectMetaAccessor).GetObjectMeta()
-		Expect(meta.GetLabels()["name"]).To(Equal("tigera-prometheus"))
-		Expect(meta.GetLabels()).NotTo(ContainElement("openshift.io/run-level"))
-		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
-	})
-
 	It("should render a namespace for openshift", func() {
 		component := render.Namespaces(instance, openshift, nil)
 		resources, _ := component.Objects()

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Rendering tests", func() {
 		instance.Spec.NodeMetricsPort = &nodeMetricsPort
 		c, err := render.Calico(instance, nil, typhaNodeTLS, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, false)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
-		Expect(componentCount(c.Render())).To(Equal(((5 + 4 + 2 + 6 + 4 + 1 + 1) + 1 + 1)))
+		Expect(componentCount(c.Render())).To(Equal(((5 + 4 + 2 + 6 + 4 + 1) + 1 + 1)))
 	})
 })
 


### PR DESCRIPTION
stop creating the prometheus namespace, instead relying on it already
being created. and move creation of imagepullsecrets to the manager
controller which is more tied to prometheus than the installation
controller.

This presents a situation where the prometheus namespace doesn't exist. This chance of this happening is reduced because it is included in our manifests (currently). Even so, I tested the error handling of this code:
- when using imagepullsecrets, you would get a nice error pointing out that the secrets couldn't be copied to the tigera-prometheus namespace because it doesn't exist.
- However, when not using imagepullsecrets, the code would silently succeed that the manager would just be not-functional because prometheus is down. As such, I added a check to the manager controller to validate that the prometheus namespace exists. An example tigerastatus of this happening is here:

```
Status:
  Conditions:
    Last Transition Time:  2020-04-22T20:45:28Z
    Status:                False
    Type:                  Available
    Last Transition Time:  2020-04-22T20:45:28Z
    Status:                False
    Type:                  Progressing
    Last Transition Time:  2020-04-22T20:45:28Z
    Message:               Dependency on tigera-prometheus not satisfied
    Reason:                prometheus namespace does not exist
    Status:                True
    Type:                  Degraded
Events:                    <none>
```