### PR TITLE
Update status once installation CR is written

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -426,6 +427,16 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 
 	ctx := context.Background()
 
+	// Get the installation object if it exists so that we can save the original
+	// status before we merge/fill that object with other values.
+	instance := &operator.Installation{}
+	if err := r.client.Get(ctx, utils.DefaultInstanceKey, instance); err != nil && apierrors.IsNotFound(err) {
+		reqLogger.Info("Installation config not found")
+		r.status.OnCRNotFound()
+		return reconcile.Result{}, nil
+	}
+	status := instance.Status
+
 	// Query for the installation object.
 	instance, err := GetInstallation(ctx, r.client, r.autoDetectedProvider)
 	if err != nil {
@@ -454,6 +465,17 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	if err = r.client.Update(ctx, instance); err != nil {
 		r.SetDegraded("Failed to write defaults", err, reqLogger)
 		return reconcile.Result{}, err
+	}
+
+	// A status is needed at this point for operator scorecard tests.
+	// status.variant is written later but for some tests the reconciliation
+	// does not get to that point.
+	if reflect.DeepEqual(status, operator.InstallationStatus{}) {
+		instance.Status = operator.InstallationStatus{}
+		if err = r.client.Status().Update(ctx, instance); err != nil {
+			r.SetDegraded("Failed to write default status", err, reqLogger)
+			return reconcile.Result{}, err
+		}
 	}
 
 	// The operator supports running in a "Calico only" mode so that it doesn't need to run TSEE specific controllers.

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -269,6 +269,7 @@ func setupManager() (client.Client, manager.Manager) {
 	err = controller.AddToManager(mgr, options.AddOptions{
 		DetectedProvider:    operator.ProviderNone,
 		EnterpriseCRDExists: true,
+		AmazonCRDExists:     true,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	return mgr.GetClient(), mgr

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -17,6 +17,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -125,6 +126,38 @@ var _ = Describe("Mainline component function tests", func() {
 
 		It("Should install resources for a CRD", func() {
 			stopChan := installResourceCRD(c, mgr)
+
+			instance := &operator.Installation{
+				TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			}
+			By("Checking that the installation status is set correctly")
+			Eventually(func() error {
+				err := GetResource(c, instance)
+				if err != nil {
+					return err
+				}
+				if instance.Status.Variant != operator.Calico {
+					return fmt.Errorf("installation status not Calico yet")
+				}
+				return nil
+			}, 60*time.Second).Should(BeNil())
+
+			By("Checking that the installation status does not change")
+			Consistently(func() error {
+				err := GetResource(c, instance)
+				if err != nil {
+					return err
+				}
+				if reflect.DeepEqual(instance.Status, operator.InstallationStatus{}) {
+					return fmt.Errorf("installation status is empty")
+				}
+				if instance.Status.Variant != operator.Calico {
+					return fmt.Errorf("installation status was %v, expected: %v", instance.Status, operator.Calico)
+				}
+				return nil
+			}, 30*time.Second, 50*time.Millisecond).Should(BeNil())
+
 			defer close(stopChan)
 		})
 	})


### PR DESCRIPTION
## Description

This PR writes an empty status block after we've written the installation CR to the datastore. We want this change because an operator scorecard test checks for the existence of the `status` in the CR after applying the CR manifest. The operator scorecard tests are run when we submit an operator metadata bundle to certify a new version of our operator.

We'll want to backport this to 1.6, 1.7 and 1.8 to cover Calico v3.14 and v3.15.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
