### PR TITLE
Auto-detect CIDR when running on kubeadm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ VALIDARCHES = $(filter-out $(EXCLUDEARCH),$(ARCHES))
 
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=v0.23
+GO_BUILD_VER?=v0.40
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./cmd -name '*.go')

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
 	github.com/hashicorp/go-version v1.2.0
+	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/openshift/api v3.9.1-0.20190927182313-d4a64ec2cbd8+incompatible
@@ -34,7 +35,6 @@ require (
 
 // Pinned to kubernetes-1.14.1
 replace (
-	git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
 	// This is cloud-on-k8s 1.0.1 tag
 	github.com/elastic/cloud-on-k8s => github.com/elastic/cloud-on-k8s v0.0.0-20200204083752-bcb7468838a8
 	github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.1-0.20190910171846-947a464dbe96

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ cloud.google.com/go v0.37.2 h1:4y4L7BdHenTfZL0HervofNTHh9Ad6mNX72cQvl+5eH0=
 cloud.google.com/go v0.37.2/go.mod h1:H8IAquKe2L30IxoupDgqTaQvKSwF/c8prYHynGIWQbA=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12 h1:jGFvw3l57ViIVEPKKEUXPcLYIXJmQxLUh6ey1eJhwyc=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
+git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v11.1.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v11.7.0+incompatible h1:gzma19dc9ejB75D90E5S+/wXouzpZyA+CV+/MJPSD/k=
@@ -315,6 +317,8 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/juju/errors v0.0.0-20200330140219-3fe23663418f h1:MCOvExGLpaSIzLYB4iQXEHP4jYVU6vmzLNQPdMVrxnM=
+github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/controller/clusterconnection/clusterconnection_suite_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_suite_test.go
@@ -19,11 +19,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 
 	"github.com/onsi/ginkgo/reporters"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func TestStatus(t *testing.T) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter))
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../../report/clusterconnection_controller_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "pkg/controller/Management Cluster Connection Suite", []Reporter{junitReporter})

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -74,9 +74,9 @@ var _ = Describe("Testing core-controller installation", func() {
 	table.DescribeTable("Installation and Openshift should be merged and defaulted by mergeAndFillDefaults",
 		func(i *operator.Installation, on *osconfigv1.Network, expectSuccess bool, calicoNet *operator.CalicoNetworkSpec) {
 			if expectSuccess {
-				Expect(mergeAndFillDefaults(i, on)).To(BeNil())
+				Expect(mergeAndFillDefaults(i, on, nil)).To(BeNil())
 			} else {
-				Expect(mergeAndFillDefaults(i, on)).ToNot(BeNil())
+				Expect(mergeAndFillDefaults(i, on, nil)).ToNot(BeNil())
 				return
 			}
 

--- a/pkg/controller/installation/pod_cidr_detection.go
+++ b/pkg/controller/installation/pod_cidr_detection.go
@@ -1,0 +1,44 @@
+package installation
+
+import (
+	"net"
+	"regexp"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// KubeadmConfigConfigMap is defined in k8s.io/kubernetes, which we can't import due to versioning issues.
+	kubeadmConfigMap = "kubeadm-config"
+)
+
+// extractKubeadmCIDRs looks through the config map and parses lines starting with 'podSubnet'.
+func extractKubeadmCIDRs(kubeadmConfig *v1.ConfigMap) ([]string, error) {
+	var line []string
+	var foundCIDRs []string
+
+	// Look through the config map for a line starting with 'podSubnet', then assign the right variable
+	// according to the IP family of the matching string.
+	re := regexp.MustCompile(`podSubnet: (.*)`)
+	for _, l := range kubeadmConfig.Data {
+		if line = re.FindStringSubmatch(l); line != nil {
+			break
+		}
+	}
+
+	if len(line) != 0 {
+		// IPv4 and IPv6 CIDRs will be separated by a comma in a dual stack setup.
+		for _, cidr := range strings.Split(line[1], ",") {
+			_, _, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return nil, err
+			}
+
+			// Parsed successfully. Add it to the list.
+			foundCIDRs = append(foundCIDRs, cidr)
+		}
+	}
+
+	return foundCIDRs, nil
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds support to the operator to auto-detect the CIDR(s) in-use when
deploying on kubeadm, similar to how we do for OpenShift already. 

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.