### PR TITLE
convert config that is configurable via operator api

### DIFF
--- a/pkg/controller/migration/convert/convert_test.go
+++ b/pkg/controller/migration/convert/convert_test.go
@@ -129,10 +129,41 @@ func emptyKubeControllerSpec() *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Name: "calico-node",
+						Name: "calico-kube-controllers",
 					}},
 				},
 			},
 		},
+	}
+}
+
+func emptyTyphaDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "calico-typha",
+			Namespace: "kube-system",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "calico-typha",
+					}},
+				},
+			},
+		},
+	}
+}
+
+// emptyComponents is a convenience function for initializing a
+// components object which meets basic validation requirements.
+func emptyComponents() components {
+	return components{
+		node: CheckedDaemonSet{
+			*emptyNodeSpec(),
+			make(map[string]checkedFields),
+		},
+		kubeControllers: *emptyKubeControllerSpec(),
+		typha:           *emptyTyphaDeployment(),
 	}
 }

--- a/pkg/controller/migration/convert/convert_test.go
+++ b/pkg/controller/migration/convert/convert_test.go
@@ -1,4 +1,4 @@
-package convert_test
+package convert
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
-	"github.com/tigera/operator/pkg/controller/migration/convert"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +19,7 @@ var _ = Describe("Parser", func() {
 
 	It("should not detect an installation if none exists", func() {
 		c := fake.NewFakeClient()
-		Expect(convert.Convert(ctx, c, &operatorv1.Installation{})).To(BeNil())
+		Expect(Convert(ctx, c, &operatorv1.Installation{})).To(BeNil())
 	})
 
 	It("should detect an installation if one exists", func() {
@@ -30,14 +29,14 @@ var _ = Describe("Parser", func() {
 				Namespace: "kube-system",
 			},
 		}, emptyKubeControllerSpec())
-		err := convert.Convert(ctx, c, &operatorv1.Installation{})
+		err := Convert(ctx, c, &operatorv1.Installation{})
 		// though it will detect an install, it will be in the form of an incompatible-cluster error
-		Expect(err).To(BeAssignableToTypeOf(convert.ErrIncompatibleCluster{}))
+		Expect(err).To(BeAssignableToTypeOf(ErrIncompatibleCluster{}))
 	})
 
 	It("should detect a valid installation", func() {
 		c := fake.NewFakeClient(emptyNodeSpec(), emptyKubeControllerSpec())
-		Expect(convert.Convert(ctx, c, &operatorv1.Installation{})).To(BeNil())
+		Expect(Convert(ctx, c, &operatorv1.Installation{})).To(BeNil())
 	})
 
 	It("should error for unchecked env vars", func() {
@@ -47,7 +46,7 @@ var _ = Describe("Parser", func() {
 			Value: "bar",
 		}}
 		c := fake.NewFakeClient(node, emptyKubeControllerSpec())
-		err := convert.Convert(ctx, c, &operatorv1.Installation{})
+		err := Convert(ctx, c, &operatorv1.Installation{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -66,7 +65,7 @@ var _ = Describe("Parser", func() {
 
 		c := fake.NewFakeClient(ds, emptyKubeControllerSpec())
 		cfg := &operatorv1.Installation{}
-		err := convert.Convert(ctx, c, cfg)
+		err := Convert(ctx, c, cfg)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg).ToNot(BeNil())
 		exp := int32(24)
@@ -81,7 +80,7 @@ var _ = Describe("Parser", func() {
 		}}
 
 		c := fake.NewFakeClient(ds, emptyKubeControllerSpec())
-		err := convert.Convert(ctx, c, &operatorv1.Installation{})
+		err := Convert(ctx, c, &operatorv1.Installation{})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -89,7 +88,7 @@ var _ = Describe("Parser", func() {
 	// 	ds := emptyNodeSpec()
 	// 	c := fake.NewFakeClient(ds, emptyKubeControllerSpec())
 
-	// 	cfg, err := convert.Convert(ctx, c, &operatorv1.Installation{})
+	// 	cfg, err := Convert(ctx, c, &operatorv1.Installation{})
 	// 	Expect(err).ToNot(HaveOccurred())
 	// 	Expect(cfg).ToNot(BeNil())
 	// })

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -46,6 +46,20 @@ func handleCore(c *components, install *Installation) error {
 	// node update-strategy
 	install.Spec.NodeUpdateStrategy = c.node.Spec.UpdateStrategy
 
+	// node volumes
+	for _, vol := range c.node.Spec.Template.Spec.Volumes {
+		switch vol.Name {
+		case "flexvol-driver-host":
+			// prefer user-defined flexvolpath over detected value
+			if install.Spec.FlexVolumePath == "" {
+				if vol.HostPath == nil {
+					return ErrIncompatibleCluster{"volume 'flexvol-driver-host' must be a HostPath"}
+				}
+				install.Spec.FlexVolumePath = vol.HostPath.Path
+			}
+		}
+	}
+
 	// TODO: handle these vars appropriately
 	c.node.ignoreEnv("calico-node", "WAIT_FOR_DATASTORE")
 	c.node.ignoreEnv("calico-node", "CLUSTER_TYPE")

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -40,6 +40,9 @@ func handleCore(c *components, install *Installation) error {
 		})
 	}
 
+	// kube-controllers nodeSelector
+	install.Spec.ControlPlaneNodeSelector = c.kubeControllers.Spec.Template.Spec.NodeSelector
+
 	// TODO: handle these vars appropriately
 	c.node.ignoreEnv("calico-node", "WAIT_FOR_DATASTORE")
 	c.node.ignoreEnv("calico-node", "CLUSTER_TYPE")

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -1,5 +1,9 @@
 package convert
 
+import (
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+)
+
 func handleCore(c *components, install *Installation) error {
 	dsType, err := c.node.getEnv(ctx, c.client, "calico-node", "DATASTORE_TYPE")
 	if err != nil {
@@ -7,6 +11,33 @@ func handleCore(c *components, install *Installation) error {
 	}
 	if dsType != nil && *dsType != "kubernetes" {
 		return ErrIncompatibleCluster{"only DATASTORE_TYPE=kubernetes is supported at this time"}
+	}
+
+	// node resource limits
+	node := getContainer(c.node.Spec.Template.Spec, "calico-node")
+	if len(node.Resources.Limits) > 0 || len(node.Resources.Requests) > 0 {
+		install.Spec.ComponentResources = append(install.Spec.ComponentResources, &operatorv1.ComponentResource{
+			ComponentName:        operatorv1.ComponentNameNode,
+			ResourceRequirements: node.Resources.DeepCopy(),
+		})
+	}
+
+	// kube-controllers
+	kubeControllers := getContainer(c.kubeControllers.Spec.Template.Spec, "calico-kube-controllers")
+	if len(kubeControllers.Resources.Limits) > 0 || len(kubeControllers.Resources.Requests) > 0 {
+		install.Spec.ComponentResources = append(install.Spec.ComponentResources, &operatorv1.ComponentResource{
+			ComponentName:        operatorv1.ComponentNameKubeControllers,
+			ResourceRequirements: kubeControllers.Resources.DeepCopy(),
+		})
+	}
+
+	// typha resource limits. typha is optional so check for nil first
+	typha := getContainer(c.typha.Spec.Template.Spec, "calico-typha")
+	if typha != nil && (len(typha.Resources.Limits) > 0 || len(typha.Resources.Requests) > 0) {
+		install.Spec.ComponentResources = append(install.Spec.ComponentResources, &operatorv1.ComponentResource{
+			ComponentName:        operatorv1.ComponentNameTypha,
+			ResourceRequirements: typha.Resources.DeepCopy(),
+		})
 	}
 
 	// TODO: handle these vars appropriately

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -43,6 +43,9 @@ func handleCore(c *components, install *Installation) error {
 	// kube-controllers nodeSelector
 	install.Spec.ControlPlaneNodeSelector = c.kubeControllers.Spec.Template.Spec.NodeSelector
 
+	// node update-strategy
+	install.Spec.NodeUpdateStrategy = c.node.Spec.UpdateStrategy
+
 	// TODO: handle these vars appropriately
 	c.node.ignoreEnv("calico-node", "WAIT_FOR_DATASTORE")
 	c.node.ignoreEnv("calico-node", "CLUSTER_TYPE")

--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -103,4 +103,28 @@ var _ = Describe("core handler", func() {
 			Expect(i.Spec.NodeUpdateStrategy).To(Equal(updateStrategy))
 		})
 	})
+
+	Context("flexvol", func() {
+		It("should not be set by default", func() {
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.FlexVolumePath).To(Equal(""))
+		})
+		It("should carry forward flexvolumepath", func() {
+			hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
+			path := "/foo/bar/"
+			hp := v1.Volume{
+				Name: "flexvol-driver-host",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: path,
+						Type: &hostPathDirectoryOrCreate,
+					},
+				},
+			}
+			comps.node.Spec.Template.Spec.Volumes = []v1.Volume{hp}
+
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.FlexVolumePath).To(Equal(path))
+		})
+	})
 })

--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -68,4 +68,17 @@ var _ = Describe("core handler", func() {
 			}))
 		})
 	})
