### PR TITLE
Add MultiInterfaceMode to installation spec

### DIFF
--- a/deploy/crds/operator_v1_installation_crd.yaml
+++ b/deploy/crds/operator_v1_installation_crd.yaml
@@ -88,6 +88,14 @@ spec:
                     for pods on the Calico network. Default: 1410'
                   format: int32
                   type: integer
+                multiInterfaceMode:
+                  description: 'MultiInterfaceMode configures what will configure
+                    multiple interface per pod. Only valid for Calico Enterprise installations.
+                    Default: None'
+                  enum:
+                  - None
+                  - Multus
+                  type: string
                 nodeAddressAutodetectionV4:
                   description: NodeAddressAutodetectionV4 specifies an approach to
                     automatically detect node IPv4 addresses. If not specified, will

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -15,6 +15,8 @@
 package v1
 
 import (
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,6 +150,17 @@ var HostPortsTypesString []string = []string{
 	HostPortsDisabled.String(),
 }
 
+type MultiInterfaceMode string
+
+func (m MultiInterfaceMode) Value() string {
+	return strings.ToLower(string(m))
+}
+
+const (
+	MultiInterfaceModeNone   MultiInterfaceMode = "None"
+	MultiInterfaceModeMultus MultiInterfaceMode = "Multus"
+)
+
 func (nt HostPortsType) String() string {
 	return string(nt)
 }
@@ -179,6 +192,12 @@ type CalicoNetworkSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Enabled,Disabled
 	HostPorts *HostPortsType `json:"hostPorts,omitempty"`
+
+	// MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise installations.
+	// Default: None
+	// +optional
+	// +kubebuilder:validation:Enum=None,Multus
+	MultiInterfaceMode *MultiInterfaceMode `json:"multiInterfaceMode,omitempty"`
 }
 
 // NodeAddressAutodetection provides configuration options for auto-detecting node addresses. At most one option

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -200,6 +200,11 @@ func (in *CalicoNetworkSpec) DeepCopyInto(out *CalicoNetworkSpec) {
 		*out = new(HostPortsType)
 		**out = **in
 	}
+	if in.MultiInterfaceMode != nil {
+		in, out := &in.MultiInterfaceMode, &out.MultiInterfaceMode
+		*out = new(MultiInterfaceMode)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -327,6 +327,11 @@ func fillDefaults(instance *operator.Installation) error {
 			hp := operator.HostPortsEnabled
 			instance.Spec.CalicoNetwork.HostPorts = &hp
 		}
+
+		if instance.Spec.CalicoNetwork.MultiInterfaceMode == nil {
+			mm := operator.MultiInterfaceModeNone
+			instance.Spec.CalicoNetwork.MultiInterfaceMode = &mm
+		}
 	}
 
 	// If not specified by the user, set the flex volume plugin location based on platform.

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		var one intstr.IntOrString = intstr.FromInt(1)
 
 		hpEnabled := operator.HostPortsEnabled
