### PR TITLE
[v1.4] Cherry-pick authentication review rbac rule

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -818,6 +818,14 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			},
 			Verbs: []string{"get", "watch", "list"},
 		},
+		// A POST to AuthenticationReviews can be compared with a POST to the TokenReviews endpoint.
+		// This api is added to circumvent a bug in the k8s-apiserver that is present in k8s
+		// versions up to v1.18 (kubernetes/pull/87612) when oidc audiences are enabled.
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"authenticationreviews"},
+			Verbs:     []string{"create"},
+		},
 	}
 
 	// If this is a managed cluster the rule to access the clusters indices in Elasticsearch need to be added to the management
@@ -928,6 +936,14 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 				"globalthreatfeeds/status",
 			},
 			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
+		},
+		// A POST to AuthenticationReviews can be compared with a POST to the TokenReviews endpoint.
+		// This api is added to circumvent a bug in the k8s-apiserver that is present in k8s
+		// versions up to v1.18 (kubernetes/pull/87612) when oidc audiences are enabled.
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"authenticationreviews"},
+			Verbs:     []string{"create"},
 		},
 	}
 


### PR DESCRIPTION
Cherry-pick authentication review rbac rule.
#597

Add clusterrole additions for authenticationreviews such that ui users can be authenticated by es-proxy and compliance.

AuthenticationReviews is a new api in the tigera-apiserver that exchanges the auth header for userinfo. This works for basic, token, oidc and it built to circumvent a bug that is present in k8s versions lower than 1,18 when the oidc audiences flag is used, see kubernetes/kubernetes#87612