### PR TITLE
Secret manager-tls must be shared with compliance and kube-controllers

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -13,7 +13,7 @@ components:
     version: v2.7.0-0.dev-74-g6ce4ce4
   cnx-kube-controllers:
     image: tigera/kube-controllers
-    version: v2.7.0-0.dev-176-g68be5b8
+    version: v3.0.0-0.dev-66-gb52ab60
   typha:
     image: tigera/typha
     version: v3.0.0-0.dev-23-g664fa65
@@ -59,7 +59,7 @@ components:
     version: v2.7.0-0.dev-81-g41d5d65
   compliance-server:
     image: tigera/compliance-server
-    version: v2.7.0-0.dev-81-g41d5d65
+    version: v3.0.0-0.dev-22-gf550e29
   compliance-benchmarker:
     image: tigera/compliance-benchmarker
     version: v2.7.0-0.dev-81-g41d5d65

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getsentry/raven-go v0.0.0-20180121060056-563b81fc02b7/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -45,8 +45,8 @@ var (
 	
 	
 	ComponentComplianceServer = component{
-		Version: "v2.7.0-0.dev-81-g41d5d65",
-		Digest:  "sha256:30b82e739fc2e392a814c07827a58f9cd7f8807b3b334ce1aeda575a13ce1036",
+		Version: "v3.0.0-0.dev-22-gf550e29",
+		Digest:  "sha256:6c6297a9cc9983aee84516f5e068a431d3b8d42cd6caa7649f5362d0eb83c099",
 		Image:   "tigera/compliance-server",
 	}
 	
@@ -150,8 +150,8 @@ var (
 	
 	
 	ComponentTigeraKubeControllers = component{
-		Version: "v2.7.0-0.dev-176-g68be5b8",
-		Digest:  "sha256:8f7400037804f3ae80168df50e6479ffba4998662f089984f3a5a92fe8b775a8",
+		Version: "v3.0.0-0.dev-66-gb52ab60",
+		Digest:  "sha256:5423330661c2d482812e2de7c82bc0c841c26d819e26265863daceff66fe3e3e",
 		Image:   "tigera/kube-controllers",
 	}
 	

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -453,6 +453,21 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
+	var managerTLSSecret *corev1.Secret
+	managerTLSSecret, err = utils.ValidateCertPair(r.client,
+		render.ManagerTLSSecretName,
+		render.ManagerSecretKeyName,
+		render.ManagerSecretCertName,
+	)
+
+	if instance.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
+		if err != nil {
+			log.Error(err, "Invalid manager TLS Cert")
+			r.status.SetDegraded("Error validating manager TLS certificate", err.Error())
+			return reconcile.Result{}, err
+		}
+	}
+
 	typhaNodeTLS, err := r.GetTyphaFelixTLSConfig()
 	if err != nil {
 		log.Error(err, "Error with Typha/Felix secrets")
@@ -497,6 +512,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		instance,
 		pullSecrets,
 		typhaNodeTLS,
+		managerTLSSecret,
 		birdTemplates,
 		instance.Spec.KubernetesProvider,
 		netConf,

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -97,7 +97,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret,
 		} {
 			if err = utils.AddSecretsWatch(c, secretName, namespace); err != nil {
-				return fmt.Errorf("compliance-controller failed to watch the secret '%s' in '%s' namespace: %v", secretName, namespace, err)
+				return fmt.Errorf("manager-controller failed to watch the secret '%s' in '%s' namespace: %v", secretName, namespace, err)
 			}
 		}
 	}
