### PR TITLE
Add check that BGP metrics server is up to readiness probe.

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -19,7 +19,7 @@ components:
     version: v3.0.0-0.dev-23-g664fa65
   cnx-node:
     image: tigera/cnx-node
-    version: v3.0.0-0.dev-79-gccc948e
+    version: v3.0.0-0.dev-80-g032b7f3
   fluentd:
     image: tigera/fluentd
     version: v3.0.0-0.dev-1-ge3d709f

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -19,7 +19,7 @@ components:
     version: v3.0.0-0.dev-23-g664fa65
   cnx-node:
     image: tigera/cnx-node
-    version: v2.7.0-0.dev-300-ge5619d5
+    version: v3.0.0-0.dev-79-gccc948e
   fluentd:
     image: tigera/fluentd
     version: v3.0.0-0.dev-1-ge3d709f

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -157,8 +157,8 @@ var (
 	
 	
 	ComponentTigeraNode = component{
-		Version: "v3.0.0-0.dev-79-gccc948e",
-		Digest:  "sha256:00901a322278c0a7abdd07bf3665e4779e9327d1103e0cdd9fe1066d104254ca",
+		Version: "v3.0.0-0.dev-80-g032b7f3",
+		Digest:  "sha256:6272729e8e1c4b625eca37e58bb8e1eb2a715388e133b38142553160bc357257",
 		Image:   "tigera/cnx-node",
 	}
 	

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -18,7 +18,7 @@ var (
 	
 	ComponentAPIServer = component{
 		Version: "v3.0.0-0.dev-29-g11260416",
-		Digest:  "sha256:9162e4a672b82e91776f2b477cb5306dd42f8e0d784c1962e8dd1954018f5900",
+		Digest:  "sha256:b8a1e376eb52e8add42d93fc975ff3550136afa436c3a414f89f588b1393ecea",
 		Image:   "tigera/cnx-apiserver",
 	}
 	
@@ -157,8 +157,8 @@ var (
 	
 	
 	ComponentTigeraNode = component{
-		Version: "v2.7.0-0.dev-300-ge5619d5",
-		Digest:  "sha256:2b7434aedd81e84b9dccc14608f0af099c4f1e6926375b8ca0c8b646934ad064",
+		Version: "v3.0.0-0.dev-79-gccc948e",
+		Digest:  "sha256:00901a322278c0a7abdd07bf3665e4779e9327d1103e0cdd9fe1066d104254ca",
 		Image:   "tigera/cnx-node",
 	}
 	

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -953,7 +953,7 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 	// Determine liveness and readiness configuration for node.
 	livenessPort := intstr.FromInt(9099)
-	readinessCmd := []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
+	readinessCmd := []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
 
 	// if not using calico networking, don't check bird status (or bgp metrics server).
 	if c.netConfig.CNI != CNICalico {

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -953,9 +953,9 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 	// Determine liveness and readiness configuration for node.
 	livenessPort := intstr.FromInt(9099)
-	readinessCmd := []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
+	readinessCmd := []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
 
-	// if not using calico networking, don't check bird status.
+	// if not using calico networking, don't check bird status (or bgp metrics server).
 	if c.netConfig.CNI != CNICalico {
 		readinessCmd = []string{"/bin/calico-node", "-felix-ready"}
 	}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -955,6 +955,11 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 	livenessPort := intstr.FromInt(9099)
 	readinessCmd := []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
 
+	// want to check for BGP metrics server if this is enterprise
+	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
+		readinessCmd = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
+	}
+
 	// if not using calico networking, don't check bird status (or bgp metrics server).
 	if c.netConfig.CNI != CNICalico {
 		readinessCmd = []string{"/bin/calico-node", "-felix-ready"}
@@ -965,7 +970,12 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 		// Additionally, since the node readiness probe doesn't yet support
 		// custom ports, we need to disable felix readiness for now.
 		livenessPort = intstr.FromInt(9199)
-		readinessCmd = []string{"/bin/calico-node", "-bird-ready"}
+
+		if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
+			readinessCmd = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
+		} else {
+			readinessCmd = []string{"/bin/calico-node", "-bird-ready"}
+		}
 	}
 	lp := &v1.Probe{
 		Handler: v1.Handler{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -996,7 +996,7 @@ var _ = Describe("Node rendering tests", func() {
 // verifyProbes asserts the expected node liveness and readiness probe.
 func verifyProbes(ds *apps.DaemonSet, isOpenshift bool) {
 	// Verify readiness and liveness probes.
-	expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}}}}
+	expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}}}}
 	expectedLiveness := &v1.Probe{Handler: v1.Handler{
 		HTTPGet: &v1.HTTPGetAction{
 			Host: "localhost",

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -996,7 +996,7 @@ var _ = Describe("Node rendering tests", func() {
 // verifyProbes asserts the expected node liveness and readiness probe.
 func verifyProbes(ds *apps.DaemonSet, isOpenshift bool) {
 	// Verify readiness and liveness probes.
-	expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}}}}
+	expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}}}}
 	expectedLiveness := &v1.Probe{Handler: v1.Handler{
 		HTTPGet: &v1.HTTPGetAction{
 			Host: "localhost",


### PR DESCRIPTION
## Description
- Add check that BGP metrics server is up to readiness probe.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
