### PR TITLE
Generate a certificate to be used for internal traffic for multiclust…

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -4,7 +4,7 @@ components:
     version: v3.0.0-0.dev-138-g711599c3
   voltron:
     image: tigera/voltron
-    version: v3.0.0-0.dev-9-ge9b5d1c
+    version: v3.1.0.calient-0.dev-2-gf6b3d1c
   cnx-apiserver:
     image: tigera/cnx-apiserver
     version: v3.0.0-0.dev-32-g771e07c7

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -101,7 +101,7 @@ var (
 	}
 
 	ComponentManagerProxy = component{
-		Version: "v3.0.0-0.dev-9-ge9b5d1c",
+		Version: "v3.1.0.calient-0.dev-2-gf6b3d1c",
 		Image:   "tigera/voltron",
 	}
 

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -17,8 +17,9 @@ package compliance
 import (
 	"context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
@@ -214,16 +215,16 @@ func (r *ReconcileCompliance) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	var managerCertSecret *corev1.Secret
+	var managerInternalTLSSecret *corev1.Secret
 	if network.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManagement {
-		managerCertSecret, err = utils.ValidateCertPair(r.client,
-			render.ManagerTLSSecretName,
-			render.ManagerSecretCertName,
-			render.ManagerSecretKeyName,
+		managerInternalTLSSecret, err = utils.ValidateCertPair(r.client,
+			render.ManagerInternalTLSSecretName,
+			render.ManagerInternalSecretCertName,
+			render.ManagerInternalSecretKeyName,
 		)
 		if err != nil {
-			log.Error(err, fmt.Sprintf("failed to retrieve / validate %s", render.ManagerTLSSecretName))
-			r.status.SetDegraded(fmt.Sprintf("failed to retrieve / validate  %s", render.ManagerTLSSecretName), err.Error())
+			log.Error(err, fmt.Sprintf("failed to retrieve / validate %s", render.ManagerInternalSecretCertName))
+			r.status.SetDegraded(fmt.Sprintf("failed to retrieve / validate  %s", render.ManagerInternalSecretKeyName), err.Error())
 			return reconcile.Result{}, err
 		}
 	}
@@ -245,7 +246,7 @@ func (r *ReconcileCompliance) Reconcile(request reconcile.Request) (reconcile.Re
 	reqLogger.V(3).Info("rendering components")
 	openshift := r.provider == operatorv1.ProviderOpenShift
 	// Render the desired objects from the CRD and create or update them.
-	component, err := render.Compliance(esSecrets, managerCertSecret, network, complianceServerCertSecret, esClusterConfig, pullSecrets, openshift)
+	component, err := render.Compliance(esSecrets, managerInternalTLSSecret, network, complianceServerCertSecret, esClusterConfig, pullSecrets, openshift)
 	if err != nil {
 		log.Error(err, "error rendering Compliance")
 		r.status.SetDegraded("Error rendering Compliance", err.Error())

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -474,17 +474,17 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
-	var managerTLSSecret *corev1.Secret
-	managerTLSSecret, err = utils.ValidateCertPair(r.client,
-		render.ManagerTLSSecretName,
-		render.ManagerSecretKeyName,
-		render.ManagerSecretCertName,
+	var managerInternalTLSSecret *corev1.Secret
+	managerInternalTLSSecret, err = utils.ValidateCertPair(r.client,
+		render.ManagerInternalTLSSecretName,
+		render.ManagerInternalSecretCertName,
+		render.ManagerInternalSecretKeyName,
 	)
 
 	if instance.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
 		if err != nil {
-			log.Error(err, "Invalid manager TLS Cert")
-			r.status.SetDegraded("Error validating manager TLS certificate", err.Error())
+			log.Error(err, "Invalid internal manager TLS Cert")
+			r.status.SetDegraded("Error validating internal manager TLS certificate", err.Error())
 			return reconcile.Result{}, err
 		}
 	}
@@ -533,7 +533,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		instance,
 		pullSecrets,
 		typhaNodeTLS,
-		managerTLSSecret,
+		managerInternalTLSSecret,
 		birdTemplates,
 		instance.Spec.KubernetesProvider,
 		netConf,

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -221,11 +221,6 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		r.status.SetDegraded("Error validating manager TLS certificate", err.Error())
 		return reconcile.Result{}, err
 	}
-	if installation.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManagement && tlsSecret == nil {
-		err = fmt.Errorf("manager TLS Secret not found")
-		r.status.SetDegraded("No TLS manager certificate", err.Error())
-		return reconcile.Result{}, err
-	}
 
 	// Check that compliance is running.
 	compliance, err := compliance.GetCompliance(ctx, r.client)
@@ -252,7 +247,6 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 		return reconcile.Result{}, err
 	}
-
 
 	pullSecrets, err := utils.GetNetworkingPullSecrets(installation, r.client)
 	if err != nil {
@@ -318,6 +312,7 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	var management = installation.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManagement
 	var tunnelSecret *corev1.Secret
+	var internalTrafficSecret *corev1.Secret
 	if management {
 
 		// If clusterType is management and the customer brings its own cert, copy it over to the manager ns.
@@ -328,6 +323,21 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 				tunnelSecret = nil
 			} else {
 				r.status.SetDegraded("Failed to check for the existence of management-cluster-connection secret", err.Error())
+				return reconcile.Result{}, nil
+			}
+		}
+
+		// We expect that the secret that holds the certificates for internal communication within the management
+		// K8S cluster is already created by the KubeControllers
+		internalTrafficSecret = &corev1.Secret{}
+		err = r.client.Get(ctx, client.ObjectKey{
+			Name: render.ManagerInternalTLSSecretName,
+			Namespace: render.OperatorNamespace(),
+		}, internalTrafficSecret)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				var message = fmt.Sprintf("Failed to check for the existence of %s secret", render.ManagerInternalTLSSecretName)
+				r.status.SetDegraded(message, err.Error())
 				return reconcile.Result{}, nil
 			}
 		}