@@ -205,6 +205,28 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
+	// Check that if the manager certpair secret exists that it is valid (has key and cert fields)
+	// If it does not exist then this function returns a nil secret but no error and a self-signed
+	// certificate will be generated when rendering below.
+	tlsSecret, err := utils.ValidateCertPair(r.client,
+		render.ManagerTLSSecretName,
+		render.ManagerSecretKeyName,
+		render.ManagerSecretCertName,
+	)
+
+	// An error is returned in case the read cannot be performed of the secret does not match the expected format
+	// In case the secret is not found, the error and the secret will be nil. This check needs to be done for all
+	// cluster types. For management cluster, we also need to check if the secret was created before hand.
+	if err != nil {
+		r.status.SetDegraded("Error validating manager TLS certificate", err.Error())
+		return reconcile.Result{}, err
+	}
+	if installation.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManagement && tlsSecret == nil {
+		err = fmt.Errorf("manager TLS Secret not found")
+		r.status.SetDegraded("No TLS manager certificate", err.Error())
+		return reconcile.Result{}, err
+	}
+
 	// Check that compliance is running.
 	compliance, err := compliance.GetCompliance(ctx, r.client)
 	if err != nil {
@@ -231,19 +253,6 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	// Check that if the manager certpair secret exists that it is valid (has key and cert fields)
-	// If it does not exist then this function returns a nil secret but no error and a self-signed
-	// certificate will be generated when rendering below.
-	tlsSecret, err := utils.ValidateCertPair(r.client,
-		render.ManagerTLSSecretName,
-		render.ManagerSecretKeyName,
-		render.ManagerSecretCertName,
-	)
-	if err != nil {
-		log.Error(err, "Invalid TLS Cert")
-		r.status.SetDegraded("Error validating TLS certificate", err.Error())
-		return reconcile.Result{}, err
-	}
 
 	pullSecrets, err := utils.GetNetworkingPullSecrets(installation, r.client)
 	if err != nil {

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -46,7 +46,7 @@ func SetTestLogger(l logr.Logger) {
 }
 
 func setCriticalPod(t *v1.PodTemplateSpec) {
-	t.Spec.PriorityClassName = priorityClassName
+	t.Spec.PriorityClassName = PriorityClassName
 }
 
 // envVarSourceFromConfigmap returns an EnvVarSource using the given configmap name and configmap key.

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -17,15 +17,17 @@ package render_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/render"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("compliance rendering tests", func() {
 	Context("Standalone cluster", func() {
 		It("should render all resources for a default configuration", func() {
-			component, err := render.Compliance(nil, &operatorv1.Installation{
+			component, err := render.Compliance(nil, nil, &operatorv1.Installation{
 				Spec: operatorv1.InstallationSpec{
 					KubernetesProvider:    operatorv1.ProviderNone,
 					Registry:              "testregistry.com/",
@@ -90,9 +92,100 @@ var _ = Describe("compliance rendering tests", func() {
 		})
 	})
 
+	Context("Management cluster", func() {
+		It("should render all resources for a default configuration", func() {
+			component, err := render.Compliance(nil, &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.ManagerTLSSecretName,
+					Namespace: render.OperatorNamespace(),
+				},
+				Data: map[string][]byte{
+					"cert": []byte("cert"),
+					"key":  []byte("key"),
+				},
+			}, &operatorv1.Installation{
+				Spec: operatorv1.InstallationSpec{
+					KubernetesProvider:    operatorv1.ProviderNone,
+					Registry:              "testregistry.com/",
+					ClusterManagementType: operatorv1.ClusterManagementTypeManagement,
+				},
+			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift)
+			Expect(err).ShouldNot(HaveOccurred())
+			resources, _ := component.Objects()
+
+			ns := "tigera-compliance"
+			rbac := "rbac.authorization.k8s.io"
+
+			expectedResources := []struct {
+				name    string
+				ns      string
+				group   string
+				version string
+				kind    string
+			}{
+				{ns, "", "", "v1", "Namespace"},
+				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
+				{"tigera-compliance-controller", ns, rbac, "v1", "Role"},
+				{"tigera-compliance-controller", "", rbac, "v1", "ClusterRole"},
+				{"tigera-compliance-controller", ns, rbac, "v1", "RoleBinding"},
+				{"tigera-compliance-controller", "", rbac, "v1", "ClusterRoleBinding"},
+				{"compliance-controller", ns, "apps", "v1", "Deployment"},
+				{"tigera-compliance-reporter", ns, "", "v1", "ServiceAccount"},
+				{"tigera-compliance-reporter", "", rbac, "v1", "ClusterRole"},
+				{"tigera-compliance-reporter", "", rbac, "v1", "ClusterRoleBinding"},
+				{"tigera.io.report", ns, "", "v1", "PodTemplate"},
+				{"tigera-compliance-snapshotter", ns, "", "v1", "ServiceAccount"},
+				{"tigera-compliance-snapshotter", "", rbac, "v1", "ClusterRole"},
+				{"tigera-compliance-snapshotter", "", rbac, "v1", "ClusterRoleBinding"},
+				{"compliance-snapshotter", ns, "apps", "v1", "Deployment"},
+				{"tigera-compliance-benchmarker", ns, "", "v1", "ServiceAccount"},
+				{"tigera-compliance-benchmarker", "", rbac, "v1", "ClusterRole"},
+				{"tigera-compliance-benchmarker", "", rbac, "v1", "ClusterRoleBinding"},
+				{"compliance-benchmarker", ns, "apps", "v1", "DaemonSet"},
+				{"inventory", "", "projectcalico.org", "v3", "GlobalReportType"},
+				{"network-access", "", "projectcalico.org", "v3", "GlobalReportType"},
+				{"policy-audit", "", "projectcalico.org", "v3", "GlobalReportType"},
+				{"cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"},
+				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
+				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
+				{render.ComplianceServerCertSecret, "tigera-operator", "", "v1", "Secret"},
+				{render.ComplianceServerCertSecret, "tigera-compliance", "", "v1", "Secret"},
+				{"tigera-compliance-server", "", rbac, "v1", "ClusterRole"},
+				{"compliance", ns, "", "v1", "Service"},
+				{"compliance-server", ns, "apps", "v1", "Deployment"},
+				{render.ManagerTLSSecretName, "tigera-compliance", "", "v1", "Secret"},
+			}
+
+			Expect(len(resources)).To(Equal(len(expectedResources)))
+
+			for i, expectedRes := range expectedResources {
+				ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+			}
+
+			ExpectGlobalReportType(resources[19], "inventory")
+			ExpectGlobalReportType(resources[20], "network-access")
+			ExpectGlobalReportType(resources[21], "policy-audit")
+			ExpectGlobalReportType(resources[22], "cis-benchmark")
+
+			var dpComplianceServer = resources[len(expectedResources) - 2].(*v1.Deployment)
+
+			Expect(len(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(3))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("cert"))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/code/apiserver.local.config/certificates"))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal("manager-cert"))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal("/manager-tls"))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name).To(Equal("elastic-ca-cert-volume"))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[2].MountPath).To(Equal("/etc/ssl/elastic/"))
+		})
+	})
+
 	Context("ManagedCluster", func() {
 		It("should render all resources for a default configuration", func() {
-			component, err := render.Compliance(nil, &operatorv1.Installation{
+			component, err := render.Compliance(nil, nil, &operatorv1.Installation{
 				Spec: operatorv1.InstallationSpec{
 					KubernetesProvider:    operatorv1.ProviderNone,
 					Registry:              "testregistry.com/",

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -16,6 +16,7 @@ package render_test
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -48,7 +49,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 	})
 
 	It("should render all resources for a custom configuration", func() {
-		component := render.KubeControllers(instance)
+		component := render.KubeControllers(instance, nil)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(4))
 
@@ -84,7 +85,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 	It("should render all resources for a default configuration using TigeraSecureEnterprise", func() {
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 
-		component := render.KubeControllers(instance)
+		component := render.KubeControllers(instance, nil)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(4))
 
@@ -100,10 +101,49 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 	})
 
+	It("should render all resources for a default configuration using TigeraSecureEnterprise and ClusterType is Management", func() {
+		instance.Spec.Variant = operator.TigeraSecureEnterprise
+		instance.Spec.ClusterManagementType = operator.ClusterManagementTypeManagement
+
+		var managerTLSSecret = v1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ManagerTLSSecretName,
+				Namespace: render.OperatorNamespace(),
+			},
+			Data: map[string][]byte{
+				"cert": []byte("cert"),
+				"key":  []byte("key"),
+			},
+		}
+		component := render.KubeControllers(instance, &managerTLSSecret)
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(5))
+
+		// Should render the correct resources.
+		ExpectResource(resources[0], "calico-kube-controllers", "calico-system", "", "v1", "ServiceAccount")
+		ExpectResource(resources[1], "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole")
+		ExpectResource(resources[2], "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
+		ExpectResource(resources[3], "calico-kube-controllers", "calico-system", "apps", "v1", "Deployment")
+		ExpectResource(resources[4], render.ManagerTLSSecretName, "calico-system", "", "v1", "Secret")
+
+		// The Deployment should have the correct configuration.
+		ds := resources[3].(*apps.Deployment)
+
+		Expect(len(ds.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
+		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("manager-cert"))
+		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/manager-tls"))
+
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
+	})
+
 	It("should include a ControlPlaneNodeSelector when specified", func() {
 		instance.Spec.ControlPlaneNodeSelector = map[string]string{"nodeName": "control01"}
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
-		component := render.KubeControllers(instance)
+		component := render.KubeControllers(instance, nil)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(4))
 

--- a/pkg/render/priority_class.go
+++ b/pkg/render/priority_class.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	priorityClassName = "calico-priority"
+	PriorityClassName = "calico-priority"
 )
 
 func PriorityClassDefinitions(cr *operator.Installation) Component {
@@ -44,7 +44,7 @@ func (c *priorityClassComponent) calicoPriority() *schedv1beta.PriorityClass {
 	return &schedv1beta.PriorityClass{
 		TypeMeta: metav1.TypeMeta{Kind: "PriorityClass", APIVersion: "scheduling.k8s.io/v1beta1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: priorityClassName,
+			Name: PriorityClassName,
 		},
 		// We would prefer to use the same value as system-node-critical (2000001000)
 		// but the highest value setable by a user is 1000000000

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -18,6 +18,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"github.com/tigera/operator/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -76,7 +78,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 4 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment)
 		// - 1 namespace
 		// - 1 PriorityClass
-		c, err := render.Calico(instance, nil, typhaNodeTLS, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, false)
+		c, err := render.Calico(instance, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, false)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(5 + 4 + 2 + 6 + 4 + 1 + 1))
 	})
@@ -89,9 +91,70 @@ var _ = Describe("Rendering tests", func() {
 		var nodeMetricsPort int32 = 9081
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		instance.Spec.NodeMetricsPort = &nodeMetricsPort
-		c, err := render.Calico(instance, nil, typhaNodeTLS, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, false)
+		c, err := render.Calico(instance, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, false)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(((5 + 4 + 2 + 6 + 4 + 1) + 1 + 1)))
+	})
+
+	It("should render all resources when variant is Tigera Secure and Management Cluster", func() {
+		// For this scenario, we expect the basic resources plus the following for Tigera Secure:
+		// - X Same as default config
+		// - 1 Service to expose calico/node metrics.
+		// - 1 ns (tigera-prometheus)
+		// - pass in managerTLSSecret
+		var nodeMetricsPort int32 = 9081
+		instance.Spec.Variant = operator.TigeraSecureEnterprise
+		instance.Spec.ClusterManagementType = operator.ClusterManagementTypeManagement
+		instance.Spec.NodeMetricsPort = &nodeMetricsPort
+
+		c, err := render.Calico(instance, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, false)
+		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
+
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{render.PriorityClassName, "", "scheduling.k8s.io", "v1beta1", "PriorityClass"},
+			{common.CalicoNamespace, "", "", "v1", "Namespace"},
+			{render.TyphaCAConfigMapName, render.OperatorNamespace(), "", "v1", "ConfigMap"},
+			{render.TyphaCAConfigMapName, common.CalicoNamespace, "", "v1", "ConfigMap"},
+			{render.TyphaTLSSecretName, render.OperatorNamespace(), "", "v1", "Secret"},
+			{render.NodeTLSSecretName, render.OperatorNamespace(), "", "v1", "Secret"},
+			{render.TyphaTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
+			{render.NodeTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
+			{render.ManagerTLSSecretName, render.OperatorNamespace(), "", "v1", "Secret"},
+			{render.TyphaServiceAccountName, common.CalicoNamespace, "", "v1", "ServiceAccount"},
+			{"calico-typha", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
+			{"calico-typha", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
+			{common.TyphaDeploymentName, common.CalicoNamespace, "", "v1", "Deployment"},
+			{render.TyphaServiceName, common.CalicoNamespace, "", "v1", "Service"},
+			{common.TyphaDeploymentName, common.CalicoNamespace, "policy", "v1beta1", "PodDisruptionBudget"},
+			{"calico-node", common.CalicoNamespace, "", "v1", "ServiceAccount"},
+			{"calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
+			{"calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
+			{"calico-node-metrics", common.CalicoNamespace, "", "v1", "Service"},
+			{"cni-config", common.CalicoNamespace, "", "v1", "ConfigMap"},
+			{common.NodeDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet"},
+			{"calico-kube-controllers", common.CalicoNamespace, "", "v1", "ServiceAccount"},
+			{"calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
+			{"calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
+			{"calico-kube-controllers", common.CalicoNamespace, "apps", "v1", "Deployment"},
+			{render.ManagerTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
+		}
+
+		var resources []runtime.Object
+		for _, component := range c.Render() {
+			var toCreate, _ = component.Objects()
+			resources = append(resources, toCreate...)
+		}
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+		for i, expectedRes := range expectedResources {
+			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+		}
 	})
 })
 


### PR DESCRIPTION
## Description

Manager-tls secret must be shared with compliance-server and kube-controllers. This will be added to the set of trusted certificates when making calls to retrieve compliance reports from a managed cluster. 

This change is required as we are currently using InsecureSkipVerify: true when making this request.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

```release-note
Verify TLS between management cluster components and managed clusters. 
```