### PR TITLE
adding curator service account

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -71,7 +71,8 @@ const (
 
 	LogStorageFinalizer = "tigera.io/eck-cleanup"
 
-	EsCuratorName = "elastic-curator"
+	EsCuratorName           = "elastic-curator"
+	EsCuratorServiceAccount = "tigera-elastic-curator"
 
 	// As soon as the total disk utilization exceeds the max-total-storage-percent,
 	// indices will be removed starting with the oldest. Picking a low value leads
@@ -242,6 +243,7 @@ func (es *elasticsearchComponent) Objects() ([]runtime.Object, []runtime.Object)
 		// If we have the curator secrets then create curator
 		if len(es.curatorSecrets) > 0 {
 			toCreate = append(toCreate, secretsToRuntimeObjects(CopySecrets(ElasticsearchNamespace, es.curatorSecrets...)...)...)
+			toCreate = append(toCreate, es.esCuratorServiceAccount())
 			toCreate = append(toCreate, es.curatorCronJob())
 		}
 
@@ -670,6 +672,17 @@ func (es elasticsearchComponent) eckOperatorServiceAccount() *corev1.ServiceAcco
 	}
 }
 
+// creating this service account without any role bindings to stop curator getting associated with default SA
+// This allows us to create stricter PodSecurityPolicy for the curator as PSP are based on service account.
+func (es elasticsearchComponent) esCuratorServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      EsCuratorServiceAccount,
+			Namespace: ElasticsearchNamespace,
+		},
+	}
+}
+
 func (es elasticsearchComponent) eckOperatorStatefulSet() *appsv1.StatefulSet {
 	gracePeriod := int64(10)
 	defaultMode := int32(420)
@@ -824,6 +837,7 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 
 func (es elasticsearchComponent) curatorCronJob() *batchv1beta.CronJob {
 	var f = false
+	var t = true
 	var elasticCuratorLivenessProbe = &corev1.Probe{
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
@@ -861,13 +875,14 @@ func (es elasticsearchComponent) curatorCronJob() *batchv1beta.CronJob {
 									Env:           es.curatorEnvVars(),
 									LivenessProbe: elasticCuratorLivenessProbe,
 									SecurityContext: &corev1.SecurityContext{
-										RunAsNonRoot:             &f,
+										RunAsNonRoot:             &t,
 										AllowPrivilegeEscalation: &f,
 									},
 								}, DefaultElasticsearchClusterName, ElasticsearchCuratorUserSecret),
 							},
 							ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
 							RestartPolicy:    corev1.RestartPolicyOnFailure,
+							ServiceAccountName: EsCuratorServiceAccount,
 						}),
 					},
 				},

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -231,6 +231,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{render.KibanaName, render.KibanaNamespace, &kbv1.Kibana{}, nil},
 					{render.ElasticsearchCuratorUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 					{render.ElasticsearchPublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+					{render.EsCuratorServiceAccount, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
 					{render.EsCuratorName, render.ElasticsearchNamespace, &batchv1beta.CronJob{}, nil},
 					{render.ECKEnterpriseTrial, render.ECKOperatorNamespace, &corev1.Secret{}, nil},
 				}


### PR DESCRIPTION
## Description

* adding a service account for curator to be able to restrict curator [PSP](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) permissions

Pod Security Policy are based on service account used by the pod, so creating a new SA for curator allows us to create stricter PSP. This SA's sole purpose is to separate the curator from getting associated with `default` SA



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
