### PR TITLE
Exit release script gracefully if not on a tag

### DIFF
--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-tag=$(git describe --exact-match --tags HEAD)
-if [[ -z "${tag}" ]]; then
+if ! tag=$(git describe --exact-match --tags HEAD); then
 	echo "Not on a tag - no need to release";
 	exit 0
 fi


### PR DESCRIPTION
## Description

I think this will fix the release script now failing with exit code 1 due to the addition of `set -e`

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
