### PR TITLE
Update the default cloudwatch fetch interval to 60sec

### DIFF
--- a/deploy/crds/operator_v1_logcollector_crd.yaml
+++ b/deploy/crds/operator_v1_logcollector_crd.yaml
@@ -40,7 +40,7 @@ spec:
                   properties:
                     fetchInterval:
                       description: 'Cloudwatch audit logs fetching interval in seconds.
-                        Default: 600'
+                        Default: 60'
                       format: int32
                       type: integer
                     groupName:

--- a/pkg/apis/operator/v1/logcollector_types.go
+++ b/pkg/apis/operator/v1/logcollector_types.go
@@ -99,7 +99,7 @@ type EksCloudwatchLogsSpec struct {
 	StreamPrefix string `json:"streamPrefix,omitempty"`
 
 	// Cloudwatch audit logs fetching interval in seconds.
-	// Default: 600
+	// Default: 60
 	// +optional
 	FetchInterval int32 `json:"fetchInterval,omitempty"`
 }

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -422,7 +422,7 @@ func getEksCloudwatchLogConfig(client client.Client, interval int32, region, gro
 	}
 
 	if interval == 0 {
-		interval = 600
+		interval = 60
 	}
 
 	secret := &corev1.Secret{}


### PR DESCRIPTION
## Description
Cloudwatch plugin for EKS reads 1MB of data for every 600s(default `fetchInterval`), overtime ES audit logs grows out of sync with cloudwatch logs. With 600sec `fetchInterval` if we do CRUD operation, the logs appear in cloudwatch immediately, but it never appear in ES audit index or appear after a long gap.

This PR reduces the `fetchInterval` to 60sec, it works fine on the test EKS cluster with minimal CRUD operation. There is no additional cost incurred as cloudwatch charges based on data stored and transferred.

PR for doc updates https://github.com/tigera/calico-private/pull/2091

Refer:
- https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/blob/4239db7b020dcab9d78a630dfc800394e6d2a4a2/lib/fluent/plugin/in_cloudwatch_logs.rb#L131

- https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/CloudWatchLogs/Client.html#get_log_events-instance_method

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
