### PR TITLE
Add operator support for RBAC for Flowviz for MCM.

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -16,16 +16,19 @@ package clusterconnection
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	"github.com/tigera/operator/pkg/controller/status"
 
 	"github.com/tigera/operator/pkg/controller/installation"
+	controllermanager "github.com/tigera/operator/pkg/controller/manager"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -87,6 +90,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return fmt.Errorf("%s failed to watch Network resource: %v", controllerName, err)
 	}
 
+	// Watch for changes to primary resource Manager
+	err = c.Watch(&source.Kind{Type: &operatorv1.Manager{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("%v failed to watch primary resource: %v", controllerName, err)
+	}
+
 	return nil
 }
 
@@ -125,7 +134,7 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 	// Fetch the managementClusterConnection.
 	mcc, err := GetClusterConnection(ctx, r.Client)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// If the resource is not found, we will not return an error. Instead, the watch on the resource will
 			// re-trigger the reconcile function when the situation changes.
 			if instl.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManaged {
@@ -145,6 +154,21 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 			operatorv1.ClusterManagementTypeManaged))
 	}
 
+	// Verify that the manager is not running.
+	_, err = controllermanager.GetManager(ctx, r.Client)
+	if err == nil {
+		// No error means that a manager was found. We do not allow both manager and guardian in the same cluster as
+		// they create overlapping resources. (The ns and sa for Guardian's impersonation).
+		err = errors.New("manager and management cluster connection should not be present at the same time")
+		log.Error(err, "")
+		r.status.SetDegraded("Manager and management cluster connection should not be present at the same time", err.Error())
+		return reconcile.Result{}, err
+	} else if !k8serrors.IsNotFound(err) {
+		log.Error(err, "Error querying Manager")
+		r.status.SetDegraded("Error querying Manager", err.Error())
+		return reconcile.Result{}, err
+	}
+
 	pullSecrets, err := utils.GetNetworkingPullSecrets(instl, r.Client)
 	if err != nil {
 		log.Error(err, "Error with Pull secrets")
@@ -157,7 +181,7 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 	err = r.Client.Get(ctx, types.NamespacedName{Name: render.GuardianSecretName, Namespace: render.OperatorNamespace()}, tunnelSecret)
 	if err != nil {
 		r.status.SetDegraded("Error copying secrets to the guardian namespace", err.Error())
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return result, nil
 		}
 		return result, err

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -16,6 +16,7 @@ package clusterconnection_test
 
 import (
 	"context"
+
 	"github.com/tigera/operator/pkg/controller/status"
 
 	"github.com/tigera/operator/pkg/controller/clusterconnection"
@@ -69,7 +70,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		mockStatus.On("ClearDegraded", mock.Anything)
 		mockStatus.On("OnCRFound").Return()
 
-		r = clusterconnection.NewReconcilerWithShims(c, scheme,mockStatus,operatorv1.ProviderNone)
+		r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone)
 		dpl = &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -108,7 +109,8 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				Spec: operatorv1.InstallationSpec{
 					Registry: "my-reg",
 					// The test is provider agnostic.
-					KubernetesProvider: operatorv1.ProviderNone,
+					KubernetesProvider:    operatorv1.ProviderNone,
+					ClusterManagementType: operatorv1.ClusterManagementTypeManaged,
 				},
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
 			})

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -79,9 +79,9 @@ func (c *GuardianComponent) Objects() ([]runtime.Object, []runtime.Object) {
 		CopySecrets(GuardianNamespace, c.tunnelSecret)[0],
 		// Add tigera-manager service account for impersonation
 		createNamespace(ManagerNamespace, c.openshift),
-		c.managerImpersonationServiceAccount(),
-		c.managerImpersonationClusterRole(),
-		c.managerImpersonationClusterRoleBinding(),
+		managerServiceAccount(),
+		managerClusterRole(true),
+		managerClusterRoleBinding(),
 	)
 
 	return objs, nil
@@ -279,54 +279,6 @@ func (c *GuardianComponent) container() []v1.Container {
 				PeriodSeconds:       5,
 			},
 			SecurityContext: securityContext(),
