### PR TITLE
Consolidate pip role and manager role

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -163,8 +163,6 @@ func (c *managerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 		managerServiceAccount(),
 		managerClusterRole(c.managementCluster != nil, false, c.openshift),
 		managerClusterRoleBinding(),
-		c.managerPolicyImpactPreviewClusterRole(),
-		c.managerPolicyImpactPreviewClusterRoleBinding(),
 	)
 	objs = append(objs, c.getTLSObjects()...)
 	objs = append(objs,
@@ -576,6 +574,40 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 				Resources: []string{"subjectaccessreviews"},
 				Verbs:     []string{"create"},
 			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"networksets",
+					"globalnetworksets",
+					"globalnetworkpolicies",
+					"tier.globalnetworkpolicies",
+					"networkpolicies",
+					"tier.networkpolicies",
+					"stagedglobalnetworkpolicies",
+					"tier.stagedglobalnetworkpolicies",
+					"stagednetworkpolicies",
+					"tier.stagednetworkpolicies",
+					"stagedkubernetesnetworkpolicies",
+				},
+				Verbs: []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"tiers",
+				},
+				Verbs: []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"serviceaccounts", "namespaces"},
+				Verbs:     []string{"list"},
+			},
 		},
 	}
 
@@ -625,71 +657,6 @@ func managerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
 			Name:     ManagerClusterRole,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      ManagerServiceAccount,
-				Namespace: ManagerNamespace,
-			},
-		},
-	}
-}
-
-// managerClusterRole returns a clusterrole that allows authn/authz review requests.
-func (c *managerComponent) managerPolicyImpactPreviewClusterRole() *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tigera-manager-pip",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{
-					"networksets",
-					"globalnetworksets",
-					"globalnetworkpolicies",
-					"tier.globalnetworkpolicies",
-					"networkpolicies",
-					"tier.networkpolicies",
-					"stagedglobalnetworkpolicies",
-					"tier.stagedglobalnetworkpolicies",
-					"stagednetworkpolicies",
-					"tier.stagednetworkpolicies",
-					"stagedkubernetesnetworkpolicies",
-				},
-				Verbs: []string{"list"},
-			},
-			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{
-					"tiers",
-				},
-				Verbs: []string{"get", "list"},
-			},
-			{
-				APIGroups: []string{"networking.k8s.io"},
-				Resources: []string{"networkpolicies"},
-				Verbs:     []string{"get", "list"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces"},
-				Verbs:     []string{"list"},
-			},
-		},
-	}
-}
-
-func (c *managerComponent) managerPolicyImpactPreviewClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager-pip"},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "tigera-manager-pip",
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 	})
 
-	const expectedResourcesNumber = 12
+	const expectedResourcesNumber = 10
 	It("should render all resources for a default configuration", func() {
 		resources := renderObjects(instance, nil, nil, nil)
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
@@ -65,8 +65,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "tigera-manager-pip", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-			{name: "tigera-manager-pip", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: render.ManagerTLSSecretName, ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: render.ManagerTLSSecretName, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Service"},
@@ -134,6 +132,40 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				APIGroups: []string{"authorization.k8s.io"},
 				Resources: []string{"subjectaccessreviews"},
 				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"networksets",
+					"globalnetworksets",
+					"globalnetworkpolicies",
+					"tier.globalnetworkpolicies",
+					"networkpolicies",
+					"tier.networkpolicies",
+					"stagedglobalnetworkpolicies",
+					"tier.stagedglobalnetworkpolicies",
+					"stagednetworkpolicies",
+					"tier.stagednetworkpolicies",
+					"stagedkubernetesnetworkpolicies",
+				},
+				Verbs: []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"tiers",
+				},
+				Verbs: []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"serviceaccounts", "namespaces"},
+				Verbs:     []string{"list"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -211,8 +243,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "tigera-manager-role", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-manager-binding", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "tigera-manager-pip", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-			{name: "tigera-manager-pip", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "manager-tls", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "manager-tls", ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
@@ -285,6 +315,40 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				APIGroups: []string{"authorization.k8s.io"},
 				Resources: []string{"subjectaccessreviews"},
 				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"networksets",
+					"globalnetworksets",
+					"globalnetworkpolicies",
+					"tier.globalnetworkpolicies",
+					"networkpolicies",
+					"tier.networkpolicies",
+					"stagedglobalnetworkpolicies",
+					"tier.stagedglobalnetworkpolicies",
+					"stagednetworkpolicies",
+					"tier.stagednetworkpolicies",
+					"stagedkubernetesnetworkpolicies",
+				},
+				Verbs: []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"tiers",
+				},
+				Verbs: []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"serviceaccounts", "namespaces"},
+				Verbs:     []string{"list"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},


### PR DESCRIPTION
By consolidating the roles, this means that sa tigera-manager in managed clusters will also get these permissions. This is part of a fix for PIP in MCM.

When a user clicks on the Preview button to evaluate a NetworkPolicy for a managed cluster, the request is routed to the managed cluster, where the service account with name `tigera-manager` will be impersonated by guardian to check what information the user is allowed to see. Without these permissions, the following error will be thrown in es-proxy:

`2020-07-28 23:41:57.888 [INFO][1] flowlogs.go 161: Error getting search results from elastic error=tiers.projectcalico.org is forbidden: User "system:serviceaccount:tigera-manager:tigera-manager" cannot list resource "tiers" in API group "projectcalico.org" at the cluster scope`
