### PR TITLE
Bump up Enterprise aggregate API priority to be above CRDs

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -156,7 +156,7 @@ func (c *apiServerComponent) apiServiceRegistration(cert []byte) *v1beta1.APISer
 		Spec: v1beta1.APIServiceSpec{
 			Group:                "projectcalico.org",
 			VersionPriority:      200,
-			GroupPriorityMinimum: 200,
+			GroupPriorityMinimum: 1500,
 			Service: &v1beta1.ServiceReference{
 				Name:      apiServiceName,
 				Namespace: APIServerNamespace,

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -490,7 +490,7 @@ func verifyAPIService(service *v1beta1.APIService) {
 	Expect(service.Name).To(Equal("v3.projectcalico.org"))
 	Expect(service.Spec.Group).To(Equal("projectcalico.org"))
 	Expect(service.Spec.Version).To(Equal("v3"))
-	Expect(service.Spec.GroupPriorityMinimum).To(BeEquivalentTo(200))
+	Expect(service.Spec.GroupPriorityMinimum).To(BeEquivalentTo(1500))
 	Expect(service.Spec.VersionPriority).To(BeEquivalentTo(200))
 	Expect(service.Spec.InsecureSkipTLSVerify).To(BeFalse())
 


### PR DESCRIPTION
## Description

Set the `GroupPriorityMinimum` value higher so that the Enterprise resources are preferred by kubectl over backend CRDs.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