-		},
-	}
-}
-
-// This is a service account that is being impersonated when calls are made from the management cluster to do
-// subject access reviews in a managed cluster.
-func (c *GuardianComponent) managerImpersonationServiceAccount() *v1.ServiceAccount {
-	return &v1.ServiceAccount{
-		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: ManagerServiceAccount, Namespace: ManagerNamespace},
-	}
-}
-
-// The manager sa is being impersonated when calls are made from the management cluster to do
-// subject access reviews in a managed cluster.
-func (c *GuardianComponent) managerImpersonationClusterRole() *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ManagerClusterRole,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"authorization.k8s.io"},
-				Resources: []string{"subjectaccessreviews"},
-				Verbs:     []string{"create"},
-			},
-		},
-	}
-}
-
-// The manager sa is being impersonated when calls are made from the management cluster to do
-// subject access reviews in a managed cluster.
-func (c *GuardianComponent) managerImpersonationClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: ManagerClusterRoleBinding},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     ManagerClusterRole,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      ManagerServiceAccount,
-				Namespace: ManagerNamespace,
-			},
 		},
 	}
 }

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -77,6 +77,11 @@ func (c *GuardianComponent) Objects() ([]runtime.Object, []runtime.Object) {
 		c.deployment(),
 		c.service(),
 		CopySecrets(GuardianNamespace, c.tunnelSecret)[0],
+		// Add tigera-manager service account for impersonation
+		createNamespace(ManagerNamespace, c.openshift),
+		c.managerImpersonationServiceAccount(),
+		c.managerImpersonationClusterRole(),
+		c.managerImpersonationClusterRoleBinding(),
 	)
 
 	return objs, nil
@@ -274,6 +279,54 @@ func (c *GuardianComponent) container() []v1.Container {
 				PeriodSeconds:       5,
 			},
 			SecurityContext: securityContext(),
+		},
+	}
+}
+
+// This is a service account that is being impersonated when calls are made from the management cluster to do
+// subject access reviews in a managed cluster.
+func (c *GuardianComponent) managerImpersonationServiceAccount() *v1.ServiceAccount {
+	return &v1.ServiceAccount{
+		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: ManagerServiceAccount, Namespace: ManagerNamespace},
+	}
+}
+
+// The manager sa is being impersonated when calls are made from the management cluster to do
+// subject access reviews in a managed cluster.
+func (c *GuardianComponent) managerImpersonationClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ManagerClusterRole,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
+			},
+		},
+	}
+}
+
+// The manager sa is being impersonated when calls are made from the management cluster to do
+// subject access reviews in a managed cluster.
+func (c *GuardianComponent) managerImpersonationClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: ManagerClusterRoleBinding},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     ManagerClusterRole,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      ManagerServiceAccount,
+				Namespace: ManagerNamespace,
+			},
 		},
 	}
 }

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -76,6 +76,10 @@ var _ = Describe("Rendering tests", func() {
 			{name: render.GuardianDeploymentName, ns: render.GuardianNamespace, group: "apps", version: "v1", kind: "Deployment"},
 			{name: render.GuardianServiceName, ns: render.GuardianNamespace, group: "", version: "", kind: ""},
 			{name: render.GuardianSecretName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.ManagerNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 		}
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 		for i, expectedRes := range expectedResources {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -474,7 +474,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		LivenessProbe:   c.managerEsProxyProbe(),
 		SecurityContext: securityContext(),
 		VolumeMounts: []corev1.VolumeMount{
-			{Name: ManagerTLSSecretCertName, MountPath: "/manager-tls"},
+			{Name: ManagerTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true},
 		},
 	}
 

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -16,12 +16,13 @@ package render
 
 import (
 	"fmt"
+	"strconv"
+	"time"
+
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strconv"
-	"time"
 
 	ocsv1 "github.com/openshift/api/security/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,17 +34,21 @@ import (
 )
 
 const (
-	managerPort             = 9443
-	managerTargetPort       = 9443
-	ManagerNamespace        = "tigera-manager"
-	ManagerServiceDNS       = "tigera-manager.tigera-manager.svc"
-	ManagerServiceIP        = "localhost"
-	ManagerTLSSecretName    = "manager-tls"
-	ManagerSecretKeyName    = "key"
-	ManagerSecretCertName   = "cert"
-	ManagerOIDCConfig       = "tigera-manager-oidc-config"
-	ManagerOIDCWellknownURI = "/usr/share/nginx/html/.well-known"
-	ManagerOIDCJwksURI      = "/usr/share/nginx/html/discovery"
+	managerPort               = 9443
+	managerTargetPort         = 9443
+	ManagerNamespace          = "tigera-manager"
+	ManagerServiceDNS         = "tigera-manager.tigera-manager.svc"
+	ManagerServiceIP          = "localhost"
+	ManagerServiceAccount     = "tigera-manager"
+	ManagerClusterRole        = "tigera-manager-role"
+	ManagerClusterRoleBinding = "tigera-manager-binding"
+	ManagerTLSSecretName      = "manager-tls"
+	ManagerTLSSecretCertName  = "manager-tls-cert"
+	ManagerSecretKeyName      = "key"
+	ManagerSecretCertName     = "cert"
+	ManagerOIDCConfig         = "tigera-manager-oidc-config"
+	ManagerOIDCWellknownURI   = "/usr/share/nginx/html/.well-known"
+	ManagerOIDCJwksURI        = "/usr/share/nginx/html/discovery"
 
 	ElasticsearchManagerUserSecret = "tigera-ee-manager-elasticsearch-access"
 	tlsSecretHashAnnotation        = "hash.operator.tigera.io/tls-secret"
@@ -213,7 +218,7 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 			NodeSelector: map[string]string{
 				"beta.kubernetes.io/os": "linux",
 			},
-			ServiceAccountName: "tigera-manager",
+			ServiceAccountName: ManagerServiceAccount,
 			Tolerations:        c.managerTolerations(),
 			ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 			Containers: []corev1.Container{
@@ -259,6 +264,21 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
 					SecretName: ManagerTLSSecretName,
+				},
+			},
+		},
+		{
+			// We only want to mount the cert, not the private key to es-proxy to establish a connection with voltron.
+			Name: ManagerTLSSecretCertName,
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: ManagerTLSSecretName,
+					Items: []v1.KeyToPath{
+						{
+							Key:  "cert",
+							Path: "cert",
+						},
+					},
 				},
 			},
 		},