@@ -350,6 +360,7 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		oidcConfig,
 		management,
 		tunnelSecret,
+		internalTrafficSecret,
 	)
 	if err != nil {
 		log.Error(err, "Error rendering Manager")

--- a/pkg/render/fixtures_test.go
+++ b/pkg/render/fixtures_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render_test
+
+import (
+	"github.com/tigera/operator/pkg/render"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var internalManagerTLSSecret = v1.Secret{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Secret",
+		APIVersion: "v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      render.ManagerInternalTLSSecretName,
+		Namespace: render.OperatorNamespace(),
+	},
+	Data: map[string][]byte{
+		"cert": []byte("cert"),
+		"key":  []byte("key"),
+	},
+}

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -30,16 +30,16 @@ import (
 
 var replicas int32 = 1
 
-func KubeControllers(cr *operator.Installation, managerSecret *v1.Secret) *kubeControllersComponent {
+func KubeControllers(cr *operator.Installation, managerInternalSecret *v1.Secret) *kubeControllersComponent {
 	return &kubeControllersComponent{
-		cr: cr,
-		managerSecret: managerSecret,
+		cr:                    cr,
+		managerInternalSecret: managerInternalSecret,
 	}
 }
 
 type kubeControllersComponent struct {
-	cr *operator.Installation
-	managerSecret *v1.Secret
+	cr                    *operator.Installation
+	managerInternalSecret *v1.Secret
 }
 
 func (c *kubeControllersComponent) Objects() ([]runtime.Object, []runtime.Object) {
@@ -49,8 +49,8 @@ func (c *kubeControllersComponent) Objects() ([]runtime.Object, []runtime.Object
 		c.controllersRoleBinding(),
 		c.controllersDeployment(),
 	}
-	if c.managerSecret != nil {
-		kubeControllerObjects = append(kubeControllerObjects, secretsToRuntimeObjects(CopySecrets(common.CalicoNamespace, c.managerSecret)...)...)
+	if c.managerInternalSecret != nil {
+		kubeControllerObjects = append(kubeControllerObjects, secretsToRuntimeObjects(CopySecrets(common.CalicoNamespace, c.managerInternalSecret)...)...)
 	}
 
 	return kubeControllerObjects, nil
@@ -227,6 +227,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 			Labels: map[string]string{
 				"k8s-app": "calico-kube-controllers",
 			},
+			Annotations: c.annotations(),
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: &replicas,
@@ -268,10 +269,10 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 									},
 								},
 							},
-							VolumeMounts: kubeControllersVolumeMounts(c.managerSecret),
+							VolumeMounts: kubeControllersVolumeMounts(c.managerInternalSecret),
 						},
 					},
-					Volumes: kubeControllersVolumes(defaultMode, c.managerSecret),
+					Volumes: kubeControllersVolumes(defaultMode, c.managerInternalSecret),
 				},
 			},
 		},
@@ -286,10 +287,20 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 	return &d
 }
 
