### PR TITLE
kube-controllers needs permissions on hostendpoints

### DIFF
--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -101,6 +101,12 @@ func (c *kubeControllersComponent) controllersRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "create", "update"},
 			},
 			{
+				// Needs to manage hostendpoints.
+				APIGroups: []string{"crd.projectcalico.org"},
+				Resources: []string{"hostendpoints"},
+				Verbs:     []string{"get", "list", "create", "update", "delete"},
+			},
+			{
 				// Needs to manipulate kubecontrollersconfiguration, which contains
 				// its config.  It creates a default if none exists, and updates status
 				// as well.


### PR DESCRIPTION
It needs the rbac even if auto hostendpoints is disabled.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

```release-note
Add permissions for kube-controllers to manage host endpoint resources
```