### PR TITLE
Update voltron's pin

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -4,7 +4,7 @@ components:
     version: v3.0.0-0.dev-138-g711599c3
   voltron:
     image: tigera/voltron
-    version: v3.0.0-0.dev-8-g4197ee4
+    version: v3.0.0-0.dev-9-ge9b5d1c
   cnx-apiserver:
     image: tigera/cnx-apiserver
     version: v3.0.0-0.dev-32-g771e07c7

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -101,7 +101,7 @@ var (
 	}
 
 	ComponentManagerProxy = component{
-		Version: "v3.0.0-0.dev-8-g4197ee4",
+		Version: "v3.0.0-0.dev-9-ge9b5d1c",
 		Image:   "tigera/voltron",
 	}
 


### PR DESCRIPTION
## Description

Update voltron's pin to `v3.0.0-0.dev-9-ge9b5d1c`

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
