### PR TITLE
bugfix copying config

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -230,7 +230,7 @@ func getInstallation(ctx context.Context, client client.Client, provider operato
 
 	if i != nil {
 		// TODO: verify that user-specified values are compatible with detected values.
-		i.DeepCopyInto(instance)
+		i.Spec.DeepCopyInto(&instance.Spec)
 	}
 
 	// Determine the provider in use by combining any auto-detected value with any value


### PR DESCRIPTION
## Description

Our hack to use detected config without worrying about existing config was broken because the metadata (which names the installation) was being overwritten with an empty one. this change _just_ copies the spec.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
