### PR TITLE
fix CR status reporting

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -456,6 +456,9 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, nil
 	}
 
+	// mark CR found so we can report converter problems via tigerastatus
+	r.status.OnCRFound()
+
 	c := convert.Converter{r.client}
 
 	// Query for the installation object.
@@ -476,7 +479,6 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		r.SetDegraded("Error querying installation", err, reqLogger)
 		return reconcile.Result{}, err
 	}
-	r.status.OnCRFound()
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 
 	// Validate the configuration.


### PR DESCRIPTION
Fix a bug in the CR reporting where converter errors weren't being reported because the tigerastatus was not initialized.

I had this fixed in a previous version of this code (https://github.com/ozdanborne/operator/commit/df37bb48d34c9543aa6cefd6f622eeb55e776df1)  but messed up a rebase so it's not included in the feature branch right now

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.