@@ -453,6 +473,9 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		Image:           components.GetReference(components.ComponentEsProxy, c.installation.Spec.Registry, c.installation.Spec.ImagePath),
 		LivenessProbe:   c.managerEsProxyProbe(),
 		SecurityContext: securityContext(),
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: ManagerTLSSecretCertName, MountPath: "/manager-tls"},
+		},
 	}
 
 	return apiServer
@@ -517,7 +540,7 @@ func voltronTunnelSecret() *v1.Secret {
 func (c *managerComponent) managerServiceAccount() *v1.ServiceAccount {
 	return &v1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: ManagerNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: ManagerServiceAccount, Namespace: ManagerNamespace},
 	}
 }
 
@@ -526,7 +549,7 @@ func (c *managerComponent) managerClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tigera-manager-role",
+			Name: ManagerClusterRole,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -553,16 +576,16 @@ func (c *managerComponent) managerClusterRole() *rbacv1.ClusterRole {
 func (c *managerComponent) managerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager-binding"},
+		ObjectMeta: metav1.ObjectMeta{Name: ManagerClusterRoleBinding},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "tigera-manager-role",
+			Name:     ManagerClusterRole,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "tigera-manager",
+				Name:      ManagerServiceAccount,
 				Namespace: ManagerNamespace,
 			},
 		},
@@ -627,7 +650,7 @@ func (c *managerComponent) managerPolicyImpactPreviewClusterRoleBinding() *rbacv
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "tigera-manager",
+				Name:      ManagerServiceAccount,
 				Namespace: ManagerNamespace,
 			},
 		},

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -152,9 +152,9 @@ func (c *managerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs = append(objs, copyImagePullSecrets(c.pullSecrets, common.TigeraPrometheusNamespace)...)
 
 	objs = append(objs,
-		c.managerServiceAccount(),
-		c.managerClusterRole(),
-		c.managerClusterRoleBinding(),
+		managerServiceAccount(),
+		managerClusterRole(false),
+		managerClusterRoleBinding(),
 		c.managerPolicyImpactPreviewClusterRole(),
 		c.managerPolicyImpactPreviewClusterRoleBinding(),
 	)
@@ -268,21 +268,6 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 			},
 		},
 		{
-			// We only want to mount the cert, not the private key to es-proxy to establish a connection with voltron.
-			Name: ManagerTLSSecretCertName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: ManagerTLSSecretName,
-					Items: []v1.KeyToPath{
-						{
-							Key:  "cert",
-							Path: "cert",
-						},
-					},
-				},
-			},
-		},
-		{
 			Name: KibanaPublicCertSecret,
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
@@ -313,6 +298,25 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 		},
 	}
 
