### PR TITLE
component resource requirements

### DIFF
--- a/deploy/crds/operator.tigera.io_installations_crd.yaml
+++ b/deploy/crds/operator.tigera.io_installations_crd.yaml
@@ -162,6 +162,53 @@ spec:
                 - Management
                 - Managed
                 type: string
+              componentResources:
+                description: ComponentResources can be used to customize the resource
+                  requirements for each component.
+                items:
+                  description: The ComponentResource struct associates a ResourceRequirements
+                    with a component by name
+                  properties:
+                    componentName:
+                      description: ComponentName CRD enum
+                      enum:
+                      - Node
+                      - Typha
+                      - KubeControllers
+                      type: string
+                    resourceRequirements:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                  required:
+                  - componentName
+                  - resourceRequirements
+                  type: object
+                type: array
               controlPlaneNodeSelector:
                 additionalProperties:
                   type: string

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -118,8 +118,10 @@ const (
 // The ComponentResource struct associates a ResourceRequirements with a component by name
 // +k8s:openapi-gen=true
 type ComponentResource struct {
+	// ComponentName is an enum which identifies the component
 	// +kubebuilder:validation:Enum=Node;Typha;KubeControllers
 	ComponentName        ComponentName            `json:"componentName"`
+	// ResourceRequirements allows customization of limits and requests for compute resources such as cpu and memory.
 	ResourceRequirements *v1.ResourceRequirements `json:"resourceRequirements"`
 }
 

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -100,6 +100,27 @@ type InstallationSpec struct {
 	// field.
 	// +optional
 	NodeUpdateStrategy appsv1.DaemonSetUpdateStrategy `json:"nodeUpdateStrategy,omitempty"`
+
+	// ComponentResources can be used to customize the resource requirements for each component.
+	// +optional
+	ComponentResources []*ComponentResource `json:"componentResources,omitempty"`
+}
+
+// ComponentName CRD enum
+type ComponentName string
+
+const (
+	ComponentNameNode            ComponentName = "Node"
+	ComponentNameTypha           ComponentName = "Typha"
+	ComponentNameKubeControllers ComponentName = "KubeControllers"
+)
+
+// The ComponentResource struct associates a ResourceRequirements with a component by name
+// +k8s:openapi-gen=true
+type ComponentResource struct {
+	// +kubebuilder:validation:Enum=Node;Typha;KubeControllers
+	ComponentName        ComponentName            `json:"componentName"`
+	ResourceRequirements *v1.ResourceRequirements `json:"resourceRequirements"`
 }
 
 // Provider represents a particular provider or flavor of Kubernetes. Valid options

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/openshift/library-go/pkg/crypto"
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -256,6 +257,19 @@ func AnnotationHash(i interface{}) string {
 	h := sha1.New()
 	h.Write([]byte(fmt.Sprintf("%q", i)))
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// GetResourceRequirements retrieves the component ResourcesRequirements from the installation
+// If it doesn't exist, it returns an empty ResourceRequirements struct
+func GetResourceRequirements(i *operatorv1.Installation, name operatorv1.ComponentName) v1.ResourceRequirements {
+	if i.Spec.ComponentResources != nil {
+		for _, cr := range i.Spec.ComponentResources {
+			if cr.ComponentName == name && cr.ResourceRequirements != nil {
+				return *cr.ResourceRequirements
+			}
+		}
+	}
+	return v1.ResourceRequirements{}
 }
 
 // secretsAnnotationHash generates a hash based off of the data in each secrets Data field that can be used by Deployments

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -281,6 +281,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 							Name:  "calico-kube-controllers",
 							Image: image,
 							Env:   env,
+							Resources: c.kubeControllersResources(),
 							ReadinessProbe: &v1.Probe{
 								Handler: v1.Handler{
 									Exec: &v1.ExecAction{
@@ -307,6 +308,11 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 	}
 
 	return &d
+}
+
+// kubeControllerResources creates the kube-controller's resource requirements.
+func (c *kubeControllersComponent) kubeControllersResources() v1.ResourceRequirements {
+	return GetResourceRequirements(c.cr, operator.ComponentNameKubeControllers)
 }
 
 func (c *kubeControllersComponent) annotations() map[string]string {

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -23,6 +23,7 @@ import (
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -164,5 +165,41 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 		d := resources[3].(*apps.Deployment)
 		Expect(d.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("nodeName", "control01"))
+	})
+
+	It("should render resourcerequirements", func() {
+		rr := &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("250m"),
+				v1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("500m"),
+				v1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		}
+
+		instance.Spec.ComponentResources = []*operator.ComponentResource{
+			{
+				ComponentName:        operator.ComponentNameKubeControllers,
+				ResourceRequirements: rr,
+			},
+		}
+
+		component := render.KubeControllers(instance, nil)
+		resources, _ := component.Objects()
+
+		depResource := GetResource(resources, "calico-kube-controllers", "calico-system", "apps", "v1", "Deployment")
+		Expect(depResource).ToNot(BeNil())
+		deployment := depResource.(*apps.Deployment)
+
+		passed := false
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == "calico-kube-controllers" {
+				Expect(container.Resources).To(Equal(*rr))
+				passed = true
+			}
+		}
+		Expect(passed).To(Equal(true))
 	})
 })

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -687,7 +687,7 @@ func (c *nodeComponent) nodeContainer() v1.Container {
 
 // nodeResources creates the node's resource requirements.
 func (c *nodeComponent) nodeResources() v1.ResourceRequirements {
-	return v1.ResourceRequirements{}
+	return GetResourceRequirements(c.cr, operator.ComponentNameNode)
 }
 
 // nodeVolumeMounts creates the node's volume mounts.

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -413,7 +413,7 @@ func (c *typhaComponent) typhaContainer() v1.Container {
 
 // typhaResources creates the typha's resource requirements.
 func (c *typhaComponent) typhaResources() v1.ResourceRequirements {
-	return v1.ResourceRequirements{}
+	return GetResourceRequirements(c.cr, operator.ComponentNameTypha)
 }
 
 // typhaEnvVars creates the typha's envvars.


### PR DESCRIPTION
## Description
This implements the component resource requirements as needed by IBM. A new ComponentResources set is now an optional value in the InstallationSpec. If present you can have a list of component name to resource requirement pairs which allows customization of the cpu/mem for each component. The component name is an enum limited to Node;Typha;KubeControllers.

## For PR author

- [ ] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
