### PR TITLE
Use CNI private for Calico Enterprise installs

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -68,3 +68,6 @@ components:
   guardian:
     image: tigera/guardian
     version: v2.7.0-0.dev-61-g73e2b02
+  tigera-cni:
+    image: tigera/cni
+    version: v3.0.0-0.dev-39-g3f96541

--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -34,6 +34,7 @@ var defaultImages = map[string]string{
 	"typha":                   "calico/typha",
 	"eck-kibana":              "tigera/kibana",
 	"guardian":                "tigera/guardian",
+	"tigera-cni":              "tigera/cni",
 }
 
 type Components map[string]*Component

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -169,4 +169,11 @@ var (
 		Image:   "{{ .Image }}",
 	}
 	{{ end }}
+	{{ with index . "tigera-cni" }}
+    ComponentTigeraCNI = component{
+        Version: "{{ .Version }}",
+        Digest:  "{{ .Digest }}",
+        Image:   "{{ .Image }}",
+    }
+    {{ end }}
 )

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -102,7 +102,7 @@ var (
 	
 	ComponentFluentd = component{
 		Version: "v3.0.0-0.dev-1-ge3d709f",
-		Digest:  "sha256:af99ee4357236c8bd4082b1df3e5b99f3f5ccf8af45c2bc3813aae9240efa30d",
+		Digest:  "sha256:84208c8d0946b23d28148f61a70f924b1a13738c9f0949656937acdd0b5d3cf6",
 		Image:   "tigera/fluentd",
 	}
 	
@@ -169,4 +169,11 @@ var (
 		Image:   "tigera/typha",
 	}
 	
+	
+    ComponentTigeraCNI = component{
+        Version: "v3.0.0-0.dev-39-g3f96541",
+        Digest:  "sha256:b3cc46ace05218b55a07b9351fe206e1a4398ab227c36bdde6ca84a076100cb9",
+        Image:   "tigera/cni",
+    }
+    
 )

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -587,9 +587,14 @@ func (c *nodeComponent) cniContainer() v1.Container {
 		{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
 	}
 
+	image := components.GetReference(components.ComponentCalicoCNI, c.cr.Spec.Registry, c.cr.Spec.ImagePath)
+	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
+		image = components.GetReference(components.ComponentTigeraCNI, c.cr.Spec.Registry, c.cr.Spec.ImagePath)
+	}
+
 	return v1.Container{
 		Name:         "install-cni",
-		Image:        components.GetReference(components.ComponentCalicoCNI, c.cr.Spec.Registry, c.cr.Spec.ImagePath),
+		Image:        image,
 		Command:      []string{"/install-cni.sh"},
 		Env:          cniEnv,
 		VolumeMounts: cniVolumeMounts,


### PR DESCRIPTION
Multi NICs is only going to be available for Calico Enterprise installations which is why this change needs to happen