### PR TITLE
Allow for a configurable storage class name.

### DIFF
--- a/deploy/crds/operator_v1_logstorage_crd.yaml
+++ b/deploy/crds/operator_v1_logstorage_crd.yaml
@@ -98,6 +98,15 @@ spec:
               - snapshots
               - complianceReports
               type: object
+            storageClassName:
+              description: 'StorageClassName will populate the PersistentVolumeClaim.StorageClassName
+                that is used to provision disks to the Tigera Elasticsearch cluster.
+                The StorageClassName should only be modified when no LogStorage is
+                currently active. We recommend choosing a storage class dedicated
+                to Tigera LogStorage only. Otherwise, data retention cannot be guaranteed
+                during upgrades. See https://docs.tigera.io/maintenance/upgrading
+                for up-to-date instructions. Default: tigera-elasticsearch'
+              type: string
           type: object
         status:
           description: Most recently observed state for Tigera log storage.

--- a/pkg/apis/operator/v1/logstorage_types.go
+++ b/pkg/apis/operator/v1/logstorage_types.go
@@ -52,6 +52,14 @@ type LogStorageSpec struct {
 	// Retention defines how long data is retained in the Elasticsearch cluster before it is cleared.
 	// +optional
 	Retention *Retention `json:"retention,omitempty"`
+
+	// StorageClassName will populate the PersistentVolumeClaim.StorageClassName that is used to provision disks to the
+	// Tigera Elasticsearch cluster. The StorageClassName should only be modified when no LogStorage is currently
+	// active. We recommend choosing a storage class dedicated to Tigera LogStorage only. Otherwise, data retention
+	// cannot be guaranteed during upgrades. See https://docs.tigera.io/maintenance/upgrading for up-to-date instructions.
+	// Default: tigera-elasticsearch
+	// +optional
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // Nodes defines the configuration for a set of identical Elasticsearch cluster nodes, each of type master, data, and ingest.

--- a/pkg/apis/operator/v1/zz_generated.openapi.go
+++ b/pkg/apis/operator/v1/zz_generated.openapi.go
@@ -634,6 +634,13 @@ func schema_pkg_apis_operator_v1_LogStorageSpec(ref common.ReferenceCallback) co
 							Ref:         ref("github.com/tigera/operator/pkg/apis/operator/v1.Retention"),
 						},
 					},
+					"storageClassName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StorageClassName will populate the PersistentVolumeClaim.StorageClassName that is used to provision disks to the Tigera Elasticsearch cluster. The StorageClassName should only be modified when no LogStorage is currently active. We recommend choosing a storage class dedicated to Tigera LogStorage only. Otherwise, data retention cannot be guaranteed during upgrades. See https://docs.tigera.io/maintenance/upgrading for up-to-date instructions. Default: tigera-elasticsearch",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -58,6 +58,7 @@ const (
 	defaultLocalDNS                    = "svc.cluster.local"
 	tigeraElasticsearchUserSecretLabel = "tigera-elasticsearch-user"
 	defaultElasticsearchShards         = 1
+	DefaultElasticsearchStorageClass   = "tigera-elasticsearch"
 )
 
 // Add creates a new LogStorage Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -142,11 +143,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return fmt.Errorf("log-storage-controller failed to watch Network resource: %v", err)
 	}
 
+	// Watch for changes in storage classes, as new storage classes may be made available for LogStorage.
 	err = c.Watch(&source.Kind{
-		Type: &storagev1.StorageClass{
-			ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchStorageClass},
-		},
-	}, &handler.EnqueueRequestForObject{})
+		Type: &storagev1.StorageClass{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return fmt.Errorf("log-storage-controller failed to watch StorageClass resource: %v", err)
 	}
@@ -265,6 +264,10 @@ func fillDefaults(opr *operatorv1.LogStorage) {
 		var replicas int32 = render.DefaultElasticsearchReplicas
 		opr.Spec.Indices.Replicas = &replicas
 	}
+
+	if opr.Spec.StorageClassName == "" {
+		opr.Spec.StorageClassName = DefaultElasticsearchStorageClass
+	}
 }
 
 // Reconcile reads that state of the cluster for a LogStorage object and makes changes based on the state read
