### PR TITLE
[master] ES NodeSelector

### DIFF
--- a/deploy/crds/operator_v1_logstorage_crd.yaml
+++ b/deploy/crds/operator_v1_logstorage_crd.yaml
@@ -40,6 +40,15 @@ spec:
                   format: int32
                   type: integer
               type: object
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: NodeSelector gives you more control over the node that
+                Elasticsearch will run on. The contents of NodeSelector will be added
+                to the PodSpec of the Elasticsearch nodes. For the pod to be eligible
+                to run on a node, the node must have each of the indicated key-value
+                pairs as labels.
+              type: object
             nodes:
               description: Nodes defines the configuration for a set of identical
                 Elasticsearch cluster nodes, each of type master, data, and ingest.

--- a/deploy/crds/operator_v1_logstorage_crd.yaml
+++ b/deploy/crds/operator_v1_logstorage_crd.yaml
@@ -30,6 +30,15 @@ spec:
         spec:
           description: Specification of the desired state for Tigera log storage.
           properties:
+            dataNodeSelector:
+              additionalProperties:
+                type: string
+              description: DataNodeSelector gives you more control over the node that
+                Elasticsearch will run on. The contents of DataNodeSelector will be
+                added to the PodSpec of the Elasticsearch nodes. For the pod to be
+                eligible to run on a node, the node must have each of the indicated
+                key-value pairs as labels as well as access to the specified StorageClassName.
+              type: object
             indices:
               description: Index defines the configuration for the indices in the
                 Elasticsearch cluster.
@@ -39,15 +48,6 @@ spec:
                     have. See https://www.elastic.co/guide/en/elasticsearch/reference/current/scalability.html
                   format: int32
                   type: integer
-              type: object
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: NodeSelector gives you more control over the node that
-                Elasticsearch will run on. The contents of NodeSelector will be added
-                to the PodSpec of the Elasticsearch nodes. For the pod to be eligible
-                to run on a node, the node must have each of the indicated key-value
-                pairs as labels.
               type: object
             nodes:
               description: Nodes defines the configuration for a set of identical

