### PR TITLE
making fluentd, apiserver, reporter privileged only on openshift

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -566,7 +566,11 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 		{Name: "tigera-apiserver-certs", MountPath: "/code/apiserver.local.config/certificates"},
 	}
 
-	isPrivileged := true
+	isPrivileged := false
+	//On OpenShift apiserver needs privileged access to write audit logs to host path volume
+	if c.openshift {
+		isPrivileged = true
+	}
 
 	env := []corev1.EnvVar{
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -377,7 +377,12 @@ func (c *complianceComponent) complianceReporterClusterRoleBinding() *rbacv1.Clu
 
 func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplate {
 	dirOrCreate := corev1.HostPathDirectoryOrCreate
-	privileged := true
+	privileged := false
+	//On OpenShift reported needs privileged access to write compliance reports to host path volume
+	if c.openshift {
+		privileged = true
+	}
+
 
 	envVars := []corev1.EnvVar{
 		{Name: "LOG_LEVEL", Value: "warning"},

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -319,7 +319,11 @@ func (c *fluentdComponent) container() corev1.Container {
 			})
 	}
 
-	isPrivileged := true
+	isPrivileged := false
+	//On OpenShift Fluentd needs privileged access to access logs on host path volume
+	if c.installation.Spec.KubernetesProvider == operatorv1.ProviderOpenShift {
+		isPrivileged = true
+	}
 
 	return ElasticsearchContainerDecorateENVVars(corev1.Container{
 		Name:            "fluentd",


### PR DESCRIPTION
## Description

Making changes to conditionally enable `privileged` mode for `apiserver`, `fluentd` and `compliance-reporter` on OCP so that on other platforms these pods can run without that permission. OCP needs privileged mode to access host path volumes. 

 
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