+	if c.management {
+		v = append(v,
+			v1.Volume{
+				// We only want to mount the cert, not the private key to es-proxy to establish a connection with voltron.
+				Name: ManagerTLSSecretCertName,
+				VolumeSource: v1.VolumeSource{
+					Secret: &v1.SecretVolumeSource{
+						SecretName: ManagerTLSSecretName,
+						Items: []v1.KeyToPath{
+							{
+								Key:  "cert",
+								Path: "cert",
+							},
+						},
+					},
+				},
+			},
+		)
+	}
 	if c.oidcConfig != nil {
 		defaultMode := int32(420)
 		v = append(v,
@@ -473,11 +477,12 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		Image:           components.GetReference(components.ComponentEsProxy, c.installation.Spec.Registry, c.installation.Spec.ImagePath),
 		LivenessProbe:   c.managerEsProxyProbe(),
 		SecurityContext: securityContext(),
-		VolumeMounts: []corev1.VolumeMount{
-			{Name: ManagerTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true},
-		},
 	}
-
+	if c.management {
+		apiServer.VolumeMounts = []corev1.VolumeMount{
+			{Name: ManagerTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true},
+		}
+	}
 	return apiServer
 }
 
@@ -537,7 +542,7 @@ func voltronTunnelSecret() *v1.Secret {
 }
 
 // managerServiceAccount creates the serviceaccount used by the Tigera Secure web app.
-func (c *managerComponent) managerServiceAccount() *v1.ServiceAccount {
+func managerServiceAccount() *v1.ServiceAccount {
 	return &v1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: ManagerServiceAccount, Namespace: ManagerNamespace},
@@ -545,35 +550,44 @@ func (c *managerComponent) managerServiceAccount() *v1.ServiceAccount {
 }
 
 // managerClusterRole returns a clusterrole that allows authn/authz review requests.
-func (c *managerComponent) managerClusterRole() *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
+// This role can also be used in mcm for impersonation purposes only.
+func managerClusterRole(impersonationOnly bool) *rbacv1.ClusterRole {
+	cr := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ManagerClusterRole,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{"authentication.k8s.io"},
-				Resources: []string{"tokenreviews"},
-				Verbs:     []string{"create"},
-			},
-			{
 				APIGroups: []string{"authorization.k8s.io"},
 				Resources: []string{"subjectaccessreviews"},
 				Verbs:     []string{"create"},
 			},
-			{
+		},
+	}
+
+	if !impersonationOnly {
+		cr.Rules = append(cr.Rules,
+			rbacv1.PolicyRule{
+
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			},
+			rbacv1.PolicyRule{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},
 				Verbs:     []string{"list", "get", "watch", "update"},
 			},
-		},
+		)
 	}
+
+	return cr
 }
 
 // managerClusterRoleBinding returns a clusterrolebinding that gives the tigera-manager serviceaccount
 // the permissions in the tigera-manager-role.
-func (c *managerComponent) managerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+func managerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: ManagerClusterRoleBinding},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -77,8 +77,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: render.ManagerTLSSecretName, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Service"},
 			{name: render.ComplianceServerCertSecret, ns: render.ManagerNamespace, group: "", version: "", kind: ""},
-			{name: render.VoltronTunnelSecretName, ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
-			{name: render.VoltronTunnelSecretName, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Deployment"},
 		}
 
@@ -134,9 +132,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(render.ManagerOIDCConfig))
 		Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal(render.ManagerOIDCJwksURI))
 
-		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(7))
-		Expect(d.Spec.Template.Spec.Volumes[5].Name).To(Equal(render.ManagerOIDCConfig))
-		Expect(d.Spec.Template.Spec.Volumes[5].ConfigMap.Name).To(Equal(render.ManagerOIDCConfig))
+		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(6))
+		Expect(d.Spec.Template.Spec.Volumes[4].Name).To(Equal(render.ManagerOIDCConfig))
+		Expect(d.Spec.Template.Spec.Volumes[4].ConfigMap.Name).To(Equal(render.ManagerOIDCConfig))
 	})
 
 	It("should set OIDC Authority environment when auth-type is OIDC", func() {
@@ -151,7 +149,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 		d := resources[expectedResourcesNumber-1].(*v1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
-		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(6))
+		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(5))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
 		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
 	})


### PR DESCRIPTION
When a user is not allowed to list pods/endpoints in a given namespace, it should also not see them in the flow visualization in the manager UI. This feature was implemented in an earlier release and now made compatible with multi-cluster management.

When a given user makes a request in the UI from the management cluster to a managed cluster, an rbac call will be made in the managed cluster by guardian, while impersonating the tigera-manager. For that reason we need the sa & ns & rbac to be setup there.