### PR TITLE
SAAS-843 Increase max_shard_count

### DIFF
--- a/pkg/apis/operator/v1/logstorage_types.go
+++ b/pkg/apis/operator/v1/logstorage_types.go
@@ -119,7 +119,7 @@ type Retention struct {
 
 	// AuditReports configures the retention period for audit logs, in days.  Logs written on a day that started at least this long ago are
 	// removed.  To keep logs for at least x days, use a retention period of x+1.
-	// Default: 367
+	// Default: 91
 	// +optional
 	AuditReports *int32 `json:"auditReports"`
 
@@ -128,7 +128,7 @@ type Retention struct {
 	// Consult the Compliance Reporting documentation for more details on snapshots.
 	// Logs written on a day that started at least this long ago are
 	// removed.  To keep logs for at least x days, use a retention period of x+1.
-	// Default: 367
+	// Default: 91
 	// +optional
 	Snapshots *int32 `json:"snapshots"`
 
@@ -137,7 +137,7 @@ type Retention struct {
 	// Consult the Compliance Reporting documentation for more details on reports.
 	// Logs written on a day that started at least this long ago are
 	// removed.  To keep logs for at least x days, use a retention period of x+1.
-	// Default: 367
+	// Default: 91
 	// +optional
 	ComplianceReports *int32 `json:"complianceReports"`
 }

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -245,15 +245,15 @@ func fillDefaults(opr *operatorv1.LogStorage) {
 		opr.Spec.Retention.Flows = &fr
 	}
 	if opr.Spec.Retention.AuditReports == nil {
-		var arr int32 = 365
+		var arr int32 = 91
 		opr.Spec.Retention.AuditReports = &arr
 	}
 	if opr.Spec.Retention.Snapshots == nil {
-		var sr int32 = 365
+		var sr int32 = 91
 		opr.Spec.Retention.Snapshots = &sr
 	}
 	if opr.Spec.Retention.ComplianceReports == nil {
-		var crr int32 = 365
+		var crr int32 = 91
 		opr.Spec.Retention.ComplianceReports = &crr
 	}
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -612,6 +612,7 @@ func (es elasticsearchComponent) nodeSetTemplate() esv1.NodeSet {
 	pvcTemplate := es.pvcTemplate()
 
 	return esv1.NodeSet{
+		// This is configuration that ends up in /usr/share/elasticsearch/config/elasticsearch.yml on the Elastic container.
 		Config: &cmnv1.Config{
 			Data: map[string]interface{}{
 				"node.master":                 "true",

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -614,9 +614,10 @@ func (es elasticsearchComponent) nodeSetTemplate() esv1.NodeSet {
 	return esv1.NodeSet{
 		Config: &cmnv1.Config{
 			Data: map[string]interface{}{
-				"node.master": "true",
-				"node.data":   "true",
-				"node.ingest": "true",
+				"node.master":                 "true",
+				"node.data":                   "true",
+				"node.ingest":                 "true",
+				"cluster.max_shards_per_node": 10000,
 			},
 		},
 		VolumeClaimTemplates: []corev1.PersistentVolumeClaim{pvcTemplate},

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -138,7 +138,8 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
 
 				// There are no node selectors in the LogStorage CR, so we expect no node selectors in the Elasticsearch CR.
-				Expect(resultES.Spec.NodeSets[0].PodTemplate.Spec.NodeSelector).To(BeEmpty())
+				nodeSet := resultES.Spec.NodeSets[0]
+				Expect(nodeSet.PodTemplate.Spec.NodeSelector).To(BeEmpty())
 
 				// Verify that the default container limist/requests are set.
 				esContainer := resultES.Spec.NodeSets[0].PodTemplate.Spec.Containers[0]
@@ -150,6 +151,14 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Expect(resources.Cpu().String()).To(Equal("250m"))
 				Expect(resources.Memory().String()).To(Equal("4Gi"))
 				Expect(esContainer.Env[0].Value).To(Equal("-Xms1398101K -Xmx1398101K"))
+
+				//Check that the expected config made it's way to the Elastic CR
+				Expect(nodeSet.Config.Data).Should(Equal(map[string]interface{}{
+					"node.master":                 "true",
+					"node.data":                   "true",
+					"node.ingest":                 "true",
+					"cluster.max_shards_per_node": 10000,
+				}))
 			})
 			It("should render an elasticsearchComponent and delete the Elasticsearch and Kibana ExternalService", func() {
 				expectedCreateResources := []resourceTestObj{
@@ -704,10 +713,11 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[0].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":    "true",
-						"node.data":      "true",
-						"node.ingest":    "true",
-						"node.attr.zone": "us-west-2a",
+						"node.master":                 "true",
+						"node.data":                   "true",
+						"node.ingest":                 "true",
+						"cluster.max_shards_per_node": 10000,
+						"node.attr.zone":              "us-west-2a",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
 
@@ -723,10 +733,11 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[1].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":    "true",
-						"node.data":      "true",
-						"node.ingest":    "true",
-						"node.attr.zone": "us-west-2b",
+						"node.master":                 "true",
+						"node.data":                   "true",
+						"node.ingest":                 "true",
+						"cluster.max_shards_per_node": 10000,
+						"node.attr.zone":              "us-west-2b",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
 				})
@@ -806,11 +817,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[0].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":    "true",
-						"node.data":      "true",
-						"node.ingest":    "true",
-						"node.attr.zone": "us-west-2a",
-						"node.attr.rack": "rack1",
+						"node.master":                 "true",
+						"node.data":                   "true",
+						"node.ingest":                 "true",
+						"cluster.max_shards_per_node": 10000,
+						"node.attr.zone":              "us-west-2a",
+						"node.attr.rack":              "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",
 					}))
 
@@ -833,11 +845,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[1].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":    "true",
-						"node.data":      "true",
-						"node.ingest":    "true",
-						"node.attr.zone": "us-west-2b",
-						"node.attr.rack": "rack1",
+						"node.master":                 "true",
+						"node.data":                   "true",
+						"node.ingest":                 "true",
+						"cluster.max_shards_per_node": 10000,
+						"node.attr.zone":              "us-west-2b",
+						"node.attr.rack":              "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",
 					}))
 				})


### PR DESCRIPTION
This is part of an ongoing effort of improving the experience with ES. Making this limit high will lower the number of clusters affected (especially MCM) that exceed the default limit. This change will end up in the elasticsearch configuration like this:
```
# "/usr/share/elasticsearch/config/elasticsearch.yml"
cluster:
  initial_master_nodes:
  - tigera-secure-es-af88276027b25097-0
  max_shards_per_node: 10000
  name: tigera-secure
discovery:
  seed_providers: file
network:
  host: 0.0.0.0
  publish_host: ${POD_IP}
node:
  data: "true"
  ingest: "true"
  master: "true"
...
```
https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-cluster.html#misc-cluster-settings