### PR TITLE
Tag and push release images to RedHat Connect for validation

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,6 +22,7 @@ blocks:
               fi
       secrets:
         - name: quay-robot-semaphore_v2
+        - name: operator-redhat-connect
       prologue:
         commands:
           - checkout

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 tag=$(git describe --exact-match --tags HEAD)
 if [[ -z "${tag}" ]]; then
@@ -16,3 +17,33 @@ make release VERSION=${tag}
 
 echo "Publish release ${tag}"
 make release-publish-images VERSION=${tag}
+
+echo "Tagging and pushing operator images to RedHat Connect for certification..."
+
+docker login -u unused scan.connect.redhat.com --password-stdin <<< ${OPERATOR_RH_REGISTRY_KEY}
+redhatImage=scan.connect.redhat.com/$OPERATOR_RH_PROJECTID/operator:$VERSION
+
+# Pushes to scan.connect.redhat.com fail if the image exists already.
+# If it already exists, skip tagging and pushing.
+if ! docker pull $redhatImage 2>/dev/null; then
+	echo "Tagging and pushing operator image..."
+	quayImage=quay.io/tigera/operator:$VERSION
+	docker pull $quayImage
+	docker tag $quayImage $redhatImage
+	docker push $redhatImage
+else
+	echo "operator image exists on scan.connect.redhat.com, skipping tagging/pushing"
+fi
+
+docker login -u unused scan.connect.redhat.com --password-stdin <<< ${OPERATOR_INIT_RH_REGISTRY_KEY}
+redhatImage=scan.connect.redhat.com/$OPERATOR_INIT_RH_PROJECTID/operator-init:$VERSION
+
+if ! docker pull $redhatImage 2>/dev/null; then
+	echo "tagging and pushing operator-init image..."
+	quayImage=quay.io/tigera/operator-init:$VERSION
+	docker pull $quayImage
+	docker tag $quayImage $redhatImage
+	docker push $redhatImage
+else
+	echo "operator-init image exists on scan.connect.redhat.com, skipping tagging/pushing"
+fi


### PR DESCRIPTION
## Description

This PR adds a step to the release process which tags and pushes the newly released operator and operator-init images to RedHat Connect for validation.
It depends on a secret that has been added to Semaphore. That secret exports a pair of env variables for each image: one variable identifies the operator "project" on RH Connect, the other is a registry key used to login to scan.connect.redhat.com.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
