### PR TITLE
Some fixes to make API generation not need additional updates.

### DIFF
--- a/deploy/crds/operator.tigera.io_installations_crd.yaml
+++ b/deploy/crds/operator.tigera.io_installations_crd.yaml
@@ -39,6 +39,14 @@ spec:
                 description: CalicoNetwork specifies configuration options for Calico
                   provided pod networking.
                 properties:
+                  containerIPForwarding:
+                    description: 'ContainerIPForwarding configures whether ip forwarding
+                      will be enabled for containers in the CNI configuration. Default:
+                      Disabled'
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   hostPorts:
                     description: 'HostPorts configures whether or not Calico will
                       support Kubernetes HostPorts. Default: Enabled'

--- a/deploy/crds/operator.tigera.io_logcollectors_crd.yaml
+++ b/deploy/crds/operator.tigera.io_logcollectors_crd.yaml
@@ -92,7 +92,7 @@ spec:
                     properties:
                       endpoint:
                         description: Location for splunk's http event collector end
-                          point. example https://1.2.3.4:8088
+                          point. example `https://1.2.3.4:8088`
                         type: string
                     required:
                     - endpoint

--- a/pkg/apis/operator/v1/logcollector_types.go
+++ b/pkg/apis/operator/v1/logcollector_types.go
@@ -81,7 +81,7 @@ type SyslogStoreSpec struct {
 
 // SplunkStoreSpec defines configuration for exporting logs to splunk.
 type SplunkStoreSpec struct {
-	// Location for splunk's http event collector end point. example https://1.2.3.4:8088
+	// Location for splunk's http event collector end point. example `https://1.2.3.4:8088`
 	Endpoint string `json:"endpoint"`
 }
 

--- a/pkg/apis/operator/v1/types.go
+++ b/pkg/apis/operator/v1/types.go
@@ -98,7 +98,7 @@ type InstallationSpec struct {
 
 	// ComponentResources can be used to customize the resource requirements for each component.
 	// +optional
-	ComponentResources []*ComponentResource `json:"componentResources,omitempty"`
+	ComponentResources []ComponentResource `json:"componentResources,omitempty"`
 }
 
 // ComponentName CRD enum

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -324,6 +324,11 @@ func (in *CalicoNetworkSpec) DeepCopyInto(out *CalicoNetworkSpec) {
 		*out = new(MultiInterfaceMode)
 		**out = **in
 	}
+	if in.ContainerIPForwarding != nil {
+		in, out := &in.ContainerIPForwarding, &out.ContainerIPForwarding
+		*out = new(ContainerIPForwardingType)
+		**out = **in
+	}
 	return
 }
 
@@ -603,13 +608,9 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 	in.NodeUpdateStrategy.DeepCopyInto(&out.NodeUpdateStrategy)
 	if in.ComponentResources != nil {
 		in, out := &in.ComponentResources, &out.ComponentResources
-		*out = make([]*ComponentResource, len(*in))
+		*out = make([]ComponentResource, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ComponentResource)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	return

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -178,7 +178,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			},
 		}
 
-		instance.Spec.ComponentResources = []*operator.ComponentResource{
+		instance.Spec.ComponentResources = []operator.ComponentResource{
 			{
 				ComponentName:        operator.ComponentNameKubeControllers,
 				ResourceRequirements: rr,

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1105,7 +1105,7 @@ var _ = Describe("Node rendering tests", func() {
 			},
 		}
 
-		defaultInstance.Spec.ComponentResources = []*operator.ComponentResource{
+		defaultInstance.Spec.ComponentResources = []operator.ComponentResource{
 			{
 				ComponentName:        operator.ComponentNameNode,
 				ResourceRequirements: rr,

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Typha rendering tests", func() {
 			},
 		}
 
-		installation.Spec.ComponentResources = []*operator.ComponentResource{
+		installation.Spec.ComponentResources = []operator.ComponentResource{
 			{
 				ComponentName:        operator.ComponentNameTypha,
 				ResourceRequirements: rr,


### PR DESCRIPTION
## Description

The non-generated changes here are to pkg/apis/operator/v1/logcollector_types.go and pkg/apis/operator/v1/types.go. The changes fix the API generation we do. The 1st ensures the url does not turn into an Anchor tag. The 2nd ensures the type is not generated into an awful `*github.com/tigera/operator/.....` but instead converts to `operator.tigera.io/v1.ComponentResource`. The 2nd change is actually an API change but from a yaml point of view it is the same so I think we should be ok to make this change.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
