### PR TITLE
Add clusterrole to components that need authentication reviews

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -472,6 +472,8 @@ func (c *complianceComponent) complianceServerClusterRole() *rbacv1.ClusterRole 
 
 	if c.installation.Spec.ClusterManagementType == operatorv1.ClusterManagementTypeManagement {
 		// For cross-cluster requests, an authentication review will be done for authenticating the compliance-server.
+		// Requests on behalf of the compliance-server will be sent to Voltron, where an authentication review will take
+		// place with its bearer token.
 		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"authenticationreviews"},

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -20,6 +20,7 @@ import (
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/render"
 	v1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var _ = Describe("compliance rendering tests", func() {
@@ -87,6 +88,13 @@ var _ = Describe("compliance rendering tests", func() {
 			ExpectGlobalReportType(resources[20], "network-access")
 			ExpectGlobalReportType(resources[21], "policy-audit")
 			ExpectGlobalReportType(resources[22], "cis-benchmark")
+
+			clusterRole := resources[27].(*rbacv1.ClusterRole)
+			Expect(clusterRole.Name).To(Equal("tigera-compliance-server"))
+			Expect(len(clusterRole.Rules)).To(Equal(2))
+			Expect(clusterRole.Rules[0].Resources[0]).To(Equal("globalreporttypes"))
+			Expect(clusterRole.Rules[0].Resources[1]).To(Equal("globalreports"))
+			Expect(clusterRole.Rules[1].Resources[0]).To(Equal("subjectaccessreviews"))
 		})
 	})
 
@@ -94,12 +102,12 @@ var _ = Describe("compliance rendering tests", func() {
 		It("should render all resources for a default configuration", func() {
 			component, err := render.Compliance(nil, &internalManagerTLSSecret,
 				&operatorv1.Installation{
-				Spec: operatorv1.InstallationSpec{
-					KubernetesProvider:    operatorv1.ProviderNone,
-					Registry:              "testregistry.com/",
-					ClusterManagementType: operatorv1.ClusterManagementTypeManagement,
-				},
-			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift)
+					Spec: operatorv1.InstallationSpec{
+						KubernetesProvider:    operatorv1.ProviderNone,
+						Registry:              "testregistry.com/",
+						ClusterManagementType: operatorv1.ClusterManagementTypeManagement,
+					},
+				}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift)
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
 
@@ -157,7 +165,7 @@ var _ = Describe("compliance rendering tests", func() {
 			ExpectGlobalReportType(resources[21], "policy-audit")
 			ExpectGlobalReportType(resources[22], "cis-benchmark")
 
-			var dpComplianceServer = resources[len(expectedResources) - 1].(*v1.Deployment)
+			var dpComplianceServer = resources[len(expectedResources)-1].(*v1.Deployment)
 
 			Expect(len(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(3))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("cert"))
@@ -174,6 +182,14 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(dpComplianceServer.Spec.Template.Spec.Volumes[1].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
 			Expect(dpComplianceServer.Spec.Template.Spec.Volumes[2].Name).To(Equal("elastic-ca-cert-volume"))
 			Expect(dpComplianceServer.Spec.Template.Spec.Volumes[2].Secret.SecretName).To(Equal(render.ElasticsearchPublicCertSecret))
+
+			clusterRole := resources[28].(*rbacv1.ClusterRole)
+			Expect(clusterRole.Name).To(Equal("tigera-compliance-server"))
+			Expect(len(clusterRole.Rules)).To(Equal(3))
+			Expect(clusterRole.Rules[0].Resources[0]).To(Equal("globalreporttypes"))
+			Expect(clusterRole.Rules[0].Resources[1]).To(Equal("globalreports"))
+			Expect(clusterRole.Rules[1].Resources[0]).To(Equal("subjectaccessreviews"))
+			Expect(clusterRole.Rules[2].Resources[0]).To(Equal("authenticationreviews"))
 		})
 	})
 
@@ -237,6 +253,13 @@ var _ = Describe("compliance rendering tests", func() {
 			ExpectGlobalReportType(resources[20], "network-access")
 			ExpectGlobalReportType(resources[21], "policy-audit")
 			ExpectGlobalReportType(resources[22], "cis-benchmark")
+
+			clusterRole := resources[25].(*rbacv1.ClusterRole)
+			Expect(clusterRole.Name).To(Equal("tigera-compliance-server"))
+			Expect(len(clusterRole.Rules)).To(Equal(2))
+			Expect(clusterRole.Rules[0].Resources[0]).To(Equal("globalreporttypes"))
+			Expect(clusterRole.Rules[0].Resources[1]).To(Equal("globalreports"))
+			Expect(clusterRole.Rules[1].Resources[0]).To(Equal("subjectaccessreviews"))
 		})
 	})
 })

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -89,8 +89,7 @@ var _ = Describe("compliance rendering tests", func() {
 			ExpectGlobalReportType(resources[21], "policy-audit")
 			ExpectGlobalReportType(resources[22], "cis-benchmark")
 
-			clusterRole := resources[27].(*rbacv1.ClusterRole)
-			Expect(clusterRole.Name).To(Equal("tigera-compliance-server"))
+			clusterRole := GetResource(resources, "tigera-compliance-server", "", rbac, "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			Expect(len(clusterRole.Rules)).To(Equal(2))
 			Expect(clusterRole.Rules[0].Resources[0]).To(Equal("globalreporttypes"))
 			Expect(clusterRole.Rules[0].Resources[1]).To(Equal("globalreports"))
@@ -183,8 +182,7 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(dpComplianceServer.Spec.Template.Spec.Volumes[2].Name).To(Equal("elastic-ca-cert-volume"))
 			Expect(dpComplianceServer.Spec.Template.Spec.Volumes[2].Secret.SecretName).To(Equal(render.ElasticsearchPublicCertSecret))
 
-			clusterRole := resources[28].(*rbacv1.ClusterRole)
-			Expect(clusterRole.Name).To(Equal("tigera-compliance-server"))
+			clusterRole := GetResource(resources, "tigera-compliance-server", "", rbac, "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			Expect(len(clusterRole.Rules)).To(Equal(3))
 			Expect(clusterRole.Rules[0].Resources[0]).To(Equal("globalreporttypes"))
 			Expect(clusterRole.Rules[0].Resources[1]).To(Equal("globalreports"))
@@ -254,8 +252,7 @@ var _ = Describe("compliance rendering tests", func() {
 			ExpectGlobalReportType(resources[21], "policy-audit")
 			ExpectGlobalReportType(resources[22], "cis-benchmark")
 
-			clusterRole := resources[25].(*rbacv1.ClusterRole)
-			Expect(clusterRole.Name).To(Equal("tigera-compliance-server"))
+			clusterRole := GetResource(resources, "tigera-compliance-server", "", rbac, "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			Expect(len(clusterRole.Rules)).To(Equal(2))
 			Expect(clusterRole.Rules[0].Resources[0]).To(Equal("globalreporttypes"))
 			Expect(clusterRole.Rules[0].Resources[1]).To(Equal("globalreports"))

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -156,6 +156,15 @@ func (c *kubeControllersComponent) controllersRole() *rbacv1.ClusterRole {
 		}
 
 		role.Rules = append(role.Rules, extraRules...)
+
+		if c.cr.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
+			// For cross-cluster requests an authentication review will be done for authenticating the kube-controllers.
+			role.Rules = append(role.Rules, rbacv1.PolicyRule{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"authenticationreviews"},
+				Verbs:     []string{"create"},
+			})
+		}
 	}
 	return role
 }
@@ -292,8 +301,8 @@ func (c *kubeControllersComponent) annotations() map[string]string {
 		return make(map[string]string)
 	}
 
-	return map[string]string {
-		ManagerInternalTLSHashAnnotation : AnnotationHash(c.managerInternalSecret.Data),
+	return map[string]string{
+		ManagerInternalTLSHashAnnotation: AnnotationHash(c.managerInternalSecret.Data),
 	}
 }
 

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -159,6 +159,8 @@ func (c *kubeControllersComponent) controllersRole() *rbacv1.ClusterRole {
 
 		if c.cr.Spec.ClusterManagementType == operator.ClusterManagementTypeManagement {
 			// For cross-cluster requests an authentication review will be done for authenticating the kube-controllers.
+			// Requests on behalf of the kube-controllers will be sent to Voltron, where an authentication review will
+			// take place with its bearer token.
 			role.Rules = append(role.Rules, rbacv1.PolicyRule{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"authenticationreviews"},

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -101,8 +101,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
-		clusterRole := resources[1].(*rbacv1.ClusterRole)
-		Expect(clusterRole.Name).To(Equal("calico-kube-controllers"))
+		clusterRole := GetResource(resources, "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(len(clusterRole.Rules)).To(Equal(12))
 	})
 
@@ -135,8 +134,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
 		// Management clusters also have a role for authenticationreviews.
-		clusterRole := resources[1].(*rbacv1.ClusterRole)
-		Expect(clusterRole.Name).To(Equal("calico-kube-controllers"))
+		clusterRole := GetResource(resources, "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(len(clusterRole.Rules)).To(Equal(13))
 		Expect(clusterRole.Rules[12].Resources[0]).To(Equal("authenticationreviews"))
 	})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -579,12 +579,6 @@ func managerClusterRole(impersonationOnly bool) *rbacv1.ClusterRole {
 	if !impersonationOnly {
 		cr.Rules = append(cr.Rules,
 			rbacv1.PolicyRule{
-
-				APIGroups: []string{"authentication.k8s.io"},
-				Resources: []string{"tokenreviews"},
-				Verbs:     []string{"create"},
-			},
-			rbacv1.PolicyRule{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},
 				Verbs:     []string{"list", "get", "watch", "update"},


### PR DESCRIPTION
Add clusterrole to components that need authentication reviews for cross cluster requests

The authentication reviews api is an api that exchanges an auth header for user information. Necessary for:
- kube-controllers to view and modify secrets in managed cluster
- compliance to fetch report data from managed cluster

Token reviews are no longer used.