### PR TITLE
BPF enable

### DIFF
--- a/deploy/crds/operator.tigera.io_installations_crd.yaml
+++ b/deploy/crds/operator.tigera.io_installations_crd.yaml
@@ -39,6 +39,14 @@ spec:
                 description: CalicoNetwork specifies configuration options for Calico
                   provided pod networking.
                 properties:
+                  bpfDataplaneMode:
+                    description: 'BPFDataplaneMode configures whether the BPF data
+                      plane is enabled anda in what form. Default: Disabled'
+                    enum:
+                    - Disabled
+                    - Enabled
+                    - EnabledDSR
+                    type: string
                   hostPorts:
                     description: 'HostPorts configures whether or not Calico will
                       support Kubernetes HostPorts. Default: Enabled'

--- a/deploy/crds/operator.tigera.io_installations_crd.yaml
+++ b/deploy/crds/operator.tigera.io_installations_crd.yaml
@@ -35,18 +35,18 @@ spec:
             description: Specification of the desired state for the Calico or Calico
               Enterprise installation.
             properties:
+              bpfDataplaneMode:
+                description: 'BPFDataplaneMode configures whether the BPF data plane
+                  is enabled anda in what form. Default: Disabled'
+                enum:
+                - Disabled
+                - Enabled
+                - EnabledDSR
+                type: string
               calicoNetwork:
                 description: CalicoNetwork specifies configuration options for Calico
                   provided pod networking.
                 properties:
-                  bpfDataplaneMode:
-                    description: 'BPFDataplaneMode configures whether the BPF data
-                      plane is enabled anda in what form. Default: Disabled'
-                    enum:
-                    - Disabled
-                    - Enabled
-                    - EnabledDSR
-                    type: string
                   hostPorts:
                     description: 'HostPorts configures whether or not Calico will
                       support Kubernetes HostPorts. Default: Enabled'

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -95,6 +95,13 @@ type InstallationSpec struct {
 	// ComponentResources can be used to customize the resource requirements for each component.
 	// +optional
 	ComponentResources []*ComponentResource `json:"componentResources,omitempty"`
+
+	// BPFDataplaneMode configures whether the BPF data plane is enabled anda in
+	// what form.
+	// Default: Disabled
+	// +optional
+	// +kubebuilder:validation:Enum=Disabled;Enabled;EnabledDSR
+	BPFDataplaneMode *BPFDataplaneMode `json:"bpfDataplaneMode,omitempty"`
 }
 
 // ComponentName CRD enum
@@ -214,13 +221,6 @@ type CalicoNetworkSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=None;Multus
 	MultiInterfaceMode *MultiInterfaceMode `json:"multiInterfaceMode,omitempty"`
-
-	// BPFDataplaneMode configures whether the BPF data plane is enabled anda in
-	// what form.
-	// Default: Disabled
-	// +optional
-	// +kubebuilder:validation:Enum=Disabled;Enabled;EnabledDSR
-	BPFDataplaneMode *BPFDataplaneMode `json:"bpfDataplaneMode,omitempty"`
 }
 
 // NodeAddressAutodetection provides configuration options for auto-detecting node addresses. At most one option

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -169,6 +169,18 @@ func (nt HostPortsType) String() string {
 	return string(nt)
 }
 
+type BPFDataplaneMode string
+
+func (bpf BPFDataplaneMode) String() string {
+	return string(bpf)
+}
+
+const (
+	BPFDisabled   BPFDataplaneMode = "Disabled"
+	BPFEnabled    BPFDataplaneMode = "Enabled"
+	BPFEnabledDSR BPFDataplaneMode = "EnabledDSR"
+)
+
 // CalicoNetworkSpec specifies configuration options for Calico provided pod networking.
 type CalicoNetworkSpec struct {
 	// IPPools contains a list of IP pools to use for allocating pod IP addresses. At most one IP pool
@@ -202,6 +214,13 @@ type CalicoNetworkSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=None;Multus
 	MultiInterfaceMode *MultiInterfaceMode `json:"multiInterfaceMode,omitempty"`
+
+	// BPFDataplaneMode configures whether the BPF data plane is enabled anda in
+	// what form.
+	// Default: Disabled
+	// +optional
+	// +kubebuilder:validation:Enum=Disabled;Enabled;EnabledDSR
+	BPFDataplaneMode *BPFDataplaneMode `json:"bpfDataplaneMode,omitempty"`
 }
 
 // NodeAddressAutodetection provides configuration options for auto-detecting node addresses. At most one option

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -308,11 +308,6 @@ func (in *CalicoNetworkSpec) DeepCopyInto(out *CalicoNetworkSpec) {
 		*out = new(MultiInterfaceMode)
 		**out = **in
 	}
-	if in.BPFDataplaneMode != nil {
-		in, out := &in.BPFDataplaneMode, &out.BPFDataplaneMode
-		*out = new(BPFDataplaneMode)
-		**out = **in
-	}
 	return
 }
 
