### PR TITLE
Set routeSource in Felix configuration to WorkloadIPs for aws-vpc CNI

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1022,6 +1022,10 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 	}
 	nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_IPTABLESBACKEND", Value: "auto"})
 
+	if c.cr.Spec.CNI.Type != operator.PluginCalico {
+		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_ROUTESOURCE", Value: "WorkloadIPs"})
+	}
+
 	if c.amazonCloudInt != nil {
 		nodeEnv = append(nodeEnv, GetTigeraSecurityGroupEnvVariables(c.amazonCloudInt)...)
 		nodeEnv = append(nodeEnv, v1.EnvVar{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -739,6 +739,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_IPTABLESBACKEND", Value: "auto"},
 			{Name: "FELIX_INTERFACEPREFIX", Value: "eni"},
 			{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"},
+			{Name: "FELIX_ROUTESOURCE", Value: "WorkloadIPs"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 


### PR DESCRIPTION
## Description

Set `routeSource` in Felix configuration to `WorkloadIPs` for aws-vpc CNI.

Default value for `routeSource` in Felix configuration is `CalicoIPAM`. With value set to `CalicoIPAM`, dataplane in Felix doesn't get RouteUpdate for remote workloads manifesting into route issues for encryption functionality.

## For PR author

- [x] Tests for change.
- [ ] ~If changing pkg/apis/, run `make gen-files`~
- [ ] ~If changing versions, run `make gen-versions`~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
