### PR TITLE
packetSize option gets ignored

### DIFF
--- a/deploy/crds/operator_v1_logcollector_crd.yaml
+++ b/deploy/crds/operator_v1_logcollector_crd.yaml
@@ -99,7 +99,7 @@ spec:
                     endpoint:
                       description: 'Location of the syslog server. example: tcp://1.2.3.4:601'
                       type: string
-                    packetsize:
+                    packetSize:
                       description: 'PacketSize defines the maximum size of packets
                         to send to syslog. In general this is only needed if you notice
                         long logs being truncated. Default: 1024'

--- a/pkg/apis/operator/v1/logcollector_types.go
+++ b/pkg/apis/operator/v1/logcollector_types.go
@@ -76,7 +76,7 @@ type SyslogStoreSpec struct {
 	// In general this is only needed if you notice long logs being truncated.
 	// Default: 1024
 	// +optional
-	PacketSize *int32 `json:"packetsize,omitempty"`
+	PacketSize *int32 `json:"packetSize,omitempty"`
 }
 
 // SplunkStoreSpec defines configuration for exporting logs to splunk.


### PR DESCRIPTION
## Description

This is perhaps slightly controversial.  I also haven't ran make gen-files at this point.

The casing of this field is wrong: it ought to have an uppercase S.  A consequence of this is, that for at least some k8s versions (I'm enquiring which this problem was seen in) you can set the packetSize field (which one of the docs says to do) and the operator ignores it silently.

Regardless of whether this is merged or not, the docs are inconsistent (both packetsize and packetSize appear) and must be fixed.  I would argue that we messed up when we created this option and that packetSize is correct, but I don't know what the impact of changing the field is.

If it's a completely horrible upgrade process, it might make sense for us to just embrace the old "packetsize" name.  If not, I'd rather make it consistent with all the other fields.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