+
+	Context("nodeSelector", func() {
+		It("should not set nodeSelector if none is set", func() {
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.ControlPlaneNodeSelector).To(BeEmpty())
+		})
+		It("should carry forward nodeSelector", func() {
+			nodeSelector := map[string]string{"foo": "bar"}
+			comps.kubeControllers.Spec.Template.Spec.NodeSelector = nodeSelector
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.ControlPlaneNodeSelector).To(Equal(nodeSelector))
+		})
+	})
 })

--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -1,0 +1,71 @@
+package convert
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+)
+
+var _ = Describe("core handler", func() {
+	var (
+		comps = emptyComponents()
+		i     = &Installation{}
+	)
+
+	BeforeEach(func() {
+		comps = emptyComponents()
+		i = &Installation{
+			Installation: &operatorv1.Installation{},
+			CNIConfig:    "",
+			FelixEnvVars: []v1.EnvVar{},
+		}
+	})
+	Context("resource migration", func() {
+		It("should not migrate resource requirements if none are set", func() {
+			err := handleCore(&comps, i)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(i.Spec.ComponentResources).To(BeEmpty())
+		})
+
+		var rqs = v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("500m"),
+				v1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("250m"),
+				v1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		}
+
+		It("should migrate resources from calico-node if they are set", func() {
+			comps.node.Spec.Template.Spec.Containers[0].Resources = rqs
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.ComponentResources).To(ConsistOf(&operatorv1.ComponentResource{
+				ComponentName:        operatorv1.ComponentNameNode,
+				ResourceRequirements: &rqs,
+			}))
+		})
+
+		It("should migrate resources from kube-controllers if they are set", func() {
+			comps.kubeControllers.Spec.Template.Spec.Containers[0].Resources = rqs
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.ComponentResources).To(ConsistOf(&operatorv1.ComponentResource{
+				ComponentName:        operatorv1.ComponentNameKubeControllers,
+				ResourceRequirements: &rqs,
+			}))
+		})
+
+		It("should migrate resources from typha if they are set", func() {
+			comps.typha.Spec.Template.Spec.Containers[0].Resources = rqs
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.ComponentResources).To(ConsistOf(&operatorv1.ComponentResource{
+				ComponentName:        operatorv1.ComponentNameTypha,
+				ResourceRequirements: &rqs,
+			}))
+		})
+	})
+})

