### PR TITLE
Bump apiserver and typha version

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -7,7 +7,7 @@ components:
     version: v2.7.0-0.dev-61-g73e2b02
   cnx-apiserver:
     image: tigera/cnx-apiserver
-    version: v2.7.0-0.dev-70-gcf61025a
+    version: v3.0.0-0.dev-29-g11260416
   cnx-queryserver:
     image: tigera/cnx-queryserver
     version: v2.7.0-0.dev-74-g6ce4ce4
@@ -16,7 +16,7 @@ components:
     version: v2.7.0-0.dev-176-g68be5b8
   typha:
     image: tigera/typha
-    version: v2.7.0-18-ge12d757
+    version: v3.0.0-0.dev-23-g664fa65
   cnx-node:
     image: tigera/cnx-node
     version: v2.7.0-0.dev-300-ge5619d5

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -17,8 +17,8 @@ package components
 var (
 	
 	ComponentAPIServer = component{
-		Version: "v2.7.0-0.dev-70-gcf61025a",
-		Digest:  "sha256:99001709c7e9079bd41f466ff75bfac87369c84b4096994a04fbceaf3c447c85",
+		Version: "v3.0.0-0.dev-29-g11260416",
+		Digest:  "sha256:9162e4a672b82e91776f2b477cb5306dd42f8e0d784c1962e8dd1954018f5900",
 		Image:   "tigera/cnx-apiserver",
 	}
 	
@@ -164,8 +164,8 @@ var (
 	
 	
 	ComponentTigeraTypha = component{
-		Version: "v2.7.0-18-ge12d757",
-		Digest:  "sha256:ee2690f1ed54e3836e0004b16ab7a9c60e071a0c7cd5233a430a5a4a28560348",
+		Version: "v3.0.0-0.dev-23-g664fa65",
+		Digest:  "sha256:596fa5fe7f80d1af871f705ff586e71761bbc0b12ae7522169a179ce24543271",
 		Image:   "tigera/typha",
 	}
 	


### PR DESCRIPTION
## Description
Bumping the version of all components that uses libcalico-go-private to fetch changes from https://github.com/tigera/libcalico-go-private/pull/349
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
