### PR TITLE
only build individual commits if on master or release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,10 +345,7 @@ ifndef BRANCH_NAME
 	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
 endif
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=${BRANCH_NAME} EXCLUDEARCH="$(EXCLUDEARCH)"
-	# only build individual commits if on master or release-v* branch
-ifneq (,$(filter master release-v%,$(BRANCH_NAME)))
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(shell git describe --tags --dirty --always --long) EXCLUDEARCH="$(EXCLUDEARCH)"
-endif
 
 ###############################################################################
 # Release

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,10 @@ ifndef BRANCH_NAME
 	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
 endif
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=${BRANCH_NAME} EXCLUDEARCH="$(EXCLUDEARCH)"
+	# only build individual commits if on master or release-v* branch
+ifneq (,$(filter master release-v%,$(BRANCH_NAME)))
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(shell git describe --tags --dirty --always --long) EXCLUDEARCH="$(EXCLUDEARCH)"
+endif
 
 ###############################################################################
 # Release

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -6,6 +6,11 @@ if [[ -z "${tag}" ]]; then
 	exit 0
 fi
 
+if [[ ! "$(git branch --show-current)" =~ (release-v*.*|master) ]]; then
+	echo "not on 'master' or 'release-vX.Y'"
+	exit 0
+fi
+
 echo "On a git tag - building release: ${tag}"
 make release VERSION=${tag}
 


### PR DESCRIPTION
## Description


**Background**

Our initial `make cd CONFIRM=true` is broken down into three groups of image tag / pushes:
1. Branch (`quay.io/tigera/operator:release-v1.1`)
1. Release / Tags (`quay.io/tigera/operator:v1.1.0`)
1. Commit (`quay.io/tigera/operator:v1.1.0-0.dev-373-g12770777`)

This PR prevents 2 from being built and pushed to dockerhub from a branch that isn't `master` or `release-v*` (e.g. feature branches). 

**Release Builds**

The changes here prevent a problem where if you push a branch that is at the same commit as a tag, it will trigger a rebuild and overwrite of that release image on the docker registry.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.