### PR TITLE
Fix setting of degraded bit in status manager

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -545,7 +545,6 @@ func (m *statusManager) setDegraded(reason, msg string) {
 	conditions := []operator.TigeraStatusCondition{
 		{Type: operator.ComponentDegraded, Status: operator.ConditionTrue, Reason: reason, Message: msg},
 	}
-	m.degraded = true
 	m.set(conditions...)
 }
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

I think this is a bug - it's not symmetrical with the other related
functions.

The `m.degraded` bit, if I understand correctly, is intended just for
explicit degraded states from the controller.

`setDegraded` shouldn't modify internal status manager state, it should
just update the CR without any side effects.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.