### PR TITLE
cherry-pick: Make metrics port configurable

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -31,9 +31,8 @@ import (
 )
 
 var (
-	metricsHost       = "0.0.0.0"
-	metricsPort int32 = 8383
-	namespace         = ""
+	defaultMetricsPort int32 = 8484
+	namespace                = ""
 )
 
 var log = logf.Log.WithName("daemon")
@@ -59,7 +58,7 @@ func Main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress: metricsAddr(),
 	})
 	if err != nil {
 		log.Error(err, "")
@@ -103,4 +102,27 @@ func Main() {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}
+}
+
+// metricsAddr processes user-specified metrics host and port and sets
+// default values accordingly.
+func metricsAddr() string {
+	metricsHost := os.Getenv("METRICS_HOST")
+	metricsPort := os.Getenv("METRICS_PORT")
+
+	// if neither are specified, disable metrics.
+	if metricsHost == "" && metricsPort == "" {
+		// the controller-runtime accepts '0' to denote that metrics should be disabled.
+		return "0"
+	}
+	// if just a host is specified, listen on port 8484 of that host.
+	if metricsHost != "" && metricsPort == "" {
+		// the controller-runtime will choose a random port if none is specified.
+		// so use the defaultMetricsPort in that case.
+		return fmt.Sprintf("%s:%d", metricsHost, defaultMetricsPort)
+	}
+
+	// finally, handle cases where just a port is specified or both are specified in the same case
+	// since controller-runtime correctly uses all interfaces if no host is specified.
+	return fmt.Sprintf("%s:%s", metricsHost, metricsPort)
 }


### PR DESCRIPTION
cherry-pick #611 

configurable metrics host and port


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.