### PR TITLE
GlobalAlertTemplates are not created for the managed cluster

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -15,6 +15,7 @@
 package render
 
 import (
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/components"
 	appsv1 "k8s.io/api/apps/v1"
@@ -24,6 +25,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"time"
 )
 
 const (
@@ -74,6 +76,7 @@ func (c *intrusionDetectionComponent) Objects() ([]runtime.Object, []runtime.Obj
 		c.intrusionDetectionRoleBinding(),
 		c.intrusionDetectionDeployment(),
 		c.intrusionDetectionElasticsearchJob())
+	objs = append(objs, c.globalAlertTemplates()...)
 
 	return objs, nil
 }
@@ -356,4 +359,189 @@ func (c *intrusionDetectionComponent) imagePullSecrets() []runtime.Object {
 		secrets = append(secrets, s)
 	}
 	return secrets
+}
+
+func (c *intrusionDetectionComponent) globalAlertTemplates() []runtime.Object {
+	return []runtime.Object{
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "policy.pod",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts on any changes to pods within the cluster",
+				Summary:     "[audit] [privileged access] change detected for pod ${objectRef.namespace}/${objectRef.name}",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "audit",
+				Query:       "(verb=create OR verb=update OR verb=delete OR verb=patch) AND 'objectRef.resource'=pods",
+				AggregateBy: []string{"objectRef.name", "objectRef.namespace"},
+				Metric:      "count",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "policy.globalnetworkpolicy",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts on any changes to network policies",
+				Summary:     "[audit] [privileged access] change detected for ${objectRef.resource} ${objectRef.name}",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "audit",
+				Query:       "(verb=create OR verb=update OR verb=delete OR verb=patch) AND 'objectRef.resource'=globalnetworkpolicies",
+				AggregateBy: []string{"objectRef.name", "objectRef.resource"},
+				Metric:      "count",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "policy.globalnetworkset",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts on any changes to global network sets",
+				Summary:     "[audit] [privileged access] change detected for ${objectRef.resource} ${objectRef.name}",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "audit",
+				Query:       "(verb=create OR verb=update OR verb=delete OR verb=patch) AND 'objectRef.resource'=globalnetworksets",
+				AggregateBy: []string{"objectRef.resource", "objectRef.name"},
+				Metric:      "count",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "policy.serviceaccount",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts on any changes to service accounts within the cluster",
+				Summary:     "[audit] [privileged access] change detected for serviceaccount ${objectRef.namespace}/${objectRef.name}",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "audit",
+				Query:       "(verb=create OR verb=update OR verb=delete OR verb=patch) AND 'objectRef.resource'='serviceaccounts'",
+				AggregateBy: []string{"objectRef.namespace", "objectRef.name"},
+				Metric:      "count",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "network.cloudapi",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts on access to cloud metadata APIs",
+				Summary:     "[flows] [cloud API] cloud metadata API accessed by ${source_namespace}/${source_name_aggr}",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "flows",
+				Query:       "(dest_name_aggr='metadata-api' OR dest_ip='169.254.169.254' OR dest_name_aggr='kse.kubernetes') AND proto='tcp' AND action='allow' AND reporter=src AND (source_namespace='default')",
+				AggregateBy: []string{"source_namespace", "source_name_aggr"},
+				Field:       "num_flows",
+				Metric:      "sum",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "network.ssh",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts on the use of ssh to and from a specific namespace (e.g. default)",
+				Summary:     "[flows] ssh flow in default namespace detected from ${source_namespace}/${source_name_aggr}",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "flows",
+				Query:       "proto='tcp' AND action='allow' AND dest_port='22' AND (source_namespace='default' OR dest_namespace='default') AND reporter=src",
+				AggregateBy: []string{"source_namespace", "source_name_aggr"},
+				Field:       "num_flows",
+				Metric:      "sum",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "network.lateral.access",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts when pods with a specific label (e.g. app=monitor) accessed by other workloads within the cluster",
+				Summary:     "[flows] [lateral movement] ${source_namespace}/${source_name_aggr} with label app=monitor is accessed",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "flows",
+				Query:       "'source_labels.labels'='app=monitor' AND proto=tcp AND action=allow AND reporter=dst",
+				AggregateBy: []string{"source_namespace", "source_name_aggr"},
+				Field:       "num_flows",
+				Metric:      "sum",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+		&v3.GlobalAlertTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GlobalAlertTemplate",
+				APIVersion: "projectcalico.org/v3",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "network.lateral.originate",
+			},
+			Spec: v3.GlobalAlertSpec{
+				Description: "Alerts when pods with a specific label (e.g. app=monitor) initiate connections to other workloads within the cluster",
+				Summary:     "[flows] [lateral movement] ${source_namespace}/${source_name_aggr} with label app=monitor initiated connection",
+				Severity:    100,
+				Period:      &metav1.Duration{Duration: 10 * time.Minute},
+				Lookback:    &metav1.Duration{Duration: 10 * time.Minute},
+				DataSet:     "flows",
+				Query:       "'source_labels.labels'='app=monitor' AND proto=tcp AND action=allow AND reporter=src AND NOT dest_name_aggr='metadata-api' AND NOT dest_name_aggr='pub' AND NOT dest_name_aggr='kse.kubernetes'",
+				AggregateBy: []string{"source_namespace", "source_name_aggr"},
+				Field:       "num_flows",
+				Metric:      "sum",
+				Condition:   "gt",
+				Threshold:   0,
+			},
+		},
+	}
 }

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -34,7 +34,6 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			esConfigMap, nil, notOpenshift,
 		)
 		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(9))
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -53,12 +52,24 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Deployment"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "batch", version: "v1", kind: "Job"},
+			{name: "policy.pod", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "policy.globalnetworkpolicy", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "policy.globalnetworkset", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "policy.serviceaccount", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.cloudapi", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.ssh", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.lateral.access", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.lateral.originate", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
 		}
 