@@ -595,6 +590,11 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 				(*in).DeepCopyInto(*out)
 			}
 		}
+	}
+	if in.BPFDataplaneMode != nil {
+		in, out := &in.BPFDataplaneMode, &out.BPFDataplaneMode
+		*out = new(BPFDataplaneMode)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -308,6 +308,11 @@ func (in *CalicoNetworkSpec) DeepCopyInto(out *CalicoNetworkSpec) {
 		*out = new(MultiInterfaceMode)
 		**out = **in
 	}
+	if in.BPFDataplaneMode != nil {
+		in, out := &in.BPFDataplaneMode, &out.BPFDataplaneMode
+		*out = new(BPFDataplaneMode)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -739,6 +739,15 @@ func GenerateRenderConfig(install *operator.Installation) render.NetworkConfig {
 	// If CalicoNetwork is specified, then use Calico networking.
 	if install.Spec.CalicoNetwork != nil {
 		config.CNI = render.CNICalico
+		if install.Spec.CalicoNetwork.BPFDataplaneMode != nil {
+			switch *install.Spec.CalicoNetwork.BPFDataplaneMode {
+			case operator.BPFEnabled:
+				config.BPFEnabled = true
+			case operator.BPFEnabledDSR:
+				config.BPFEnabled = true
+				config.BPFDSR = true
+			}
+		}
 	}
 
 	// Set other provider-specific settings.

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -71,7 +71,6 @@ var _ = Describe("Testing core-controller installation", func() {
 	var twentySix int32 = 26
 	var hpEnabled operator.HostPortsType = operator.HostPortsEnabled
 	var hpDisabled operator.HostPortsType = operator.HostPortsDisabled
-	bpfEnabled := operator.BPFEnabled
 
 	table.DescribeTable("Installation and Openshift should be merged and defaulted by mergeAndFillDefaults",
 		func(i *operator.Installation, on *osconfigv1.Network, expectSuccess bool, calicoNet *operator.CalicoNetworkSpec) {
@@ -99,7 +98,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			pExpect := calicoNet.IPPools[0]
 			Expect(pool).To(Equal(pExpect))
 			Expect(i.Spec.CalicoNetwork.HostPorts).To(Equal(calicoNet.HostPorts))
-			Expect(i.Spec.CalicoNetwork.BPFDataplaneMode).To(Equal(calicoNet.BPFDataplaneMode))
 		},
 
 		table.Entry("Empty config (with OpenShift) defaults IPPool", &operator.Installation{},
@@ -122,35 +120,6 @@ var _ = Describe("Testing core-controller installation", func() {
 				},
 				MTU:       &defaultMTU,
 				HostPorts: &hpEnabled,
-			}),
-		table.Entry("Config with BPF enabled (with OpenShift) defaults IPPool",
-			&operator.Installation{
-				Spec: operator.InstallationSpec{
-					CalicoNetwork: &operator.CalicoNetworkSpec{
-						BPFDataplaneMode: &bpfEnabled,
-					},
-				},
-			},
-			&osconfigv1.Network{
-				Spec: osconfigv1.NetworkSpec{
-					ClusterNetwork: []osconfigv1.ClusterNetworkEntry{
-						{CIDR: "192.168.0.0/16"},
-					},
-				},
-			}, true,
-			&operator.CalicoNetworkSpec{
-				IPPools: []operator.IPPool{
-					{
-						CIDR:          "192.168.0.0/16",
-						Encapsulation: "IPIP",
-						NATOutgoing:   "Enabled",
-						NodeSelector:  "all()",
-						BlockSize:     &twentySix,
-					},
-				},
-				MTU:              &defaultMTU,
-				HostPorts:        &hpEnabled,
-				BPFDataplaneMode: &bpfEnabled,
 			}),
 		table.Entry("Openshift only CIDR",
 			&operator.Installation{
@@ -289,23 +258,5 @@ var _ = Describe("Testing core-controller installation", func() {
 				MTU:       &defaultMTU,
 				HostPorts: &hpDisabled,
 			}),
-	)
-
-	table.DescribeTable("BPF settings",
-		func(mode operator.BPFDataplaneMode, exp bool) {
-			nc := GenerateRenderConfig(&operator.Installation{
-				Spec: operator.InstallationSpec{
-					CalicoNetwork: &operator.CalicoNetworkSpec{
-						BPFDataplaneMode: &mode,
-					},
-				},
-			})
-
-			Expect(nc.BPFEnabled).To(Equal(exp))
-		},
-		table.Entry("nil", nil, false),
-		table.Entry("Disabled", operator.BPFDisabled, false),
-		table.Entry("Enabled", operator.BPFEnabled, true),
-		table.Entry("EnabledDSR", operator.BPFEnabledDSR, true),
 	)
 })

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -71,6 +71,8 @@ var _ = Describe("Testing core-controller installation", func() {
 	var twentySix int32 = 26
 	var hpEnabled operator.HostPortsType = operator.HostPortsEnabled
 	var hpDisabled operator.HostPortsType = operator.HostPortsDisabled
+	bpfEnabled := operator.BPFEnabled
+
 	table.DescribeTable("Installation and Openshift should be merged and defaulted by mergeAndFillDefaults",
 		func(i *operator.Installation, on *osconfigv1.Network, expectSuccess bool, calicoNet *operator.CalicoNetworkSpec) {
 			if expectSuccess {
@@ -97,6 +99,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			pExpect := calicoNet.IPPools[0]
 			Expect(pool).To(Equal(pExpect))
 			Expect(i.Spec.CalicoNetwork.HostPorts).To(Equal(calicoNet.HostPorts))
+			Expect(i.Spec.CalicoNetwork.BPFDataplaneMode).To(Equal(calicoNet.BPFDataplaneMode))
 		},
 
 		table.Entry("Empty config (with OpenShift) defaults IPPool", &operator.Installation{},
@@ -119,6 +122,35 @@ var _ = Describe("Testing core-controller installation", func() {
 				},
 				MTU:       &defaultMTU,
 				HostPorts: &hpEnabled,
+			}),
+		table.Entry("Config with BPF enabled (with OpenShift) defaults IPPool",
+			&operator.Installation{
+				Spec: operator.InstallationSpec{
+					CalicoNetwork: &operator.CalicoNetworkSpec{
+						BPFDataplaneMode: &bpfEnabled,
+					},
+				},
+			},
+			&osconfigv1.Network{
+				Spec: osconfigv1.NetworkSpec{
+					ClusterNetwork: []osconfigv1.ClusterNetworkEntry{
+						{CIDR: "192.168.0.0/16"},
+					},
+				},
+			}, true,
+			&operator.CalicoNetworkSpec{
+				IPPools: []operator.IPPool{
+					{
+						CIDR:          "192.168.0.0/16",
+						Encapsulation: "IPIP",
+						NATOutgoing:   "Enabled",
+						NodeSelector:  "all()",
+						BlockSize:     &twentySix,
+					},
+				},
+				MTU:              &defaultMTU,
+				HostPorts:        &hpEnabled,
+				BPFDataplaneMode: &bpfEnabled,
 			}),
 		table.Entry("Openshift only CIDR",
 			&operator.Installation{
@@ -257,5 +289,23 @@ var _ = Describe("Testing core-controller installation", func() {
 				MTU:       &defaultMTU,
 				HostPorts: &hpDisabled,
 			}),
+	)
+
+	table.DescribeTable("BPF settings",
+		func(mode operator.BPFDataplaneMode, exp bool) {
+			nc := GenerateRenderConfig(&operator.Installation{
+				Spec: operator.InstallationSpec{
+					CalicoNetwork: &operator.CalicoNetworkSpec{
+						BPFDataplaneMode: &mode,
+					},
+				},
+			})
+
+			Expect(nc.BPFEnabled).To(Equal(exp))
+		},
+		table.Entry("nil", nil, false),
+		table.Entry("Disabled", operator.BPFDisabled, false),
+		table.Entry("Enabled", operator.BPFEnabled, true),
+		table.Entry("EnabledDSR", operator.BPFEnabledDSR, true),
 	)
 })

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -275,7 +275,6 @@ func GetAmazonCloudIntegration(ctx context.Context, client client.Client) (*oper
 	return instance, nil
 }
 
-// GetK8sEndpointOverride returns an ip:port override for the KUBERNETES_SERVICE_HOST/PORT
 func GetK8sEndpointOverride() (string, string, error) {
 	host := os.Getenv("TIGERA_OPERATOR_OVERRIDE_K8S_HOST")
 	port := os.Getenv("TIGERA_OPERATOR_OVERRIDE_K8S_PORT")

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/go-logr/logr"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -272,4 +273,16 @@ func GetAmazonCloudIntegration(ctx context.Context, client client.Client) (*oper
 	}
 
 	return instance, nil
+}
+
+// GetK8sEndpointOverride returns an ip:port override for the KUBERNETES_SERVICE_HOST/PORT
+func GetK8sEndpointOverride() (string, string, error) {
+	host := os.Getenv("TIGERA_OPERATOR_OVERRIDE_K8S_HOST")
+	port := os.Getenv("TIGERA_OPERATOR_OVERRIDE_K8S_PORT")
+
+	if host == "" || port == "" {
+		return "", "", fmt.Errorf("k8s host and/or port override env vars empty")
+	}
+
+	return host, port, nil
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -39,6 +39,23 @@ var (
 var log = logf.Log.WithName("daemon")
 
 func Main() {
+	// Try to get k8s api override from env and set the KUBERNETES_SERVICE_HOST/PORT if
+	// kubeconfig is not specified. Kubeconfig has a precedence, but it unlikely to be set
+	// in-cluster where we need the override to happen if there if the current setting
+	// were to use a k8s service to acces k8s API, while the kube-proxy was disabled, e.g.
+	// when about to switch to BPF dataplane.
+	k8sHostOverride, k8sPortOverride, err := utils.GetK8sEndpointOverride()
+	if err != nil {
+		if err := os.Setenv("KUBERNETES_SERVICE_HOST", k8sHostOverride); err != nil {
+			log.Error(err, "Failed to set KUBERNETES_SERVICE_HOST from an override.")
+			os.Exit(1)
+		}
+		if err := os.Setenv("KUBERNETES_SERVICE_PORT", k8sPortOverride); err != nil {
+			log.Error(err, "Failed to set KUBERNETES_SERVICE_PORT from an override.")
+			os.Exit(1)
+		}
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -29,4 +29,6 @@ type NetworkConfig struct {
 	IPPools              []operatorv1.IPPool
 	BPFEnabled           bool
 	BPFDSR               bool
+	K8sHost              string
+	K8sPort              int
 }

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -27,4 +27,6 @@ type NetworkConfig struct {
 	CNI                  string
 	NodenameFileOptional bool
 	IPPools              []operatorv1.IPPool
+	BPFEnabled           bool
+	BPFDSR               bool
 }

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -27,8 +27,27 @@ type NetworkConfig struct {
 	CNI                  string
 	NodenameFileOptional bool
 	IPPools              []operatorv1.IPPool
-	BPFEnabled           bool
-	BPFDSR               bool
-	K8sHost              string
-	K8sPort              int
+}
+
+type BPFConfig struct {
+	BPFEnabled bool
+	BPFDSR     bool
+	K8sHost    string
+	K8sPort    int
+}
+
+func GenerateBPFConfig(install *operatorv1.Installation) (BPFConfig, error) {
+	var cfg BPFConfig
+
+	if install.Spec.BPFDataplaneMode != nil {
+		switch *install.Spec.BPFDataplaneMode {
+		case operatorv1.BPFEnabledDSR:
+			cfg.BPFDSR = true
+			fallthrough
+		case operatorv1.BPFEnabled:
+			cfg.BPFEnabled = true
+		}
+	}
+
+	return cfg, nil
 }

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -963,6 +963,16 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 			Value: "udp:53,udp:67,tcp:179,tcp:443,tcp:5473,tcp:6443",
 		})
 	}
+
+	if c.netConfig.BPFEnabled {
+		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_BPFENABLED", Value: "true"})
+		if c.netConfig.BPFDSR {
+			nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_BPFEXTERNALSERVICEMODE", Value: "DSR"})
+		}
+	} else {
+		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_BPFENABLED", Value: "false"})
+	}
+
 	return nodeEnv
 }
 

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -653,6 +653,13 @@ func (c *nodeComponent) cniEnvvars() []v1.EnvVar {
 		},
 	}
 
+	if c.netConfig.BPFEnabled {
+		envVars = append(envVars, []v1.EnvVar{
+			{Name: "KUBERNETES_SERVICE_HOST", Value: c.netConfig.K8sHost},
+			{Name: "KUBERNETES_SERVICE_PORT", Value: strconv.Itoa(c.netConfig.K8sPort)},
+		}...)
+	}
+
 	if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
 		if c.cr.Spec.CalicoNetwork != nil && c.cr.Spec.CalicoNetwork.MultiInterfaceMode != nil {
 			envVars = append(envVars, v1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cr.Spec.CalicoNetwork.MultiInterfaceMode.Value()})
@@ -965,7 +972,11 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 	}
 
 	if c.netConfig.BPFEnabled {
-		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_BPFENABLED", Value: "true"})
+		nodeEnv = append(nodeEnv, []v1.EnvVar{
+			{Name: "FELIX_BPFENABLED", Value: "true"},
+			{Name: "KUBERNETES_SERVICE_HOST", Value: c.netConfig.K8sHost},
+			{Name: "KUBERNETES_SERVICE_PORT", Value: strconv.Itoa(c.netConfig.K8sPort)},
+		}...)
 		if c.netConfig.BPFDSR {
 			nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_BPFEXTERNALSERVICEMODE", Value: "DSR"})
 		}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should render all resources for a default configuration", func() {
 		defaultInstance.Spec.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
@@ -286,7 +286,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should render all resources for a default configuration using TigeraSecureEnterprise", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
@@ -328,7 +328,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should render all resources when running on openshift", func() {
 		defaultInstance.Spec.FlexVolumePath = "/etc/kubernetes/kubelet-plugins/volume/exec/"
-		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
@@ -396,7 +396,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should render all resources when variant is TigeraSecureEnterprise and running on openshift", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 
-		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
@@ -445,7 +445,7 @@ var _ = Describe("Node rendering tests", func() {
 		bt := map[string]string{
 			"template-1.yaml": "dataforTemplate1 that is not used here",
 		}
-		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, bt, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, bt, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
@@ -490,7 +490,7 @@ var _ = Describe("Node rendering tests", func() {
 		It("should support canReach", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.CanReach = "1.1.1.1"
-			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
@@ -505,7 +505,7 @@ var _ = Describe("Node rendering tests", func() {
 		It("should support interface regex", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.Interface = "eth*"
-			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
@@ -520,7 +520,7 @@ var _ = Describe("Node rendering tests", func() {
 		It("should support skip-interface regex", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.SkipInterface = "eth*"
-			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
@@ -534,7 +534,7 @@ var _ = Describe("Node rendering tests", func() {
 	})
 
 	It("should include updates needed for the core upgrade", func() {
-		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, true)
+		component := render.Node(defaultInstance, operator.ProviderOpenShift, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, true, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5), fmt.Sprintf("resources are %v", resources))
 
@@ -569,7 +569,7 @@ var _ = Describe("Node rendering tests", func() {
 		func(pool operator.IPPool, expect map[string]string) {
 			// Provider does not matter for IPPool configuration
 			defaultInstance.Spec.CalicoNetwork.IPPools = []operator.IPPool{pool}
-			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+			component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 
@@ -696,7 +696,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should not enable prometheus metrics if NodeMetricsPort is nil", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		defaultInstance.Spec.NodeMetricsPort = nil
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
@@ -716,7 +716,7 @@ var _ = Describe("Node rendering tests", func() {
 		var nodeMetricsPort int32 = 1234
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		defaultInstance.Spec.NodeMetricsPort = &nodeMetricsPort
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(6))
 
@@ -740,7 +740,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should not render a FlexVolume container if FlexVolumePath is set to None", func() {
 		defaultInstance.Spec.FlexVolumePath = "None"
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
@@ -754,7 +754,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should render MaxUnavailable if a custom value was set", func() {
 		two := intstr.FromInt(2)
 		defaultInstance.Spec.NodeUpdateStrategy.RollingUpdate.MaxUnavailable = &two
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
@@ -770,7 +770,7 @@ var _ = Describe("Node rendering tests", func() {
 		defaultInstance.Spec.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		hpd := operator.HostPortsDisabled
 		defaultInstance.Spec.CalicoNetwork.HostPorts = &hpd
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
@@ -846,7 +846,7 @@ var _ = Describe("Node rendering tests", func() {
 		seccompProf := "localhost/calico-node-v1"
 		defaultInstance.ObjectMeta.Annotations = make(map[string]string)
 		defaultInstance.ObjectMeta.Annotations["tech-preview.operator.tigera.io/node-apparmor-profile"] = seccompProf
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 
 		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -864,7 +864,7 @@ var _ = Describe("Node rendering tests", func() {
 				PodSecurityGroupID:   "sg-podsgid",
 			},
 		}
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, aci, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, aci, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 
 		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -900,7 +900,7 @@ var _ = Describe("Node rendering tests", func() {
 			},
 		}
 
-		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false)
+		component := render.Node(defaultInstance, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, typhaNodeTLS, nil, false, render.BPFConfig{})
 		resources, _ := component.Objects()
 
 		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -921,12 +921,15 @@ var _ = Describe("Node rendering tests", func() {
 		It("should override k8s endpoints", func() {
 			component := render.Node(defaultInstance, operator.ProviderNone,
 				render.NetworkConfig{
-					CNI:        render.CNICalico,
+					CNI: render.CNICalico,
+				},
+				nil, typhaNodeTLS, nil, false,
+				render.BPFConfig{
 					BPFEnabled: true,
 					K8sHost:    "k8shost",
 					K8sPort:    1234,
 				},
-				nil, typhaNodeTLS, nil, false)
+			)
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(5))
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -38,6 +38,68 @@ var (
 	notOpenshift = false
 )
 
+func defaultEnvVars(opt bool) []v1.EnvVar {
+	optional := opt
+	return []v1.EnvVar{
+		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
+		{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+		{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
+		{Name: "IP", Value: "autodetect"},
+		{Name: "IP_AUTODETECTION_METHOD", Value: "first-found"},
+		{Name: "IP6", Value: "none"},
+		{Name: "CALICO_IPV4POOL_CIDR", Value: "192.168.1.0/16"},
+		{Name: "CALICO_IPV4POOL_IPIP", Value: "Always"},
+		{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
+		{Name: "FELIX_IPINIPMTU", Value: "1440"},
+		{Name: "FELIX_VXLANMTU", Value: "1410"},
+		{Name: "FELIX_WIREGUARDMTU", Value: "1400"},
+		{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
+		{Name: "FELIX_IPV6SUPPORT", Value: "false"},
+		{Name: "FELIX_HEALTHENABLED", Value: "true"},
+		{
+			Name: "NODENAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+			},
+		},
+		{
+			Name: "NAMESPACE",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			},
+		},
+		{Name: "FELIX_TYPHAK8SNAMESPACE", Value: "calico-system"},
+		{Name: "FELIX_TYPHAK8SSERVICENAME", Value: "calico-typha"},
+		{Name: "FELIX_TYPHACAFILE", Value: "/typha-ca/caBundle"},
+		{Name: "FELIX_TYPHACERTFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretCertName)},
+		{Name: "FELIX_TYPHAKEYFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretKeyName)},
+		{Name: "FELIX_TYPHACN", ValueFrom: &v1.EnvVarSource{
+			SecretKeyRef: &v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: render.TyphaTLSSecretName,
+				},
+				Key:      render.CommonName,
+				Optional: &optional,
+			},
+		}},
+		{Name: "FELIX_TYPHAURISAN", ValueFrom: &v1.EnvVarSource{
+			SecretKeyRef: &v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: render.TyphaTLSSecretName,
+				},
+				Key:      render.URISAN,
+				Optional: &optional,
+			},
+		}},
+		{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
+	}
+}
+
+func expectedEnvVars(optional bool, additional []v1.EnvVar) []v1.EnvVar {
+	def := defaultEnvVars(optional)
+	return append(def[:len(def):len(def)], additional...)
+}
+
 var _ = Describe("Node rendering tests", func() {
 	var defaultInstance *operator.Installation
 	var typhaNodeTLS *render.TyphaNodeTLS
@@ -132,60 +194,9 @@ var _ = Describe("Node rendering tests", func() {
 
 		optional := true
 		// Verify env
-		expectedNodeEnv := []v1.EnvVar{
-			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
-			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
-			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
-			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
+		expectedNodeEnv := expectedEnvVars(optional, []v1.EnvVar{
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,bgp"},
-			{Name: "IP", Value: "autodetect"},
-			{Name: "IP_AUTODETECTION_METHOD", Value: "first-found"},
-			{Name: "IP6", Value: "none"},
-			{Name: "CALICO_IPV4POOL_CIDR", Value: "192.168.1.0/16"},
-			{Name: "CALICO_IPV4POOL_IPIP", Value: "Always"},
-			{Name: "FELIX_IPINIPMTU", Value: "1440"},
-			{Name: "FELIX_VXLANMTU", Value: "1410"},
-			{Name: "FELIX_WIREGUARDMTU", Value: "1400"},
-			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
-			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
-			{Name: "FELIX_HEALTHENABLED", Value: "true"},
-			{
-				Name: "NODENAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-				},
-			},
-			{
-				Name: "NAMESPACE",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-				},
-			},
-			{Name: "FELIX_TYPHAK8SNAMESPACE", Value: "calico-system"},
-			{Name: "FELIX_TYPHAK8SSERVICENAME", Value: "calico-typha"},
-			{Name: "FELIX_TYPHACAFILE", Value: "/typha-ca/caBundle"},
-			{Name: "FELIX_TYPHACERTFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretCertName)},
-			{Name: "FELIX_TYPHAKEYFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretKeyName)},
-			{Name: "FELIX_TYPHACN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.CommonName,
-					Optional: &optional,
-				},
-			}},
-			{Name: "FELIX_TYPHAURISAN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.URISAN,
-					Optional: &optional,
-				},
-			}},
-			{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
-		}
+		})
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		// Expect the SECURITY_GROUP env variables to not be set
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_DEFAULT_SECURITY_GROUPS")})))
@@ -295,59 +306,8 @@ var _ = Describe("Node rendering tests", func() {
 		ExpectEnv(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env, "CNI_NET_DIR", "/etc/cni/net.d")
 
 		optional := true
-		expectedNodeEnv := []v1.EnvVar{
-			// Default envvars.
-			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
-			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
-			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
+		expectedNodeEnv := expectedEnvVars(optional, []v1.EnvVar{
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,bgp"},
-			{Name: "IP", Value: "autodetect"},
-			{Name: "IP_AUTODETECTION_METHOD", Value: "first-found"},
-			{Name: "IP6", Value: "none"},
-			{Name: "CALICO_IPV4POOL_CIDR", Value: "192.168.1.0/16"},
-			{Name: "CALICO_IPV4POOL_IPIP", Value: "Always"},
-			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
-			{Name: "FELIX_IPINIPMTU", Value: "1440"},
-			{Name: "FELIX_VXLANMTU", Value: "1410"},
-			{Name: "FELIX_WIREGUARDMTU", Value: "1400"},
-			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
-			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
-			{Name: "FELIX_HEALTHENABLED", Value: "true"},
-			{
-				Name: "NODENAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-				},
-			},
-			{
-				Name: "NAMESPACE",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-				},
-			},
-			{Name: "FELIX_TYPHAK8SNAMESPACE", Value: "calico-system"},
-			{Name: "FELIX_TYPHAK8SSERVICENAME", Value: "calico-typha"},
-			{Name: "FELIX_TYPHACAFILE", Value: "/typha-ca/caBundle"},
-			{Name: "FELIX_TYPHACERTFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretCertName)},
-			{Name: "FELIX_TYPHAKEYFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretKeyName)},
-			{Name: "FELIX_TYPHACN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.CommonName,
-					Optional: &optional,
-				},
-			}},
-			{Name: "FELIX_TYPHAURISAN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.URISAN,
-					Optional: &optional,
-				},
-			}},
 			// Tigera-specific envvars
 			{Name: "FELIX_PROMETHEUSREPORTERENABLED", Value: "true"},
 			{Name: "FELIX_PROMETHEUSREPORTERPORT", Value: "9081"},
@@ -358,8 +318,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
 			{Name: "MULTI_INTERFACE_MODE", Value: operator.MultiInterfaceModeNone.Value()},
-			{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
-		}
+		})
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		Expect(len(ds.Spec.Template.Spec.Containers[0].Env)).To(Equal(len(expectedNodeEnv)))
 
@@ -422,63 +381,11 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Volumes).To(ConsistOf(expectedVols))
 
 		optional := true
-		expectedNodeEnv := []v1.EnvVar{
-			// Default envvars.
-			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
-			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
-			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
+		expectedNodeEnv := expectedEnvVars(optional, []v1.EnvVar{
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,openshift,bgp"},
-			{Name: "IP", Value: "autodetect"},
-			{Name: "IP_AUTODETECTION_METHOD", Value: "first-found"},
-			{Name: "IP6", Value: "none"},
-			{Name: "CALICO_IPV4POOL_CIDR", Value: "192.168.1.0/16"},
-			{Name: "CALICO_IPV4POOL_IPIP", Value: "Always"},
-			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
-			{Name: "FELIX_IPINIPMTU", Value: "1440"},
-			{Name: "FELIX_VXLANMTU", Value: "1410"},
-			{Name: "FELIX_WIREGUARDMTU", Value: "1400"},
-			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
-			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
-			{Name: "FELIX_HEALTHENABLED", Value: "true"},
-			{
-				Name: "NODENAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-				},
-			},
-			{
-				Name: "NAMESPACE",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-				},
-			},
-			{Name: "FELIX_TYPHAK8SNAMESPACE", Value: "calico-system"},
-			{Name: "FELIX_TYPHAK8SSERVICENAME", Value: "calico-typha"},
-			{Name: "FELIX_TYPHACAFILE", Value: "/typha-ca/caBundle"},
-			{Name: "FELIX_TYPHACERTFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretCertName)},
-			{Name: "FELIX_TYPHAKEYFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretKeyName)},
-			{Name: "FELIX_TYPHACN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.CommonName,
-					Optional: &optional,
-				},
-			}},
-			{Name: "FELIX_TYPHAURISAN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.URISAN,
-					Optional: &optional,
-				},
-			}},
 			// The OpenShift envvar overrides.
 			{Name: "FELIX_HEALTHPORT", Value: "9199"},
-			{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
-		}
+		})
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		Expect(len(ds.Spec.Template.Spec.Containers[0].Env)).To(Equal(len(expectedNodeEnv)))
 
@@ -510,59 +417,8 @@ var _ = Describe("Node rendering tests", func() {
 		ExpectEnv(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env, "CNI_NET_DIR", "/var/run/multus/cni/net.d")
 
 		optional := true
-		expectedNodeEnv := []v1.EnvVar{
-			// Default envvars.
-			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
-			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
-			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
+		expectedNodeEnv := expectedEnvVars(optional, []v1.EnvVar{
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,openshift,bgp"},
-			{Name: "IP", Value: "autodetect"},
-			{Name: "IP_AUTODETECTION_METHOD", Value: "first-found"},
-			{Name: "IP6", Value: "none"},
-			{Name: "CALICO_IPV4POOL_CIDR", Value: "192.168.1.0/16"},
-			{Name: "CALICO_IPV4POOL_IPIP", Value: "Always"},
-			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
-			{Name: "FELIX_IPINIPMTU", Value: "1440"},
-			{Name: "FELIX_VXLANMTU", Value: "1410"},
-			{Name: "FELIX_WIREGUARDMTU", Value: "1400"},
-			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
-			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
-			{Name: "FELIX_HEALTHENABLED", Value: "true"},
-			{
-				Name: "NODENAME",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
-				},
-			},
-			{
-				Name: "NAMESPACE",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
-				},
-			},
-			{Name: "FELIX_TYPHAK8SNAMESPACE", Value: "calico-system"},
-			{Name: "FELIX_TYPHAK8SSERVICENAME", Value: "calico-typha"},
-			{Name: "FELIX_TYPHACAFILE", Value: "/typha-ca/caBundle"},
-			{Name: "FELIX_TYPHACERTFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretCertName)},
-			{Name: "FELIX_TYPHAKEYFILE", Value: fmt.Sprintf("/felix-certs/%s", render.TLSSecretKeyName)},
-			{Name: "FELIX_TYPHACN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.CommonName,
-					Optional: &optional,
-				},
-			}},
-			{Name: "FELIX_TYPHAURISAN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: render.TyphaTLSSecretName,
-					},
-					Key:      render.URISAN,
-					Optional: &optional,
-				},
-			}},
 			// Tigera-specific envvars
 			{Name: "FELIX_PROMETHEUSREPORTERENABLED", Value: "true"},
 			{Name: "FELIX_PROMETHEUSREPORTERPORT", Value: "9081"},
@@ -575,10 +431,9 @@ var _ = Describe("Node rendering tests", func() {
 
 			// The OpenShift envvar overrides.
 			{Name: "FELIX_HEALTHPORT", Value: "9199"},
-			{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
 			{Name: "MULTI_INTERFACE_MODE", Value: operator.MultiInterfaceModeNone.Value()},
 			{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"},
-		}
+		})
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		Expect(len(ds.Spec.Template.Spec.Containers[0].Env)).To(Equal(len(expectedNodeEnv)))
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -916,6 +916,49 @@ var _ = Describe("Node rendering tests", func() {
 		}
 		Expect(passed).To(Equal(true))
 	})
+
+	Context("with BPF enabled", func() {
+		It("should override k8s endpoints", func() {
+			component := render.Node(defaultInstance, operator.ProviderNone,
+				render.NetworkConfig{
+					CNI:        render.CNICalico,
+					BPFEnabled: true,
+					K8sHost:    "k8shost",
+					K8sPort:    1234,
+				},
+				nil, typhaNodeTLS, nil, false)
+			resources, _ := component.Objects()
+			Expect(len(resources)).To(Equal(5))
+
+			dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+			ds := dsResource.(*apps.DaemonSet)
+
+			// FIXME update gomega to include ContainElements
+			Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "k8shost"},
+			))
+			Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "1234"},
+			))
+
+			var cni v1.Container
+
+			for _, c := range ds.Spec.Template.Spec.InitContainers {
+				if c.Name == "install-cni" {
+					cni = c
+					break
+				}
+			}
+			Expect(cni).NotTo(BeNil())
+
+			Expect(cni.Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "k8shost"},
+			))
+			Expect(cni.Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "1234"},
+			))
+		})
+	})
 })
 
 // verifyProbes asserts the expected node liveness and readiness probe.

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -92,6 +92,7 @@ func defaultEnvVars(opt bool) []v1.EnvVar {
 			},
 		}},
 		{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
+		{Name: "FELIX_BPFENABLED", Value: "false"},
 	}
 }
 

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -71,6 +71,7 @@ func Calico(
 	nc NetworkConfig,
 	aci *operator.AmazonCloudIntegration,
 	up bool,
+	bpfConfig BPFConfig,
 ) (Renderer, error) {
 
 	tcms := []*corev1.ConfigMap{}
@@ -146,6 +147,7 @@ func Calico(
 		networkConfig:               nc,
 		amazonCloudInt:              aci,
 		upgrade:                     up,
+		bpfConfig:                   bpfConfig,
 	}, nil
 }
 
@@ -219,6 +221,7 @@ type calicoRenderer struct {
 	networkConfig               NetworkConfig
 	amazonCloudInt              *operator.AmazonCloudIntegration
 	upgrade                     bool
+	bpfConfig                   BPFConfig
 }
 
 func (r calicoRenderer) Render() []Component {
@@ -228,7 +231,7 @@ func (r calicoRenderer) Render() []Component {
 	components = appendNotNil(components, ConfigMaps(r.tlsConfigMaps))
 	components = appendNotNil(components, Secrets(r.tlsSecrets))
 	components = appendNotNil(components, Typha(r.installation, r.provider, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade))
-	components = appendNotNil(components, Node(r.installation, r.provider, r.networkConfig, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade))
+	components = appendNotNil(components, Node(r.installation, r.provider, r.networkConfig, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade, r.bpfConfig))
 	components = appendNotNil(components, KubeControllers(r.installation, r.managementCluster, r.managementClusterConnection, r.managerInternalTLSecret))
 	return components
 }

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 4 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment)
 		// - 1 namespace
 		// - 1 PriorityClass
-		c, err := render.Calico(instance, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, false)
+		c, err := render.Calico(instance, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, false, render.BPFConfig{})
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(5 + 4 + 2 + 6 + 4 + 1 + 1))
 	})
@@ -92,7 +92,7 @@ var _ = Describe("Rendering tests", func() {
 		var nodeMetricsPort int32 = 9081
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		instance.Spec.NodeMetricsPort = &nodeMetricsPort
-		c, err := render.Calico(instance, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, false)
+		c, err := render.Calico(instance, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, false, render.BPFConfig{})
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(((5 + 4 + 2 + 6 + 4 + 1) + 1 + 1)))
 	})
@@ -107,7 +107,7 @@ var _ = Describe("Rendering tests", func() {
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		instance.Spec.NodeMetricsPort = &nodeMetricsPort
 
-		c, err := render.Calico(instance, &operator.ManagementCluster{}, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, false)
+		c, err := render.Calico(instance, &operator.ManagementCluster{}, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, render.NetworkConfig{CNI: render.CNICalico}, nil, false, render.BPFConfig{})
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 
 		expectedResources := []struct {


### PR DESCRIPTION
## Description

The idea is that since we cannot rely on kube-proxy being present and thus kubernetes service working, we need k8s client with direct connection, hence we need to be able to override the host:port and these values need to be propagated to other components, namely Felix and CNI. There might be better, more automated, ways of getting these values, however, these are going to be very much environment dependent.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
