### PR TITLE
Add instructions to update registry for enterprise images

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,8 @@ Checkout the branch from which you want to release. For a major or minor release
 you will need to create a new `release-vX.Y` branch based on the target minor version.
 
 Make sure the appropriate versions have been updated in `config/ee_versions.yaml` or `config/os_versions.yaml`
-and then `make gen-versions` has been ran and the resulting updates have been committed.
+and then `make gen-versions` has been ran and the resulting updates have been committed. When updating versions
+for enterprise, if necessary also update the `TigeraRegistry` field in `pkg/components/images.go`.
 
 Make sure the branch is in a good state, e.g. Update any pins in go.mod, create PR, ensure tests pass and merge.
 


### PR DESCRIPTION
## Description

I missed this step when tagging the 1.6.0 release yesterday. The correct fix might be to maybe pick this up from `enterprise_versions.yaml` perhaps but until then adding this so as to not miss this step. 
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