-		i := 0
-		for _, expectedRes := range expectedResources {
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+
+		for i, expectedRes := range expectedResources {
 			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-			i++
+			if expectedRes.kind == "GlobalAlertTemplate" {
+				ExpectGlobalAlertTemplateToBePopulated(resources[i])
+			}
 		}
 	})
 })

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -54,9 +54,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 	})
 
+	const expectedResourcesNumber = 13
 	It("should render all resources for a default configuration", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(21))
+		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -95,7 +96,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	It("should ensure cnx policy recommendation support is always set to true", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(21))
+		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
 		// Should render the correct resource based on test case.
 		Expect(GetResource(resources, "tigera-manager", "tigera-manager", "", "v1", "Deployment")).ToNot(BeNil())
@@ -119,7 +120,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 		// Should render the correct resource based on test case.
 		resources := renderObjects(instance, oidcConfig)
-		Expect(len(resources)).To(Equal(22))
+		Expect(len(resources)).To(Equal(expectedResourcesNumber + 1))
 
 		Expect(GetResource(resources, render.ManagerOIDCConfig, "tigera-manager", "", "v1", "ConfigMap")).ToNot(BeNil())
 		d := resources[13].(*v1.Deployment)
@@ -147,7 +148,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		// Should render the correct resource based on test case.
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(21))
+		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 		d := resources[12].(*v1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
 		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(5))
@@ -157,7 +158,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	It("should render multicluster settings properly", func() {
 		resources := renderObjects(instance, nil)
-		Expect(len(resources)).To(Equal(21))
+		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
 		By("creating a valid self-signed cert")
 		// Use the x509 package to validate that the cert was signed with the privatekey

--- a/pkg/render/render_utils_test.go
+++ b/pkg/render/render_utils_test.go
@@ -74,6 +74,14 @@ func ExpectGlobalReportType(resource runtime.Object, name string) {
 	}
 }
 
+func ExpectGlobalAlertTemplateToBePopulated(resource runtime.Object) {
+	v, ok := resource.(*v3.GlobalAlertTemplate)
+	Expect(ok).To(BeTrue(), fmt.Sprintf("resource (%v) should convert to GlobalAlertTemplate", resource))
+	Expect(v.Spec.Description).ToNot(BeEmpty(), fmt.Sprintf("Description should not be empty for resource (%v)", resource))
+	Expect(v.Spec.Severity).ToNot(BeNumerically("==", 0), fmt.Sprintf("Severity should not be empty for resource (%v)", resource))
+	Expect(v.Spec.DataSet).ToNot(BeEmpty(), fmt.Sprintf("DataSet should not be empty for resource (%v)", resource))
+}
+
 func ExpectEnv(env []v1.EnvVar, key, value string) {
 	for _, e := range env {
 		if e.Name == key {


### PR DESCRIPTION
When creating a managed cluster, global alert templates should be present in the managed cluster. 

This requires that the creation of the global alert templates should be moved from tigera-manager to a component that gets installed in each cluster (ex: intrusion detection). 