### PR TITLE
restore ability to set platform to empty string

### DIFF
--- a/deploy/crds/operator.tigera.io_installations_crd.yaml
+++ b/deploy/crds/operator.tigera.io_installations_crd.yaml
@@ -253,6 +253,7 @@ spec:
                   compare the auto-detected value to the specified value to confirm
                   they match.
                 enum:
+                - ""
                 - EKS
                 - GKE
                 - AKS

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -63,7 +63,7 @@ type InstallationSpec struct {
 	// If the specified value is not empty, the Operator will still attempt auto-detection, but
 	// will additionally compare the auto-detected value to the specified value to confirm they match.
 	// +optional
-	// +kubebuilder:validation:Enum=EKS;GKE;AKS;OpenShift;DockerEnterprise
+	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;
 	KubernetesProvider Provider `json:"kubernetesProvider,omitempty"`
 
 	// CalicoNetwork specifies configuration options for Calico provided pod networking.


### PR DESCRIPTION
This was lost during the upgrade to v1 CRDs / operator-sdk v0.18.1 /
kubebuilder as the syntax for specifying enums changed


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.