### PR TITLE
make amazon cloud CRD optional

### DIFF
--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
@@ -46,7 +46,7 @@ var log = logf.Log.WithName("controller_amazoncloudintegration")
 // Add creates a new AmazonCloudIntegration Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.AmazonCRDExists {
 		// No need to start this controller.
 		return nil
 	}

--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
@@ -30,6 +30,7 @@ import (
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	operatorv1beta1 "github.com/tigera/operator/pkg/apis/operator/v1beta1"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -44,12 +45,12 @@ var log = logf.Log.WithName("controller_amazoncloudintegration")
 
 // Add creates a new AmazonCloudIntegration Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, provider operatorv1.Provider, tsee bool) error {
-	if !tsee {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, provider))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
 }
 
 // newReconciler returns a new reconcile.Reconciler

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -17,8 +17,9 @@ package apiserver
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	operatorv1beta1 "github.com/tigera/operator/pkg/apis/operator/v1beta1"
@@ -43,27 +44,28 @@ var log = logf.Log.WithName("controller_apiserver")
 // Add creates a new APIServer Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.EnterpriseCRDExists {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider, opts.AmazonCRDExists))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, provider operatorv1.Provider, amazonCRDExists bool) *ReconcileAPIServer {
 	r := &ReconcileAPIServer{
-		client:   mgr.GetClient(),
-		scheme:   mgr.GetScheme(),
-		provider: provider,
-		status:   status.New(mgr.GetClient(), "apiserver"),
+		client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		provider:        provider,
+		amazonCRDExists: amazonCRDExists,
+		status:          status.New(mgr.GetClient(), "apiserver"),
 	}
 	r.status.Run()
 	return r
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r *ReconcileAPIServer) error {
 	// Create a new controller
 	c, err := controller.New("apiserver-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -92,10 +94,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		}
 	}
 
-	err = c.Watch(&source.Kind{Type: &operatorv1beta1.AmazonCloudIntegration{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		log.V(5).Info("Failed to create AmazonCloudIntegration watch", "err", err)
-		return fmt.Errorf("apiserver-controller failed to watch primary resource: %v", err)
+	if r.amazonCRDExists {
+		err = c.Watch(&source.Kind{Type: &operatorv1beta1.AmazonCloudIntegration{}}, &handler.EnqueueRequestForObject{})
+		if err != nil {
+			log.V(5).Info("Failed to create AmazonCloudIntegration watch", "err", err)
+			return fmt.Errorf("apiserver-controller failed to watch primary resource: %v", err)
+		}
 	}
 
 	// TODO: Watch for dependent objects.
@@ -111,10 +115,11 @@ var _ reconcile.Reconciler = &ReconcileAPIServer{}
 type ReconcileAPIServer struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client   client.Client
-	scheme   *runtime.Scheme
-	provider operatorv1.Provider
-	status   status.StatusManager
+	client          client.Client
+	scheme          *runtime.Scheme
+	provider        operatorv1.Provider
+	amazonCRDExists bool
+	status          status.StatusManager
 }
 
 // Reconcile reads that state of the cluster for a APIServer object and makes changes based on the state read
@@ -194,13 +199,16 @@ func (r *ReconcileAPIServer) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 
-	aci, err := utils.GetAmazonCloudIntegration(ctx, r.client)
-	if errors.IsNotFound(err) {
-		aci = nil
-	} else if err != nil {
-		log.Error(err, "Error reading AmazonCloudIntegration")
-		r.status.SetDegraded("Error reading AmazonCloudIntegration", err.Error())
-		return reconcile.Result{}, err
+	var amazon *operatorv1beta1.AmazonCloudIntegration
+	if r.amazonCRDExists {
+		amazon, err = utils.GetAmazonCloudIntegration(ctx, r.client)
+		if errors.IsNotFound(err) {
+			amazon = nil
+		} else if err != nil {
+			log.Error(err, "Error reading AmazonCloudIntegration")
+			r.status.SetDegraded("Error reading AmazonCloudIntegration", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Create a component handler to manage the rendered component.
@@ -208,7 +216,7 @@ func (r *ReconcileAPIServer) Reconcile(request reconcile.Request) (reconcile.Res
 
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
-	component, err := render.APIServer(network, aci, tlsSecret, pullSecrets, r.provider == operatorv1.ProviderOpenShift,
+	component, err := render.APIServer(network, amazon, tlsSecret, pullSecrets, r.provider == operatorv1.ProviderOpenShift,
 		tunnelCASecret)
 	if err != nil {
 		log.Error(err, "Error rendering APIServer")

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -23,6 +23,7 @@ import (
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	operatorv1beta1 "github.com/tigera/operator/pkg/apis/operator/v1beta1"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -41,12 +42,12 @@ var log = logf.Log.WithName("controller_apiserver")
 
 // Add creates a new APIServer Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, provider operatorv1.Provider, tsee bool) error {
-	if !tsee {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, provider))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
 }
 
 // newReconciler returns a new reconcile.Reconciler

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 
 	"github.com/tigera/operator/pkg/controller/installation"
@@ -45,13 +46,13 @@ var log = logf.Log.WithName(controllerName)
 
 // Add creates a new ManagementClusterConnection Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and start it when the Manager is started. This controller is meant only for enterprise users.
-func Add(mgr manager.Manager, p operatorv1.Provider, enterpriseEnabled bool) error {
-	if !enterpriseEnabled {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		// No need to start this controller.
 		return nil
 	}
 	statusManager := status.New(mgr.GetClient(), "management-cluster-connection")
-	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme(), statusManager, p))
+	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme(), statusManager, opts.DetectedProvider))
 }
 
 // newReconciler returns a new reconcile.Reconciler

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -47,7 +47,7 @@ var log = logf.Log.WithName(controllerName)
 // Add creates a new ManagementClusterConnection Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and start it when the Manager is started. This controller is meant only for enterprise users.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.EnterpriseCRDExists {
 		// No need to start this controller.
 		return nil
 	}

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -44,7 +44,7 @@ var log = logf.Log.WithName("controller_compliance")
 // Add creates a new Compliance Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.EnterpriseCRDExists {
 		// No need to start this controller.
 		return nil
 	}

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -23,6 +23,7 @@ import (
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -42,12 +43,12 @@ var log = logf.Log.WithName("controller_compliance")
 
 // Add creates a new Compliance Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, provider operatorv1.Provider, tsee bool) error {
-	if !tsee {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, provider))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
 }
 
 // newReconciler returns a new reconcile.Reconciler

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,19 +15,19 @@
 package controller
 
 import (
-	"github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/options"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 // Each func takes the manager as well as a Provider indicating any detected provider,
 // as well as a boolean indicating whether we need to start TSEE controllers.
-var AddToManagerFuncs []func(manager.Manager, v1.Provider, bool) error
+var AddToManagerFuncs []func(manager.Manager, options.AddOptions) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, provider v1.Provider, tsee bool) error {
+func AddToManager(m manager.Manager, opts options.AddOptions) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, provider, tsee); err != nil {
+		if err := f(m, opts); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -23,6 +23,7 @@ import (
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -44,12 +45,12 @@ var log = logf.Log.WithName("controller_intrusiondetection")
 
 // Add creates a new IntrusionDetection Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, p operatorv1.Provider, tsee bool) error {
-	if !tsee {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, p))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
 }
 
 // newReconciler returns a new reconcile.Reconciler

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -46,7 +46,7 @@ var log = logf.Log.WithName("controller_intrusiondetection")
 // Add creates a new IntrusionDetection Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.EnterpriseCRDExists {
 		// No need to start this controller.
 		return nil
 	}

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -33,6 +33,7 @@ import (
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -42,12 +43,12 @@ var log = logf.Log.WithName("controller_logcollector")
 
 // Add creates a new LogCollector Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, provider operatorv1.Provider, tsee bool) error {
-	if !tsee {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, provider))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -84,7 +85,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	for _, secretName := range []string{
 		render.ElasticsearchLogCollectorUserSecret, render.ElasticsearchEksLogForwarderUserSecret,
 		render.ElasticsearchPublicCertSecret, render.S3FluentdSecretName, render.EksLogForwarderSecret,
-	    render.SplunkFluentdTokenSecretName, render.SplunkFluentdCertificateSecretName} {
+		render.SplunkFluentdTokenSecretName, render.SplunkFluentdCertificateSecretName} {
 		if err = utils.AddSecretsWatch(c, secretName, render.OperatorNamespace()); err != nil {
 			return fmt.Errorf("log-collector-controller failed to watch the Secret resource(%s): %v", secretName, err)
 		}

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -44,7 +44,7 @@ var log = logf.Log.WithName("controller_logcollector")
 // Add creates a new LogCollector Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.EnterpriseCRDExists {
 		// No need to start this controller.
 		return nil
 	}

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -65,7 +65,7 @@ const (
 // Add creates a new LogStorage Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.EnterpriseCRDExists {
 		return nil
 	}
 

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -34,6 +34,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -63,12 +64,12 @@ const (
 
 // Add creates a new LogStorage Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, provider operatorv1.Provider, tsee bool) error {
-	if !tsee {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		return nil
 	}
 
-	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage"), defaultResolveConfPath, provider)
+	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage"), defaultResolveConfPath, opts.DetectedProvider)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/compliance"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -44,12 +45,12 @@ var log = logf.Log.WithName("controller_manager")
 
 // Add creates a new Manager Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, provider operatorv1.Provider, tsee bool) error {
-	if !tsee {
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnableEnterpriseControllers {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, provider))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -324,11 +325,13 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, nil
 		}
 
-		internalTrafficSecret, err = utils.ValidateCertPair(r.client,
-			render.ManagerInternalTLSSecretName,
-			render.ManagerInternalSecretCertName,
-			render.ManagerInternalSecretKeyName,
-		)
+		// We expect that the secret that holds the certificates for internal communication within the management
+		// K8S cluster is already created by the KubeControllers
+		internalTrafficSecret = &corev1.Secret{}
+		err = r.client.Get(ctx, client.ObjectKey{
+			Name:      render.ManagerInternalTLSSecretName,
+			Namespace: render.OperatorNamespace(),
+		}, internalTrafficSecret)
 		if err != nil {
 			r.status.SetDegraded(fmt.Sprintf("Error validating TLS secret %s", render.ManagerInternalTLSSecretName), err.Error())
 			return reconcile.Result{}, err

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -46,7 +46,7 @@ var log = logf.Log.WithName("controller_manager")
 // Add creates a new Manager Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
-	if !opts.EnableEnterpriseControllers {
+	if !opts.EnterpriseCRDExists {
 		// No need to start this controller.
 		return nil
 	}

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -1,0 +1,12 @@
+package options
+
+import v1 "github.com/tigera/operator/pkg/apis/operator/v1"
+
+// AddOptions are passed to controllers when added to the controller manager. They
+// detail options detected by the daemon at startup that some controllers may either
+// use to determine if they should run at all, or store them and influence their
+// reconciliation loops.
+type AddOptions struct {
+	DetectedProvider            v1.Provider
+	EnableEnterpriseControllers bool
+}

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -7,6 +7,7 @@ import v1 "github.com/tigera/operator/pkg/apis/operator/v1"
 // use to determine if they should run at all, or store them and influence their
 // reconciliation loops.
 type AddOptions struct {
-	DetectedProvider            v1.Provider
-	EnableEnterpriseControllers bool
+	DetectedProvider    v1.Provider
+	EnterpriseCRDExists bool
+	AmazonCRDExists     bool
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -83,17 +83,24 @@ func Main() {
 	log.WithValues("provider", provider).Info("Checking type of cluster")
 
 	// Determine if we need to start the TSEE specific controllers.
-	startTSEE, err := utils.RequiresTigeraSecure(mgr.GetConfig())
+	enterpriseCRDExists, err := utils.RequiresTigeraSecure(mgr.GetConfig())
 	if err != nil {
 		log.Error(err, "Failed to determine if TSEE is required")
 		os.Exit(1)
 	}
-	log.WithValues("required", startTSEE).Info("Checking if TSEE controllers are required")
+	log.WithValues("required", enterpriseCRDExists).Info("Checking if TSEE controllers are required")
+
+	amazonCRDExists, err := utils.RequiresAmazonController(mgr.GetConfig())
+	if err != nil {
+		log.Error(err, "Failed to determine if AmazonCloudIntegration is required")
+		os.Exit(1)
+	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr, options.AddOptions{
-		DetectedProvider:            provider,
-		EnableEnterpriseControllers: startTSEE,
+		DetectedProvider:    provider,
+		EnterpriseCRDExists: enterpriseCRDExists,
+		AmazonCRDExists:     amazonCRDExists,
 	}); err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/controller"
+	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -90,7 +91,10 @@ func Main() {
 	log.WithValues("required", startTSEE).Info("Checking if TSEE controllers are required")
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr, provider, startTSEE); err != nil {
+	if err := controller.AddToManager(mgr, options.AddOptions{
+		DetectedProvider:            provider,
+		EnableEnterpriseControllers: startTSEE,
+	}); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tigera/operator/pkg/apis"
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/controller"
+	"github.com/tigera/operator/pkg/controller/options"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
@@ -232,8 +233,10 @@ func setupManager() (client.Client, manager.Manager) {
 	err = apis.AddToScheme(mgr.GetScheme())
 	Expect(err).NotTo(HaveOccurred())
 	// Setup all Controllers
-	runTSEEControllers := true
-	err = controller.AddToManager(mgr, operator.ProviderNone, runTSEEControllers)
+	err = controller.AddToManager(mgr, options.AddOptions{
+		DetectedProvider:            operator.ProviderNone,
+		EnableEnterpriseControllers: true,
+	})
 	Expect(err).NotTo(HaveOccurred())
 	return mgr.GetClient(), mgr
 }

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -234,8 +234,8 @@ func setupManager() (client.Client, manager.Manager) {
 	Expect(err).NotTo(HaveOccurred())
 	// Setup all Controllers
 	err = controller.AddToManager(mgr, options.AddOptions{
-		DetectedProvider:            operator.ProviderNone,
-		EnableEnterpriseControllers: true,
+		DetectedProvider:    operator.ProviderNone,
+		EnterpriseCRDExists: true,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	return mgr.GetClient(), mgr


### PR DESCRIPTION
## Description

The Operator will deadlock if the new v1beta1 amazoncloudintegration CRD is not created. We encountered this briefly when merging operator code in conjunction with docs code. We now always include the CRD on docs. 

However, down the road, it may be desirable to not force installation of this CRD when a user isn't running on AWS nor have any plans to do so.

This PR copies the mechanism already established by the core controller to not launch the Enterprise controllers if we're not running Enterprise. In this case, we skip launching the AmazonCloudIntegration controller if we're OS or not using EKS networking. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
