### PR TITLE
Replace cat utility with in built application

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -611,8 +611,8 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 	apiServer := corev1.Container{
 		Name:  "tigera-apiserver",
 		Image: components.GetReference(components.ComponentAPIServer, c.installation.Spec.Registry, c.installation.Spec.ImagePath),
-		Args: c.startUpArgs(),
-		Env:  env,
+		Args:  c.startUpArgs(),
+		Env:   env,
 		// Needed for permissions to write to the audit log
 		SecurityContext: &corev1.SecurityContext{Privileged: &isPrivileged},
 		VolumeMounts:    volumeMounts,
@@ -631,8 +631,7 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
-						"cat",
-						"/tmp/ready",
+						"/code/filecheck",
 					},
 				},
 			},


### PR DESCRIPTION
## Description
At a high level, use a scratch based image for Api-server. Replace dependencies on Linux utils/tools.
1) replace `cat` utility with an inbuilt application.

