### PR TITLE
add new pointer type helpers

### DIFF
--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -280,17 +280,14 @@ func (c *amazonCloudIntegrationComponent) container() corev1.Container {
 		env = append(env, corev1.EnvVar{Name: "ALLOW_POD_METADATA_ACCESS", Value: "true"})
 	}
 
-	nonRoot := true
-	privEscalation := false
-
 	return corev1.Container{
 		Name:  AmazonCloudIntegrationComponentName,
 		Image: components.GetReference(components.ComponentCloudControllers, c.installation.Spec.Registry, c.installation.Spec.ImagePath),
 		Env:   env,
 		// Needed for permissions to write to the audit log
 		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot:             &nonRoot,
-			AllowPrivilegeEscalation: &privEscalation,
+			RunAsNonRoot:             Bool(true),
+			AllowPrivilegeEscalation: Bool(false),
 		},
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1058,12 +1058,10 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 }
 
 func (c *apiServerComponent) apiServerPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	trueBool := true
-	ptrBoolTrue := &trueBool
 	psp := basePodSecurityPolicy()
 	psp.GetObjectMeta().SetName("tigera-apiserver")
 	psp.Spec.Privileged = true
-	psp.Spec.AllowPrivilegeEscalation = ptrBoolTrue
+	psp.Spec.AllowPrivilegeEscalation = Bool(true)
 	psp.Spec.Volumes = append(psp.Spec.Volumes, policyv1beta1.HostPath)
 	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
 	return psp

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -293,11 +293,9 @@ func OperatorNamespace() string {
 }
 
 func securityContext() *v1.SecurityContext {
-	runAsNonRoot := true
-	allowPriviledgeEscalation := false
 	return &v1.SecurityContext{
-		RunAsNonRoot:             &runAsNonRoot,
-		AllowPrivilegeEscalation: &allowPriviledgeEscalation,
+		RunAsNonRoot:             Bool(true),
+		AllowPrivilegeEscalation: Bool(false),
 	}
 }
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -483,14 +483,11 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	}
 
 	// https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
