### PR TITLE
Remove hardcoded registry path in tests

### DIFF
--- a/pkg/components/images_test.go
+++ b/pkg/components/images_test.go
@@ -24,13 +24,13 @@ var _ = Describe("No registry override", func() {
 		Expect(GetReference(ComponentCalicoNode, "", "")).To(Equal("docker.io/calico/node:" + ComponentCalicoNode.Version))
 	})
 	It("should render a tigera image correctly", func() {
-		Expect(GetReference(ComponentTigeraNode, "", "")).To(Equal("gcr.io/unique-caldron-775/cnx/tigera/cnx-node:" + ComponentTigeraNode.Version))
+		Expect(GetReference(ComponentTigeraNode, "", "")).To(Equal(TigeraRegistry + "tigera/cnx-node:" + ComponentTigeraNode.Version))
 	})
 	It("should render an ECK image correctly", func() {
 		Expect(GetReference(ComponentElasticsearchOperator, "", "")).To(Equal("docker.elastic.co/eck/eck-operator:" + ComponentElasticsearchOperator.Version))
 	})
 	It("should render an operator init image correctly", func() {
-		Expect(GetOperatorInitReference("", "")).To(Equal("gcr.io/unique-caldron-775/cnx/tigera/operator-init:" + ComponentOperatorInit.Version))
+		Expect(GetOperatorInitReference("", "")).To(Equal(TigeraRegistry + "tigera/operator-init:" + ComponentOperatorInit.Version))
 	})
 })
 
@@ -53,13 +53,13 @@ var _ = Describe("imagepath override", func() {
 		Expect(GetReference(ComponentCalicoNode, "", "userpath")).To(Equal("docker.io/userpath/node:" + ComponentCalicoNode.Version))
 	})
 	It("should render a tigera image correctly", func() {
-		Expect(GetReference(ComponentTigeraNode, "", "userpath")).To(Equal("gcr.io/unique-caldron-775/cnx/userpath/cnx-node:" + ComponentTigeraNode.Version))
+		Expect(GetReference(ComponentTigeraNode, "", "userpath")).To(Equal(TigeraRegistry + "userpath/cnx-node:" + ComponentTigeraNode.Version))
 	})
 	It("should render an ECK image correctly", func() {
 		Expect(GetReference(ComponentElasticsearchOperator, "", "userpath")).To(Equal("docker.elastic.co/userpath/eck-operator:" + ComponentElasticsearchOperator.Version))
 	})
 	It("should render an operator init image correctly", func() {
-		Expect(GetOperatorInitReference("", "userpath")).To(Equal("gcr.io/unique-caldron-775/cnx/userpath/operator-init:" + ComponentOperatorInit.Version))
+		Expect(GetOperatorInitReference("", "userpath")).To(Equal(TigeraRegistry + "userpath/operator-init:" + ComponentOperatorInit.Version))
 	})
 })
 var _ = Describe("registry and imagepath override", func() {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -81,9 +81,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 
 		deployment := resources[expectedResourcesNumber-1].(*appsv1.Deployment)
-		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/cnx-manager:" + components.ComponentManager.Version))
-		Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/es-proxy:" + components.ComponentEsProxy.Version))
-		Expect(deployment.Spec.Template.Spec.Containers[2].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/voltron:" + components.ComponentManagerProxy.Version))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(components.TigeraRegistry + "tigera/cnx-manager:" + components.ComponentManager.Version))
+		Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal(components.TigeraRegistry + "tigera/es-proxy:" + components.ComponentEsProxy.Version))
+		Expect(deployment.Spec.Template.Spec.Containers[2].Image).Should(Equal(components.TigeraRegistry + "tigera/voltron:" + components.ComponentManagerProxy.Version))
 
 		// Expect 1 volume mounts for es proxy
 		var esProxy = deployment.Spec.Template.Spec.Containers[1]


### PR DESCRIPTION
## Description

Updating the tests to not use hardcoded registry paths so that changing the `TigeraRegistry` path doesn't fail tests.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
