### PR TITLE
Migrate non-calico CNI plugins

### DIFF
--- a/pkg/controller/migration/convert/aws-cni-policy-only_test.go
+++ b/pkg/controller/migration/convert/aws-cni-policy-only_test.go
@@ -1,0 +1,203 @@
+package convert
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func awsCNIPolicyOnlyConfig() []runtime.Object {
+	fileOrCreate := corev1.HostPathFileOrCreate
+	isPrivileged := true
+	_true := true
+	_false := false
+	var terminationGracePeriod int64 = 0
+	maxUnav := intstr.FromInt(1)
+	updateStrat := appsv1.RollingUpdateDaemonSet{MaxUnavailable: &maxUnav}
+	_intStr9098 := intstr.FromInt(9098)
+	var _65534 int64 = 65534
+	var _2 int32 = 2
+	return []runtime.Object{
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "calico-node",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"k8s-app": "calico-node",
+				},
+			},
+			Spec: appsv1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "calico-node"}},
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+					Type:          appsv1.RollingUpdateDaemonSetStrategyType,
+					RollingUpdate: &updateStrat,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"k8s-app": "calico-node",
+						},
+					},
+					Spec: corev1.PodSpec{
+						PriorityClassName:             "system-node-critical",
+						NodeSelector:                  map[string]string{"beta.kubernetes.io/os": "linux"},
+						HostNetwork:                   true,
+						ServiceAccountName:            "calico-node",
+						TerminationGracePeriodSeconds: &terminationGracePeriod,
+						Containers: []corev1.Container{{
+							Name:  "calico-node",
+							Image: "quay.io/calico/node:v3.13.4",
+							Env: []corev1.EnvVar{
+								{Name: "DATASTORE_TYPE", Value: "kubernetes"},
+								{Name: "FELIX_INTERFACEPREFIX", Value: "eni"},
+								{Name: "FELIX_LOGSEVERITYSCREEN", Value: "info"},
+								{Name: "CALICO_NETWORKING_BACKEND", Value: "none"},
+								{Name: "CLUSTER_TYPE", Value: "k8s,ecs"},
+								{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
+								{Name: "FELIX_TYPHAK8SSERVICENAME", Value: "calico-typha"},
+								{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
+								{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"},
+								{Name: "FELIX_IPV6SUPPORT", Value: "false"},
+								{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+								{Name: "FELIX_LOGSEVERITYSYS", Value: "none"},
+								{Name: "FELIX_PROMETHEUSMETRICSENABLED", Value: "true"},
+								{Name: "NO_DEFAULT_POOLS", Value: "true"},
+								{
+									Name: "NODENAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+									},
+								},
+								{Name: "IP", Value: ""},
+								{Name: "FELIX_HEALTHENABLED", Value: "true"},
+							},
+							SecurityContext: &corev1.SecurityContext{Privileged: &isPrivileged},
+							LivenessProbe: &corev1.Probe{
+								Handler:             corev1.Handler{Exec: &corev1.ExecAction{Command: []string{"/bin/calico-node", "-felix-live"}}},
+								PeriodSeconds:       10,
+								InitialDelaySeconds: 10,
+								FailureThreshold:    6,
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler:       corev1.Handler{Exec: &corev1.ExecAction{Command: []string{"/bin/calico-node", "-felix-ready"}}},
+								PeriodSeconds: 10,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{MountPath: "/lib/modules", Name: "lib-modules", ReadOnly: true},
+								{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
+								{MountPath: "/var/run/calico", Name: "var-run-calico"},
+								{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
+							},
+						}},
+						Tolerations: []corev1.Toleration{
+							{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+							{Operator: corev1.TolerationOpExists, Key: "CriticalAddonsOnly"},
+							{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+						},
+						Volumes: []corev1.Volume{
+							{Name: "lib-modules", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/lib/modules"}}},
+							{Name: "var-run-calico", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/calico"}}},
+							{Name: "var-lib-calico", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/calico"}}},
+							{Name: "xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run/xtables.lock", Type: &fileOrCreate}}},
+						},
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "calico-typha",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"k8s-app": "calico-typha",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &_2,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "calico-typha"}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"k8s-app": "calico-typha",
+						},
+						Annotations: map[string]string{
+							"cluster-autoscaler.kubernetes.io/safe-to-evict": "'true'",
+						},
+					},
+					Spec: corev1.PodSpec{
+						PriorityClassName: "system-cluster-critical",
+						NodeSelector:      map[string]string{"beta.kubernetes.io/os": "linux"},
+						Tolerations: []corev1.Toleration{
+							{Operator: corev1.TolerationOpExists, Key: "CriticalAddonsOnly"},
+						},
+						HostNetwork:        true,
+						ServiceAccountName: "calico-node",
+						SecurityContext:    &corev1.PodSecurityContext{FSGroup: &_65534},
+						Containers: []corev1.Container{{
+							Name:  "calico-node",
+							Image: "quay.io/calico/typha:v3.13.4",
+							Ports: []corev1.ContainerPort{
+								{Name: "calico-typha", Protocol: corev1.ProtocolTCP, ContainerPort: 5473},
+							},
+							Env: []corev1.EnvVar{
+								{Name: "FELIX_INTERFACEPREFIX", Value: "eni"},
+								{Name: "TYPHA_LOGFILEPATH", Value: "none"},
+								{Name: "TYPHA_LOGSEVERITYSYS", Value: "none"},
+								{Name: "TYPHA_LOGSEVERITYSCREEN", Value: "info"},
+								{Name: "TYPHA_PROMETHEUSMETRICSENABLED", Value: "true"},
+								{Name: "TYPHA_CONNECTIONREBALANCINGMODE", Value: "kubernetes"},
+								{Name: "TYPHA_PROMETHEUSMETRICSPORT", Value: "9093"},
+								{Name: "TYPHA_DATASTORETYPE", Value: "kubernetes"},
+								{Name: "TYPHA_MAXCONNECTIONSLOWERLIMIT", Value: "1"},
+								{Name: "TYPHA_HEALTHENABLED", Value: "true"},
+								{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"},
+							},
+							LivenessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Host: "localhost",
+										Path: "/liveness",
+										Port: _intStr9098,
+									},
+								},
+								PeriodSeconds:       30,
+								InitialDelaySeconds: 30,
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &_false,
+								RunAsNonRoot:             &_true,
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Host: "localhost",
+										Path: "/readiness",
+										Port: _intStr9098,
+									},
+								},
+								PeriodSeconds: 10,
+							},
+						}},
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "calico-kube-controllers",
+				Namespace: "kube-system",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "calico-node",
+						}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/migration/convert/cni.go
+++ b/pkg/controller/migration/convert/cni.go
@@ -12,6 +12,15 @@ import (
 // loadCNI loads CNI config into the components for all other handlers to use.
 // No verification is done here beyond checking for valid json.
 func loadCNI(c *components) error {
+
+	cntnr := getContainer(c.node.Spec.Template.Spec, containerInstallCNI)
+	if cntnr == nil {
+		// It is valid to not have an install-cni container in the cases
+		// of non Calico CNI so nothing more to do in that case.
+		log.Print("no install-cni container detected on node")
+		return nil
+	}
+
 	cniConfig, err := c.node.getEnv(ctx, c.client, containerInstallCNI, "CNI_NETWORK_CONFIG")
 	if err != nil {
 		return err

--- a/pkg/controller/migration/convert/handler.go
+++ b/pkg/controller/migration/convert/handler.go
@@ -12,4 +12,7 @@ type handler func(*components, *Installation) error
 var handlers = []handler{
 	handleNetwork,
 	handleCore,
+	handleFelixNodeMetrics,
+	handleCalicoCNI,
+	handleNonCalicoCNI,
 }

--- a/pkg/controller/migration/convert/k8s.go
+++ b/pkg/controller/migration/convert/k8s.go
@@ -78,7 +78,7 @@ func getEnv(ctx context.Context, client client.Client, env []corev1.EnvVar, key 
 }
 
 func getEnvVar(ctx context.Context, client client.Client, e corev1.EnvVar) (string, error) {
-	if e.Value != "" {
+	if e.ValueFrom == nil {
 		return e.Value, nil
 	}
 	// if Value is empty, one of the ConfigMapKeyRefs must be used

--- a/pkg/controller/migration/convert/network.go
+++ b/pkg/controller/migration/convert/network.go
@@ -16,24 +16,6 @@ const (
 )
 
 func handleNetwork(c *components, install *Installation) error {
-	// TODO: be more elegant about creation of this spec field if it already exists
-	if install.Spec.CalicoNetwork == nil {
-		install.Spec.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
-	}
-
-	// CALICO_NETWORKING_BACKEND
-	netBackend, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "CALICO_NETWORKING_BACKEND")
-	if err != nil {
-		return err
-	}
-	if netBackend != nil && *netBackend != "" && *netBackend != "bird" {
-		return ErrIncompatibleCluster{"only CALICO_NETWORKING_BACKEND=bird is supported at this time"}
-	}
-
-	// Calico CNI
-	if c.calicoCNIConfig == nil {
-		return fmt.Errorf("no 'calico' cni conf found in CNI_NETWORK_CONFIG on install-cni")
-	}
 
 	// FELIX_DEFAULTENDPOINTTOHOSTACTION
 	defaultWepAction, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "FELIX_DEFAULTENDPOINTTOHOSTACTION")
@@ -46,6 +28,40 @@ func handleNetwork(c *components, install *Installation) error {
 		}
 	}
 
+	return nil
+}
+
+func handleCalicoCNI(c *components, install *Installation) error {
+	plugin, err := getCNIPlugin(c)
+	if err != nil {
+		return err
+	}
+	if plugin != operatorv1.PluginCalico {
+		return nil
+	}
+
+	context := fmt.Sprintf("detected %s CNI plugin", plugin)
+
+	// CALICO_NETWORKING_BACKEND
+	netBackend, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "CALICO_NETWORKING_BACKEND")
+	if err != nil {
+		return err
+	}
+
+	if netBackend != nil && *netBackend != "" && *netBackend != "bird" {
+		return ErrIncompatibleCluster{fmt.Sprintf("%s, only CALICO_NETWORKING_BACKEND=bird is supported at this time", context)}
+	}
+
+	// Calico CNI
+	if c.calicoCNIConfig == nil {
+		return ErrIncompatibleCluster{fmt.Sprintf("%s, required cni config was not found ", context)}
+	}
+
+	// TODO: be more elegant about creation of this spec field if it already exists
+	if install.Spec.CalicoNetwork == nil {
+		install.Spec.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
+	}
+
 	// IP
 	ipMethod, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "IP")
 	if err != nil {
@@ -53,7 +69,7 @@ func handleNetwork(c *components, install *Installation) error {
 	}
 	if ipMethod != nil && strings.ToLower(*ipMethod) != "autodetect" {
 		return ErrIncompatibleCluster{
-			fmt.Sprintf("unexpected IP value: '%s'. Only 'autodetect' is supported.", *ipMethod),
+			fmt.Sprintf("%s, unexpected IP value: '%s'. Only 'autodetect' is supported.", context, *ipMethod),
 		}
 	}
 
@@ -65,7 +81,7 @@ func handleNetwork(c *components, install *Installation) error {
 	if am != nil {
 		tam, err := getAutoDetection(*am)
 		if err != nil {
-			return ErrIncompatibleCluster{"error parsing IP_AUTODETECTION_METHOD: " + err.Error()}
+			return ErrIncompatibleCluster{fmt.Sprintf("%s, error parsing IP_AUTODETECTION_METHOD: "+err.Error(), context)}
 		}
 		install.Spec.CalicoNetwork.NodeAddressAutodetectionV4 = &tam
 	}
@@ -77,11 +93,6 @@ func handleNetwork(c *components, install *Installation) error {
 	} else {
 		hp := v1.HostPortsDisabled
 		install.Spec.CalicoNetwork.HostPorts = &hp
-	}
-
-	if c.calicoCNIConfig == nil {
-		// TODO: don't return an error once we support this, instead just returning nil.
-		return ErrIncompatibleCluster{"operator does not yet support running without calico CNI"}
 	}
 
 	if c.calicoCNIConfig.MTU == -1 {
@@ -114,6 +125,107 @@ func handleNetwork(c *components, install *Installation) error {
 	}
 	if c.calicoCNIConfig.FeatureControl.IPAddrsNoIpam {
 		return ErrIncompatibleCluster{"IpAddrsNoIpam not supported"}
+	}
+
+	return nil
+}
+
+func handleNonCalicoCNI(c *components, install *Installation) error {
+	plugin, err := getCNIPlugin(c)
+	if err != nil {
+		return err
+	}
+	if plugin == operatorv1.PluginCalico {
+		return nil
+	}
+
+	context := fmt.Sprintf("detected %s CNI plugin", plugin)
+
+	icc := getContainer(c.node.Spec.Template.Spec, containerInstallCNI)
+	if icc != nil {
+		return ErrIncompatibleCluster{
+			fmt.Sprintf("%s, %s container is not supported in the node daemonset", context, containerInstallCNI),
+		}
+	}
+
+	// CALICO_NETWORKING_BACKEND
+	netBackend, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "CALICO_NETWORKING_BACKEND")
+	if err != nil {
+		return err
+	}
+	if netBackend == nil || *netBackend != "none" {
+		return ErrIncompatibleCluster{fmt.Sprintf("%s, CALICO_NETWORKING_BACKEND=none is expected", context)}
+	}
+
+	if install.Spec.CNI == nil {
+		install.Spec.CNI = &operatorv1.CNISpec{}
+	}
+
+	switch plugin {
+	case operatorv1.PluginAmazonVPC:
+		install.Spec.CNI.Type = plugin
+		// FELIX_IPTABLESMANGLEALLOWACTION
+		mangleAllow, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "FELIX_IPTABLESMANGLEALLOWACTION")
+		if err != nil {
+			return err
+		}
+
+		// check that IPTABLESMANGLE is set Return
+		if mangleAllow == nil {
+			return ErrIncompatibleCluster{fmt.Sprintf("%s, FELIX_IPTABLESMANGLEALLOWACTION was unset, expected it to be 'Return'.", context)}
+		} else if *mangleAllow != "Return" {
+			return ErrIncompatibleCluster{fmt.Sprintf("%s, FELIX_IPTABLESMANGLEALLOWACTION was %s, expected it to be 'Return'.", context, *mangleAllow)}
+		}
+	case operatorv1.PluginAzureVNET:
+		install.Spec.CNI.Type = plugin
+	case operatorv1.PluginGKE:
+		install.Spec.CNI.Type = plugin
+		// FELIX_IPTABLESMANGLEALLOWACTION
+		mangleAllow, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "FELIX_IPTABLESMANGLEALLOWACTION")
+		if err != nil {
+			return err
+		}
+
+		// check that IPTABLESMANGLE is set Return
+		if mangleAllow == nil {
+			return ErrIncompatibleCluster{fmt.Sprintf("%s, FELIX_IPTABLESMANGLEALLOWACTION was unset, expected it to be 'Return'.", context)}
+		} else if *mangleAllow != "Return" {
+			return ErrIncompatibleCluster{fmt.Sprintf("%s, FELIX_IPTABLESMANGLEALLOWACTION was %s, expected it to be 'Return'.", context, *mangleAllow)}
+		}
+
+		// FELIX_IPTABLESFILTERALLOWACTION
+		filterAllow, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "FELIX_IPTABLESFILTERALLOWACTION")
+		if err != nil {
+			return err
+		}
+		// check that IPTABLESFILTER is set Return
+		if filterAllow == nil {
+			return ErrIncompatibleCluster{fmt.Sprintf("%s, FELIX_IPTABLESFILTERALLOWACTION was unset, expected it to be 'Return'.", context)}
+		} else if *filterAllow != "Return" {
+			return ErrIncompatibleCluster{fmt.Sprintf("%s, FELIX_IPTABLESFILTERALLOWACTION was set to %s, expected it to be 'Return'.", context, *filterAllow)}
+		}
+	default:
+		return ErrIncompatibleCluster{
+			fmt.Sprintf("unsupported plugin migrate: '%s'.", plugin),
+		}
+	}
+
+	// TODO: Handle configuration with IPs and Pools specified.
+	// We need to relax the restriction on CalicoNetwork and non-Calico CNI to do this.
+
+	ip, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "IP")
+	if err != nil {
+		return err
+	}
+	if ip != nil && *ip != "" {
+		return ErrIncompatibleCluster{fmt.Sprintf("%s, IP was set to %s, it is only supported as empty or unset with non-Calico CNI.", context, *ip)}
+	}
+	dp, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "NO_DEFAULT_POOLS")
+	if err != nil {
+		return err
+	}
+	if dp != nil && *dp != "true" {
+		return ErrIncompatibleCluster{fmt.Sprintf("%s, expected NO_DEFAULT_POOLS to be set 'true' with non-Calico CNI.", context)}
 	}
 
 	return nil
@@ -154,4 +266,30 @@ func getAutoDetection(method string) (operatorv1.NodeAddressAutodetection, error
 	}
 
 	return operatorv1.NodeAddressAutodetection{}, errors.New("unrecognized method: " + method)
+}
+
+func getCNIPlugin(c *components) (operatorv1.CNIPluginType, error) {
+	// FELIX_INTERFACEPREFIX
+	prefix, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "FELIX_INTERFACEPREFIX")
+	if err != nil {
+		return "", err
+	}
+
+	if prefix == nil {
+		return operatorv1.PluginCalico, nil
+	}
+	switch *prefix {
+	case "eni":
+		return operatorv1.PluginAmazonVPC, nil
+	case "avz":
+		return operatorv1.PluginAzureVNET, nil
+	case "gke":
+		return operatorv1.PluginGKE, nil
+	case "cali":
+		return operatorv1.PluginCalico, nil
+	default:
+		return "", ErrIncompatibleCluster{
+			fmt.Sprintf("unexpected FELIX_INTERFACEPREFIX value: '%s'. Only 'eni, avz, gke, cali' are supported.", *prefix),
+		}
+	}
 }

--- a/pkg/controller/migration/convert/utils.go
+++ b/pkg/controller/migration/convert/utils.go
@@ -1,6 +1,8 @@
 package convert
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	corev1 "k8s.io/api/core/v1"
+)
 
 func getContainer(spec corev1.PodSpec, name string) *corev1.Container {
 	for _, container := range spec.Containers {


### PR DESCRIPTION
## Description

I'm not confident on using the install-cni init container as the main flag for putting the config migration into non-Calico CNI mode. I had initially used CALICO_NETWORKING_BACKEND but then thought maybe that wasn't good enough. I think another good option would be to use the FELIX_INTERFACEPREFIX.
So I'd like feed back on which to use as the initial indication we're using a non-Calico CNI.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
