### PR TITLE
[release-v1.3] ES NodeSelector

### DIFF
--- a/deploy/crds/operator_v1_logstorage_crd.yaml
+++ b/deploy/crds/operator_v1_logstorage_crd.yaml
@@ -40,6 +40,15 @@ spec:
                   format: int32
                   type: integer
               type: object
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: NodeSelector gives you more control over the node that
+                Elasticsearch will run on. The contents of NodeSelector will be added
+                to the PodSpec of the Elasticsearch nodes. For the pod to be eligible
+                to run on a node, the node must have each of the indicated key-value
+                pairs as labels.
+              type: object
             nodes:
               description: Nodes defines the configuration for a set of identical
                 Elasticsearch cluster nodes, each of type master, data, and ingest.

--- a/deploy/crds/operator_v1_logstorage_crd.yaml
+++ b/deploy/crds/operator_v1_logstorage_crd.yaml
@@ -30,6 +30,15 @@ spec:
         spec:
           description: Specification of the desired state for Tigera log storage.
           properties:
+            dataNodeSelector:
+              additionalProperties:
+                type: string
+              description: DataNodeSelector gives you more control over the node that
+                Elasticsearch will run on. The contents of DataNodeSelector will be
+                added to the PodSpec of the Elasticsearch nodes. For the pod to be
+                eligible to run on a node, the node must have each of the indicated
+                key-value pairs as labels as well as access to the specified StorageClassName.
+              type: object
             indices:
               description: Index defines the configuration for the indices in the
                 Elasticsearch cluster.
@@ -39,15 +48,6 @@ spec:
                     have. See https://www.elastic.co/guide/en/elasticsearch/reference/current/scalability.html
                   format: int32
                   type: integer
-              type: object
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: NodeSelector gives you more control over the node that
-                Elasticsearch will run on. The contents of NodeSelector will be added
-                to the PodSpec of the Elasticsearch nodes. For the pod to be eligible
-                to run on a node, the node must have each of the indicated key-value
-                pairs as labels.
               type: object
             nodes:
               description: Nodes defines the configuration for a set of identical

