### PR TITLE
Make init registry be a separate define

### DIFF
--- a/pkg/components/images.go
+++ b/pkg/components/images.go
@@ -17,6 +17,12 @@ package components
 const (
 	CalicoRegistry = "docker.io/"
 	TigeraRegistry = "gcr.io/unique-caldron-775/cnx/"
+	// For production InitRegistry should match TigeraRegistry.
+	// For the master branch and other testing scenarios we switch TigeraRegistry to
+	// point to a testing repo but the init image will be pushed to quay, so having
+	// these separate allows pulling the proper test images for the Tigera components
+	// and Init image when testing.
+	InitRegistry   = "quay.io/"
 	K8sGcrRegistry = "gcr.io/"
 	ECKRegistry    = "docker.elastic.co/"
 )

--- a/pkg/components/images_test.go
+++ b/pkg/components/images_test.go
@@ -30,7 +30,7 @@ var _ = Describe("No registry override", func() {
 		Expect(GetReference(ComponentElasticsearchOperator, "", "")).To(Equal("docker.elastic.co/eck/eck-operator:" + ComponentElasticsearchOperator.Version))
 	})
 	It("should render an operator init image correctly", func() {
-		Expect(GetOperatorInitReference("", "")).To(Equal(TigeraRegistry + "tigera/operator-init:" + ComponentOperatorInit.Version))
+		Expect(GetOperatorInitReference("", "")).To(Equal(InitRegistry + "tigera/operator-init:" + ComponentOperatorInit.Version))
 	})
 })
 
@@ -59,7 +59,7 @@ var _ = Describe("imagepath override", func() {
 		Expect(GetReference(ComponentElasticsearchOperator, "", "userpath")).To(Equal("docker.elastic.co/userpath/eck-operator:" + ComponentElasticsearchOperator.Version))
 	})
 	It("should render an operator init image correctly", func() {
-		Expect(GetOperatorInitReference("", "userpath")).To(Equal(TigeraRegistry + "userpath/operator-init:" + ComponentOperatorInit.Version))
+		Expect(GetOperatorInitReference("", "userpath")).To(Equal(InitRegistry + "userpath/operator-init:" + ComponentOperatorInit.Version))
 	})
 })
 var _ = Describe("registry and imagepath override", func() {

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -70,7 +70,7 @@ func GetOperatorInitReference(registry, imagepath string) string {
 	// If a user did not supply a registry, use the default registry
 	// based on component
 	if registry == "" {
-		registry = TigeraRegistry
+		registry = InitRegistry
 	}
 
 	image := ComponentOperatorInit.Image


### PR DESCRIPTION
This allows us to set a TigeraRegistry for pulling dev images from
gcr.io but keep pulling the Init image from quay.io.

## Description

## For PR author

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
