### PR TITLE
Automated cherry pick of #642: Bump up Enterprise aggregate API priority to be above CRDs

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -156,7 +156,7 @@ func (c *apiServerComponent) apiServiceRegistration(cert []byte) *v1beta1.APISer
 		Spec: v1beta1.APIServiceSpec{
 			Group:                "projectcalico.org",
 			VersionPriority:      200,
-			GroupPriorityMinimum: 200,
+			GroupPriorityMinimum: 1500,
 			Service: &v1beta1.ServiceReference{
 				Name:      apiServiceName,
 				Namespace: APIServerNamespace,

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -490,7 +490,7 @@ func verifyAPIService(service *v1beta1.APIService) {
 	Expect(service.Name).To(Equal("v3.projectcalico.org"))
 	Expect(service.Spec.Group).To(Equal("projectcalico.org"))
 	Expect(service.Spec.Version).To(Equal("v3"))
-	Expect(service.Spec.GroupPriorityMinimum).To(BeEquivalentTo(200))
+	Expect(service.Spec.GroupPriorityMinimum).To(BeEquivalentTo(1500))
 	Expect(service.Spec.VersionPriority).To(BeEquivalentTo(200))
 	Expect(service.Spec.InsecureSkipTLSVerify).To(BeFalse())
 


### PR DESCRIPTION
Cherry pick of #642 on release-v1.8.

#642: Bump up Enterprise aggregate API priority to be above CRDs