--- a/pkg/apis/operator/v1/logstorage_types.go
+++ b/pkg/apis/operator/v1/logstorage_types.go
@@ -60,6 +60,12 @@ type LogStorageSpec struct {
 	// Default: tigera-elasticsearch
 	// +optional
 	StorageClassName string `json:"storageClassName,omitempty"`
+
+	// NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will
+	// be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have
+	// each of the indicated key-value pairs as labels.
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // Nodes defines the configuration for a set of identical Elasticsearch cluster nodes, each of type master, data, and ingest.

--- a/pkg/apis/operator/v1/logstorage_types.go
+++ b/pkg/apis/operator/v1/logstorage_types.go
@@ -61,11 +61,11 @@ type LogStorageSpec struct {
 	// +optional
 	StorageClassName string `json:"storageClassName,omitempty"`
 
-	// NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will
+	// DataNodeSelector gives you more control over the node that Elasticsearch will run on. The contents of DataNodeSelector will
 	// be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have
-	// each of the indicated key-value pairs as labels.
+	// each of the indicated key-value pairs as labels as well as access to the specified StorageClassName.
 	// +optional
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	DataNodeSelector map[string]string `json:"dataNodeSelector,omitempty"`
 }
 
 // Nodes defines the configuration for a set of identical Elasticsearch cluster nodes, each of type master, data, and ingest.

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -755,6 +755,13 @@ func (in *LogStorageSpec) DeepCopyInto(out *LogStorageSpec) {
 		*out = new(Retention)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -755,8 +755,8 @@ func (in *LogStorageSpec) DeepCopyInto(out *LogStorageSpec) {
 		*out = new(Retention)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.NodeSelector != nil {
-		in, out := &in.NodeSelector, &out.NodeSelector
+	if in.DataNodeSelector != nil {
+		in, out := &in.DataNodeSelector, &out.DataNodeSelector
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/apis/operator/v1/zz_generated.openapi.go
+++ b/pkg/apis/operator/v1/zz_generated.openapi.go
@@ -641,6 +641,20 @@ func schema_pkg_apis_operator_v1_LogStorageSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"nodeSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/operator/v1/zz_generated.openapi.go
+++ b/pkg/apis/operator/v1/zz_generated.openapi.go
@@ -641,9 +641,9 @@ func schema_pkg_apis_operator_v1_LogStorageSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
-					"nodeSelector": {
+					"dataNodeSelector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NodeSelector gives you more control over the node that Elasticsearch will run on. The contents of NodeSelector will be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels.",
+							Description: "DataNodeSelector gives you more control over the node that Elasticsearch will run on. The contents of DataNodeSelector will be added to the PodSpec of the Elasticsearch nodes. For the pod to be eligible to run on a node, the node must have each of the indicated key-value pairs as labels as well as access to the specified StorageClassName.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -417,6 +417,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			InitContainers:   []corev1.Container{initContainer},
 			Containers:       []corev1.Container{esContainer},
 			ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
+			NodeSelector:     es.logStorage.Spec.NodeSelector,
 		},
 	}
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -417,7 +417,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			InitContainers:   []corev1.Container{initContainer},
 			Containers:       []corev1.Container{esContainer},
 			ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
-			NodeSelector:     es.logStorage.Spec.NodeSelector,
+			NodeSelector:     es.logStorage.Spec.DataNodeSelector,
 		},
 	}
 

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -66,6 +66,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						Snapshots:         &retention,
 						ComplianceReports: &retention,
 					},
+					NodeSelector: map[string]string{
+						"label": "value",
+					},
 				},
 				Status: operator.LogStorageStatus{
 					State: "",
@@ -132,6 +135,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 				compareResources(createResources, expectedCreateResources)
 				compareResources(deleteResources, []resourceTestObj{})
+
+				// Verify that the node selectors are passed into the Elasticsearch pod spec.
+				Expect(createResources[15].(*esv1.Elasticsearch).Spec.NodeSets[0].PodTemplate.Spec.NodeSelector["label"]).To(Equal("value"))
 			})
 			It("should render an elasticsearchComponent and delete the Elasticsearch and Kibana ExternalService", func() {
 				expectedCreateResources := []resourceTestObj{

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						Snapshots:         &retention,
 						ComplianceReports: &retention,
 					},
-					NodeSelector: map[string]string{
+					DataNodeSelector: map[string]string{
 						"label": "value",
 					},
 				},

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -66,9 +66,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						Snapshots:         &retention,
 						ComplianceReports: &retention,
 					},
-					DataNodeSelector: map[string]string{
-						"label": "value",
-					},
 				},
 				Status: operator.LogStorageStatus{
 					State: "",
@@ -136,8 +133,8 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				compareResources(createResources, expectedCreateResources)
 				compareResources(deleteResources, []resourceTestObj{})
 
-				// Verify that the node selectors are passed into the Elasticsearch pod spec.
-				Expect(createResources[15].(*esv1.Elasticsearch).Spec.NodeSets[0].PodTemplate.Spec.NodeSelector["label"]).To(Equal("value"))
+				// There are no node selectors in the LogStorage CR, so we expect no node selectors in the Elasticsearch CR.
+				Expect(createResources[15].(*esv1.Elasticsearch).Spec.NodeSets[0].PodTemplate.Spec.NodeSelector).To(BeEmpty())
 			})
 			It("should render an elasticsearchComponent and delete the Elasticsearch and Kibana ExternalService", func() {
 				expectedCreateResources := []resourceTestObj{
@@ -269,6 +266,33 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		})
 
 		Context("Deleting LogStorage", deleteLogStorageTests(operatorv1.ClusterManagementTypeStandalone))
+
+		It("should render DataNodeSelectors defined in the LogStorage CR", func() {
+			logStorage.Spec.DataNodeSelector = map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			}
+			component := render.LogStorage(
+				logStorage,
+				installation, nil, nil,
+				esConfig,
+				[]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.ElasticsearchNamespace}},
+				},
+				[]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: render.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: render.KibanaNamespace}},
+				}, true,
+				[]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
+				}, operator.ProviderNone, nil, nil, nil, "cluster.local", true)
+			// Verify that the node selectors are passed into the Elasticsearch pod spec.
+			createResouces, _ := component.Objects()
+			nodeSelectors := createResouces[15].(*esv1.Elasticsearch).Spec.NodeSets[0].PodTemplate.Spec.NodeSelector
+			Expect(nodeSelectors["k1"]).To(Equal("v1"))
+			Expect(nodeSelectors["k2"]).To(Equal("v2"))
+		})
 	})
 
 	Context("Managed cluster", func() {


### PR DESCRIPTION
Allows the user to add a NodeSelector to the podSpec of ES by adding it to the LogStorage CR. This allows some of our users to schedule the ES onto the pods with the right volumes and resources.

Cherry picks:
- ff7a7400534b46045aa45931167dfe5a33318a68 
- 44b210874f54a2fceffeb208fe49be24dee220f4
- 72494ceb2a68cb25537dcab8c6147c2c65256d90
- 77719004c070e3a9a4e12e1081ea0592209a952e
