### PR TITLE
Increase timeout for liveness and readiness probe for fluentD

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -45,17 +45,17 @@ const (
 	ElasticsearchLogCollectorUserSecret      = "tigera-fluentd-elasticsearch-access"
 	ElasticsearchEksLogForwarderUserSecret   = "tigera-eks-log-forwarder-elasticsearch-access"
 	EksLogForwarderSecret                    = "tigera-eks-log-forwarder-secret"
-	EksLogForwarderAwsId                     = "aws-id"
-	EksLogForwarderAwsKey                    = "aws-key"
-	eksLogForwarderName                      = "eks-log-forwarder"
-	SplunkFluentdTokenSecretName             = "logcollector-splunk-credentials"
-	SplunkFluentdSecretTokenKey              = "token"
-	SplunkFluentdCertificateSecretName       = "logcollector-splunk-public-certificate"
-	SplunkFluentdSecretCertificateKey        = "ca.pem"
-	SplunkFluentdSecretsVolName              = "splunk-certificates"
-	SplunkFluentdDefaultCertDir              = "/etc/ssl/splunk/"
-	SplunkFluentdDefaultCertPath             = SplunkFluentdDefaultCertDir + SplunkFluentdSecretCertificateKey
-
+	EksLogForwarderAwsId               = "aws-id"
+	EksLogForwarderAwsKey              = "aws-key"
+	eksLogForwarderName                = "eks-log-forwarder"
+	SplunkFluentdTokenSecretName       = "logcollector-splunk-credentials"
+	SplunkFluentdSecretTokenKey        = "token"
+	SplunkFluentdCertificateSecretName = "logcollector-splunk-public-certificate"
+	SplunkFluentdSecretCertificateKey  = "ca.pem"
+	SplunkFluentdSecretsVolName        = "splunk-certificates"
+	SplunkFluentdDefaultCertDir        = "/etc/ssl/splunk/"
+	SplunkFluentdDefaultCertPath       = SplunkFluentdDefaultCertDir + SplunkFluentdSecretCertificateKey
+	ProbeTimeoutSeconds                = 5
 )
 
 type FluentdFilters struct {
@@ -197,7 +197,7 @@ func (c *fluentdComponent) splunkCredentialSecret() []*corev1.Secret {
 			Namespace: LogCollectorNamespace,
 		},
 		Data: map[string][]byte{
-			SplunkFluentdSecretTokenKey:     c.splkCredential.Token,
+			SplunkFluentdSecretTokenKey: c.splkCredential.Token,
 		},
 	}
 
@@ -211,7 +211,7 @@ func (c *fluentdComponent) splunkCredentialSecret() []*corev1.Secret {
 				Namespace: LogCollectorNamespace,
 			},
 			Data: map[string][]byte{
-				SplunkFluentdSecretCertificateKey:     c.splkCredential.Certificate,
+				SplunkFluentdSecretCertificateKey: c.splkCredential.Certificate,
 			},
 		}
 		splunkSecrets = append(splunkSecrets, certificate)
@@ -314,8 +314,8 @@ func (c *fluentdComponent) container() corev1.Container {
 	if c.splkCredential != nil && len(c.splkCredential.Certificate) != 0 {
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
-				Name:       SplunkFluentdSecretsVolName,
-				MountPath:  SplunkFluentdDefaultCertDir,
+				Name:      SplunkFluentdSecretsVolName,
+				MountPath: SplunkFluentdDefaultCertDir,
 			})
 	}
 
@@ -457,6 +457,7 @@ func (c *fluentdComponent) liveness() *corev1.Probe {
 				Command: []string{"sh", "-c", "/bin/liveness.sh"},
 			},
 		},
+		TimeoutSeconds: ProbeTimeoutSeconds,
 	}
 }
 
@@ -467,6 +468,7 @@ func (c *fluentdComponent) readiness() *corev1.Probe {
 				Command: []string{"sh", "-c", "/bin/readiness.sh"},
 			},
 		},
+		TimeoutSeconds: ProbeTimeoutSeconds,
 	}
 }
 


### PR DESCRIPTION
## Description

Increase the timeout to 5 seconds for the readiness and liveness probe. FluentD makes 2 HTTP requests to determine the size of the buffer. These checks are used for the liveness and readiness probe.