--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -3,8 +3,11 @@ package convert
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 )
@@ -79,6 +82,25 @@ var _ = Describe("core handler", func() {
 			comps.kubeControllers.Spec.Template.Spec.NodeSelector = nodeSelector
 			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
 			Expect(i.Spec.ControlPlaneNodeSelector).To(Equal(nodeSelector))
+		})
+	})
+
+	Context("node update strategy", func() {
+		It("should not set updateStrategy if none is set", func() {
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.NodeUpdateStrategy).To(Equal(appsv1.DaemonSetUpdateStrategy{}))
+		})
+		It("should carry forward updateStrategy", func() {
+			twelve := intstr.FromInt(12)
+			updateStrategy := appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.OnDeleteDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &twelve,
+				},
+			}
+			comps.node.Spec.UpdateStrategy = updateStrategy
+			Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			Expect(i.Spec.NodeUpdateStrategy).To(Equal(updateStrategy))
 		})
 	})
 })


### PR DESCRIPTION
## Description

This includes (see individual commits):
- mem / cpu limits / requests for node, kubeControllers, & typha
- flexvolpath
- node updatestrategy
- nodeselector (kubecontrollers)

Also included: made the converter test apart of the package so the handler tests (which test private methods) could use the the helper methods provided by the converter tests.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.