### PR TITLE
add tech preview seccomp selection for node

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -37,6 +37,8 @@ const (
 	birdTemplateHashAnnotation = "hash.operator.tigera.io/bird-templates"
 	nodeCertHashAnnotation     = "hash.operator.tigera.io/node-cert"
 	nodeCniConfigAnnotation    = "hash.operator.tigera.io/cni-config"
+
+	techPreviewFeatureSeccompApparmor = "tech-preview.operator.tigera.io/node-apparmor-profile"
 )
 
 var (
@@ -427,6 +429,12 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *v1.ConfigMap) *apps.DaemonSet {
 	if c.cr.Spec.NodeMetricsPort != nil {
 		annotations["prometheus.io/scrape"] = "true"
 		annotations["prometheus.io/port"] = fmt.Sprintf("%d", *c.cr.Spec.NodeMetricsPort)
+	}
+
+	// check tech preview annotation for calico-node apparmor profile
+	a := c.cr.GetObjectMeta().GetAnnotations()
+	if val, ok := a[techPreviewFeatureSeccompApparmor]; ok {
+		annotations["container.apparmor.security.beta.kubernetes.io/calico-node"] = val
 	}
 
 	initContainers := []v1.Container{}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -976,6 +976,21 @@ var _ = Describe("Node rendering tests", func() {
 		}
 		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 	})
+
+	It("should render seccomp profiles", func() {
+		seccompProf := "localhost/calico-node-v1"
+		defaultInstance.ObjectMeta.Annotations = make(map[string]string)
+		defaultInstance.ObjectMeta.Annotations["tech-preview.operator.tigera.io/node-apparmor-profile"] = seccompProf
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, false)
+		resources, _ := component.Objects()
+
+		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+		Expect(dsResource).ToNot(BeNil())
+		ds := dsResource.(*apps.DaemonSet)
+		Expect(ds).ToNot(BeNil())
+
+		Expect(ds.Spec.Template.Annotations["container.apparmor.security.beta.kubernetes.io/calico-node"]).To(Equal(seccompProf))
+	})
 })
 
 // verifyProbes asserts the expected node liveness and readiness probe.


### PR DESCRIPTION
## Description

Allows setting seccomp profile for the calico-node container. User can annotate the Installation resource with the following:
```
"tech-preview.operator.tigera.io/node-apparmor-profile": "%s"
```

This will apply the following annotation to the calico-node pod:
```
"container.apparmor.security.beta.kubernetes.io/calico-node": "%s"
```

This is exposed through the helm chart as `nodeApparmorPolicyName` here: https://github.com/tigera/calico-private/pull/2087/

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

```release-note
[tech-preview] Support for enabling apparmor profile on calico/node 