### PR TITLE
Upgrade ES and Kibana to 7.6

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -27,10 +27,10 @@ components:
     image: tigera/es-proxy
     version: v3.0.0-0.dev-29-gfe7b046
   eck-kibana:
-    version: 7.3.2
+    version: 7.6.2
   kibana:
-    image: tigera/kibana
-    version: v3.0.0-0.dev-0-gddc3967
+    image: kibana/kibana
+    version: 7.6.2
   elasticsearch-operator:
     registry: docker.elastic.co
     image: eck/eck-operator
@@ -38,7 +38,7 @@ components:
   elasticsearch:
     registry: docker.elastic.co
     image: elasticsearch/elasticsearch
-    version: 7.3.2
+    version: 7.6.2
   elastic-tsee-installer:
     image: tigera/intrusion-detection-job-installer
     version: v3.0.0-0.dev-15-g466c351

--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -32,7 +32,7 @@ var defaultImages = map[string]string{
 	"flannel":                 "coreos/flannel",
 	"flexvol":                 "calico/pod2daemon-flexvol",
 	"typha":                   "calico/typha",
-	"eck-kibana":              "tigera/kibana",
+	"eck-kibana":              "kibana/kibana",
 	"guardian":                "tigera/guardian",
 	"tigera-cni":              "tigera/cni",
 }

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -46,8 +46,8 @@ var (
 	}
 
 	ComponentEckKibana = component{
-		Version: "7.3.2",
-		Image:   "tigera/kibana",
+		Version: "7.6.2",
+		Image:   "kibana/kibana",
 	}
 
 	ComponentElasticTseeInstaller = component{
@@ -56,7 +56,7 @@ var (
 	}
 
 	ComponentElasticsearch = component{
-		Version: "7.3.2",
+		Version: "7.6.2",
 		Image:   "elasticsearch/elasticsearch",
 	}
 
@@ -91,8 +91,8 @@ var (
 	}
 
 	ComponentKibana = component{
-		Version: "v3.0.0-0.dev-0-gddc3967",
-		Image:   "tigera/kibana",
+		Version: "7.6.2",
+		Image:   "kibana/kibana",
 	}
 
 	ComponentManager = component{
@@ -125,8 +125,8 @@ var (
 		Image:   "tigera/typha",
 	}
 
-    ComponentTigeraCNI = component{
+	ComponentTigeraCNI = component{
 		Version: "v3.0.0-0.dev-53-gb3668d9",
 		Image:   "tigera/cni",
-    }
+	}
 )

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -37,7 +37,7 @@ func GetReference(c component, registry, imagepath string) string {
 			ComponentFlexVolume:
 
 			registry = CalicoRegistry
-		case ComponentElasticsearch, ComponentElasticsearchOperator:
+		case ComponentElasticsearch, ComponentElasticsearchOperator, ComponentEckKibana, ComponentKibana:
 			registry = ECKRegistry
 		default:
 			registry = TigeraRegistry


### PR DESCRIPTION
## Description

Upgrade to 7.6 images for ES. Kibana will use 7.6 from docker.elastic.co/kibana/kibana:7.6.2 instead of tigera/kibana.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