@@ -348,9 +351,11 @@ func (r *ReconcileLogStorage) Reconcile(request reconcile.Request) (reconcile.Re
 
 		var flowShards = calculateFlowShards(ls.Spec.Nodes, defaultElasticsearchShards)
 		clusterConfig = render.NewElasticsearchClusterConfig(render.DefaultElasticsearchClusterName, ls.Replicas(), defaultElasticsearchShards, flowShards)
-		if err := r.client.Get(ctx, client.ObjectKey{Name: render.ElasticsearchStorageClass}, &storagev1.StorageClass{}); err != nil {
+
+		// Check if there is a StorageClass available to run Elasticsearch on.
+		if err := r.client.Get(ctx, client.ObjectKey{Name: ls.Spec.StorageClassName}, &storagev1.StorageClass{}); err != nil {
 			if errors.IsNotFound(err) {
-				err := fmt.Errorf("couldn't find storage class %s, this must be provided", render.ElasticsearchStorageClass)
+				err := fmt.Errorf("couldn't find storage class %s, this must be provided", ls.Spec.StorageClassName)
 				log.Error(err, err.Error())
 				r.status.SetDegraded("Failed to get storage class", err.Error())
 				return reconcile.Result{}, nil

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -61,6 +61,7 @@ var (
 	esPublicCertObjMeta     = metav1.ObjectMeta{Name: render.ElasticsearchPublicCertSecret, Namespace: render.ElasticsearchNamespace}
 	kbPublicCertObjMeta     = metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}
 	curatorUsrSecretObjMeta = metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: render.OperatorNamespace()}
+	storageClassName        = "test-storage-class"
 )
 
 var _ = Describe("LogStorage controller", func() {
@@ -154,7 +155,7 @@ var _ = Describe("LogStorage controller", func() {
 
 				Context("LogStorage exists", func() {
 					BeforeEach(func() {
-						setUpLogStorageComponents(cli)
+						setUpLogStorageComponents(cli, storageClassName)
 						mockStatus.On("OnCRFound").Return()
 					})
 
@@ -249,7 +250,7 @@ var _ = Describe("LogStorage controller", func() {
 					ctx := context.Background()
 					Expect(cli.Create(ctx, &storagev1.StorageClass{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: render.ElasticsearchStorageClass,
+							Name: storageClassName,
 						},
 					})).ShouldNot(HaveOccurred())
 
@@ -261,6 +262,7 @@ var _ = Describe("LogStorage controller", func() {
 							Nodes: &operatorv1.Nodes{
 								Count: int64(1),
 							},
+							StorageClassName: storageClassName,
 						},
 					})).ShouldNot(HaveOccurred())
 
@@ -277,6 +279,7 @@ var _ = Describe("LogStorage controller", func() {
 					ls := &operatorv1.LogStorage{}
 					Expect(cli.Get(context.Background(), types.NamespacedName{Name: "tigera-secure"}, ls)).ShouldNot(HaveOccurred())
 					Expect(ls.Finalizers).Should(ContainElement("tigera.io/eck-cleanup"))
+					Expect(ls.Spec.StorageClassName).To(Equal(storageClassName))
 
 					Expect(cli.Get(ctx, eckOperatorObjKey, &appsv1.StatefulSet{})).ShouldNot(HaveOccurred())
 
@@ -333,7 +336,7 @@ var _ = Describe("LogStorage controller", func() {
 						},
 					})).ShouldNot(HaveOccurred())
 
-					setUpLogStorageComponents(cli)
+					setUpLogStorageComponents(cli, "")
 
 					mockStatus = &status.MockStatus{}
 					mockStatus.On("Run").Return()
@@ -363,6 +366,7 @@ var _ = Describe("LogStorage controller", func() {
 					now := metav1.Now()
 					ls.DeletionTimestamp = &now
 					Expect(cli.Update(context.Background(), ls)).ShouldNot(HaveOccurred())
+					Expect(ls.Spec.StorageClassName).To(Equal(logstorage.DefaultElasticsearchStorageClass))
 
 					result, err = r.Reconcile(reconcile.Request{})
 					Expect(err).ShouldNot(HaveOccurred())
@@ -398,13 +402,22 @@ var _ = Describe("LogStorage controller", func() {
 })
 var log = logf.Log.WithName("controller_logstorage")
 
-func setUpLogStorageComponents(cli client.Client) {
+func setUpLogStorageComponents(cli client.Client, storageClass string) {
 	ctx := context.Background()
-	Expect(cli.Create(ctx, &storagev1.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: render.ElasticsearchStorageClass,
-		},
-	})).ShouldNot(HaveOccurred())
+	if storageClass == "" {
+		Expect(cli.Create(ctx, &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: logstorage.DefaultElasticsearchStorageClass,
+			},
+		})).ShouldNot(HaveOccurred())
+	} else {
+		Expect(cli.Create(ctx, &storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: storageClass,
+			},
+		})).ShouldNot(HaveOccurred())
+	}
+
 	retention := int32(1)
 	ls := &operatorv1.LogStorage{
 		ObjectMeta: metav1.ObjectMeta{
@@ -420,6 +433,7 @@ func setUpLogStorageComponents(cli client.Client) {
 				Snapshots:         &retention,
 				ComplianceReports: &retention,
 			},
+			StorageClassName: storageClass,
 		},
 	}
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -46,7 +46,6 @@ const (
 	ECKEnterpriseTrial      = "eck-trial-license"
 	ECKWebhookConfiguration = "elastic-webhook.k8s.elastic.co"
 
-	ElasticsearchStorageClass  = "tigera-elasticsearch"
 	ElasticsearchNamespace     = "tigera-elasticsearch"
 	ElasticsearchHTTPURL       = "tigera-secure-es-http.tigera-elasticsearch.svc"
 	ElasticsearchHTTPSEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
@@ -302,7 +301,6 @@ func (es elasticsearchComponent) kibanaExternalService() *corev1.Service {
 
 // generate the PVC required for the Elasticsearch nodes
 func (es elasticsearchComponent) pvcTemplate() corev1.PersistentVolumeClaim {
-	storageClassName := ElasticsearchStorageClass
 	pvcTemplate := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "elasticsearch-data", // ECK requires this name
@@ -320,7 +318,7 @@ func (es elasticsearchComponent) pvcTemplate() corev1.PersistentVolumeClaim {
 					"storage": resource.MustParse("10Gi"),
 				},
 			},
-			StorageClassName: &storageClassName,
+			StorageClassName: &es.logStorage.Spec.StorageClassName,
 		},
 	}
 


### PR DESCRIPTION
Introduce a new field to the LogStorage CR(D) to allow for users to specify the storage class that is used by the ECK operator to create PVC's based on storage classes other than the default ("tigera-elasticsearch).