--- a/pkg/apis/operator/v1/logstorage_types.go
+++ b/pkg/apis/operator/v1/logstorage_types.go
@@ -60,6 +60,12 @@ type LogStorageSpec struct {
 	// Default: tigera-elasticsearch
 	// +optional
 	StorageClassName string `json:"storageClassName,omitempty"`
+
+	// NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will
+	// be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have
+	// each of the indicated key-value pairs as labels.
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // Nodes defines the configuration for a set of identical Elasticsearch cluster nodes, each of type master, data, and ingest.

--- a/pkg/apis/operator/v1/logstorage_types.go
+++ b/pkg/apis/operator/v1/logstorage_types.go
@@ -61,11 +61,11 @@ type LogStorageSpec struct {
 	// +optional
 	StorageClassName string `json:"storageClassName,omitempty"`
 
-	// NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will
+	// DataNodeSelector gives you more control over the node that Elasticsearch will run on. The contents of DataNodeSelector will
 	// be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have
-	// each of the indicated key-value pairs as labels.
+	// each of the indicated key-value pairs as labels as well as access to the specified StorageClassName.
 	// +optional
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	DataNodeSelector map[string]string `json:"dataNodeSelector,omitempty"`
 }
 
 // Nodes defines the configuration for a set of identical Elasticsearch cluster nodes, each of type master, data, and ingest.

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -738,8 +738,8 @@ func (in *LogStorageSpec) DeepCopyInto(out *LogStorageSpec) {
 		*out = new(Retention)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.NodeSelector != nil {
-		in, out := &in.NodeSelector, &out.NodeSelector
+	if in.DataNodeSelector != nil {
+		in, out := &in.DataNodeSelector, &out.DataNodeSelector
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -738,6 +738,13 @@ func (in *LogStorageSpec) DeepCopyInto(out *LogStorageSpec) {
 		*out = new(Retention)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/operator/v1/zz_generated.openapi.go
+++ b/pkg/apis/operator/v1/zz_generated.openapi.go
@@ -620,6 +620,20 @@ func schema_pkg_apis_operator_v1_LogStorageSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"nodeSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/operator/v1/zz_generated.openapi.go
+++ b/pkg/apis/operator/v1/zz_generated.openapi.go
@@ -620,9 +620,9 @@ func schema_pkg_apis_operator_v1_LogStorageSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
-					"nodeSelector": {
+					"dataNodeSelector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels.",
+							Description: "DataNodeSelector gives you more control over the node that Elasticsearch will run on. The contents of DataNodeSelector will be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels as well as access to the specified StorageClassName.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -241,7 +241,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 		Spec: corev1.PodSpec{
 			Containers:       []corev1.Container{esContainer},
 			ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
-			NodeSelector:     es.logStorage.Spec.NodeSelector,
+			NodeSelector:     es.logStorage.Spec.DataNodeSelector,
 		},
 	}
 

--- a/pkg/render/elasticsearch.go
+++ b/pkg/render/elasticsearch.go
@@ -241,6 +241,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 		Spec: corev1.PodSpec{
 			Containers:       []corev1.Container{esContainer},
 			ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
+			NodeSelector:     es.logStorage.Spec.NodeSelector,
 		},
 	}
 

--- a/pkg/render/elasticsearch_test.go
+++ b/pkg/render/elasticsearch_test.go
@@ -15,6 +15,7 @@
 package render_test
 
 import (
+	esalpha1 "github.com/elastic/cloud-on-k8s/operators/pkg/apis/elasticsearch/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
@@ -38,6 +39,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				},
 				Indices: &operator.Indices{
 					Replicas: &replicas,
+				},
+				NodeSelector: map[string]string{
+					"label": "value",
 				},
 			},
 			Status: operator.LogStorageStatus{
@@ -79,6 +83,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+		// Verify that the node selectors are passed into the Elasticsearch pod spec.
+		Expect(resources[9].(*esalpha1.Elasticsearch).Spec.Nodes[0].PodTemplate.Spec.NodeSelector["label"]).To(Equal("value"))
 
 		for i, expectedRes := range expectedResources {
 			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)

--- a/pkg/render/elasticsearch_test.go
+++ b/pkg/render/elasticsearch_test.go
@@ -40,9 +40,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Indices: &operator.Indices{
 					Replicas: &replicas,
 				},
-				DataNodeSelector: map[string]string{
-					"label": "value",
-				},
 			},
 			Status: operator.LogStorageStatus{
 				State: "",
@@ -83,9 +80,8 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 		resources := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
-
-		// Verify that the node selectors are passed into the Elasticsearch pod spec.
-		Expect(resources[9].(*esalpha1.Elasticsearch).Spec.Nodes[0].PodTemplate.Spec.NodeSelector["label"]).To(Equal("value"))
+		// There are no node selectors in the LogStorage CR, so we expect no node selectors in the Elasticsearch CR.
+		Expect(resources[9].(*esalpha1.Elasticsearch).Spec.Nodes[0].PodTemplate.Spec.NodeSelector).To(BeEmpty())
 
 		for i, expectedRes := range expectedResources {
 			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
@@ -237,5 +233,20 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		for i, expectedRes := range expectedResources {
 			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
+	})
+
+	It("should render DataNodeSelectors are defined in the LogStorage CR", func() {
+		logStorage.Spec.DataNodeSelector = map[string]string{
+			"k1": "v1",
+			"k2": "v2",
+		}
+		component, err := render.Elasticsearch(logStorage, esConfig, nil, nil, false, nil, operator.ProviderNone,
+			&operator.Installation{Spec: operator.InstallationSpec{}},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		// Verify that the node selectors are passed into the Elasticsearch pod spec.
+		nodeSelectors := component.Objects()[9].(*esalpha1.Elasticsearch).Spec.Nodes[0].PodTemplate.Spec.NodeSelector
+		Expect(nodeSelectors["k1"]).To(Equal("v1"))
+		Expect(nodeSelectors["k2"]).To(Equal("v2"))
 	})
 })

--- a/pkg/render/elasticsearch_test.go
+++ b/pkg/render/elasticsearch_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Indices: &operator.Indices{
 					Replicas: &replicas,
 				},
-				NodeSelector: map[string]string{
+				DataNodeSelector: map[string]string{
 					"label": "value",
 				},
 			},


### PR DESCRIPTION
Allows the user to add a NodeSelector to the podSpec of ES by adding it to the LogStorage CR. This allows some of our users to schedule the ES onto the nodes with the right volumes and resources.