-	trueBool := true
-	falseBool := false
-	var user int64 = 0
 	initOSSettingsContainer := corev1.Container{
 		Name: "elastic-internal-init-os-settings",
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: &trueBool,
-			RunAsUser:  &user,
+			Privileged: Bool(true),
+			RunAsUser:  Int64(0),
 		},
 		Image: components.GetReference(components.ComponentElasticsearch, es.installation.Spec.Registry, es.installation.Spec.ImagePath),
 		Command: []string{
@@ -510,7 +507,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			Name:  "elastic-internal-init-keystore",
 			Image: components.GetReference(components.ComponentElasticsearch, es.installation.Spec.Registry, es.installation.Spec.ImagePath),
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: &falseBool,
+				Privileged: Bool(false),
 			},
 			Command: []string{"/usr/bin/env", "bash", "-c", keystoreInitScript},
 			VolumeMounts: []corev1.VolumeMount{{

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -636,7 +636,6 @@ func (c *nodeComponent) nodeVolumes() []v1.Volume {
 
 // cniContainer creates the node's init container that installs CNI.
 func (c *nodeComponent) cniContainer() v1.Container {
-	t := true
 	// Determine environment to pass to the CNI init container.
 	cniEnv := c.cniEnvvars()
 	cniVolumeMounts := []v1.VolumeMount{
@@ -656,7 +655,7 @@ func (c *nodeComponent) cniContainer() v1.Container {
 		Env:          cniEnv,
 		VolumeMounts: cniVolumeMounts,
 		SecurityContext: &v1.SecurityContext{
-			Privileged: &t,
+			Privileged: Bool(true),
 		},
 	}
 }
@@ -664,7 +663,6 @@ func (c *nodeComponent) cniContainer() v1.Container {
 // flexVolumeContainer creates the node's init container that installs the Unix Domain Socket to allow Dikastes
 // to communicate with Felix over the Policy Sync API.
 func (c *nodeComponent) flexVolumeContainer() v1.Container {
-	t := true
 	flexVolumeMounts := []v1.VolumeMount{
 		{MountPath: "/host/driver", Name: "flexvol-driver-host"},
 	}
@@ -674,7 +672,7 @@ func (c *nodeComponent) flexVolumeContainer() v1.Container {
 		Image:        components.GetReference(components.ComponentFlexVolume, c.cr.Spec.Registry, c.cr.Spec.ImagePath),
 		VolumeMounts: flexVolumeMounts,
 		SecurityContext: &v1.SecurityContext{
-			Privileged: &t,
+			Privileged: Bool(true),
 		},
 	}
 }
@@ -717,7 +715,6 @@ func (c *nodeComponent) cniEnvvars() []v1.EnvVar {
 // nodeContainer creates the main node container.
 func (c *nodeComponent) nodeContainer() v1.Container {
 	lp, rp := c.nodeLivenessReadinessProbes()
-	isPrivileged := true
 
 	// Select which image to use.
 	image := components.GetReference(components.ComponentCalicoNode, c.cr.Spec.Registry, c.cr.Spec.ImagePath)
@@ -728,7 +725,7 @@ func (c *nodeComponent) nodeContainer() v1.Container {
 		Name:            "calico-node",
 		Image:           image,
 		Resources:       c.nodeResources(),
-		SecurityContext: &v1.SecurityContext{Privileged: &isPrivileged},
+		SecurityContext: &v1.SecurityContext{Privileged: Bool(true)},
 		Env:             c.nodeEnvVars(),
 		VolumeMounts:    c.nodeVolumeMounts(),
 		LivenessProbe:   lp,
@@ -1105,12 +1102,10 @@ func (c *nodeComponent) nodeMetricsService() *v1.Service {
 }
 
 func (c *nodeComponent) nodePodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	trueBool := true
-	ptrBoolTrue := &trueBool
 	psp := basePodSecurityPolicy()
 	psp.GetObjectMeta().SetName(common.NodeDaemonSetName)
 	psp.Spec.Privileged = true
-	psp.Spec.AllowPrivilegeEscalation = ptrBoolTrue
+	psp.Spec.AllowPrivilegeEscalation = Bool(true)
 	psp.Spec.Volumes = append(psp.Spec.Volumes, policyv1beta1.HostPath)
 	psp.Spec.HostNetwork = true
 	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny

--- a/pkg/render/types.go
+++ b/pkg/render/types.go
@@ -1,0 +1,9 @@
+package render
+
+func Bool(b bool) *bool {
+	return &b
+}
+
+func Int64(i int64) *int64 {
+	return &i
+}

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -440,7 +440,6 @@ func (c *typhaComponent) typhaResources() v1.ResourceRequirements {
 
 // typhaEnvVars creates the typha's envvars.
 func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
-	optional := true
 	typhaEnv := []v1.EnvVar{
 		{Name: "TYPHA_LOGSEVERITYSCREEN", Value: "info"},
 		{Name: "TYPHA_LOGFILEPATH", Value: "none"},
@@ -460,7 +459,7 @@ func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
 					Name: NodeTLSSecretName,
 				},
 				Key:      CommonName,
-				Optional: &optional,
+				Optional: Bool(true),
 			},
 		}},
 		{Name: "TYPHA_CLIENTURISAN", ValueFrom: &v1.EnvVarSource{
@@ -469,7 +468,7 @@ func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
 					Name: NodeTLSSecretName,
 				},
 				Key:      URISAN,
-				Optional: &optional,
+				Optional: Bool(true),
 			},
 		}},
 	}


### PR DESCRIPTION
## Description

Introduce some helper functions to get pointers to primitive types.

I was 'inspired' by the Amazon SDK which includes functions for getting the commonly used pointer primitives: https://github.com/aws/aws-sdk-go/blob/v1.33.11/aws/convert_types.go

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.