### PR TITLE
Tunnel secret will be created by the API server

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -17,6 +17,7 @@ package apiserver
 import (
 	"context"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"time"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
@@ -164,6 +165,21 @@ func (r *ReconcileAPIServer) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 
+	var isManagement = network.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManagement
+	var tunnelCASecret *v1.Secret
+	if isManagement {
+		tunnelCASecret, err = utils.ValidateCertPair(r.client,
+			render.VoltronTunnelSecretName,
+			render.VoltronTunnelSecretKeyName,
+			render.VoltronTunnelSecretCertName,
+		)
+		if err != nil {
+			log.Error(err, "Invalid TLS Cert")
+			r.status.SetDegraded("Error validating TLS certificate", err.Error())
+			return reconcile.Result{}, err
+		}
+	}
+
 	pullSecrets, err := utils.GetNetworkingPullSecrets(network, r.client)
 	if err != nil {
 		log.Error(err, "Error retrieving Pull secrets")
@@ -185,7 +201,8 @@ func (r *ReconcileAPIServer) Reconcile(request reconcile.Request) (reconcile.Res
 
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
-	component, err := render.APIServer(network, aci, tlsSecret, pullSecrets, r.provider == operatorv1.ProviderOpenShift)
+	component, err := render.APIServer(network, aci, tlsSecret, pullSecrets, r.provider == operatorv1.ProviderOpenShift,
+		tunnelCASecret)
 	if err != nil {
 		log.Error(err, "Error rendering APIServer")
 		r.status.SetDegraded("Error rendering APIServer", err.Error())

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -314,17 +314,13 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 	var tunnelSecret *corev1.Secret
 	var internalTrafficSecret *corev1.Secret
 	if management {
-
-		// If clusterType is management and the customer brings its own cert, copy it over to the manager ns.
+		// We expect that the secret that holds the certificates for tunnel certificate generation
+		// is already created by the Api Server
 		tunnelSecret = &corev1.Secret{}
 		err := r.client.Get(ctx, client.ObjectKey{Name: render.VoltronTunnelSecretName, Namespace: render.OperatorNamespace()}, tunnelSecret)
 		if err != nil {
-			if errors.IsNotFound(err) {
-				tunnelSecret = nil
-			} else {
-				r.status.SetDegraded("Failed to check for the existence of management-cluster-connection secret", err.Error())
-				return reconcile.Result{}, nil
-			}
+			r.status.SetDegraded("Failed to check for the existence of management-cluster-connection secret", err.Error())
+			return reconcile.Result{}, nil
 		}
 
 		// We expect that the secret that holds the certificates for internal communication within the management
@@ -335,11 +331,9 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 			Namespace: render.OperatorNamespace(),
 		}, internalTrafficSecret)
 		if err != nil {
-			if errors.IsNotFound(err) {
-				var message = fmt.Sprintf("Failed to check for the existence of %s secret", render.ManagerInternalTLSSecretName)
-				r.status.SetDegraded(message, err.Error())
-				return reconcile.Result{}, nil
-			}
+			var message = fmt.Sprintf("Failed to check for the existence of %s secret", render.ManagerInternalTLSSecretName)
+			r.status.SetDegraded(message, err.Error())
+			return reconcile.Result{}, nil
 		}
 	}
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -15,13 +15,16 @@
 package render_test
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
+	"github.com/openshift/library-go/pkg/crypto"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -39,15 +42,14 @@ var _ = Describe("API server rendering tests", func() {
 	BeforeEach(func() {
 		instance = &operator.Installation{
 			Spec: operator.InstallationSpec{
-				ClusterManagementType: operator.ClusterManagementTypeManagement,
-				Registry:              "testregistry.com/",
+				Registry: "testregistry.com/",
 			},
 		}
 	})
 
 	It("should render an API server with default configuration", func() {
 		//APIServer(registry string, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool
-		component, err := render.APIServer(instance, nil, nil, nil, openshift)
+		component, err := render.APIServer(instance, nil, nil, nil, openshift, nil)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 
 		resources, _ := component.Objects()
@@ -221,7 +223,7 @@ var _ = Describe("API server rendering tests", func() {
 	})
 
 	It("should render an API server with custom configuration", func() {
-		component, err := render.APIServer(instance, nil, nil, nil, openshift)
+		component, err := render.APIServer(instance, nil, nil, nil, openshift, nil)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -236,7 +238,7 @@ var _ = Describe("API server rendering tests", func() {
 	})
 
 	It("should render needed resources for k8s kube-controller", func() {
-		component, err := render.APIServer(instance, nil, nil, nil, openshift)
+		component, err := render.APIServer(instance, nil, nil, nil, openshift, nil)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -260,7 +262,7 @@ var _ = Describe("API server rendering tests", func() {
 
 	It("should include a ControlPlaneNodeSelector when specified", func() {
 		instance.Spec.ControlPlaneNodeSelector = map[string]string{"nodeName": "control01"}
-		component, err := render.APIServer(instance, nil, nil, nil, openshift)
+		component, err := render.APIServer(instance, nil, nil, nil, openshift, nil)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -272,7 +274,7 @@ var _ = Describe("API server rendering tests", func() {
 	})
 
 	It("should include a ClusterRole and ClusterRoleBindings for reading webhook configuration", func() {
-		component, err := render.APIServer(instance, nil, nil, nil, openshift)
+		component, err := render.APIServer(instance, nil, nil, nil, openshift, nil)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -305,7 +307,7 @@ var _ = Describe("API server rendering tests", func() {
 				PodSecurityGroupID:   "sg-podsgid",
 			},
 		}
-		component, err := render.APIServer(instance, aci, nil, nil, openshift)
+		component, err := render.APIServer(instance, aci, nil, nil, openshift, nil)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -325,6 +327,162 @@ var _ = Describe("API server rendering tests", func() {
 		for _, v := range expectedEnvVars {
 			Expect(qc.Env).To(ContainElement(v))
 		}
+	})
+
+	It("should render an API server with custom configuration with MCM enabled at startup", func() {
+		instance.Spec.ClusterManagementType = operator.ClusterManagementTypeManagement
+		component, err := render.APIServer(instance, nil, nil, nil, openshift, nil)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+
+		resources, _ := component.Objects()
+
+		// Should render the correct resources.
+		// - 1 namespace
+		// - 1 ConfigMap audit Policy
+		// - 1 Service account
+		// - 2 ServiceAccount ClusterRole and binding
+		// - 2 ClusterRole and binding for auth configmap
+		// - 2 tiered policy passthru ClusterRole and binding
+		// - 1 delegate auth binding
+		// - 1 auth reader binding
+		// - 2 webhook reader ClusterRole and binding
+		// - 4 cert secrets
+		// - 1 api server
+		// - 1 service registration
+		// - 1 Server service
+
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{name: "tigera-system", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: "tigera-audit-policy", ns: "tigera-system", group: "", version: "v1", kind: "ConfigMap"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: "tigera-crds", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-apiserver-access-crds", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-tiered-policy-passthrough", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-tiered-policy-passthrough", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
+			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
+			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
+			{name: render.VoltronTunnelSecretName, ns: render.OperatorNamespace(), group: "", version: "v1", kind: "Secret"},
+			{name: render.VoltronTunnelSecretName, ns: render.APIServerNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "", version: "v1", kind: "Deployment"},
+			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1beta1", kind: "APIService"},
+			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-ui-user", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+		}
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+		i := 0
+		for _, expectedRes := range expectedResources {
+			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+			i++
+		}
+
+		By("Validating the newly created tunnel secret")
+		// Use the x509 package to validate that the cert was signed with the privatekey
+		operatorTunnelSec := GetResource(resources, render.VoltronTunnelSecretName, render.OperatorNamespace(), "", "v1", "Secret")
+		apiServerTunnelSec := GetResource(resources, render.VoltronTunnelSecretName, render.APIServerNamespace, "", "v1", "Secret")
+		validateTunnelSecret(operatorTunnelSec.(*corev1.Secret))
+		validateTunnelSecret(apiServerTunnelSec.(*corev1.Secret))
+
+		dep := GetResource(resources, "tigera-apiserver", render.APIServerNamespace, "", "v1", "Deployment")
+		Expect(dep).ToNot(BeNil())
+
+		By("Validating startup args")
+		expectedArgs := []string{
+			"--secure-port=5443",
+			"--audit-policy-file=/etc/tigera/audit/policy.conf",
+			"--audit-log-path=/var/log/calico/audit/tsee-audit.log",
+			"--enable-managed-clusters-create-api=true",
+		}
+		Expect((dep.(*v1.Deployment)).Spec.Template.Spec.Containers[0].Args).To(ConsistOf(expectedArgs))
+	})
+
+	It("should render an API server with custom configuration with MCM enabled at restart", func() {
+		instance.Spec.ClusterManagementType = operator.ClusterManagementTypeManagement
+		component, err := render.APIServer(instance, nil, nil, nil, openshift, &voltronTunnelSecret)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+
+		resources, _ := component.Objects()
+
+		// Should render the correct resources.
+		// - 1 namespace
+		// - 1 ConfigMap audit Policy
+		// - 1 Service account
+		// - 2 ServiceAccount ClusterRole and binding
+		// - 2 ClusterRole and binding for auth configmap
+		// - 2 tiered policy passthru ClusterRole and binding
+		// - 1 delegate auth binding
+		// - 1 auth reader binding
+		// - 2 webhook reader ClusterRole and binding
+		// - 3 cert secrets
+		// - 1 api server
+		// - 1 service registration
+		// - 1 Server service
+
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{name: "tigera-system", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: "tigera-audit-policy", ns: "tigera-system", group: "", version: "v1", kind: "ConfigMap"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: "tigera-crds", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-apiserver-access-crds", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-tiered-policy-passthrough", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-tiered-policy-passthrough", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
+			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
+			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
+			{name: render.VoltronTunnelSecretName, ns: render.APIServerNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "", version: "v1", kind: "Deployment"},
+			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1beta1", kind: "APIService"},
+			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-ui-user", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+		}
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+		i := 0
+		for _, expectedRes := range expectedResources {
+			ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+			i++
+		}
+
+		dep := GetResource(resources, "tigera-apiserver", render.APIServerNamespace, "", "v1", "Deployment")
+		Expect(dep).ToNot(BeNil())
+
+		By("Validating startup args")
+		expectedArgs := []string{
+			"--secure-port=5443",
+			"--audit-policy-file=/etc/tigera/audit/policy.conf",
+			"--audit-log-path=/var/log/calico/audit/tsee-audit.log",
+			"--enable-managed-clusters-create-api=true",
+		}
+		Expect((dep.(*v1.Deployment)).Spec.Template.Spec.Containers[0].Args).To(ConsistOf(expectedArgs))
 	})
 })
 
@@ -352,4 +510,41 @@ func verifyCertSANs(certBytes []byte) {
 	cert, err := x509.ParseCertificate(pemBlock.Bytes)
 	Expect(err).To(BeNil(), "Error parsing bytes from secret into certificate")
 	Expect(cert.DNSNames).To(ConsistOf([]string{"tigera-api.tigera-system.svc"}), "Expect cert SAN's to match extension API server service DNS name")
+}
+
+func validateTunnelSecret(voltronSecret *corev1.Secret) {
+	var newCert *x509.Certificate
+
+	cert := voltronSecret.Data["cert"]
+	key := voltronSecret.Data["key"]
+	_, err := tls.X509KeyPair(cert, key)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(cert))
+	Expect(ok).To(BeTrue())
+
+	block, _ := pem.Decode([]byte(cert))
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(block).To(Not(BeNil()))
+
+	newCert, err = x509.ParseCertificate(block.Bytes)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	opts := x509.VerifyOptions{
+		DNSName: render.VoltronDnsName,
+		Roots:   roots,
+	}
+
+	_, err = newCert.Verify(opts)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	opts = x509.VerifyOptions{
+		DNSName:     render.VoltronDnsName,
+		Roots:       x509.NewCertPool(),
+		CurrentTime: time.Now().AddDate(0, 0, crypto.DefaultCACertificateLifetimeInDays+1),
+	}
+	_, err = newCert.Verify(opts)
+	Expect(err).Should(HaveOccurred())
+
 }

--- a/pkg/render/fixtures_test.go
+++ b/pkg/render/fixtures_test.go
@@ -34,3 +34,18 @@ var internalManagerTLSSecret = v1.Secret{
 		"key":  []byte("key"),
 	},
 }
+
+var voltronTunnelSecret = v1.Secret{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Secret",
+		APIVersion: "v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      render.VoltronTunnelSecretName,
+		Namespace: render.OperatorNamespace(),
+	},
+	Data: map[string][]byte{
+		render.VoltronTunnelSecretCertName: []byte("cert"),
+		render.VoltronTunnelSecretKeyName:  []byte("key"),
+	},
+}

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -63,6 +63,8 @@ const (
 const (
 	VoltronName                 = "tigera-voltron"
 	VoltronTunnelSecretName     = "tigera-management-cluster-connection"
+	VoltronTunnelSecretCertName = "cert"
+	VoltronTunnelSecretKeyName  = "key"
 	voltronTunnelHashAnnotation = "hash.operator.tigera.io/voltron-tunnel"
 	defaultVoltronPort          = "9443"
 	defaultTunnelVoltronPort    = "9449"
@@ -105,12 +107,6 @@ func Manager(
 	tlsAnnotations[tlsSecretHashAnnotation] = AnnotationHash(tlsKeyPair.Data)
 
 	if management {
-		// If there is no secret create one and add it to the operator namespace.
-		if tunnelSecret == nil {
-			tunnelSecret = voltronTunnelSecret()
-			tlsSecrets = append(tlsSecrets, tunnelSecret)
-		}
-
 		// Copy tunnelSecret and internalTrafficSecret to TLS secrets
 		// tunnelSecret contains the ca cert to generate guardian certificates
 		// internalTrafficCert containts the cert used to communicated within the management K8S cluster
@@ -551,22 +547,6 @@ func (c *managerComponent) managerService() *v1.Service {
 			Selector: map[string]string{
 				"k8s-app": "tigera-manager",
 			},
-		},
-	}
-}
-
-// managerService returns the service exposing the Tigera Secure web app.
-func voltronTunnelSecret() *v1.Secret {
-	key, cert := ceateSelfSignedVoltronSecret()
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      VoltronTunnelSecretName,
-			Namespace: OperatorNamespace(),
-		},
-		Data: map[string][]byte{
-			"cert": []byte(cert),
-			"key":  []byte(key),
 		},
 	}
 }

--- a/pkg/render/voltron_secret.go
+++ b/pkg/render/voltron_secret.go
@@ -24,6 +24,9 @@ import (
 	"math/big"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openshift/library-go/pkg/crypto"
 )
 
@@ -35,9 +38,26 @@ const (
 	blockTypeCert       = "CERTIFICATE"
 )
 
+// Creates a secret that will store the CA needed to generated certificates
+// for managed cluster registration
+func voltronTunnelSecret() *corev1.Secret {
+	key, cert := createSelfSignedVoltronSecret()
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VoltronTunnelSecretName,
+			Namespace: OperatorNamespace(),
+		},
+		Data: map[string][]byte{
+			VoltronTunnelSecretCertName: []byte(cert),
+			VoltronTunnelSecretKeyName:  []byte(key),
+		},
+	}
+}
+
 // Secrets to establish a tunnel between Voltron and Guardian
 // Differs from other secrets in the way that it needs a DNS name and KeyUsage.
-func ceateSelfSignedVoltronSecret() (string, string) {
+func createSelfSignedVoltronSecret() (string, string) {
 	template := template()
 	privateKey, err := rsa.GenerateKey(rand.Reader, VoltronKeySizeBits)
 	if err != nil {


### PR DESCRIPTION
## Description

The tunnel secret will be created by the API server, instead of the manager. This change is needed in order to share the CA with the API server, that will be solely responsible for generating managed cluster resources. At creation, a client cert and key will be provided as a one time event. The cert and private key are signed by the CA from secret `tigera-management-cluster-connection`

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
