### PR TITLE
Remove annotations for secret

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -672,11 +672,6 @@ func complianceVolumes(defaultMode int32, managerSecret *corev1.Secret) []corev1
 func complianceAnnotations(c *complianceComponent) map[string]string {
 	var annotations = map[string]string{
 		complianceServerTLSHashAnnotation: AnnotationHash(c.complianceServerCertSecrets[0].Data),
-		ManagerTLSHashAnnotation:          AnnotationHash(c.managerSecret),
-	}
-
-	if c.managerSecret != nil {
-		annotations[ManagerTLSHashAnnotation] = AnnotationHash(c.managerSecret)
 	}
 
 	return annotations

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -245,7 +245,6 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 					Labels: map[string]string{
 						"k8s-app": "calico-kube-controllers",
 					},
-					Annotations: kubeControllerAnnotations(c),
 				},
 				Spec: v1.PodSpec{
 					NodeSelector: map[string]string{
@@ -285,16 +284,6 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 	}
 
 	return &d
-}
-
-func kubeControllerAnnotations(c *kubeControllersComponent) map[string]string {
-	var annotations = make(map[string]string)
-
-	if c.managerSecret != nil {
-		annotations[ManagerTLSHashAnnotation] = AnnotationHash(c.managerSecret)
-	}
-
-	return annotations
 }
 
 func kubeControllersVolumeMounts(managerSecret *v1.Secret) []v1.VolumeMount {


### PR DESCRIPTION
## Description

Removing annotations for manager-secret tls as the compliance and kube-controllers are restarted continuously by operator.

Please see the large number of replica sets for compliance and kube-controllers

![perpetum_mobile](https://user-images.githubusercontent.com/41362174/80550579-682a4100-8975-11ea-954f-1b0c5332e413.png)


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
