### PR TITLE
Add support for only reconciling our desired annotations

### DIFF
--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
@@ -186,7 +186,7 @@ func (r *ReconcileAmazonCloudIntegration) Reconcile(request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
 		r.SetDegraded("Error creating / updating resource", err, reqLogger)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -253,7 +253,7 @@ func (r *ReconcileAPIServer) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -178,7 +178,7 @@ func (r *ReconcileConnection) Reconcile(request reconcile.Request) (reconcile.Re
 		tunnelSecret,
 	)
 
-	if err := ch.CreateOrUpdate(ctx, component, r.status, utils.NoUserAddedMetadata); err != nil {
+	if err := ch.CreateOrUpdate(ctx, component, r.status); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return result, err
 	}

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -287,7 +287,7 @@ func (r *ReconcileCompliance) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdate(ctx, component, r.status, utils.NoUserAddedMetadata); err != nil {
+	if err := handler.CreateOrUpdate(ctx, component, r.status); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -732,7 +732,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	components = append(components, calico.Render()...)
 
 	for _, component := range components {
-		if err := handler.CreateOrUpdate(ctx, component, nil, utils.NoUserAddedMetadata); err != nil {
+		if err := handler.CreateOrUpdate(ctx, component, nil); err != nil {
 			r.SetDegraded("Error creating / updating resource", err, reqLogger)
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -230,7 +230,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 		pullSecrets,
 		r.provider == operatorv1.ProviderOpenShift,
 	)
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -287,7 +287,7 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 		installation,
 	)
 
-	if err := handler.CreateOrUpdate(context.Background(), component, r.status, utils.NoUserAddedMetadata); err != nil {
+	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -497,7 +497,7 @@ func (r *ReconcileLogStorage) Reconcile(request reconcile.Request) (reconcile.Re
 		authentication,
 	)
 
-	if err := hdler.CreateOrUpdate(ctx, component, r.status, utils.NoUserAddedMetadata); err != nil {
+	if err := hdler.CreateOrUpdate(ctx, component, r.status); err != nil {
 		log.Error(err, err.Error())
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -398,11 +398,7 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	allowedMetadata := utils.NoUserAddedMetadata
-	if r.provider == operatorv1.ProviderOpenShift {
-		allowedMetadata = utils.AllowOpenshiftSCCAnnotations
-	}
-	if err := handler.CreateOrUpdate(ctx, component, r.status, allowedMetadata); err != nil {
+	if err := handler.CreateOrUpdate(ctx, component, r.status); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/utils/utils_suite_test.go
+++ b/pkg/controller/utils/utils_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/utils_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/controller/utils Suite", []Reporter{junitReporter})
+}


### PR DESCRIPTION
## Description
Annotations have other use cases by other controllers and systems. Instead of going into a reconcile battle with other controllers, we only reconcile annotations that our components specify and leave other annotations as-is. Note that this change currently is perhaps a bit broad and allows annotations on all components given that it's hard to understand how other controllers use annotations but perhaps this is too broad and we should restrict this further?

This also removes support for the earlier concept of allowed annotations, which explicity allowed only some pre determined annotations.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
