### PR TITLE
Update operator defaults

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -569,7 +569,7 @@ func (c *apiServerComponent) apiServer() *appsv1.Deployment {
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/os": "linux",
+						"kubernetes.io/os": "linux",
 					},
 					ServiceAccountName: "tigera-apiserver",
 					Tolerations:        c.tolerations(),

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -144,7 +144,7 @@ var _ = Describe("API server rendering tests", func() {
 		Expect(d.Spec.Template.Labels).To(HaveKeyWithValue("k8s-app", "tigera-apiserver"))
 
 		Expect(len(d.Spec.Template.Spec.NodeSelector)).To(Equal(1))
-		Expect(d.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("beta.kubernetes.io/os", "linux"))
+		Expect(d.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("kubernetes.io/os", "linux"))
 		Expect(d.Spec.Template.Spec.ServiceAccountName).To(Equal("tigera-apiserver"))
 
 		expectedTolerations := []corev1.Toleration{

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -319,7 +319,7 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
 			NodeSelector: map[string]string{
-				"beta.kubernetes.io/os": "linux",
+				"kubernetes.io/os": "linux",
 			},
 			ServiceAccountName: "tigera-compliance-controller",
 			Tolerations: []corev1.Toleration{
@@ -447,7 +447,7 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 				},
 			},
 			Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-				NodeSelector:       map[string]string{"beta.kubernetes.io/os": "linux"},
+				NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 				ServiceAccountName: "tigera-compliance-reporter",
 				Tolerations: []corev1.Toleration{
 					{
@@ -617,7 +617,7 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 			Annotations: complianceAnnotations(c),
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector:       map[string]string{"beta.kubernetes.io/os": "linux"},
+			NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 			ServiceAccountName: "tigera-compliance-server",
 			Tolerations: []corev1.Toleration{
 				{
@@ -839,7 +839,7 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 			},
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector:       map[string]string{"beta.kubernetes.io/os": "linux"},
+			NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 			ServiceAccountName: "tigera-compliance-snapshotter",
 			Tolerations: []corev1.Toleration{
 				{
@@ -988,7 +988,7 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 			},
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector:       map[string]string{"beta.kubernetes.io/os": "linux"},
+			NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 			ServiceAccountName: "tigera-compliance-benchmarker",
 			HostPID:            true,
 			Tolerations: []corev1.Toleration{

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -678,7 +678,7 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/os": "linux",
+						"kubernetes.io/os": "linux",
 					},
 					ServiceAccountName: eksLogForwarderName,
 					ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -202,7 +202,7 @@ func (c *GuardianComponent) deployment() runtime.Object {
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/os": "linux",
+						"kubernetes.io/os": "linux",
 					},
 					ServiceAccountName: GuardianServiceAccountName,
 					Tolerations:        c.tolerations(),

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -319,7 +319,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 				},
 				Spec: v1.PodSpec{
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/os": "linux",
+						"kubernetes.io/os": "linux",
 					},
 					Tolerations:        tolerations,
 					ImagePullSecrets:   c.cr.Spec.ImagePullSecrets,

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -227,7 +227,7 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
 			NodeSelector: map[string]string{
-				"beta.kubernetes.io/os": "linux",
+				"kubernetes.io/os": "linux",
 			},
 			ServiceAccountName: ManagerServiceAccount,
 			Tolerations:        c.managerTolerations(),

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -506,7 +506,9 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *v1.ConfigMap) *apps.DaemonSet {
 					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
-					NodeSelector:                  map[string]string{},
+					NodeSelector: map[string]string{
+						"kubernetes.io/os": "linux",
+					},
 					Tolerations:                   c.nodeTolerations(),
 					ImagePullSecrets:              c.cr.Spec.ImagePullSecrets,
 					ServiceAccountName:            "calico-node",

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -396,6 +396,10 @@ func (c *nodeComponent) nodeCNIConfigMap() *v1.ConfigMap {
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       }
+    },
+    {
+      "type": "bandwidth",
+      "capabilities": {"bandwidth": true}
     }%s
   ]
 }`, mtu, nodenameFileOptional, assign_ipv4, assign_ipv6, ipForward, portmap)

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -129,6 +129,10 @@ var _ = Describe("Node rendering tests", func() {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       }
     },
+    {
+      "type": "bandwidth",
+      "capabilities": {"bandwidth": true}
+    },
     {"type": "portmap", "snat": true, "capabilities": {"portMappings": true}}
   ]
 }`))
@@ -1202,6 +1206,10 @@ var _ = Describe("Node rendering tests", func() {
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       }
+    },
+    {
+      "type": "bandwidth",
+      "capabilities": {"bandwidth": true}
     }
   ]
 }`))
@@ -1277,6 +1285,10 @@ var _ = Describe("Node rendering tests", func() {
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       }
+    },
+    {
+      "type": "bandwidth",
+      "capabilities": {"bandwidth": true}
     },
     {"type": "portmap", "snat": true, "capabilities": {"portMappings": true}}
   ]

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -352,7 +352,7 @@ func (c *typhaComponent) typhaDeployment() *apps.Deployment {
 }
 
 func (c *typhaComponent) nodeSelector() map[string]string {
-	return map[string]string{"beta.kubernetes.io/os": "linux"}
+	return map[string]string{"kubernetes.io/os": "linux"}
 }
 
 // tolerations creates the typha's tolerations.


### PR DESCRIPTION
## Description

Update various defaults in Operator to better match non-operator calico installs. This includes:

- use `kubernetes.io/os` selectors over `beta.kubernetes.io/os` (which has been deprecated since v1.16 anyways)
- ~use a privileged securityContext for install-cni and flexvol (which honestly is probably a bug that we weren't)~
  - rebasing onto master picked up this change! so no longer including it
- always use bandwidth cni plugin by default

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
