### PR TITLE
AmazonCloud: Add SG env vars to apiserver

### DIFF
--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -315,3 +315,27 @@ func (c *amazonCloudIntegrationComponent) tolerations() []corev1.Toleration {
 
 	return tolerations
 }
+
+func GetTigeraSecurityGroupEnvVariables(aci *operatorv1beta1.AmazonCloudIntegration) []corev1.EnvVar {
+	envs := []corev1.EnvVar{}
+	if aci == nil {
+		return envs
+	}
+
+	nodeSGIDs := aci.Spec.NodeSecurityGroupIDs
+	if len(nodeSGIDs) > 0 {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "TIGERA_DEFAULT_SECURITY_GROUPS",
+			Value: strings.Join(nodeSGIDs, ","),
+		})
+	}
+	podSGID := aci.Spec.PodSecurityGroupID
+	if podSGID != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "TIGERA_POD_SECURITY_GROUP",
+			Value: podSGID,
+		})
+	}
+
+	return envs
+}

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
+	operatorv1beta1 "github.com/tigera/operator/pkg/apis/operator/v1beta1"
 	"github.com/tigera/operator/pkg/components"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +41,7 @@ const (
 
 var apiServiceHostname = apiServiceName + "." + APIServerNamespace + ".svc"
 
-func APIServer(installation *operator.Installation, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool) (Component, error) {
+func APIServer(installation *operator.Installation, aci *operatorv1beta1.AmazonCloudIntegration, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool) (Component, error) {
 	tlsSecrets := []*corev1.Secret{}
 	if tlsKeyPair == nil {
 		var err error
@@ -67,18 +68,20 @@ func APIServer(installation *operator.Installation, tlsKeyPair *corev1.Secret, p
 	tlsSecrets = append(tlsSecrets, copy)
 
 	return &apiServerComponent{
-		installation: installation,
-		tlsSecrets:   tlsSecrets,
-		pullSecrets:  pullSecrets,
-		openshift:    openshift,
+		installation:           installation,
+		amazonCloudIntegration: aci,
+		tlsSecrets:             tlsSecrets,
+		pullSecrets:            pullSecrets,
+		openshift:              openshift,
 	}, nil
 }
 
 type apiServerComponent struct {
-	installation *operator.Installation
-	tlsSecrets   []*corev1.Secret
-	pullSecrets  []*corev1.Secret
-	openshift    bool
+	installation           *operator.Installation
+	amazonCloudIntegration *operatorv1beta1.AmazonCloudIntegration
+	tlsSecrets             []*corev1.Secret
+	pullSecrets            []*corev1.Secret
+	openshift              bool
 }
 
 func (c *apiServerComponent) Objects() ([]runtime.Object, []runtime.Object) {
@@ -624,6 +627,8 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		{Name: "LOGLEVEL", Value: "info"},
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 	}
+
+	env = append(env, GetTigeraSecurityGroupEnvVariables(c.amazonCloudIntegration)...)
 
 	if c.installation.Spec.CalicoNetwork != nil && c.installation.Spec.CalicoNetwork.MultiInterfaceMode != nil {
 		env = append(env, corev1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.installation.Spec.CalicoNetwork.MultiInterfaceMode.Value()})

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	operatorv1beta1 "github.com/tigera/operator/pkg/apis/operator/v1beta1"
@@ -951,20 +950,7 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 	nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_IPTABLESBACKEND", Value: "auto"})
 
 	if c.amazonCloudInt != nil {
-		nodeSGIDs := c.amazonCloudInt.Spec.NodeSecurityGroupIDs
-		if len(nodeSGIDs) > 0 {
-			nodeEnv = append(nodeEnv, v1.EnvVar{
-				Name:  "TIGERA_DEFAULT_SECURITY_GROUPS",
-				Value: strings.Join(nodeSGIDs, ","),
-			})
-		}
-		podSGID := c.amazonCloudInt.Spec.PodSecurityGroupID
-		if podSGID != "" {
-			nodeEnv = append(nodeEnv, v1.EnvVar{
-				Name:  "TIGERA_POD_SECURITY_GROUP",
-				Value: podSGID,
-			})
-		}
+		nodeEnv = append(nodeEnv, GetTigeraSecurityGroupEnvVariables(c.amazonCloudInt)...)
 		nodeEnv = append(nodeEnv, v1.EnvVar{
 			Name:  "FELIX_FAILSAFEINBOUNDHOSTPORTS",
 			Value: "tcp:22,udp:68,tcp:179,tcp:443,tcp:5473,tcp:6443",

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -16,7 +16,6 @@ package render
 
 import (
 	"fmt"
-	"strings"
 
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -467,22 +466,7 @@ func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
 		}
 	}
 
-	if c.amazonCloudInt != nil {
-		nodeSGIDs := c.amazonCloudInt.Spec.NodeSecurityGroupIDs
-		if len(nodeSGIDs) > 0 {
-			typhaEnv = append(typhaEnv, v1.EnvVar{
-				Name:  "TIGERA_DEFAULT_SECURITY_GROUPS",
-				Value: strings.Join(nodeSGIDs, ","),
-			})
-		}
-		podSGID := c.amazonCloudInt.Spec.PodSecurityGroupID
-		if podSGID != "" {
-			typhaEnv = append(typhaEnv, v1.EnvVar{
-				Name:  "TIGERA_POD_SECURITY_GROUP",
-				Value: podSGID,
-			})
-		}
-	}
+	typhaEnv = append(typhaEnv, GetTigeraSecurityGroupEnvVariables(c.amazonCloudInt)...)
 
 	return typhaEnv
 }


### PR DESCRIPTION
- Created utility function for getting TigeraSecurityGroup env vars
- Switch typha and node renders to new function
- Added UTs to apiserver, typha, and node for TigeraSecurityGroup env
vars

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
