### PR TITLE
Add support for allowing some pre-determined metadata

### DIFF
--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
@@ -187,7 +187,7 @@ func (r *ReconcileAmazonCloudIntegration) Reconcile(request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
 		r.SetDegraded("Error creating / updating resource", err, reqLogger)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -224,7 +224,7 @@ func (r *ReconcileAPIServer) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -178,7 +178,7 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 		tunnelSecret,
 	)
 
-	if err := ch.CreateOrUpdate(ctx, component, r.status); err != nil {
+	if err := ch.CreateOrUpdate(ctx, component, r.status, utils.NoUserAddedMetadata); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return result, err
 	}

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -254,7 +254,7 @@ func (r *ReconcileCompliance) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdate(ctx, component, r.status); err != nil {
+	if err := handler.CreateOrUpdate(ctx, component, r.status, utils.NoUserAddedMetadata); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -602,7 +602,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	components = append(components, calico.Render()...)
 
 	for _, component := range components {
-		if err := handler.CreateOrUpdate(ctx, component, nil); err != nil {
+		if err := handler.CreateOrUpdate(ctx, component, nil, utils.NoUserAddedMetadata); err != nil {
 			r.SetDegraded("Error creating / updating resource", err, reqLogger)
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -230,7 +230,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 		pullSecrets,
 		r.provider == operatorv1.ProviderOpenShift,
 	)
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -287,7 +287,7 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 		installation,
 	)
 
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -445,7 +445,7 @@ func (r *ReconcileLogStorage) Reconcile(request reconcile.Request) (reconcile.Re
 		applyTrial,
 	)
 
-	if err := hdler.CreateOrUpdate(ctx, component, r.status); err != nil {
+	if err := hdler.CreateOrUpdate(ctx, component, r.status, utils.NoUserAddedMetadata); err != nil {
 		log.Error(err, err.Error())
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -366,7 +366,11 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdate(ctx, component, r.status); err != nil {
+	allowedMetadata := utils.NoUserAddedMetadata
+	if r.provider == operatorv1.ProviderOpenShift {
+		allowedMetadata = utils.AllowOpenshiftSCCAnnotations
+	}
+	if err := handler.CreateOrUpdate(ctx, component, r.status, allowedMetadata); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"context"
+
+	ocsv1 "github.com/openshift/api/security/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/tigera/operator/pkg/apis"
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/render"
+	v1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var log = logf.Log.WithName("test_utils_logger")
+
+var _ = Describe("Component handler tests", func() {
+	var (
+		c        client.Client
+		instance *operatorv1.Manager
+		ctx      context.Context
+		scheme   *runtime.Scheme
+		sm       status.StatusManager
+		fc       render.Component
+		handler  utils.ComponentHandler
+	)
+
+	BeforeEach(func() {
+		// Create a Kubernetes client.
+		scheme = runtime.NewScheme()
+		err := apis.AddToScheme(scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(v1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+
+		c = fake.NewFakeClientWithScheme(scheme)
+		ctx = context.Background()
+		sm = status.New(c, "fake-component")
+		fc = &fakeComponent{}
+
+		// We need to provide something to handler even though it seems to be unused..
+		instance = &operatorv1.Manager{
+			TypeMeta:   metav1.TypeMeta{Kind: "Manager", APIVersion: "operator.tigera.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+		}
+		handler = utils.NewComponentHandler(log, c, scheme, instance)
+	})
+	It("merges metadata according to AllowedMetadataKeys", func() {
+		// We are creating the namespace. AllowedMetadataKeys parameter can be anything.
+		err := handler.CreateOrUpdate(ctx, fc, sm, utils.NoUserAddedMetadata)
+		Expect(err).To(BeNil())
+
+		By("checking that the namespace is created")
+		nsKey := client.ObjectKey{
+			Name: "test-namespace",
+		}
+		ns := &v1.Namespace{}
+		c.Get(ctx, nsKey, ns)
+		Expect(ns.GetAnnotations()).To(BeNil())
+
+		By("updating the namespace with SCC annotations")
+		annotations := make(map[string]string)
+		annotations[ocsv1.UIDRangeAnnotation] = "1-65535"
+		updatedNs := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-namespace",
+				Annotations: annotations,
+			},
+		}
+		c.Update(ctx, updatedNs)
+
+		// Define an explicit expected annotation here just in case the original one
+		// were to get modified.
+		expectedAnnotations := map[string]string{
+			ocsv1.UIDRangeAnnotation: "1-65535",
+		}
+
+		By("checking that the namespace is updated")
+		nsKey = client.ObjectKey{
+			Name: "test-namespace",
+		}
+		ns = &v1.Namespace{}
+		c.Get(ctx, nsKey, ns)
+		Expect(ns.GetAnnotations()).To(Equal(expectedAnnotations))
+
+		By("initiating a merge with allowed Openshift SCC annotations")
+		err = handler.CreateOrUpdate(ctx, fc, sm, utils.AllowOpenshiftSCCAnnotations)
+		Expect(err).To(BeNil())
+
+		By("retrieving the namespace and checking that the annotations are still present")
+		ns = &v1.Namespace{}
+		c.Get(ctx, nsKey, ns)
+		Expect(ns.GetAnnotations()).To(Equal(expectedAnnotations))
+
+		By("initiating a merge with no user allowed metadata")
+		err = handler.CreateOrUpdate(ctx, fc, sm, utils.NoUserAddedMetadata)
+		Expect(err).To(BeNil())
+
+		By("retrieving the namespace and checking that the annotations are not present")
+		ns = &v1.Namespace{}
+		c.Get(ctx, nsKey, ns)
+		Expect(ns.GetAnnotations()).To(BeNil())
+
+	})
+})
+
+// A fake component that only returns ready and always creates the "test-namespace" Namespace.
+type fakeComponent struct {
+}
+
+func (c *fakeComponent) Ready() bool {
+	return true
+}
+
+func (c *fakeComponent) Objects() ([]runtime.Object, []runtime.Object) {
+	objsToCreate := []runtime.Object{
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-namespace",
+			},
+		},
+	}
+	return objsToCreate, nil
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

When enabling SecurityContextConstraints for some Enterprise components. Our operator and kube-controller-manager (I think specifically the cluster-policy-controller container: https://github.com/openshift/cluster-policy-controller/) seem to be clashing over adding SCC annotations on the tigera-manager Namespace resource. This PR adds the ability to ignore certain explicitly allowed annotations (and labels) during the reconcile stage.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
