### PR TITLE
Make metrics port configurable

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	defaultMetricsPort int32 = 8383
+	defaultMetricsPort int32 = 8484
 	namespace                = ""
 )
 
@@ -115,7 +115,7 @@ func metricsAddr() string {
 		// the controller-runtime accepts '0' to denote that metrics should be disabled.
 		return "0"
 	}
-	// if just a host is specified, listen on port 8383 of that host.
+	// if just a host is specified, listen on port 8484 of that host.
 	if metricsHost != "" && metricsPort == "" {
 		// the controller-runtime will choose a random port if none is specified.
 		// so use the defaultMetricsPort in that case.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,7 +16,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -31,9 +30,7 @@ import (
 )
 
 var (
-	metricsHost       = "0.0.0.0"
-	metricsPort int32 = 8383
-	namespace         = ""
+	namespace = ""
 )
 
 var log = logf.Log.WithName("daemon")
@@ -44,6 +41,13 @@ func Main() {
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)
+	}
+
+	metricsAddr := os.Getenv("METRICS_BIND_ADDRESS")
+	// empty value should disable metrics. the controller-runtime manager accepts '0' to
+	// denote that metrics should be disabled.
+	if metricsAddr == "" {
+		metricsAddr = "0"
 	}
 
 	ctx := context.Background()
@@ -59,7 +63,7 @@ func Main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress: metricsAddr,
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,6 +16,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -30,7 +31,8 @@ import (
 )
 
 var (
-	namespace = ""
+	defaultMetricsPort int32 = 8383
+	namespace                = ""
 )
 
 var log = logf.Log.WithName("daemon")
@@ -41,13 +43,6 @@ func Main() {
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)
-	}
-
-	metricsAddr := os.Getenv("METRICS_BIND_ADDRESS")
-	// empty value should disable metrics. the controller-runtime manager accepts '0' to
-	// denote that metrics should be disabled.
-	if metricsAddr == "" {
-		metricsAddr = "0"
 	}
 
 	ctx := context.Background()
@@ -63,7 +58,7 @@ func Main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
-		MetricsBindAddress: metricsAddr,
+		MetricsBindAddress: metricsAddr(),
 	})
 	if err != nil {
 		log.Error(err, "")
@@ -107,4 +102,27 @@ func Main() {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}
+}
+
+// metricsAddr processes user-specified metrics host and port and sets
+// default values accordingly.
+func metricsAddr() string {
+	metricsHost := os.Getenv("METRICS_HOST")
+	metricsPort := os.Getenv("METRICS_PORT")
+
+	// if neither are specified, disable metrics.
+	if metricsHost == "" && metricsPort == "" {
+		// the controller-runtime accepts '0' to denote that metrics should be disabled.
+		return "0"
+	}
+	// if just a host is specified, listen on port 8383 of that host.
+	if metricsHost != "" && metricsPort == "" {
+		// the controller-runtime will choose a random port if none is specified.
+		// so use the defaultMetricsPort in that case.
+		return fmt.Sprintf("%s:%d", metricsHost, defaultMetricsPort)
+	}
+
+	// finally, handle cases where just a port is specified or both are specified in the same case
+	// since controller-runtime correctly uses all interfaces if no host is specified.
+	return fmt.Sprintf("%s:%s", metricsHost, metricsPort)
 }


### PR DESCRIPTION
## Description

Fixes #515

Replaces #604 

Operator currently serves prometheus metrics on port 8383. This is not configurable. This is problematic because operator is run in hostNetworked mode, and will conflict with any other service running on port 8383 on the node. Several users have reported this happening due to a service in openshift that also uses 8383.

It seems like this code hasn't been touched since the original boiler plate was checked in during the initial commit. Given that, I've taken some liberties to adjust the default behavior from here on out.

This PR:
- Exposes host and port via the `METRICS_HOST` and `METRICS_PORT` environment variables. If both are empty strings, metrics will be shut off.
- Changes default port to 8484. This will be used if only `METRICS_HOST` is specified.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

I did some validation testing:
- :heavy_check_mark: running without setting `METRICS_HOST` and `METRICS_PORT` (or setting them to a blank string) results in metrics not being run
- :heavy_check_mark: running with `METRICS_HOST=localhost` runs metrics on 8383
- :heavy_check_mark: running with `METRICS_PORT=8384` runs metrics on 8484


## For PR author

- [ ] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.