+func (c *kubeControllersComponent) annotations() map[string]string {
+	if c.managerInternalSecret == nil {
+		return make(map[string]string)
+	}
+
+	return map[string]string {
+		ManagerInternalTLSHashAnnotation : AnnotationHash(c.managerInternalSecret.Data),
+	}
+}
+
 func kubeControllersVolumeMounts(managerSecret *v1.Secret) []v1.VolumeMount {
 	if managerSecret != nil {
 		return []v1.VolumeMount{{
-			Name:      "manager-cert",
+			Name:      ManagerInternalTLSSecretName,
 			MountPath: "/manager-tls",
 			ReadOnly:  true,
 		}}
@@ -303,11 +314,11 @@ func kubeControllersVolumes(defaultMode int32, managerSecret *v1.Secret) []v1.Vo
 
 		return []v1.Volume{
 			{
-				Name: "manager-cert",
+				Name: ManagerInternalTLSSecretName,
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
 						DefaultMode: &defaultMode,
-						SecretName:  ManagerTLSSecretName,
+						SecretName:  ManagerInternalTLSSecretName,
 						Items: []v1.KeyToPath{
 							{
 								Key:  "cert",

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -16,8 +16,6 @@ package render_test
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/tigera/operator/pkg/components"
@@ -105,21 +103,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		instance.Spec.ClusterManagementType = operator.ClusterManagementTypeManagement
 
-		var managerTLSSecret = v1.Secret{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      render.ManagerTLSSecretName,
-				Namespace: render.OperatorNamespace(),
-			},
-			Data: map[string][]byte{
-				"cert": []byte("cert"),
-				"key":  []byte("key"),
-			},
-		}
-		component := render.KubeControllers(instance, &managerTLSSecret)
+		component := render.KubeControllers(instance, &internalManagerTLSSecret)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
@@ -128,16 +112,21 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		ExpectResource(resources[1], "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole")
 		ExpectResource(resources[2], "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
 		ExpectResource(resources[3], "calico-kube-controllers", "calico-system", "apps", "v1", "Deployment")
-		ExpectResource(resources[4], render.ManagerTLSSecretName, "calico-system", "", "v1", "Secret")
+		ExpectResource(resources[4], render.ManagerInternalTLSSecretName, "calico-system", "", "v1", "Secret")
 
 		// The Deployment should have the correct configuration.
-		ds := resources[3].(*apps.Deployment)
+		dp := resources[3].(*apps.Deployment)
 
-		Expect(len(ds.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
-		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("manager-cert"))
-		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/manager-tls"))
+		Expect(len(dp.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/manager-tls"))
 
-		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
+		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
+		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
+		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
+
+
+		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 	})
 
 	It("should include a ControlPlaneNodeSelector when specified", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -34,25 +34,29 @@ import (
 )
 
 const (
-	managerPort               = 9443
-	managerTargetPort         = 9443
-	ManagerNamespace          = "tigera-manager"
-	ManagerServiceDNS         = "tigera-manager.tigera-manager.svc"
-	ManagerServiceIP          = "localhost"
-	ManagerServiceAccount     = "tigera-manager"
-	ManagerClusterRole        = "tigera-manager-role"
-	ManagerClusterRoleBinding = "tigera-manager-binding"
-	ManagerTLSSecretName      = "manager-tls"
-	ManagerTLSSecretCertName  = "manager-tls-cert"
-	ManagerSecretKeyName      = "key"
-	ManagerSecretCertName     = "cert"
-	ManagerOIDCConfig         = "tigera-manager-oidc-config"
-	ManagerOIDCWellknownURI   = "/usr/share/nginx/html/.well-known"
-	ManagerOIDCJwksURI        = "/usr/share/nginx/html/discovery"
+	managerPort                      = 9443
+	managerTargetPort                = 9443
+	ManagerNamespace                 = "tigera-manager"
+	ManagerServiceDNS                = "tigera-manager.tigera-manager.svc"
+	ManagerServiceIP                 = "localhost"
+	ManagerServiceAccount            = "tigera-manager"
+	ManagerClusterRole               = "tigera-manager-role"
+	ManagerClusterRoleBinding        = "tigera-manager-binding"
+	ManagerTLSSecretName             = "manager-tls"
+	ManagerSecretKeyName             = "key"
+	ManagerSecretCertName            = "cert"
+	ManagerInternalTLSSecretName     = "internal-manager-tls"
+	ManagerInternalTLSSecretCertName = "internal-manager-tls-cert"
+	ManagerInternalSecretKeyName     = "key"
+	ManagerInternalSecretCertName    = "cert"
+	ManagerOIDCConfig                = "tigera-manager-oidc-config"
+	ManagerOIDCWellknownURI          = "/usr/share/nginx/html/.well-known"
+	ManagerOIDCJwksURI               = "/usr/share/nginx/html/discovery"
 
-	ElasticsearchManagerUserSecret = "tigera-ee-manager-elasticsearch-access"
-	tlsSecretHashAnnotation        = "hash.operator.tigera.io/tls-secret"
-	oidcConfigHashAnnotation       = "hash.operator.tigera.io/oidc-config"
+	ElasticsearchManagerUserSecret   = "tigera-ee-manager-elasticsearch-access"
+	tlsSecretHashAnnotation          = "hash.operator.tigera.io/tls-secret"
+	ManagerInternalTLSHashAnnotation = "hash.operator.tigera.io/internal-tls-secret"
+	oidcConfigHashAnnotation         = "hash.operator.tigera.io/oidc-config"
 )
 
 // ManagementClusterConnection configuration constants
@@ -77,10 +81,12 @@ func Manager(
 	oidcConfig *corev1.ConfigMap,
 	management bool,
 	tunnelSecret *corev1.Secret,
+	internalTrafficSecret *corev1.Secret,
 ) (Component, error) {
 	tlsSecrets := []*corev1.Secret{}
+	tlsAnnotations := make(map[string]string)
 
-	if tlsKeyPair == nil && !management {
+	if tlsKeyPair == nil {
 		var err error
 		tlsKeyPair, err = CreateOperatorTLSSecret(nil,
 			ManagerTLSSecretName,
@@ -96,15 +102,22 @@ func Manager(
 	}
 
 	tlsSecrets = append(tlsSecrets, CopySecrets(ManagerNamespace, tlsKeyPair)...)
-	var tunnelSecrets []*corev1.Secret
+	tlsAnnotations[tlsSecretHashAnnotation] = AnnotationHash(tlsKeyPair.Data)
+
 	if management {
 		// If there is no secret create one and add it to the operator namespace.
 		if tunnelSecret == nil {
 			tunnelSecret = voltronTunnelSecret()
-			tunnelSecrets = append(tunnelSecrets, tunnelSecret)
+			tlsSecrets = append(tlsSecrets, tunnelSecret)
 		}
 
-		tunnelSecrets = append(tunnelSecrets, CopySecrets(ManagerNamespace, tunnelSecret)...)
+		// Copy tunnelSecret and internalTrafficSecret to TLS secrets
+		// tunnelSecret contains the ca cert to generate guardian certificates
+		// internalTrafficCert containts the cert used to communicated within the management K8S cluster
+		tlsSecrets = append(tlsSecrets, CopySecrets(ManagerNamespace, tunnelSecret)...)
+		tlsSecrets = append(tlsSecrets, CopySecrets(ManagerNamespace, internalTrafficSecret)...)
+		tlsAnnotations[voltronTunnelHashAnnotation] = AnnotationHash(tunnelSecret.Data)
+		tlsAnnotations[ManagerInternalTLSHashAnnotation] = AnnotationHash(internalTrafficSecret.Data)
 	}
 	return &managerComponent{
 		cr:                         cr,
@@ -113,12 +126,12 @@ func Manager(
 		complianceServerCertSecret: complianceServerCertSecret,
 		esClusterConfig:            esClusterConfig,
 		tlsSecrets:                 tlsSecrets,
+		tlsAnnotations:             tlsAnnotations,
 		pullSecrets:                pullSecrets,
 		openshift:                  openshift,
 		installation:               installation,
 		oidcConfig:                 oidcConfig,
 		management:                 management,
-		tunnelSecrets:              tunnelSecrets,
 	}, nil
 }
 
@@ -129,14 +142,13 @@ type managerComponent struct {
 	complianceServerCertSecret *corev1.Secret
 	esClusterConfig            *ElasticsearchClusterConfig
 	tlsSecrets                 []*corev1.Secret
+	tlsAnnotations             map[string]string
 	pullSecrets                []*corev1.Secret
 	openshift                  bool
 	installation               *operator.Installation
 	oidcConfig                 *corev1.ConfigMap
 	// If true, this is a management cluster.
 	management bool
-	// The tunnel secret if present in the operator namespace
-	tunnelSecrets []*corev1.Secret
 }
 
 func (c *managerComponent) Objects() ([]runtime.Object, []runtime.Object) {
@@ -170,7 +182,6 @@ func (c *managerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs = append(objs, secretsToRuntimeObjects(CopySecrets(ManagerNamespace, c.esSecrets...)...)...)
 	objs = append(objs, secretsToRuntimeObjects(CopySecrets(ManagerNamespace, c.kibanaSecrets...)...)...)
 	objs = append(objs, secretsToRuntimeObjects(CopySecrets(ManagerNamespace, c.complianceServerCertSecret)...)...)
-	objs = append(objs, secretsToRuntimeObjects(c.tunnelSecrets...)...)
 	if c.oidcConfig != nil {
 		objs = append(objs, copyConfigMaps(ManagerNamespace, c.oidcConfig)...)
 	}
@@ -193,13 +204,14 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 		"scheduler.alpha.kubernetes.io/critical-pod": "",
 		complianceServerTLSHashAnnotation:            AnnotationHash(c.complianceServerCertSecret.Data),
 	}
-	if c.management {
-		annotations[voltronTunnelHashAnnotation] = AnnotationHash(c.tunnelSecrets[0].Data)
-	}
-	if len(c.tlsSecrets) > 0 {
-		// Add a hash of the Secret to ensure if it changes the manager will be
-		// redeployed.
-		annotations[tlsSecretHashAnnotation] = AnnotationHash(c.tlsSecrets[0].Data)
+
+	// Add a hash of the Secret to ensure if it changes the manager will be
+	// redeployed.	The following secrets are annotated:
+	// manager-tls : cert used for tigera UI
+	// internal-manager-tls : cert used for internal communication within K8S cluster
+	// tigera-management-cluster-connection : cert used to generate guardian certificates
+	for k, v := range c.tlsAnnotations {
+		annotations[k] = v
 	}
 	if c.oidcConfig != nil {
 		annotations[oidcConfigHashAnnotation] = AnnotationHash(c.oidcConfig.Data)
@@ -257,7 +269,6 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 
 // managerVolumes returns the volumes for the Tigera Secure manager component.
 func (c *managerComponent) managerVolumes() []v1.Volume {
-	optional := true
 	v := []v1.Volume{
 		{
 			Name: ManagerTLSSecretName,
@@ -272,15 +283,6 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
 					SecretName: KibanaPublicCertSecret,
-				},
-			},
-		},
-		{
-			Name: VoltronTunnelSecretName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					SecretName: VoltronTunnelSecretName,
-					Optional:   &optional,
 				},
 			},
 		},
@@ -302,16 +304,34 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 		v = append(v,
 			v1.Volume{
 				// We only want to mount the cert, not the private key to es-proxy to establish a connection with voltron.
-				Name: ManagerTLSSecretCertName,
+				Name: ManagerInternalTLSSecretCertName,
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
-						SecretName: ManagerTLSSecretName,
+						SecretName: ManagerInternalTLSSecretName,
 						Items: []v1.KeyToPath{
 							{
 								Key:  "cert",
 								Path: "cert",
 							},
 						},
+					},
+				},
+			},
+			v1.Volume{
+				// We mount the full secret to be shared with Voltron.
+				Name: ManagerInternalTLSSecretName,
+				VolumeSource: v1.VolumeSource{
+					Secret: &v1.SecretVolumeSource{
+						SecretName: ManagerInternalTLSSecretName,
+					},
+				},
+			},
+			v1.Volume{
+				// Append volume for tunnel certificate
+				Name: VoltronTunnelSecretName,
+				VolumeSource: v1.VolumeSource{
+					Secret: &v1.SecretVolumeSource{
+						SecretName: VoltronTunnelSecretName,
 					},
 				},
 			},
@@ -459,15 +479,25 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 			{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.management)},
 			{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
 		},
-		VolumeMounts: []corev1.VolumeMount{
-			{Name: ManagerTLSSecretName, MountPath: "/certs/https"},
-			{Name: KibanaPublicCertSecret, MountPath: "/certs/kibana"},
-			{Name: ComplianceServerCertSecret, MountPath: "/certs/compliance"},
-			{Name: VoltronTunnelSecretName, MountPath: "/certs/tunnel/"},
-		},
+		VolumeMounts:    c.volumeMountsForProxyManager(),
 		LivenessProbe:   c.managerProxyProbe(),
 		SecurityContext: securityContext(),
 	}
+}
+
+func (c *managerComponent) volumeMountsForProxyManager() []v1.VolumeMount {
+	var mounts = []corev1.VolumeMount{
+		{Name: ManagerTLSSecretName, MountPath: "/certs/https"},
+		{Name: KibanaPublicCertSecret, MountPath: "/certs/kibana"},
+		{Name: ComplianceServerCertSecret, MountPath: "/certs/compliance"},
+	}
+
+	if c.management {
+		mounts = append(mounts, corev1.VolumeMount{Name: ManagerInternalTLSSecretName, MountPath: "/certs/internal"})
+		mounts = append(mounts, corev1.VolumeMount{Name: VoltronTunnelSecretName, MountPath: "/certs/tunnel"})
+	}
+
+	return mounts
 }
 
 // managerEsProxyContainer returns the ES proxy container
@@ -480,7 +510,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 	}
 	if c.management {
 		apiServer.VolumeMounts = []corev1.VolumeMount{
-			{Name: ManagerTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true},
+			{Name: ManagerInternalTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true},
 		}
 	}
 	return apiServer

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -56,11 +56,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	const expectedResourcesNumber = 11
 	It("should render all resources for a default configuration", func() {
-		resources := renderObjects(instance, nil, false, nil)
+		resources := renderObjects(instance, nil, false, nil, nil)
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
 		// Should render the correct resources.
 		expectedResources := []struct {
+
 			name    string
 			ns      string
 			group   string
@@ -90,10 +91,37 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/cnx-manager:" + components.ComponentManager.Version))
 		Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/es-proxy:" + components.ComponentEsProxy.Version))
 		Expect(deployment.Spec.Template.Spec.Containers[2].Image).Should(Equal("gcr.io/unique-caldron-775/cnx/tigera/voltron:" + components.ComponentManagerProxy.Version))
+
+		// Expect 1 volume mounts for es proxy
+		var esProxy = deployment.Spec.Template.Spec.Containers[1]
+		Expect(len(esProxy.VolumeMounts)).To(Equal(1))
+		Expect(esProxy.VolumeMounts[0].Name).To(Equal("elastic-ca-cert-volume"))
+		Expect(esProxy.VolumeMounts[0].MountPath).To(Equal("/etc/ssl/elastic/"))
+
+		// Expect 3 volume mounts for voltron
+		var voltron = deployment.Spec.Template.Spec.Containers[2]
+		Expect(len(voltron.VolumeMounts)).To(Equal(3))
+		Expect(voltron.VolumeMounts[0].Name).To(Equal(render.ManagerTLSSecretName))
+		Expect(voltron.VolumeMounts[0].MountPath).To(Equal("/certs/https"))
+		Expect(voltron.VolumeMounts[1].Name).To(Equal(render.KibanaPublicCertSecret))
+		Expect(voltron.VolumeMounts[1].MountPath).To(Equal("/certs/kibana"))
+		Expect(voltron.VolumeMounts[2].Name).To(Equal(render.ComplianceServerCertSecret))
+		Expect(voltron.VolumeMounts[2].MountPath).To(Equal("/certs/compliance"))
+
+		//Expect 4 volumes mapped to 4 secrets
+		Expect(len(deployment.Spec.Template.Spec.Volumes)).To(Equal(4))
+		Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerTLSSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerTLSSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[1].Name).To(Equal(render.KibanaPublicCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[1].Secret.SecretName).To(Equal(render.KibanaPublicCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[2].Name).To(Equal(render.ComplianceServerCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[2].Secret.SecretName).To(Equal(render.ComplianceServerCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[3].Name).To(Equal("elastic-ca-cert-volume"))
+		Expect(deployment.Spec.Template.Spec.Volumes[3].Secret.SecretName).To(Equal(render.ElasticsearchPublicCertSecret))
 	})
 
 	It("should ensure cnx policy recommendation support is always set to true", func() {
-		resources := renderObjects(instance, nil, false, nil)
+		resources := renderObjects(instance, nil, false, nil, nil)
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
 		// Should render the correct resource based on test case.
@@ -117,7 +145,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 		}
 		// Should render the correct resource based on test case.
-		resources := renderObjects(instance, oidcConfig, false, nil)
+		resources := renderObjects(instance, oidcConfig, false, nil, nil)
 		Expect(len(resources)).To(Equal(expectedResourcesNumber + 1))
 
 		Expect(GetResource(resources, render.ManagerOIDCConfig, "tigera-manager", "", "v1", "ConfigMap")).ToNot(BeNil())
@@ -132,9 +160,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(render.ManagerOIDCConfig))
 		Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal(render.ManagerOIDCJwksURI))
 
-		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(6))
-		Expect(d.Spec.Template.Spec.Volumes[4].Name).To(Equal(render.ManagerOIDCConfig))
-		Expect(d.Spec.Template.Spec.Volumes[4].ConfigMap.Name).To(Equal(render.ManagerOIDCConfig))
+		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(5))
+		Expect(d.Spec.Template.Spec.Volumes[3].Name).To(Equal(render.ManagerOIDCConfig))
+		Expect(d.Spec.Template.Spec.Volumes[3].ConfigMap.Name).To(Equal(render.ManagerOIDCConfig))
 	})
 
 	It("should set OIDC Authority environment when auth-type is OIDC", func() {
@@ -145,30 +173,17 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		oidcEnvVar.Value = authority
 
 		// Should render the correct resource based on test case.
-		resources := renderObjects(instance, nil, false, nil)
+		resources := renderObjects(instance, nil, false, nil, nil)
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 		d := resources[expectedResourcesNumber-1].(*v1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
-		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(5))
+		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(4))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
 		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
 	})
 
 	It("should render multicluster settings properly", func() {
-		resources := renderObjects(instance, nil, true, &corev1.Secret{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      render.ManagerTLSSecretName,
-				Namespace: render.OperatorNamespace(),
-			},
-			Data: map[string][]byte{
-				"cert": []byte("cert"),
-				"key":  []byte("key"),
-			},
-		})
+		resources := renderObjects(instance, nil, true, nil, &internalManagerTLSSecret)
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -184,11 +199,13 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager-binding", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-manager-pip", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-manager-pip", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "manager-tls", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "manager-tls", ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
-			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Service"},
-			{name: render.ComplianceServerCertSecret, ns: "tigera-manager", group: "", version: "", kind: ""},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
+			{name: render.ManagerInternalTLSSecretName, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
+			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Service"},
+			{name: render.ComplianceServerCertSecret, ns: "tigera-manager", group: "", version: "", kind: ""},
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Deployment"},
 		}
 
@@ -202,17 +219,56 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		By("creating a valid self-signed cert")
 		// Use the x509 package to validate that the cert was signed with the privatekey
+		validateSecret(resources[8].(*corev1.Secret))
 		validateSecret(resources[9].(*corev1.Secret))
-		validateSecret(resources[10].(*corev1.Secret))
 
 		By("configuring the manager deployment")
-		manager := resources[11].(*v1.Deployment).Spec.Template.Spec.Containers[0]
+		deployment := resources[len(resources) - 1].(*v1.Deployment)
+		manager := deployment.Spec.Template.Spec.Containers[0]
 		Expect(manager.Name).To(Equal("tigera-manager"))
 		ExpectEnv(manager.Env, "ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
 
-		voltron := resources[11].(*v1.Deployment).Spec.Template.Spec.Containers[2]
+		voltron := deployment.Spec.Template.Spec.Containers[2]
+		esProxy := deployment.Spec.Template.Spec.Containers[1]
 		Expect(voltron.Name).To(Equal("tigera-voltron"))
 		ExpectEnv(voltron.Env, "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
+
+		// Expect 2 volume mounts for es proxy
+		Expect(len(esProxy.VolumeMounts)).To(Equal(2))
+		Expect(esProxy.VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretCertName))
+		Expect(esProxy.VolumeMounts[0].MountPath).To(Equal("/manager-tls"))
+		Expect(esProxy.VolumeMounts[1].Name).To(Equal("elastic-ca-cert-volume"))
+		Expect(esProxy.VolumeMounts[1].MountPath).To(Equal("/etc/ssl/elastic/"))
+
+		// Expect 5 volume mounts for voltron
+		Expect(len(voltron.VolumeMounts)).To(Equal(5))
+		Expect(voltron.VolumeMounts[0].Name).To(Equal(render.ManagerTLSSecretName))
+		Expect(voltron.VolumeMounts[0].MountPath).To(Equal("/certs/https"))
+		Expect(voltron.VolumeMounts[1].Name).To(Equal(render.KibanaPublicCertSecret))
+		Expect(voltron.VolumeMounts[1].MountPath).To(Equal("/certs/kibana"))
+		Expect(voltron.VolumeMounts[2].Name).To(Equal(render.ComplianceServerCertSecret))
+		Expect(voltron.VolumeMounts[2].MountPath).To(Equal("/certs/compliance"))
+		Expect(voltron.VolumeMounts[3].Name).To(Equal(render.ManagerInternalTLSSecretName))
+		Expect(voltron.VolumeMounts[3].MountPath).To(Equal("/certs/internal"))
+		Expect(voltron.VolumeMounts[4].Name).To(Equal(render.VoltronTunnelSecretName))
+		Expect(voltron.VolumeMounts[4].MountPath).To(Equal("/certs/tunnel"))
+
+		// Expect 7 volumes mapped to 6 secrets
+		Expect(len(deployment.Spec.Template.Spec.Volumes)).To(Equal(7))
+		Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerTLSSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerTLSSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[1].Name).To(Equal(render.KibanaPublicCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[1].Secret.SecretName).To(Equal(render.KibanaPublicCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[2].Name).To(Equal(render.ComplianceServerCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[2].Secret.SecretName).To(Equal(render.ComplianceServerCertSecret))
+		Expect(deployment.Spec.Template.Spec.Volumes[3].Name).To(Equal(render.ManagerInternalTLSSecretCertName))
+		Expect(deployment.Spec.Template.Spec.Volumes[3].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[4].Name).To(Equal(render.ManagerInternalTLSSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[4].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[5].Name).To(Equal(render.VoltronTunnelSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[5].Secret.SecretName).To(Equal(render.VoltronTunnelSecretName))
+		Expect(deployment.Spec.Template.Spec.Volumes[6].Name).To(Equal("elastic-ca-cert-volume"))
+		Expect(deployment.Spec.Template.Spec.Volumes[6].Secret.SecretName).To(Equal(render.ElasticsearchPublicCertSecret))
 	})
 })
 
@@ -253,7 +309,7 @@ func validateSecret(voltronSecret *corev1.Secret) {
 
 }
 
-func renderObjects(instance *operator.Manager, oidcConfig *corev1.ConfigMap, isManagement bool, tlsSecret *corev1.Secret) []runtime.Object {
+func renderObjects(instance *operator.Manager, oidcConfig *corev1.ConfigMap, isManagement bool, tlsSecret *corev1.Secret, internalTLSSecret *corev1.Secret) []runtime.Object {
 	esConfigMap := render.NewElasticsearchClusterConfig("clusterTestName", 1, 1, 1)
 	component, err := render.Manager(instance,
 		nil,
@@ -267,6 +323,7 @@ func renderObjects(instance *operator.Manager, oidcConfig *corev1.ConfigMap, isM
 				"tls.crt": []byte("crt"),
 				"tls.key": []byte("crt"),
 			},
+
 		},
 		esConfigMap,
 		tlsSecret,
@@ -275,7 +332,8 @@ func renderObjects(instance *operator.Manager, oidcConfig *corev1.ConfigMap, isM
 		&operator.Installation{Spec: operator.InstallationSpec{}},
 		oidcConfig,
 		isManagement,
-		nil)
+		nil,
+		internalTLSSecret)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 	resources, _ := component.Objects()
 	return resources

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -63,7 +63,7 @@ func Calico(
 	cr *operator.Installation,
 	pullSecrets []*corev1.Secret,
 	typhaNodeTLS *TyphaNodeTLS,
-	managerTLSSecret *corev1.Secret,
+	managerInternalTLSSecret *corev1.Secret,
 	bt map[string]string,
 	p operator.Provider,
 	nc NetworkConfig,
@@ -109,14 +109,15 @@ func Calico(
 	ns.ObjectMeta = metav1.ObjectMeta{Name: ns.Name, Namespace: common.CalicoNamespace}
 	tss = append(tss, ts, ns)
 
-	if managerTLSSecret == nil && cr.Spec.Variant == operator.TigeraSecureEnterprise && cr.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
-		// Generate CA and TLS certificate for tigera-manager
-		log.Info("Creating secret for manager")
+	if managerInternalTLSSecret == nil && cr.Spec.Variant == operator.TigeraSecureEnterprise && cr.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
+		// Generate CA and TLS certificate for tigera-manager for internal traffic within the K8s cluster
+		// The certificate will be issued for ManagerServiceDNS and localhost
+		log.Info("Creating secret for internal manager credentials")
 		var err error
-		managerTLSSecret, err = CreateOperatorTLSSecret(nil,
-			ManagerTLSSecretName,
-			ManagerSecretKeyName,
-			ManagerSecretCertName,
+		managerInternalTLSSecret, err = CreateOperatorTLSSecret(nil,
+			ManagerInternalTLSSecretName,
+			ManagerInternalSecretKeyName,
+			ManagerInternalSecretCertName,
 			825*24*time.Hour, // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
 			nil,
 			ManagerServiceIP,
@@ -125,20 +126,20 @@ func Calico(
 		if err != nil {
 			return nil, fmt.Errorf("generating certificates for manager was not finalized due to %v", err)
 		}
-		tss = append(tss, managerTLSSecret)
+		tss = append(tss, managerInternalTLSSecret)
 	}
 
 	return calicoRenderer{
-		installation:    cr,
-		pullSecrets:     pullSecrets,
-		typhaNodeTLS:    typhaNodeTLS,
-		tlsConfigMaps:   tcms,
-		tlsSecrets:      tss,
-		managerTLSecret: managerTLSSecret,
-		birdTemplates:   bt,
-		provider:        p,
-		networkConfig:   nc,
-		upgrade:         up,
+		installation:            cr,
+		pullSecrets:             pullSecrets,
+		typhaNodeTLS:            typhaNodeTLS,
+		tlsConfigMaps:           tcms,
+		tlsSecrets:              tss,
+		managerInternalTLSecret: managerInternalTLSSecret,
+		birdTemplates:           bt,
+		provider:                p,
+		networkConfig:           nc,
+		upgrade:                 up,
 	}, nil
 }
 
@@ -199,16 +200,16 @@ func createTLS() (*TyphaNodeTLS, error) {
 }
 
 type calicoRenderer struct {
-	installation    *operator.Installation
-	pullSecrets     []*corev1.Secret
-	typhaNodeTLS    *TyphaNodeTLS
-	tlsConfigMaps   []*corev1.ConfigMap
-	tlsSecrets      []*corev1.Secret
-	managerTLSecret *corev1.Secret
-	birdTemplates   map[string]string
-	provider        operator.Provider
-	networkConfig   NetworkConfig
-	upgrade         bool
+	installation            *operator.Installation
+	pullSecrets             []*corev1.Secret
+	typhaNodeTLS            *TyphaNodeTLS
+	tlsConfigMaps           []*corev1.ConfigMap
+	tlsSecrets              []*corev1.Secret
+	managerInternalTLSecret *corev1.Secret
+	birdTemplates           map[string]string
+	provider                operator.Provider
+	networkConfig           NetworkConfig
+	upgrade                 bool
 }
 
 func (r calicoRenderer) Render() []Component {
@@ -219,7 +220,7 @@ func (r calicoRenderer) Render() []Component {
 	components = appendNotNil(components, Secrets(r.tlsSecrets))
 	components = appendNotNil(components, Typha(r.installation, r.provider, r.typhaNodeTLS, r.upgrade))
 	components = appendNotNil(components, Node(r.installation, r.provider, r.networkConfig, r.birdTemplates, r.typhaNodeTLS, r.upgrade))
-	components = appendNotNil(components, KubeControllers(r.installation, r.managerTLSecret))
+	components = appendNotNil(components, KubeControllers(r.installation, r.managerInternalTLSecret))
 	return components
 }
 

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Rendering tests", func() {
 		// - X Same as default config
 		// - 1 Service to expose calico/node metrics.
 		// - 1 ns (tigera-prometheus)
-		// - pass in managerTLSSecret
+		// - pass in internalManagerTLSSecret
 		var nodeMetricsPort int32 = 9081
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		instance.Spec.ClusterManagementType = operator.ClusterManagementTypeManagement
@@ -125,7 +125,7 @@ var _ = Describe("Rendering tests", func() {
 			{render.NodeTLSSecretName, render.OperatorNamespace(), "", "v1", "Secret"},
 			{render.TyphaTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
 			{render.NodeTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
-			{render.ManagerTLSSecretName, render.OperatorNamespace(), "", "v1", "Secret"},
+			{render.ManagerInternalTLSSecretName, render.OperatorNamespace(), "", "v1", "Secret"},
 			{render.TyphaServiceAccountName, common.CalicoNamespace, "", "v1", "ServiceAccount"},
 			{"calico-typha", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
 			{"calico-typha", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
@@ -142,7 +142,7 @@ var _ = Describe("Rendering tests", func() {
 			{"calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
 			{"calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 			{"calico-kube-controllers", common.CalicoNamespace, "apps", "v1", "Deployment"},
-			{render.ManagerTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
+			{render.ManagerInternalTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
 		}
 
 		var resources []runtime.Object


### PR DESCRIPTION
…er management

## Description

When multicluster management is enabled, Voltron will make use of 3 certificates:
- manager-tls (This certificate can be changed with certificated registered to a valid dns domain). This certificate will be used for TLS communication between a browser and tigera UI
- manager-internal-tls (This certificate will be used for internal traffic within K8s cluster). This will be used when compliance/kube-controller/es-proxy need to initiate a TLS connection with tigera-manager.svc or localhost via Voltron)
- tigera-management-cluster-connection (This is a ca certificate that is generated by operator and provided to Voltron). This certificate is used to generate certificates for managed clusters.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