-
+		miMode := operator.MultiInterfaceModeNone
 		instance := &operator.Installation{
 			Spec: operator.InstallationSpec{
 				Variant:  operator.TigeraSecureEnterprise,
@@ -111,7 +111,8 @@ var _ = Describe("Defaulting logic tests", func() {
 					NodeAddressAutodetectionV6: &operator.NodeAddressAutodetection{
 						FirstFound: &false_,
 					},
-					HostPorts: &hpEnabled,
+					HostPorts:          &hpEnabled,
+					MultiInterfaceMode: &miMode,
 				},
 				NodeMetricsPort: &nodeMetricsPort,
 				FlexVolumePath:  "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -196,6 +196,10 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 		if c.cr.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
 			enabledControllers = append(enabledControllers, "managedcluster")
 		}
+
+		if c.cr.Spec.CalicoNetwork != nil && c.cr.Spec.CalicoNetwork.MultiInterfaceMode != nil {
+			env = append(env, v1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cr.Spec.CalicoNetwork.MultiInterfaceMode.Value()})
+		}
 	}
 
 	env = append(env, v1.EnvVar{Name: "ENABLED_CONTROLLERS", Value: strings.Join(enabledControllers, ",")})

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -33,10 +33,13 @@ var _ = Describe("kube-controllers rendering tests", func() {
 	BeforeEach(func() {
 		// Initialize a default instance to use. Each test can override this to its
 		// desired configuration.
+
+		miMode := operator.MultiInterfaceModeNone
 		instance = &operator.Installation{
 			Spec: operator.InstallationSpec{
 				CalicoNetwork: &operator.CalicoNetworkSpec{
-					IPPools: []operator.IPPool{{CIDR: "192.168.1.0/16"}},
+					IPPools:            []operator.IPPool{{CIDR: "192.168.1.0/16"}},
+					MultiInterfaceMode: &miMode,
 				},
 				Registry: "test-reg/",
 			},

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -619,7 +619,7 @@ func (c *nodeComponent) cniEnvvars() []v1.EnvVar {
 	// Determine directories to use for CNI artifacts based on the provider.
 	cniNetDir, _ := c.cniDirectories()
 
-	return []v1.EnvVar{
+	envVars := []v1.EnvVar{
 		{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 		{Name: "SLEEP", Value: "false"},
 		{Name: "CNI_NET_DIR", Value: cniNetDir},
@@ -635,6 +635,14 @@ func (c *nodeComponent) cniEnvvars() []v1.EnvVar {
 			},
 		},
 	}
+
+	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
+		if c.cr.Spec.CalicoNetwork != nil && c.cr.Spec.CalicoNetwork.MultiInterfaceMode != nil {
+			envVars = append(envVars, v1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cr.Spec.CalicoNetwork.MultiInterfaceMode.Value()})
+		}
+	}
+
+	return envVars
 }
 
 // nodeContainer creates the main node container.
@@ -882,6 +890,11 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 			{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
 		}
+
+		if c.cr.Spec.CalicoNetwork != nil && c.cr.Spec.CalicoNetwork.MultiInterfaceMode != nil {
+			extraNodeEnv = append(extraNodeEnv, v1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cr.Spec.CalicoNetwork.MultiInterfaceMode.Value()})
+		}
+
 		nodeEnv = append(nodeEnv, extraNodeEnv...)
 	}
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -44,12 +44,14 @@ var _ = Describe("Node rendering tests", func() {
 	BeforeEach(func() {
 		ff := true
 		hp := operator.HostPortsEnabled
+		miMode := operator.MultiInterfaceModeNone
 		defaultInstance = &operator.Installation{
 			Spec: operator.InstallationSpec{
 				CalicoNetwork: &operator.CalicoNetworkSpec{
 					IPPools:                    []operator.IPPool{{CIDR: "192.168.1.0/16"}},
 					NodeAddressAutodetectionV4: &operator.NodeAddressAutodetection{FirstFound: &ff},
 					HostPorts:                  &hp,
+					MultiInterfaceMode:         &miMode,
 				},
 				NodeUpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
@@ -348,6 +350,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_FLOWLOGSENABLENETWORKSETS", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
+			{Name: "MULTI_INTERFACE_MODE", Value: operator.MultiInterfaceModeNone.Value()},
 			{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
@@ -564,6 +567,7 @@ var _ = Describe("Node rendering tests", func() {
 			// The OpenShift envvar overrides.
 			{Name: "FELIX_HEALTHPORT", Value: "9199"},
 			{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
+			{Name: "MULTI_INTERFACE_MODE", Value: operator.MultiInterfaceModeNone.Value()},
 			{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -35,13 +35,18 @@ var _ = Describe("Rendering tests", func() {
 	var logWriter *bufio.Writer
 	var typhaNodeTLS *render.TyphaNodeTLS
 	one := intstr.FromInt(1)
+	miMode := operator.MultiInterfaceModeNone
+
 	BeforeEach(func() {
 		// Initialize a default instance to use. Each test can override this to its
 		// desired configuration.
 		instance = &operator.Installation{
 			Spec: operator.InstallationSpec{
-				CalicoNetwork: &operator.CalicoNetworkSpec{IPPools: []operator.IPPool{{CIDR: "192.168.1.0/16"}}},
-				Registry:      "test-reg/",
+				CalicoNetwork: &operator.CalicoNetworkSpec{
+					IPPools:            []operator.IPPool{{CIDR: "192.168.1.0/16"}},
+					MultiInterfaceMode: &miMode,
+				},
+				Registry: "test-reg/",
 				NodeUpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 						MaxUnavailable: &one,

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -458,6 +458,12 @@ func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
 		typhaEnv = append(typhaEnv, v1.EnvVar{Name: "FELIX_INTERFACEPREFIX", Value: "azv"})
 	}
 
+	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
+		if c.cr.Spec.CalicoNetwork != nil && c.cr.Spec.CalicoNetwork.MultiInterfaceMode != nil {
+			typhaEnv = append(typhaEnv, v1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cr.Spec.CalicoNetwork.MultiInterfaceMode.Value()})
+		}
+	}
+
 	return typhaEnv
 }
 


### PR DESCRIPTION
## Description
This configures if multiple interfaces are allowed per pod and what configures them. We only allow multus for now.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