```
/ # time curl -s http://localhost:24220/api/plugins.json
{"plugins":[{"plugin_id":"object:2b1633739348","plugin_category":"input","type":"monitor_agent","config":{"@type":"monitor_agent","bind":"127.0.0.1","port":"24220"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_flow_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_flow_logs","path":"/var/log/calico/flowlogs/flows.log","read_from_head":"true","pos_file":"/var/log/calico/flows.log.pos","tag":"flows","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_dns_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_dns_logs","path":"/var/log/calico/dnslogs/dns.log","read_from_head":"true","pos_file":"/var/log/calico/dns.log.pos","tag":"dns","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b163362c52c","plugin_category":"input","type":"tail","config":{"@type":"tail","path":"/var/log/calico/audit/tsee-audit.log","read_from_head":"true","pos_file":"/var/log/calico/tsee-audit.log.pos","tag":"audit.tsee","emit_unmatched_lines":"false","format":"json","time_key":"time","time_format":"%Y-%m-%dT%H:%M:%S.%N%z"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16333cf4f0","plugin_category":"input","type":"tail","config":{"@type":"tail","path":"/var/log/calico/audit/kube-audit.log","pos_file":"/var/log/calico/kube-audit.log.pos","tag":"audit.kube","emit_unmatched_lines":"false","format":"json","time_key":"time","time_format":"%Y-%m-%dT%H:%M:%S.%N%z"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_compliance_report_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_compliance_report_logs","path":"/var/log/calico/compliance/compliance.*.reports.log","read_from_head":"true","pos_file":"/var/log/calico/compliance.reports.log.pos","tag":"compliance.reports","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_bird_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_bird_logs","path":"/var/log/calico/bird/current","read_from_head":"true","pos_file":"/var/log/calico/bird.log.pos","tag":"bird","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_bird6_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_bird6_logs","path":"/var/log/calico/bird6/current","read_from_head":"true","pos_file":"/var/log/calico/bird6.log.pos","tag":"bird6","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16337a4e90","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b1633032ef0","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_flows.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_flows.template","template_name":"tigera_secure_ee_flows","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[1588723200],"buffer_total_queued_size":0,"retry_count":0,"emit_records":140,"emit_count":2,"write_count":2,"rollback_count":0,"slow_flush_count":0,"flush_time_count":631,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"buffer_oldest_timekey":1588723200,"buffer_newest_timekey":1588723200,"retry":{}},{"plugin_id":"object:2b163366c334","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b1633668720","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_dns.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_dns.template","template_name":"tigera_secure_ee_dns","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[1588723200],"buffer_total_queued_size":0,"retry_count":0,"emit_records":117,"emit_count":2,"write_count":2,"rollback_count":0,"slow_flush_count":0,"flush_time_count":468,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"buffer_oldest_timekey":1588723200,"buffer_newest_timekey":1588723200,"retry":{}},{"plugin_id":"object:2b16333fb410","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b16330eba7c","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_audit_ee.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_audits.template","template_name":"tigera_secure_ee_audit","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[],"buffer_total_queued_size":0,"retry_count":0,"emit_records":0,"emit_count":0,"write_count":0,"rollback_count":0,"slow_flush_count":0,"flush_time_count":0,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"retry":{}},{"plugin_id":"object:2b163330b050","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b16332fd388","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_audit_kube.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_audits.template","template_name":"tigera_secure_ee_audit","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[],"buffer_total_queued_size":0,"retry_count":0,"emit_records":0,"emit_count":0,"write_count":0,"rollback_count":0,"slow_flush_count":0,"flush_time_count":0,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"retry":{}},{"plugin_id":"object:2b1633004910","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b1632ff2a58","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_bgp.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_bgp.template","template_name":"tigera_secure_ee_bgp","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[1588723200],"buffer_total_queued_size":0,"retry_count":0,"emit_records":25,"emit_count":2,"write_count":2,"rollback_count":0,"slow_flush_count":0,"flush_time_count":269,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"buffer_oldest_timekey":1588723200,"buffer_newest_timekey":1588723200,"retry":{}},{"plugin_id":"object:2b16336e7160","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16336ede98","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16336ec3b8","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer","enable_ruby":""},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b1633727314","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b163328a7c0","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b163377099c","plugin_category":"filter","type":"grep","config":{"@type":"grep"},"output_plugin":false,"retry_count":null}]}
real	0m 1.30s
user	0m 0.03s
sys	0m 0.00s
/ # time curl -s http://localhost:24220/api/plugins.json
{"plugins":[{"plugin_id":"object:2b1633739348","plugin_category":"input","type":"monitor_agent","config":{"@type":"monitor_agent","bind":"127.0.0.1","port":"24220"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_flow_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_flow_logs","path":"/var/log/calico/flowlogs/flows.log","read_from_head":"true","pos_file":"/var/log/calico/flows.log.pos","tag":"flows","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_dns_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_dns_logs","path":"/var/log/calico/dnslogs/dns.log","read_from_head":"true","pos_file":"/var/log/calico/dns.log.pos","tag":"dns","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b163362c52c","plugin_category":"input","type":"tail","config":{"@type":"tail","path":"/var/log/calico/audit/tsee-audit.log","read_from_head":"true","pos_file":"/var/log/calico/tsee-audit.log.pos","tag":"audit.tsee","emit_unmatched_lines":"false","format":"json","time_key":"time","time_format":"%Y-%m-%dT%H:%M:%S.%N%z"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16333cf4f0","plugin_category":"input","type":"tail","config":{"@type":"tail","path":"/var/log/calico/audit/kube-audit.log","pos_file":"/var/log/calico/kube-audit.log.pos","tag":"audit.kube","emit_unmatched_lines":"false","format":"json","time_key":"time","time_format":"%Y-%m-%dT%H:%M:%S.%N%z"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_compliance_report_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_compliance_report_logs","path":"/var/log/calico/compliance/compliance.*.reports.log","read_from_head":"true","pos_file":"/var/log/calico/compliance.reports.log.pos","tag":"compliance.reports","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_bird_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_bird_logs","path":"/var/log/calico/bird/current","read_from_head":"true","pos_file":"/var/log/calico/bird.log.pos","tag":"bird","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"in_tail_bird6_logs","plugin_category":"input","type":"tail","config":{"@type":"tail","@id":"in_tail_bird6_logs","path":"/var/log/calico/bird6/current","read_from_head":"true","pos_file":"/var/log/calico/bird6.log.pos","tag":"bird6","emit_unmatched_lines":"false"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16337a4e90","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b1633032ef0","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_flows.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_flows.template","template_name":"tigera_secure_ee_flows","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[1588723200],"buffer_total_queued_size":0,"retry_count":0,"emit_records":140,"emit_count":2,"write_count":2,"rollback_count":0,"slow_flush_count":0,"flush_time_count":631,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"buffer_oldest_timekey":1588723200,"buffer_newest_timekey":1588723200,"retry":{}},{"plugin_id":"object:2b163366c334","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b1633668720","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_dns.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_dns.template","template_name":"tigera_secure_ee_dns","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[1588723200],"buffer_total_queued_size":0,"retry_count":0,"emit_records":117,"emit_count":2,"write_count":2,"rollback_count":0,"slow_flush_count":0,"flush_time_count":468,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"buffer_oldest_timekey":1588723200,"buffer_newest_timekey":1588723200,"retry":{}},{"plugin_id":"object:2b16333fb410","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b16330eba7c","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_audit_ee.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_audits.template","template_name":"tigera_secure_ee_audit","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[],"buffer_total_queued_size":0,"retry_count":0,"emit_records":0,"emit_count":0,"write_count":0,"rollback_count":0,"slow_flush_count":0,"flush_time_count":0,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"retry":{}},{"plugin_id":"object:2b163330b050","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b16332fd388","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_audit_kube.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_audits.template","template_name":"tigera_secure_ee_audit","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[],"buffer_total_queued_size":0,"retry_count":0,"emit_records":0,"emit_count":0,"write_count":0,"rollback_count":0,"slow_flush_count":0,"flush_time_count":0,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"retry":{}},{"plugin_id":"object:2b1633004910","plugin_category":"output","type":"copy","config":{"@type":"copy"},"output_plugin":false,"retry_count":0},{"plugin_id":"object:2b1632ff2a58","plugin_category":"output","type":"elasticsearch","config":{"@type":"elasticsearch","host":"tigera-secure-es-http.tigera-elasticsearch.svc","port":"9200","scheme":"https","user":"tigera-fluentd","password":"xxxxxx","ca_file":"/etc/fluentd/elastic/ca.pem","ssl_verify":"true","ssl_version":"TLSv1_2","reload_connections":"false","reload_on_failure":"false","reconnect_on_error":"true","index_name":"tigera_secure_ee_bgp.cluster.%Y%m%d","template_file":"/fluentd/etc/elastic_mapping_bgp.template","template_name":"tigera_secure_ee_bgp","template_overwrite":"true"},"output_plugin":true,"buffer_queue_length":0,"buffer_timekeys":[1588723200],"buffer_total_queued_size":0,"retry_count":0,"emit_records":25,"emit_count":2,"write_count":2,"rollback_count":0,"slow_flush_count":0,"flush_time_count":269,"buffer_stage_length":0,"buffer_stage_byte_size":0,"buffer_queue_byte_size":0,"buffer_available_buffer_space_ratios":100.0,"buffer_oldest_timekey":1588723200,"buffer_newest_timekey":1588723200,"retry":{}},{"plugin_id":"object:2b16336e7160","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16336ede98","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b16336ec3b8","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer","enable_ruby":""},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b1633727314","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b163328a7c0","plugin_category":"filter","type":"record_transformer","config":{"@type":"record_transformer"},"output_plugin":false,"retry_count":null},{"plugin_id":"object:2b163377099c","plugin_category":"filter","type":"grep","config":{"@type":"grep"},"output_plugin":false,"retry_count":null}]}
real	0m 1.48s
user	0m 0.01s
sys	0m 0.00s
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
