### PR TITLE
Allow updates to Logstorage resource limits

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -546,12 +546,17 @@ func (es elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 // As storage requirements of NodeSets are immutable,
 // renaming a NodeSet automatically creates a new StatefulSet with new PersistentVolumeClaim.
 // https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-orchestration.html#k8s-orchestration-limitations
-func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim) string{
+func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim) string {
 	pvcTemplateHash := fnv.New64a()
-	templateBytes, _ := json.Marshal(pvcTemplate)
+	templateBytes, err := json.Marshal(pvcTemplate)
+	if err != nil {
+		log.V(5).Info("Failed to create unique name for ElasticSearch NodeSet.", "err", err)
+		return "es"
+	}
 	pvcTemplateHash.Write(templateBytes)
 	return hex.EncodeToString(pvcTemplateHash.Sum(nil))
 }
+
 func (es elasticsearchComponent) eckOperatorWebhookSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -15,7 +15,10 @@
 package render
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	"github.com/elastic/cloud-on-k8s/pkg/utils/stringsutil"
@@ -499,6 +502,7 @@ func memoryQuantityToJVMHeapSize(q *resource.Quantity) string {
 // render the Elasticsearch CR that the ECK operator uses to create elasticsearch cluster
 func (es elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 	nodeConfig := es.logStorage.Spec.Nodes
+	pvcTemplate := es.pvcTemplate()
 
 	return &esv1.Elasticsearch{
 		TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch", APIVersion: "elasticsearch.k8s.elastic.co/v1"},
@@ -522,7 +526,7 @@ func (es elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 			NodeSets: []esv1.NodeSet{
 				{
 					Count: int32(nodeConfig.Count),
-					Name:  "es",
+					Name: nodeSetName(pvcTemplate),
 					Config: &cmnv1.Config{
 						Data: map[string]interface{}{
 							"node.master": "true",
@@ -530,7 +534,7 @@ func (es elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 							"node.ingest": "true",
 						},
 					},
-					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{es.pvcTemplate()},
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{pvcTemplate},
 					PodTemplate:          es.podTemplate(),
 				},
 			},
@@ -538,6 +542,16 @@ func (es elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 	}
 }
 
+// nodeSetName returns thumbprint of PersistentVolumeClaim object as string.
+// As storage requirements of NodeSets are immutable,
+// renaming a NodeSet automatically creates a new StatefulSet with new PersistentVolumeClaim.
+// https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-orchestration.html#k8s-orchestration-limitations
+func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim) string{
+	pvcTemplateHash := fnv.New64a()
+	templateBytes, _ := json.Marshal(pvcTemplate)
+	pvcTemplateHash.Write(templateBytes)
+	return hex.EncodeToString(pvcTemplateHash.Sum(nil))
+}
 func (es elasticsearchComponent) eckOperatorWebhookSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
Updating the Logstroage resource limit fails as storage requirements are immutable from ECK 1.0 https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-orchestration.html#k8s-orchestration-limitations

This PR uses hash of the volumeClaimTemplates as NodeSet name so a new StatefulSet is created if storage requirements change.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
