### PR TITLE
Add ClusterServiceVersions

### DIFF
--- a/deploy/olm-catalog/tigera-operator/1.3.1/operator_v1_installation_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.3.1/operator_v1_installation_crd.yaml
@@ -1,0 +1,176 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installations.operator.tigera.io
+spec:
+  group: operator.tigera.io
+  names:
+    kind: Installation
+    listKind: InstallationList
+    plural: installations
+    singular: installation
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the desired state for the Calico or Calico
+            Enterprise installation.
+          properties:
+            calicoNetwork:
+              description: CalicoNetwork specifies configuration options for Calico
+                provided pod networking.
+              properties:
+                ipPools:
+                  description: IPPools contains a list of IP pools to use for allocating
+                    pod IP addresses. At most one IP pool may be specified. If omitted,
+                    a single pool will be configured when needed.
+                  items:
+                    properties:
+                      blockSize:
+                        description: 'BlockSize specifies the CIDR prefex length to
+                          use when allocating per-node IP blocks from the main IP
+                          pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
+                        format: int32
+                        type: integer
+                      cidr:
+                        description: CIDR contains the address range for the IP Pool
+                          in classless inter-domain routing format.
+                        type: string
+                      encapsulation:
+                        description: 'Encapsulation specifies the encapsulation type
+                          that will be used with the IP Pool. Default: IPIP'
+                        enum:
+                        - IPIPCrossSubnet
+                        - IPIP
+                        - VXLAN
+                        - VXLANCrossSubnet
+                        - None
+                        type: string
+                      natOutgoing:
+                        description: 'NATOutgoing specifies if NAT will be enabled
+                          or disabled for outgoing traffic. Default: Enabled'
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      nodeSelector:
+                        description: 'NodeSelector specifies the node selector that
+                          will be set for the IP Pool. Default: ''all()'''
+                        type: string
+                    required:
+                    - cidr
+                    type: object
+                  type: array
+                mtu:
+                  description: 'MTU specifies the maximum transmission unit to use
+                    for pods on the Calico network. Default: 1410'
+                  format: int32
+                  type: integer
+              type: object
+            clusterManagementType:
+              description: 'How the cluster is managed. Valid values for this field
+                are: Standalone, Management, Managed. Standalone clusters are fully
+                self-contained installations of Calico Enterprise. Management clusters
+                provide a single view to manage any number of Managed clusters, which
+                are a lighter weight installation. Default: Standalone'
+              enum:
+              - Standalone
+              - Management
+              - Managed
+              type: string
+            controlPlaneNodeSelector:
+              additionalProperties:
+                type: string
+              description: ControlPlaneNodeSelector is used to select control plane
+                nodes on which to run specific Calico components. This currently only
+                applies to kube-controllers and the apiserver.
+              type: object
+            flexVolumePath:
+              description: FlexVolumePath optionally specifies a custom path for FlexVolume.
+                If not specified, FlexVolume will be enabled by default. If set to
+                'None', FlexVolume will be disabled. The default is based on the kubernetesProvider.
+              type: string
+            imagePath:
+              description: 'ImagePath allows for the path part of an image to be specified.
+                If specified then the specified value will be used as the image path
+                for each image. If not specified or empty, the default for each image
+                will be used.  Image format:    `<registry>/<imagePath>/<imageName>@sha256:<image-sha>`  This
+                option allows configuring the `<imagePath>` portion of the above format.'
+              type: string
+            imagePullSecrets:
+              description: ImagePullSecrets is an array of references to container
+                registry pull secrets to use. These are applied to all images to be
+                pulled.
+              items:
+                type: object
+              type: array
+            kubernetesProvider:
+              description: KubernetesProvider specifies a particular provider of the
+                Kubernetes platform and enables provider-specific configuration. If
+                the specified value is empty, the Operator will attempt to automatically
+                determine the current provider. If the specified value is not empty,
+                the Operator will still attempt auto-detection, but will additionally
+                compare the auto-detected value to the specified value to confirm
+                they match.
+              enum:
+              - ""
+              - EKS
+              - GKE
+              - AKS
+              - OpenShift
+              - DockerEnterprise
+              type: string
+            nodeMetricsPort:
+              description: NodeMetricsPort specifies which port calico/node serves
+                prometheus metrics on. By default, metrics are not enabled. If specified,
+                this overrides any FelixConfiguration resources which may exist. If
+                omitted, then prometheus metrics may still be configured through FelixConfiguration.
+              format: int32
+              type: integer
+            registry:
+              description: 'Registry is the default Docker registry used for component
+                Docker images. If specified, all images will be pulled from this registry.
+                If not specified then the default registries will be used.  Image
+                format:    `<registry>/<imagePath>/<imageName>@sha256:<image-sha>`  This
+                option allows configuring the `<registry>` portion of the above format.'
+              type: string
+            variant:
+              description: 'Variant is the product to install - one of Calico or TigeraSecureEnterprise
+                Default: Calico'
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+        status:
+          description: Most recently observed state for the Calico or Calico Enterprise
+            installation.
+          properties:
+            variant:
+              description: Variant is the most recently observed installed variant
+                - one of Calico or TigeraSecureEnterprise
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/tigera-operator/1.3.1/operator_v1_tigerastatus_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.3.1/operator_v1_tigerastatus_crd.yaml
@@ -1,0 +1,90 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tigerastatuses.operator.tigera.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Available")].status
+    description: Whether the component running and stable.
+    name: Available
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Progressing")].status
+    description: Whether the component is processing changes.
+    name: Progressing
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: Whether the component is degraded.
+    name: Degraded
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
+    description: The time the component's Available status last changed.
+    name: Since
+    type: date
+  group: operator.tigera.io
+  names:
+    kind: TigeraStatus
+    listKind: TigeraStatusList
+    plural: tigerastatuses
+    singular: tigerastatus
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest observed set of conditions
+                for this component. A component may be one or more of Available, Progressing,
+                or Degraded.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: The timestamp representing the start time for the
+                      current status.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Optionally, a detailed message providing additional
+                      context.
+                    type: string
+                  reason:
+                    description: A brief reason explaining the condition.
+                    type: string
+                  status:
+                    description: The status of the condition. May be True, False,
+                      or Unknown.
+                    type: string
+                  type:
+                    description: The type of condition. May be Available, Progressing,
+                      or Degraded.
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/tigera-operator/1.3.1/tigera-operator.v1.3.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.3.1/tigera-operator.v1.3.1.clusterserviceversion.yaml
@@ -1,0 +1,349 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.tigera.io/v1",
+          "kind": "Installation",
+          "metadata": {
+            "name": "default"
+          }
+        }
+      ]
+    capabilities: "Seamless Upgrades"
+    categories: "Logging & Tracing, Monitoring, Networking, Security"
+    certified: "true"
+    containerImage: quay.io/tigera/operator:v1.3.1
+    createdAt: '"2020-03-25T18:28:00.678494706Z"'
+    description: "An operator which manages the lifecycle of a Calico or Calico Enterprise
+      installation on Kubernetes or OpenShift. Its goal is to make installation, upgrades,
+      and ongoing lifecycle management of Calico and Calico Enterprise as simple and
+      reliable as possible."
+    support: Tigera
+    repository: https://github.com/tigera/operator
+    marketplace.openshift.io/remote-workflow: "https://docs.projectcalico.org/getting-started/openshift/installation"
+    marketplace.openshift.io/action-text: "Install-time Instructions"
+  name: tigera-operator.v1.3.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Installation configures an installation of Calico or Calico Enterprise.
+        At most one instance of this resource is supported. It must be named "default".
+        The Installation API installs core networking and network policy components,
+        and provides general install-time configuration.
+      kind: Installation
+      name: installations.operator.tigera.io
+      displayName: Installation
+      version: v1
+    - description: TigeraStatus represents the most recently observed status for Calico
+        or a Calico Enterprise functional area.
+      kind: TigeraStatus
+      name: tigerastatuses.operator.tigera.io
+      displayName: TigeraStatus
+      version: v1
+  description: "An operator which manages the lifecycle of a Calico or Calico Enterprise
+    installation on Kubernetes or OpenShift. Its goal is to make installation, upgrades,
+    and ongoing lifecycle management of Calico and Calico Enterprise as simple and
+    reliable as possible"
+  displayName: Tigera Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          - pods
+          - podtemplates
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - statefulsets
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - tigera-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.tigera.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - networks/status
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - networks
+          - infrastructures
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - hostnetwork
+          verbs:
+          - use
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - projectcalico.org
+          resources:
+          - globalreporttypes
+          - licensekeys
+          - globalalerttemplates
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - elasticsearch.k8s.elastic.co
+          resources:
+          - elasticsearches
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        - apiGroups:
+          - kibana.k8s.elastic.co
+          resources:
+          - kibanas
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+          - delete
+          - watch
+        serviceAccountName: tigera-operator
+      deployments:
+      - name: tigera-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: tigera-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: tigera-operator
+            spec:
+              containers:
+              - command:
+                - operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: tigera-operator
+                - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
+                  value: v1.3.1
+                image: quay.io/tigera/operator@sha256:5e1d551b5a711592472f4a3cc4645698d5f826da4253f0d47cfa5d5b641a2e1a
+                imagePullPolicy: Always
+                name: tigera-operator
+                resources: {}
+              serviceAccountName: tigera-operator
+              hostNetwork: true
+              tolerations:
+              - effect: NoSchedule
+                operator: Exists
+              - effect: NoSchedule
+                operator: Exists
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: stable
+  provider: {name: Tigera}
+  version: 1.3.1
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAADHlJREFUeNrMWAlwVdUZ/u7bX16Wl0BCNpIXtmwsERIh0EqCKKCCcUAQazXAOIJOgVBpZxjEra1Y2oa6jIwzElRURkAQkCUCiQEMJMBEhISQPUL2vLxsj7zl3tv/nLcYkiBi22nPzHn33XPvOec7379f4P+8CXc7YXR0dHa4P9Y2dKGEbl+tqqvbf5v3MjVKITtArzB23pRq7aJ8D71r+a8CpE3TksOEvO1LgW4b8NIxGScrwTY1Dnw33F+J5JEa2B0Simt70W5XbSWAWXcLUHk3LwcZjS+vn6pKMvkooTNImBsrgJjUhU+Yhb9lZ2PxE0/AYDCgpeoSUk1a2JyA5aaIiZE+KGt2hNL8Lzs6Oy3/cQaJuQy6ZFM3nV6uQtbXTlxtAbYvdk1f/rmMuRlL+P/Dhw5hYrATaqWAwlobHKKMBYl6FNbZ0dojsle2ulXD8m8DJGBMdNk+BkPmvIceQu6B3TjzgoCJ/5D5cwaCidKgEYgpCbPGiHTPWJVR/ANQ3upa577ROtSZnUie/RjOFxejrraWgXuMQOb/YhG7weVFR0fPzVq3DtNSU1H17V6+aWW7gEnhGkyN0iI8QIlgXxK5WoHIABEr7gVmmAQsniQQYAHtVqCkQYJORfcPPYYlS5ey5XVlZWWZJPI6EnnJXQP0gJs8ZUrSmrVrMWz4cMiyjHd3fIHOPhVmEiOVbSRG2pSJUKcWYHXICDGISBnpMiAG7EwtOKPzE0j0VyUkTpqC0NBQxMXHI5jWvFpWluFnMPwkSOXtwN0zeXLS6jVroFKpOLhPd34Cp7mOWyYDdd0iot6qR0D0BA62t7sLo4fJOH8deOtqPAo7R+Pz09cREwQ8NVnA0XLg3HeVmDFjBl9zZFQUJkyYgPy8vIyfYlIxxFj2yJEjk5YtWw6nU+S9ubkZZ/OOcHAe3SPvgfzTp7Fw0SLsPfgV1CHj+LOWiIXY9v77yFy+HJ/s2sXHvrwCiLIKIcpOHDt61LtueEQkltF7bE8iJumOAJm1+vj4ZK56/nlotVpIosj7udMFCNaJqGjohVN0GUhEZCS//um113Dj+nX4+/vz+7jRkTh39ize2roV8QkJ8NMKOFAqY+xwNcYMV6Go8Ix3XdanTUtF6vTpTGo5P4fB7PT0WTAaAyHSZE+vKL8KrVoJFTHHOmvDxGbs/2wH3iO2Sr49gR9Ki0nfgF/35PDrxk2bcHTbiyReuFl3MS9aO25Zm/VFJAW9Xp/Eos9AgKr+oSkoaJhp7rx5fFL/ZpPItUT6eu+ZzjH3cuWrbby39krQB4aiXaPDt9UNmIP18HWokGgTcKGLHUjmc+JHqPn8getrNFosXLgIO3d+/DLd7rgdgy/PnTt30OlYDwwM5CA8jeIrGYMdBdU2HKtWoFU7CpJSh3Md4dh20R8rTsRi8W4RSw44UVanxOsPEHOSA3UdZEx2acg9klNSGIumgSwq3OwxBTUlJiZyvVAqFFzHku9NQQKNxcbFcUfLGtukjSICc8xaYxgeWbAA+w8exPwF82Ext+ODnBxkv/02wpJmorxDQmOvjC8vA6tSBYoKdowal4i21laup709PbfoYwqBpPboUCLOSEwcj+CQEESbosmtAPW1tdDpdHyxWbPux4njxwmUGdGBKs7m7KUvIJIOMWrMGAiCgNXkL1ljhmG322GKicHB9evx6oqHsf1h1ybvFQIPL56Dffv2oa+pDEVF57By5SovmMmTp6CgoCBjKBHPjKEFmW+qqarGle+/h5L7P8l7ukWLHkdxgyukUdDA0SNHQI4cWzZvRnFRkXfBrq4uvLRhA+KI9by8PKSYXOMs8wkbn4609HQ6uBYRRjU6GypRUXENotPJe+iIEZwUljUNBJjEHtptNiiVSuoKDGfRQ5IhSRLvI4jdpzNXcL1rY0bRXYOnnnwS96Wl4VRBAdauXo3q6mps2rgRWtrk8OHDOLVrC48sj38s4wfNZGRlreNrmqJNXE3GDhdw/vz5W3QxLCyM4xkoYmMUsSfJLjCiKPH/rLF7j+W1k44lhMho6rSh26GgiNKE/E828+csu2EhjgGyal0L+9E164CEaaEKtJDeeNak+I6CXAkmoxIFV0tp7R+lGjoiFDU1NcZBboYBkCWXhUnu//1dwtTpqThy7Cg23KuGX5ATu0pEHLsm4FIDxUuSg1EvIC4EdC/DKQsYrpcxIVTCOxkKTNCrsWT/d7hpvcnF6+fn54qzCpKWaOVr95DB+Pr64kppKQrPFmJIgJJbpJ7//RlsJWMxl51F7Bg1BJ0SL6YDZW0ynvvNanKUnaituOJKreaMhKQJwOXjO/D3R0iP7QrI3cD8GCWJsxjTp88Y5AcrKyox6Z4kNDU0kseUh3bUnDUuYpF32Sti0pXYWFy8cBHpI4kqDY0LMsukoYiYhqdXrhsyC5mfX0QiL4OvgjZUy3zuH48dQyqlbZTFwEfNfKMLaEhIMNrb2sjAOnliMqSjNpvNnDWDwZeyDTVCw8JdjJI+lpeWYd/evUiOoskiRQalKyF94MEHb5vHsWcsdxTYDnSmiGAJvY2VfM2C06cQHaRCj9UObUAoH2PG09bSiqsk4qEA1nZ0dLgZdLkWRrX3njrLaOKjJSgCHRDULgaZz7tdY8/YIdhhFEYnFJQrDlPasfmNv8BfMsNX5UCtRUYivcf28bi05uYWjmcgwJL6+nqvW2FWzKju72YYYGaVP7d5spsfM08ZySMUkJqvYBzljY3mm7AIQYiPjXPvI/N9W1o5wJKBAL+prKr0uhmmd3C7BY+jVttab9mPgWVO+XatjEQV7j94XE3hztxpxTWLGm9u2cLV6WZfH2ewoqqCs0e1SslAI9nf2taW3dnZxazCzSD4yUS3FdvVw+i30bsR83e7cnNvq4df07NXxw8e77I6cKNXg2m/uh9+pO9nz53Ftp2fQwcn3es4lkE6SIiZzPfv2L4ddTW1FPTNOPNNgVe8XMSyyxF7Wmwwxetze/DFnj2DQLCx0O6zXga5q3FQ1GiWUGs14LnfvQhfqp9XrVqJk6ootM7+Pay6WWgw8wqE5YWmQTUJ1QXNNxpuZEZRGq5QCBg/aSKiKHHwDwhAc2Mjz5q1tibujD2NVW2vvJ+LS9dcGTV7523KpAv3bsXrcwRoST5yH4GzKtFFm+dU6fGHDZtw6NBB5N6womneWthGJ0NpE2Gob4dCPwqCNswEh3ltoJ/WSJjOCQNS/rzoqKi02ZRV/zrNFa9P5btKV+bpq4v24IPHBe4+GIOetvPij+yGU5B4tJ9o2btjBQ12XpZwQkxEU3MTypKXoo+AeZq2tQPB+RcQPzYUNxot6Orpg2Q5BclamT4w5V9WV19vKb92zStakYob1vU6PXoN8RzMX/NlfHhBy/s/z+hoTEH5HngvrlJAbNFAalfz/ubXVMhTTphTLpDFxiKQyglJaxjslgjcR+8+gzc2utNBpd+tkcSji8RiVtGF8zlGEi1bzNM6LBZ093RzcIy9Yiovgw2u87EKjzHFdO58K3kAUQ2ZHHq33cVs1kknbNCjorKSuy+FrZfPeyohBJdae6E0KPHRhtl87J0PvnGHNttggG6QOwjkzNwTJzJnp6VTAWVEA4mlvcOMXqvVKzZRdiLt/nkYNT4Fz8amIOv5ZxEmXMd7nx6CzlYBsaYI+YdyKavucxGi7ENzWytP5zQ3yriI30yL+XFjhxNPv/Ahyiqa3IbVxLDkD1UXswfL7A77juP5J7nO9Fp7+cIsJUsgzx8REQELjEjJWIWp85bCTqVoh1XE1UYB18lQ7HEPojllJT5rGYHg4GCwZJgV6UFBQTxj8al1ubl5uy+7XMkAcBB7yOrN+3/Ox6NXWDEVNy6WZ7u9N610UFdtwtL6pqYmftVoNAgglWCHYDGdjbH/DBwD5DUGeo+8Py6XXkHDjN/iZsJ9mBhs4EbSuLvA+57bQJYxad7x85s7/c6hgt6UPCmJcjl/Kt6dHASLNDaH47Zz9RpXbNRpdVBQ3VJeWYHKmmr+CY4MJbP9yT8bRf9grxVz0fbVQzSfyCdw6XfzfZBluKwqWuOj1xtHm2IQRoxSmXjHuU2UZDS2NKOeRE8t3/1tMJ9VkgQyz/JIllHQhnKAUm8ppO6SEjKQdM/3w7v9BMyAsrr1Gebx/YlNAgx/d4bsaU5Sg87uLorV3aQSDos7fH048Hugu9zNlgJj0pQ9nUzvWNGe1f/j5l1/RO+3uMld3LAezerqfo+Zr2Cb5PcP/HdYy/JLPrL/z9u/BBgAxapz7tnoxv8AAAAASUVORK5CYII=
+    mediatype: image/png
+  keywords:
+  - networking
+  - security
+  - monitoring
+  links:
+  - name: Calico Introduction
+    url: https://docs.projectcalico.org/introduction/
+  - name: Install an OpenShift v4 cluster with Calico
+    url: https://docs.projectcalico.org/v3.13/getting-started/openshift/installation
+  maintainers:
+  - name: Laurence Man
+    email: laurence@tigera.io

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-bgpconfiguration.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-bgpconfiguration.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-bgppeer.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-bgppeer.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-blockaffinity.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-blockaffinity.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-clusterinformation.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-clusterinformation.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-felixconfiguration.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-felixconfiguration.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-globalnetworkpolicy.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-globalnetworkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+    shortNames:
+    - gnp

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-globalnetworkset.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-globalnetworkset.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-hostendpoint.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-hostendpoint.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ipamblock.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ipamblock.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ipamconfig.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ipamconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMConfig
+    plural: ipamconfigs
+    singular: ipamconfig

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ipamhandle.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ipamhandle.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMHandle
+    plural: ipamhandles
+    singular: ipamhandle

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ippool.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-ippool.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-kubecontrollersconfiguration.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-kubecontrollersconfiguration.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: KubeControllersConfiguration
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-networkpolicy.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy

--- a/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-networkset.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/02-crd-networkset.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset

--- a/deploy/olm-catalog/tigera-operator/1.5.2/operator.tigera.io_installations_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/operator.tigera.io_installations_crd.yaml
@@ -1,0 +1,242 @@
+---
+# Source: tigera-operator/templates/crds/01-crd-installation.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installations.operator.tigera.io
+  annotations:
+    "helm.sh/hook": "crd-install"
+spec:
+  group: operator.tigera.io
+  names:
+    kind: Installation
+    listKind: InstallationList
+    plural: installations
+    singular: installation
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the desired state for the Calico or Calico
+            Enterprise installation.
+          properties:
+            calicoNetwork:
+              description: CalicoNetwork specifies configuration options for Calico
+                provided pod networking.
+              properties:
+                hostPorts:
+                  description: 'HostPorts configures whether or not Calico will support
+                    Kubernetes HostPorts. Default: Enabled'
+                  enum:
+                  - Enabled
+                  - Disabled
+                  type: string
+                ipPools:
+                  description: IPPools contains a list of IP pools to use for allocating
+                    pod IP addresses. At most one IP pool may be specified. If omitted,
+                    a single pool will be configured when needed.
+                  items:
+                    properties:
+                      blockSize:
+                        description: 'BlockSize specifies the CIDR prefex length to
+                          use when allocating per-node IP blocks from the main IP
+                          pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
+                        format: int32
+                        type: integer
+                      cidr:
+                        description: CIDR contains the address range for the IP Pool
+                          in classless inter-domain routing format.
+                        type: string
+                      encapsulation:
+                        description: 'Encapsulation specifies the encapsulation type
+                          that will be used with the IP Pool. Default: IPIP'
+                        enum:
+                        - IPIPCrossSubnet
+                        - IPIP
+                        - VXLAN
+                        - VXLANCrossSubnet
+                        - None
+                        type: string
+                      natOutgoing:
+                        description: 'NATOutgoing specifies if NAT will be enabled
+                          or disabled for outgoing traffic. Default: Enabled'
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      nodeSelector:
+                        description: 'NodeSelector specifies the node selector that
+                          will be set for the IP Pool. Default: ''all()'''
+                        type: string
+                    required:
+                    - cidr
+                    type: object
+                  type: array
+                mtu:
+                  description: 'MTU specifies the maximum transmission unit to use
+                    for pods on the Calico network. Default: 1410'
+                  format: int32
+                  type: integer
+                nodeAddressAutodetectionV4:
+                  description: NodeAddressAutodetectionV4 specifies an approach to
+                    automatically detect node IPv4 addresses. If not specified, will
+                    use default auto-detection settings to acquire an IPv4 address
+                    for each node.
+                  properties:
+                    canReach:
+                      description: CanReach enables IP auto-detection based on which
+                        source address on the node is used to reach the specified
+                        IP or domain.
+                      type: string
+                    firstFound:
+                      description: FirstFound uses default interface matching parameters
+                        to select an interface, performing best-effort filtering based
+                        on well-known interface names.
+                      type: boolean
+                    interface:
+                      description: Interface enables IP auto-detection based on interfaces
+                        that match the given regex.
+                      type: string
+                    skipInterface:
+                      description: SkipInterface enables IP auto-detection based on
+                        interfaces that do not match the given regex.
+                      type: string
+                  type: object
+                nodeAddressAutodetectionV6:
+                  description: NodeAddressAutodetectionV6 specifies an approach to
+                    automatically detect node IPv4 addresses. If not specified, IPv6
+                    addresses will not be auto-detected.
+                  properties:
+                    canReach:
+                      description: CanReach enables IP auto-detection based on which
+                        source address on the node is used to reach the specified
+                        IP or domain.
+                      type: string
+                    firstFound:
+                      description: FirstFound uses default interface matching parameters
+                        to select an interface, performing best-effort filtering based
+                        on well-known interface names.
+                      type: boolean
+                    interface:
+                      description: Interface enables IP auto-detection based on interfaces
+                        that match the given regex.
+                      type: string
+                    skipInterface:
+                      description: SkipInterface enables IP auto-detection based on
+                        interfaces that do not match the given regex.
+                      type: string
+                  type: object
+              type: object
+            clusterManagementType:
+              description: 'How the cluster is managed. Valid values for this field
+                are: Standalone, Management, Managed. Standalone clusters are fully
+                self-contained installations of Calico Enterprise. Management clusters
+                provide a single view to manage any number of Managed clusters, which
+                are a lighter weight installation. Default: Standalone'
+              enum:
+              - Standalone
+              - Management
+              - Managed
+              type: string
+            controlPlaneNodeSelector:
+              additionalProperties:
+                type: string
+              description: ControlPlaneNodeSelector is used to select control plane
+                nodes on which to run specific Calico components. This currently only
+                applies to kube-controllers and the apiserver.
+              type: object
+            flexVolumePath:
+              description: FlexVolumePath optionally specifies a custom path for FlexVolume.
+                If not specified, FlexVolume will be enabled by default. If set to
+                'None', FlexVolume will be disabled. The default is based on the kubernetesProvider.
+              type: string
+            imagePath:
+              description: 'ImagePath allows for the path part of an image to be specified.
+                If specified then the specified value will be used as the image path
+                for each image. If not specified or empty, the default for each image
+                will be used.  Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`  This
+                option allows configuring the `<imagePath>` portion of the above format.'
+              type: string
+            imagePullSecrets:
+              description: ImagePullSecrets is an array of references to container
+                registry pull secrets to use. These are applied to all images to be
+                pulled.
+              items:
+                type: object
+              type: array
+            kubernetesProvider:
+              description: KubernetesProvider specifies a particular provider of the
+                Kubernetes platform and enables provider-specific configuration. If
+                the specified value is empty, the Operator will attempt to automatically
+                determine the current provider. If the specified value is not empty,
+                the Operator will still attempt auto-detection, but will additionally
+                compare the auto-detected value to the specified value to confirm
+                they match.
+              enum:
+              - ""
+              - EKS
+              - GKE
+              - AKS
+              - OpenShift
+              - DockerEnterprise
+              type: string
+            nodeMetricsPort:
+              description: NodeMetricsPort specifies which port calico/node serves
+                prometheus metrics on. By default, metrics are not enabled. If specified,
+                this overrides any FelixConfiguration resources which may exist. If
+                omitted, then prometheus metrics may still be configured through FelixConfiguration.
+              format: int32
+              type: integer
+            nodeUpdateStrategy:
+              description: NodeUpdateStrategy can be used to customize the desired
+                update strategy, such as the MaxUnavailable field.
+              type: object
+            registry:
+              description: 'Registry is the default Docker registry used for component
+                Docker images. If specified, all images will be pulled from this registry.
+                If not specified then the default registries will be used.  Image
+                format:    `<registry>/<imagePath>/<imageName>:<image-tag>`  This
+                option allows configuring the `<registry>` portion of the above format.'
+              type: string
+            variant:
+              description: 'Variant is the product to install - one of Calico or TigeraSecureEnterprise
+                Default: Calico'
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+        status:
+          description: Most recently observed state for the Calico or Calico Enterprise
+            installation.
+          properties:
+            variant:
+              description: Variant is the most recently observed installed variant
+                - one of Calico or TigeraSecureEnterprise
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+
+

--- a/deploy/olm-catalog/tigera-operator/1.5.2/operator.tigera.io_tigerastatuses_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/operator.tigera.io_tigerastatuses_crd.yaml
@@ -1,0 +1,94 @@
+---
+# Source: tigera-operator/templates/crds/01-crd-tigerastatus.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tigerastatuses.operator.tigera.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Available")].status
+    description: Whether the component running and stable.
+    name: Available
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Progressing")].status
+    description: Whether the component is processing changes.
+    name: Progressing
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: Whether the component is degraded.
+    name: Degraded
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
+    description: The time the component's Available status last changed.
+    name: Since
+    type: date
+  group: operator.tigera.io
+  names:
+    kind: TigeraStatus
+    listKind: TigeraStatusList
+    plural: tigerastatuses
+    singular: tigerastatus
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest observed set of conditions
+                for this component. A component may be one or more of Available, Progressing,
+                or Degraded.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: The timestamp representing the start time for the
+                      current status.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Optionally, a detailed message providing additional
+                      context.
+                    type: string
+                  reason:
+                    description: A brief reason explaining the condition.
+                    type: string
+                  status:
+                    description: The status of the condition. May be True, False,
+                      or Unknown.
+                    type: string
+                  type:
+                    description: The type of condition. May be Available, Progressing,
+                      or Degraded.
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+
+

--- a/deploy/olm-catalog/tigera-operator/1.5.2/tigera-operator.v1.5.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.2/tigera-operator.v1.5.2.clusterserviceversion.yaml
@@ -1,0 +1,369 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.tigera.io/v1",
+          "kind": "Installation",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "variant": "Calico"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Logging & Tracing, Monitoring, Networking, Security
+    certified: "true"
+    description: An operator which manages the lifecycle of a Calico or Calico Enterprise installation on Kubernetes or OpenShift.
+    marketplace.openshift.io/action-text: Install-time Instructions
+    marketplace.openshift.io/remote-workflow: https://docs.projectcalico.org/archive/v3.14/getting-started/openshift/installation
+    operators.operatorframework.io/internal-objects: '["blockaffinities.crd.projectcalico.org","clusterinformations.crd.projectcalico.org","ipamblocks.crd.projectcalico.org","ipamconfigs.crd.projectcalico.org","ipamhandles.crd.projectcalico.org"]'
+    repository: https://github.com/tigera/operator
+    support: Tigera
+    containerImage: quay.io/tigera/operator:v1.5.2
+    createdAt: 2020-07-24T21:17:49.449412261Z
+  name: tigera-operator.v1.5.2
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: BGPConfiguration represents BGP specific configuration options for the cluster or a specific node.
+        displayName: BGPConfiguration
+        kind: BGPConfiguration
+        name: bgpconfigurations.crd.projectcalico.org
+        version: v1
+      - description: BGPPeer represents a remote BGP peer with which the node(s) in a Calico cluster will peer. Configuring BGP peers allows you to peer a Calico network with your datacenter fabric (e.g. ToR).
+        displayName: BGPPeer
+        kind: BGPPeer
+        name: bgppeers.crd.projectcalico.org
+        version: v1
+      - description: BlockAffinity maintains a block affinity's state.
+        displayName: BlockAffinity
+        kind: BlockAffinity
+        name: blockaffinities.crd.projectcalico.org
+        version: v1
+      - description: ClusterInformation contains the cluster specific information.
+        displayName: ClusterInformation
+        kind: ClusterInformation
+        name: clusterinformations.crd.projectcalico.org
+        version: v1
+      - description: FelixConfiguration represents Felix configuration options for the cluster.
+        displayName: FelixConfiguration
+        kind: FelixConfiguration
+        name: felixconfigurations.crd.projectcalico.org
+        version: v1
+      - description: GlobalNetworkPolicy represents an ordered set of rules which are applied to a collection of endpoints that match a label selector.
+        displayName: GlobalNetworkPolicy
+        kind: GlobalNetworkPolicy
+        name: globalnetworkpolicies.crd.projectcalico.org
+        version: v1
+      - description: GlobalNetworkSet represents an arbitrary set of IP subnetworks/CIDRs, allowing it to be matched by Calico policy. Network sets are useful for applying policy to traffic coming from (or going to) external, non-Calico, networks.
+        displayName: GlobalNetworkSet
+        kind: GlobalNetworkSet
+        name: globalnetworksets.crd.projectcalico.org
+        version: v1
+      - description: HostEndpoint represents one or more real or virtual interfaces attached to a host that is running Calico. It enforces Calico policy on the traffic that is entering or leaving the host’s default network namespace through those interfaces.
+        displayName: HostEndpoint
+        kind: HostEndpoint
+        name: hostendpoints.crd.projectcalico.org
+        version: v1
+      - description: Installation configures an installation of Calico or Calico Enterprise. At most one instance of this resource is supported. It must be named "default". The Installation API installs core networking and network policy components, and provides general install-time configuration.
+        kind: Installation
+        name: installations.operator.tigera.io
+        version: v1
+      - description: IPAMBlock contains information about a block for IP address assignment.
+        displayName: IPAMBlock
+        kind: IPAMBlock
+        name: ipamblocks.crd.projectcalico.org
+        version: v1
+      - description: IPAMConfig contains information about a block for IP address assignment.
+        displayName: IPAMConfig
+        kind: IPAMConfig
+        name: ipamconfigs.crd.projectcalico.org
+        version: v1
+      - description: IPAMHandle contains information about an IPAMHandle resource.
+        displayName: IPAMHandle
+        kind: IPAMHandle
+        name: ipamhandles.crd.projectcalico.org
+        version: v1
+      - kind: IPPool
+        name: ippools.crd.projectcalico.org
+        version: v1
+      - description: KubeControllersConfiguration represents configuration options for the Calico Kubernetes controllers.
+        displayName: KubeControllersConfiguration
+        kind: KubeControllersConfiguration
+        name: kubecontrollersconfigurations.crd.projectcalico.org
+        version: v1
+      - description: NetworkPolicy represents an ordered set of rules which are applied to a collection of endpoints that match a label selector.
+        displayName: NetworkPolicy
+        kind: NetworkPolicy
+        name: networkpolicies.crd.projectcalico.org
+        version: v1
+      - description: NetworkSet represents an arbitrary set of IP subnetworks/CIDRs, allowing it to be matched by Calico policy. Network sets are useful for applying policy to traffic coming from (or going to) external, non-Calico, networks.
+        displayName: NetworkSet
+        kind: NetworkSet
+        name: networksets.crd.projectcalico.org
+        version: v1
+      - description: TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
+        kind: TigeraStatus
+        name: tigerastatuses.operator.tigera.io
+        version: v1
+  description: 'An operator which manages the lifecycle of a Calico or Calico Enterprise installation on Kubernetes or OpenShift. Its goal is to make installation, upgrades, and ongoing lifecycle management of Calico and Calico Enterprise as simple and reliable as possible. **Important**: this operator should only be installed if the cluster was already provisioned with Calico.'
+  displayName: Tigera Operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAyMzQuMiAyMjQuMSIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjM0LjIgMjI0LjE7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDp1cmwoI1NWR0lEXzFfKTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6NC42ODQyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDF7ZmlsbDojMTczRjc0O30KCS5zdDJ7ZmlsbDojMDAyMTRDO30KCS5zdDN7ZmlsbDojNzU0QzI5O3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDR7ZmlsbDojNjAzOTEzO30KCS5zdDV7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDZ7ZmlsbDojRjc5NDFEO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjc2ODc7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0N3tmaWxsOiNGNDc3Mjk7fQoJLnN0OHtmaWxsOiNGRkZGRkY7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuNjkzNDtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0OXtmaWxsOiM3NTRDMjk7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuOTE5NDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxMHtmaWxsOiMyMzFGMjA7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuOTE5NDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxMXtmaWxsOiMzQzI0MTU7fQoJLnN0MTJ7ZmlsbDojRjc5NDFEO30KCS5zdDEze2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi45MTk0O3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDE0e2ZpbGw6bm9uZTt9Cgkuc3QxNXtmaWxsOiM2MDNEMTk7fQoJLnN0MTZ7ZmlsbDojNTczODE5O30KCS5zdDE3e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi42OTM0O3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxOHtmaWxsOiM1MzM0MTQ7fQoJLnN0MTl7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjc2ODc7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0MjB7ZmlsbDojRjc5NDFEO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDIxe2ZpbGw6IzIzMUYyMDt9Cgkuc3QyMntmaWxsOiNGRkZGRkY7fQoJLnN0MjN7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoxLjk0NjM7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0MjR7ZmlsbDojRTZFN0U4O30KCS5zdDI1e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi45MTk0O3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDI2e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi4yNzgyO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDI3e2ZpbGw6I0E3QTlBQzt9Cgkuc3QyOHtmaWxsOm5vbmU7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuNDM0NztzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QyOXtmaWxsOiM3NTRDMjk7fQoJLnN0MzB7ZmlsbDojRUY0MTM2O30KCS5zdDMxe2ZpbGw6bm9uZTtzdHJva2U6I0ZCQjA0MDtzdHJva2Utd2lkdGg6MS40MzEyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDMye2ZpbGw6I0ZCQjA0MDt9Cjwvc3R5bGU+CjxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfMV8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iMTEwLjYzMDQiIHkxPSIyLjgwMDIiIHgyPSIxMTAuNjMwNCIgeTI9IjIwNS45MDMxIj4KCTxzdG9wICBvZmZzZXQ9IjAiIHN0eWxlPSJzdG9wLWNvbG9yOiNGRkZGRkYiLz4KCTxzdG9wICBvZmZzZXQ9IjEiIHN0eWxlPSJzdG9wLWNvbG9yOiMwMDU0OUUiLz4KPC9saW5lYXJHcmFkaWVudD4KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTEwLjYiIGN5PSIxMTMiIHI9Ijk4LjciLz4KPHBhdGggY2xhc3M9InN0MSIgZD0iTTE1OC4xLDE3Ni42Yy00LjMsNi45LTIzLjgsMTIuMS00Ny4yLDEyLjFzLTQyLjgtNS4yLTQ3LjItMTIuMWMtNS42LDIuMi04LjksNC43LTguOSw3LjUKCWMwLDcuNywyNS4xLDEzLjksNTYsMTMuOXM1Ni02LjIsNTYtMTMuOUMxNjcsMTgxLjMsMTYzLjcsMTc4LjcsMTU4LjEsMTc2LjZ6Ii8+CjxwYXRoIGNsYXNzPSJzdDIiIGQ9Ik0xMTEsMTg4LjdjMjMuNCwwLDQyLjgtNS4yLDQ3LjItMTIuMWMtMTAtMy44LTI3LjMtNi40LTQ3LjItNi40cy0zNy4yLDIuNi00Ny4yLDYuNAoJQzY4LjEsMTgzLjQsODcuNiwxODguNywxMTEsMTg4Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDMiIGQ9Ik0xNTAuNiwxNDEuMmMwLDAsMy44LTMuNywxMC4yLTguMWMxNi40LTExLjEsMTEuOS0yOC41LDcuOS00Mi42Yy0yLjgtMTAuMSwxMC44LTEyLjgsMTYsMTYuNAoJYzUuMiwyOC43LTI2LjYsNTEuMi0zNS4xLDUxLjIiLz4KPHBhdGggY2xhc3M9InN0NCIgZD0iTTE3NC41LDg1LjJjMy40LDguMiwxMS44LDMxLjEsMC4yLDQ1LjdjLTExLjUsMTQuNS0xOS40LDEzLjktMTkuNCwxMy45bDEuMSwxMS4xYzEyLjMtNi4zLDMyLjYtMjUuNiwyOC40LTQ5CglDMTgyLDkxLjUsMTc4LjMsODYuNCwxNzQuNSw4NS4yeiIvPgo8cGF0aCBjbGFzcz0ic3Q1IiBkPSJNMTUwLjYsMTQxLjJjMCwwLDMuOC0zLjcsMTAuMi04LjFjMTYuNC0xMS4xLDExLjktMjguNSw3LjktNDIuNmMtMi44LTEwLjEsMTAuOC0xMi44LDE2LDE2LjQKCWM1LjIsMjguNy0yNi42LDUxLjItMzUuMSw1MS4yIi8+CjxwYXRoIGNsYXNzPSJzdDYiIGQ9Ik0xNTguNCwxNDIuM2MwLDI5LjctMjEuNiw0Ni40LTQ4LjEsNDYuNFM2Mi4yLDE3Miw2Mi4yLDE0Mi4zczIxLjYtNzYuMSw0OC4xLTc2LjFTMTU4LjQsMTEyLjYsMTU4LjQsMTQyLjN6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xMTAuMyw2Ni4yYy0wLjMsMC0wLjYsMC0xLDAuMWMyMC43LDEuMSw0NS40LDQ3LjgsNDUuNCw3NC45YzAsMjcuNS0yMC43LDQyLjgtNDYuMiw0Mi44CgljLTkuNSwwLTE4LjItMC4xLTI1LjQtMi4zYzcuNyw0LjYsMTcsNywyNy4xLDdjMjYuNiwwLDQ4LjEtMTYuNyw0OC4xLTQ2LjRDMTU4LjQsMTEyLjYsMTM2LjksNjYuMiwxMTAuMyw2Ni4yeiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTQ3LjUsMTA2LjhsLTcuNiw2LjdjMCwwLDguNi0xLjgsOC45LTMuNEMxNDkuMiwxMDguNiwxNDcuNSwxMDYuOCwxNDcuNSwxMDYuOHoiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTE0OS41LDExMi40bC04LjgsNi43YzAsMCw5LjktMS44LDEwLjMtMy40QzE1MS40LDExNC4yLDE0OS41LDExMi40LDE0OS41LDExMi40eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTUxLjUsMTE4LjNsLTEwLjMsNy44YzAsMCwxMS42LTIuMSwxMi4xLTMuOUMxNTMuOCwxMjAuNCwxNTEuNSwxMTguMywxNTEuNSwxMTguM3oiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTE1MS4xLDE2My45bC0xMS02LjdjMCwwLDYuMywxMCw4LjEsOS44UzE1MS4xLDE2My45LDE1MS4xLDE2My45eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTU1LjksMTU4LjJsLTEyLjMtNGMwLDAsOC40LDguMywxMC4xLDcuN0MxNTUuNSwxNjEuMywxNTUuOSwxNTguMiwxNTUuOSwxNTguMnoiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTcxLjEsMTA2LjhsOSw2LjdjMCwwLTEwLjEtMS44LTEwLjUtMy40QzY5LjEsMTA4LjYsNzEuMSwxMDYuOCw3MS4xLDEwNi44eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjguOCwxMTIuNGwxMC40LDYuN2MwLDAtMTEuOC0xLjgtMTIuMy0zLjRTNjguOCwxMTIuNCw2OC44LDExMi40eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjYuNCwxMTguM2wxMi4yLDcuOGMwLDAtMTMuOC0yLjEtMTQuMy0zLjlDNjMuNywxMjAuNCw2Ni40LDExOC4zLDY2LjQsMTE4LjN6Ii8+CjxwYXRoIGNsYXNzPSJzdDgiIGQ9Ik0xMzEuOSwxMzQuOWMwLDE0LjQtOC4xLDI3LTIyLjgsMjdzLTIyLjgtMTIuNi0yMi44LTI3czguMS0zNC45LDIyLjgtMzQuOVMxMzEuOSwxMjAuNSwxMzEuOSwxMzQuOXoiLz4KPHBhdGggY2xhc3M9InN0OSIgZD0iTTE1Mi43LDQ4LjdjLTAuMiwyLjQtNC43LTAuNy02LjIsMUwxMTUsMzAuNWMwLjgtMi4yLDEuOS00LjMsMy4yLTYuM2M2LjYtMTAuOSwyMC45LTIxLjksMjguMS0xMy45CglDMTUxLjEsMTUuNiwxNTMuOCwzNC43LDE1Mi43LDQ4Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDEwIiBkPSJNMTQyLjcsMzkuMmMtMC4xLDAuOC0xMy4zLTctMTMuMy03YzAuMy0wLjcsMC42LTEuNCwxLjEtMi4xYzIuMi0zLjYsNi45LTkuMiw5LjQtNgoJQzE0MC41LDI1LDE0My4xLDM0LjUsMTQyLjcsMzkuMnoiLz4KPHBhdGggY2xhc3M9InN0MTEiIGQ9Ik0xNDYuNywxMWwtNy42LDYuN2MwLDAsOC42LTEuOCw4LjktMy40UzE0Ni43LDExLDE0Ni43LDExeiIvPgo8cGF0aCBjbGFzcz0ic3QxMiIgZD0iTTY3LjIsNDkuN2MwLjIsMi40LDQuNy0wLjcsNi4yLDFsMzEuNS0xOS4yYy0wLjgtMi4yLTEuOS00LjMtMy4yLTYuM0M5NS4xLDE0LjIsODAuOCwzLjIsNzMuNywxMS4yCglDNjguOCwxNi42LDY2LjEsMzUuNyw2Ny4yLDQ5Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik03Mi4xLDE0LjNsOSw2LjdjMCwwLTEwLjEtMS44LTEwLjUtMy40QzcwLjEsMTYuMSw3Mi4xLDE0LjMsNzIuMSwxNC4zeiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjksMjAuNWw2LjgsNC44YzAsMC03LjctMS4zLTgtMi40QzY3LjUsMjEuOCw2OSwyMC41LDY5LDIwLjV6Ii8+CjxwYXRoIGNsYXNzPSJzdDEzIiBkPSJNNjcuMiw0OS43YzAuMiwyLjQsNC43LTAuNyw2LjIsMWwzMS41LTE5LjJjLTAuOC0yLjItMS45LTQuMy0zLjItNi4zQzk1LjEsMTQuMiw4MC44LDMuMiw3My43LDExLjIKCUM2OC44LDE2LjYsNjYuMSwzNS43LDY3LjIsNDkuN3oiLz4KPHBhdGggY2xhc3M9InN0MTAiIGQ9Ik03Ny4xLDQwLjJjMC4xLDAuOCwxMy4zLTcsMTMuMy03Yy0wLjMtMC43LTAuNi0xLjQtMS4xLTIuMWMtMi4yLTMuNi02LjktOS4yLTkuNC02CglDNzkuMywyNiw3Ni44LDM1LjUsNzcuMSw0MC4yeiIvPgo8cGF0aCBjbGFzcz0ic3QxNCIgZD0iTTExMC4zLDQ3LjRjLTAuNiwyNi4yLTkuNSw0OC41LTIyLjksNTcuM0MxMDAuOCw5NS45LDExMC4zLDczLjYsMTEwLjMsNDcuNHoiLz4KPGc+Cgk8cGF0aCBjbGFzcz0ic3QxNSIgZD0iTTEyMi45LDEwNy40YzEuMiwxLjUsMi4zLDMuMSwzLjIsNC45YzkuNS0yLjUsMTcuMS03LjIsMjEuNC0xMy4xYy0wLjMtMC43LTAuNy0xLjMtMS0yCgkJQzE0MC4xLDEwMi4xLDEzMiwxMDUuNywxMjIuOSwxMDcuNEMxMjIuOSwxMDcuNCwxMjIuOSwxMDcuNCwxMjIuOSwxMDcuNHoiLz4KCTxwYXRoIGNsYXNzPSJzdDE1IiBkPSJNOTIuMiwxMTEuOWMxLTEuNywyLTMuMywzLjItNC43Yy04LjItMS44LTE1LjYtNS4xLTIxLjYtOS41Yy0wLjQsMC43LTAuNywxLjUtMS4xLDIuMgoJCUM3Ni45LDEwNS4xLDgzLjgsMTA5LjQsOTIuMiwxMTEuOXoiLz4KCTxwYXRoIGNsYXNzPSJzdDE2IiBkPSJNMTA5LjksMTA4LjdjLTUsMC05LjktMC41LTE0LjUtMS42bDAsMGMtMS4yLDEuNC0yLjMsMy0zLjIsNC43YzAsMCwwLDAsMCwwYzUuNCwxLjYsMTEuNCwyLjUsMTcuNywyLjUKCQljNS44LDAsMTEuMi0wLjcsMTYuMi0yLjFjMCwwLDAsMCwwLDBjLTEtMS43LTItMy40LTMuMi00LjlDMTE4LjgsMTA4LjMsMTE0LjQsMTA4LjcsMTA5LjksMTA4Ljd6Ii8+CjwvZz4KPHBhdGggY2xhc3M9InN0MTciIGQ9Ik0xMzEuOSwxMzQuOWMwLDE0LjQtOC4xLDI3LTIyLjgsMjdzLTIyLjgtMTIuNi0yMi44LTI3czguMS0zNC45LDIyLjgtMzQuOVMxMzEuOSwxMjAuNSwxMzEuOSwxMzQuOXoiLz4KPHBhdGggY2xhc3M9InN0MTgiIGQ9Ik0xNTAuMyw5NC4xYy0xLjIsMS4xLTIuNCwyLjEtMy44LDMuMWMwLjMsMC43LDAuNywxLjMsMSwyQzE0OC43LDk3LjYsMTQ5LjcsOTUuOCwxNTAuMyw5NC4xeiIvPgo8cGF0aCBjbGFzcz0ic3QxOSIgZD0iTTE1OC40LDE0Mi4zYzAsMjkuNy0yMS42LDQ2LjQtNDguMSw0Ni40UzYyLjIsMTcyLDYyLjIsMTQyLjNzMjEuNi03Ni4xLDQ4LjEtNzYuMVMxNTguNCwxMTIuNiwxNTguNCwxNDIuM3oiCgkvPgo8cGF0aCBjbGFzcz0ic3QyMCIgZD0iTTE0Ni4xLDYxLjljMC02LjQsMy4zLTEyLjEsOC40LTE1LjhjLTkuNC0xMS0yNS43LTE4LjMtNDQuMi0xOC4zYy0wLjYsMC0xLjIsMC0xLjksMGMxLjUsNS44LDIsMTIuNSwxLjksMTkuNQoJYzAsMjYuMi05LjUsNDguNS0yMi45LDU3LjNjNi45LDIuNiwxNC43LDQsMjIuOSw0YzIzLjQsMCw0My4zLTExLjcsNTAuMi0yNy45QzE1Mi4xLDc3LjgsMTQ2LjEsNzAuNSwxNDYuMSw2MS45eiIvPgo8cGF0aCBjbGFzcz0ic3QzIiBkPSJNMTEwLjMsNDcuNGMwLTYuOC0wLjctMTMuNC0xLjktMTkuNWMtMjguMywwLjctNTEsMTguNS01MSw0MC40YzAsMTYuMSwxMi4yLDI5LjksMjkuOSwzNi41CglDMTAwLjgsOTUuOSwxMDkuNyw3My42LDExMC4zLDQ3LjR6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xNDIuOCw3OS40YzAtNS43LTQuMy0xMC4zLTkuNS0xMC4zYy0zLjgsMC03LDIuNC04LjYsNS44YzguMywyLjMsMTMuOSw2LjYsMTMuOSwxMi40YzAsMC4zLDAsMC41LTAuMSwwLjgKCUMxNDEuMSw4Ni4yLDE0Mi44LDgzLDE0Mi44LDc5LjR6Ii8+CjxwYXRoIGNsYXNzPSJzdDMiIGQ9Ik0xMDguNSwyNy44YzEuMiw2LjEsMS45LDEyLjcsMS45LDE5LjVDMTEwLjUsNDAuNCwxMTAsMzMuNywxMDguNSwyNy44eiIvPgo8cGF0aCBjbGFzcz0ic3Q5IiBkPSJNMTU0LjUsNDYuMWMtNS4xLDMuNy04LjQsOS40LTguNCwxNS44YzAsOC42LDYsMTYsMTQuNCwxOWMxLjctNCwyLjYtOC4yLDIuNi0xMi42CglDMTYzLjEsNjAuMSwxNTkuOSw1Mi40LDE1NC41LDQ2LjF6Ii8+CjxwYXRoIGNsYXNzPSJzdDExIiBkPSJNNjEuOCw1My41bDksNi43YzAsMC0xMC4xLTEuOC0xMC41LTMuNEM1OS44LDU1LjQsNjEuOCw1My41LDYxLjgsNTMuNXoiLz4KPHBhdGggY2xhc3M9InN0MTEiIGQ9Ik01OS41LDU5LjJsMTAuNCw2LjdjMCwwLTExLjgtMS44LTEyLjMtMy40QzU3LjIsNjEsNTkuNSw1OS4yLDU5LjUsNTkuMnoiLz4KPGVsbGlwc2UgdHJhbnNmb3JtPSJtYXRyaXgoMC45OTE5IC0wLjEyNyAwLjEyNyAwLjk5MTkgLTYuMjU3MSAxMi41NjM4KSIgY2xhc3M9InN0MjEiIGN4PSI5NS40IiBjeT0iNTUuNCIgcng9IjEyLjMiIHJ5PSIxMC42Ii8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuOTkxOSAtMC4xMjcgMC4xMjcgMC45OTE5IC02LjQ1MDYgMTIuNjQ0NSkiIGNsYXNzPSJzdDIyIiBjeD0iOTUuOSIgY3k9IjU2LjkiIHJ4PSI4LjkiIHJ5PSI3LjciLz4KPGVsbGlwc2UgdHJhbnNmb3JtPSJtYXRyaXgoMC45OTE5IC0wLjEyNjcgMC4xMjY3IDAuOTkxOSAtNi40ODU2IDEyLjYxNDkpIiBjbGFzcz0ic3QyMSIgY3g9Ijk1LjkiIGN5PSI1Ny4zIiByeD0iMy40IiByeT0iMyIvPgo8bGluZSBjbGFzcz0ic3QyMyIgeDE9Ijg1LjkiIHkxPSI0Ni42IiB4Mj0iODIuNSIgeTI9IjQ1LjMiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSI4OC42IiB5MT0iNDQuMyIgeDI9Ijg0LjUiIHkyPSI0MS40Ii8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuMTI3IC0wLjk5MTkgMC45OTE5IDAuMTI3IDU2LjM3NjMgMTc0Ljc1OTUpIiBjbGFzcz0ic3QyMSIgY3g9IjEyNy41IiBjeT0iNTUuNCIgcng9IjEwLjYiIHJ5PSIxMi4zIi8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuMTI3IC0wLjk5MTkgMC45OTE5IDAuMTI3IDU0LjM2MjkgMTc1LjU4ODMpIiBjbGFzcz0ic3QyMiIgY3g9IjEyNi45IiBjeT0iNTYuOSIgcng9IjcuNyIgcnk9IjguOSIvPgo8ZWxsaXBzZSB0cmFuc2Zvcm09Im1hdHJpeCgwLjEyNjcgLTAuOTkxOSAwLjk5MTkgMC4xMjY3IDU0LjAxNTkgMTc1Ljk1MDUpIiBjbGFzcz0ic3QyMSIgY3g9IjEyNi45IiBjeT0iNTcuMyIgcng9IjMiIHJ5PSIzLjQiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSIxMzciIHkxPSI0Ni42IiB4Mj0iMTQwLjQiIHkyPSI0NS4zIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iMTM0LjMiIHkxPSI0NC4zIiB4Mj0iMTM4LjQiIHkyPSI0MS40Ii8+CjxwYXRoIGNsYXNzPSJzdDIyIiBkPSJNMTM4LjYsODcuM2MwLDguNy0xMi43LDE1LjctMjguNCwxNS43cy0yOC40LTctMjguNC0xNS43czEyLjctMTQuMiwyOC40LTE0LjJTMTM4LjYsNzguNiwxMzguNiw4Ny4zeiIvPgo8cGF0aCBjbGFzcz0ic3QyNCIgZD0iTTExMC4zLDEwMEMxMDAsMTAwLDkwLjQsOTcuNCw4MS44LDg3LjNjMC43LDEwLjYsMTMuNiwxNS4zLDI4LjIsMTUuM2MxNS43LDAsMjctNiwyOC40LTE1LjMKCUMxMzAuMyw5Ni4xLDEyNC45LDk5LjksMTEwLjMsMTAweiIvPgo8cGF0aCBjbGFzcz0ic3QyMyIgZD0iTTkxLjQsODYuM2MzLjQsNi42LDEwLjksMTEuMSwxOS42LDExYzguNC0wLjEsMTUuNi00LjUsMTguOS0xMC45Ii8+CjxwYXRoIGNsYXNzPSJzdDI1IiBkPSJNMTM4LjYsODcuM2MwLDguNy0xMi43LDE1LjctMjguNCwxNS43cy0yOC40LTctMjguNC0xNS43czEyLjctMTQuMiwyOC40LTE0LjJTMTM4LjYsNzguNiwxMzguNiw4Ny4zeiIvPgo8bGluZSBjbGFzcz0ic3QyNiIgeDE9IjExMC42IiB5MT0iNzkiIHgyPSIxMTAuNiIgeTI9Ijk3LjkiLz4KPHBhdGggY2xhc3M9InN0MjEiIGQ9Ik0xMTksNzRjMCw0LjYtOC4zLDcuNC04LjMsNy40cy04LjMtMi44LTguMy03LjRzMy43LTQuMSw4LjMtNC4xUzExOSw2OS40LDExOSw3NHoiLz4KPGVsbGlwc2UgY2xhc3M9InN0MjciIGN4PSIxMTAuNiIgY3k9IjczIiByeD0iNS40IiByeT0iMC45Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xMzguOCwxNzAuMmMwLDQuMS0xLjksMjEuNS0xMi4zLDIwLjJjLTUuNi0wLjctMTMuNy05LjUtMTAuMy0xMS44YzMuNi0yLjQtMy42LTE0LjksMS4yLTExLjgKCUMxMjIuMiwxNjkuOSwxMzguOCwxNjYuMSwxMzguOCwxNzAuMnoiLz4KPHBhdGggY2xhc3M9InN0MjIiIGQ9Ik0xMzMuMiwxODUuNmMwLDQuMS0zLjksNS41LTkuOSw1LjVzLTExLTMuMy0xMS03LjRzMi43LTcuNSw3LjktNC4zQzEyNS4yLDE4Mi41LDEzMy4yLDE4MS41LDEzMy4yLDE4NS42eiIvPgo8cGF0aCBjbGFzcz0ic3QyNCIgZD0iTTEyMi42LDE4Ny4yYy0zLjgtMS40LTcuMi0zLjYtOS45LTYuM2MtMC4zLDAuNy0wLjQsMS4zLTAuNCwyLjFjMCw0LjUsNS4zLDguMSwxMS44LDguMWMzLjEsMCw1LjktMC44LDgtMi4yCglDMTI5LDE4OC45LDEyNS44LDE4OC40LDEyMi42LDE4Ny4yeiIvPgo8cGF0aCBjbGFzcz0ic3QyOCIgZD0iTTExNy41LDE2Ni44YzAuMSwzLjIsMC41LDYuMywxLjIsOWMtMy44LDEuNC02LjMsNC4xLTYuMyw3LjJjMCw0LjUsNS4zLDguMSwxMS44LDguMWM1LjMsMCw5LjgtMi40LDExLjMtNS43CgljMi00LjgsNC0xMC45LDUuMi0xOC44Ii8+CjxwYXRoIGNsYXNzPSJzdDI5IiBkPSJNODEsMTcwLjJjMCw0LjEsMS45LDIxLjUsMTIuMywyMC4yYzUuNi0wLjcsMTMuNy05LjUsMTAuMy0xMS44Yy0zLjYtMi40LDIuMi0xNC45LTIuNi0xMS44CglDOTYuMiwxNjkuOSw4MSwxNjYuMSw4MSwxNzAuMnoiLz4KPHBhdGggY2xhc3M9InN0MjIiIGQ9Ik04Ni42LDE4NS42YzAsNC4xLDMuOSw1LjUsOS45LDUuNWM2LjEsMCwxMS0zLjMsMTEtNy40cy0yLjctNy41LTcuOS00LjNDOTQuNiwxODIuNSw4Ni42LDE4MS41LDg2LjYsMTg1LjZ6IgoJLz4KPHBhdGggY2xhc3M9InN0MjQiIGQ9Ik05OC4yLDE4Ny42YzMuOC0xLjYsNy00LDkuNi02LjhjMC4zLDAuNiwwLjUsMS4zLDAuNSwyYzAuMiw0LjUtNC45LDguNC0xMS40LDguN2MtMy4xLDAuMi02LTAuNS04LjEtMS44CglDOTEuOSwxODkuNiw5NS4xLDE4OC45LDk4LjIsMTg3LjZ6Ii8+CjxwYXRoIGNsYXNzPSJzdDI4IiBkPSJNMTAyLjQsMTY2LjhjLTAuMSwzLjItMC41LDYuMy0xLjIsOWMzLjgsMS40LDYuMyw0LjEsNi4zLDcuMmMwLDQuNS01LjMsOC4xLTExLjgsOC4xYy01LjMsMC05LjgtMi40LTExLjMtNS43CgljLTItNC44LTQtMTAuOS01LjItMTguOCIvPgo8Y2lyY2xlIGNsYXNzPSJzdDI0IiBjeD0iMTI3LjciIGN5PSI4MiIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSIxMjQuOSIgY3k9Ijc4LjYiIHI9IjEuNCIvPgo8Y2lyY2xlIGNsYXNzPSJzdDI0IiBjeD0iMTI0IiBjeT0iODMuNSIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5My45IiBjeT0iODIuMiIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5Ny43IiBjeT0iODMuNSIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5Ny4xIiBjeT0iNzkiIHI9IjEuNCIvPgo8bGluZSBjbGFzcz0ic3QyMyIgeDE9IjEyOC43IiB5MT0iODIiIHgyPSIxNDguOSIgeTI9IjgyLjMiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSIxMjUuOSIgeTE9Ijc4LjUiIHgyPSIxNDQuOSIgeTI9IjcxIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iOTMuMiIgeTE9IjgyIiB4Mj0iNzMiIHkyPSI4Mi4zIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iOTYiIHkxPSI3OC41IiB4Mj0iNzciIHkyPSI3MSIvPgo8Zz4KCTxnPgoJCTxjaXJjbGUgY2xhc3M9InN0MzAiIGN4PSIxOTIiIGN5PSIxNzguMiIgcj0iMzAuNCIvPgoJCTxwYXRoIGNsYXNzPSJzdDMwIiBkPSJNMTkyLDE0OC40YzE2LjUsMCwyOS45LDEzLjQsMjkuOSwyOS45cy0xMy40LDI5LjktMjkuOSwyOS45cy0yOS45LTEzLjQtMjkuOS0yOS45UzE3NS41LDE0OC40LDE5MiwxNDguNAoJCQkgTTE5MiwxNDcuM2MtMTcuMSwwLTMxLDEzLjktMzEsMzFzMTMuOSwzMSwzMSwzMXMzMS0xMy45LDMxLTMxUzIwOS4xLDE0Ny4zLDE5MiwxNDcuM0wxOTIsMTQ3LjN6Ii8+Cgk8L2c+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE2NS41LDE2Ny44Yy0wLjEsMC4yLDEzLjYtMTYuNiwzMi4zLTE3LjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTYzLjUsMTczLjljMCwwLDE0LjYtMjIuMSwzOS4xLTIyLjEiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTYzLjUsMTc3LjhjMCwwLDE1LjYtMjYuNSw0Mi44LTIzLjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA0LjcsMTU2YzAsMCwxMy41LDYuMiwxMy41LDM0LjQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAwLjcsMTU1LjVjMCwwLDE1LDQuNSwxNS42LDM3LjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk4LjksMTU3Yy0yLjQtMC45LDE3LjEsNSwxNC45LDM5LjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk0LjMsMTU3YzAsMCwyMi44LDguOCwxNi41LDQzLjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkzLjQsMTU4LjVjMCwwLTEzLjQsMjQuOC0xMyw0NS4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE5MS4yLDE1Ny42YzAsMC0xMy43LDI1LTEzLjQsNDUuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTUuMywxNjAuMWMwLDAtMTEuNiwyMS4yLTEyLjUsNDQuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTkuMiwxNjIuM2MwLDAtMTIuOCwyMy42LTExLjcsNDMuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTcuMiwxNjEuMmMwLDAtMTMuMSwyNC43LTExLjksNDQuNiIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDAuOSwxNjMuOGMwLDAtMTIuNiwyMy40LTEwLjksNDMuMSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDUuNCwxNjkuN2MtMC45LTAuMi0zLjEtMC42LTQtMC44Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTIwOC4xLDE3Ny44Yy0xLjktMC42LTcuMy0yLjUtOS4yLTMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjIsMTgwLjVjLTIuOC0wLjktOC40LTMtMTEuMy0zLjQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjgsMTgzYy0zLjYtMS4zLTguMS0yLjgtMTEuOS0zLjIiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjgsMTg1LjVjLTQuMS0xLjYtOS4zLTMuMS0xMy41LTMuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDkuOCwxODhjLTMuNy0yLjItMTAtMy0xNC41LTMuOSIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxOTcuMiIgeTE9IjE4Ni4zIiB4Mj0iMTk0LjMiIHkyPSIxODcuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTkuNywxODdjMCwwLTYuMiwzLjYtNywzLjYiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAzLjQsMTg3LjdjMCwwLTkuMyw1LjYtMTAuNiw1LjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA1LjUsMTg4LjNjMCwwLTEwLjMsNy4zLTEyLjgsNy4yIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE4Ni44LDE1OC44YzAsMCwwLjcsMS4xLDEuMSwxLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTgxLjksMTYyYzAsMCwxLjksMy4yLDMsMy44Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ny44LDE2NWMwLDAsMy45LDUuMyw1LDUuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuNCwxNjYuNmMwLDAsMy43LDQuNiw1LjYsNi4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Mi4zLDE2OS4zYzAsMCw2LjMsNi44LDguMSw3LjEiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTcxLjEsMTcxLjVjMCwwLDYuMyw2LjcsNy42LDcuNCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzIuMSwxNzYuM2MwLDAtNS4xLDAuNy01LjcsMC42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3NCwxNzguMmMwLDAtOCwxLjEtOS42LDEuMSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzguNywxODEuOGMwLDAtMTEuNywxLjUtMTQuMywyLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc3LjgsMTg0LjFjMCwwLTEwLjMsMS42LTEyLjIsMi4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ni45LDE4N2MwLDAtOC4zLDEuMy0xMC42LDEuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuOSwxODkuNmMwLDAtOSwyLjEtOS41LDEuNiIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuNCwxOTEuOGMwLDAtNy42LDIuNS04LjEsMi4yIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ni40LDE5NC40YzAsMC01LDIuMS02LDIuMSIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNzYuNCIgeTE9IjE5Ny4zIiB4Mj0iMTcyLjEiIHkyPSIxOTkuMiIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNjMuNSIgeTE9IjE4MS44IiB4Mj0iMTc2LjQiIHkyPSIxNzkuOSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTEuMSwxNDkuMmMwLDAtMTMuMywxLjYtMjMuNiwxMy42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTIwNy41LDE1NS41YzAsMCwxMi42LDkuNCwxMi41LDMwLjgiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc5LjgsMTYzLjhjMCwwLDIuOSwzLjIsMy42LDQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc0LjksMTY4LjVjMCwwLDQuMyw0LjYsNS40LDUuNCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xODMuMSwxNjAuN2MwLDAsMi41LDMsMywzLjIiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTg0LjksMTYwLjFjMCwwLDEuNCwyLDEuOSwyLjIiLz4KCTxsaW5lIGNsYXNzPSJzdDMxIiB4MT0iMTY4LjMiIHkxPSIxNzQuNSIgeDI9IjE3MS4xIiB5Mj0iMTczLjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk5LjcsMTcyLjljMCwwLDcuNSwyLDguNCwyLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAwLjIsMTcwLjdjMCwwLDUuOCwxLjQsNi4yLDEuNyIvPgoJPGVsbGlwc2UgY2xhc3M9InN0MzIiIGN4PSIyMDMuMiIgY3k9IjE2Ny4zIiByeD0iMC42IiByeT0iMC41Ii8+Cgk8ZWxsaXBzZSBjbGFzcz0ic3QzMiIgY3g9IjE4OSIgY3k9IjE1OCIgcng9IjAuOCIgcnk9IjAuNCIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNzQiIHkxPSIyMDAuNSIgeDI9IjE3NS44IiB5Mj0iMTk5LjgiLz4KCQoJCTxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuODE2OSAtMC41NzY3IDAuNTc2NyAwLjgxNjkgLTg0LjM2NTggMTM4LjcyNDIpIiBjbGFzcz0ic3QzMiIgY3g9IjE3Ni4zIiBjeT0iMjAyLjMiIHJ4PSIwLjkiIHJ5PSIwLjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkyLDE5OC4yYzAsMCwxMy44LTYuMywxNi04LjciLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkxLjUsMjAxLjZjMCwwLDE2LjEtNy4yLDE4LjMtMTAuOSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTEuNSwyMDQuMWMwLDAsMTcuMi04LjMsMTguMy0xMC42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE5MiwyMDUuOGMwLDAsMTYuNi02LjcsMTcuNy05LjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk0LjMsMjA3YzAsMCwxNC4yLTUuNSwxNC45LTYuOCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMTAuNywxNTZjMC0wLjIsNy41LDQuNiwxMC41LDIzLjMiLz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDIxIiBkPSJNMTkyLDE0OC40YzE2LjUsMCwyOS45LDEzLjQsMjkuOSwyOS45cy0xMy40LDI5LjktMjkuOSwyOS45cy0yOS45LTEzLjQtMjkuOS0yOS45UzE3NS41LDE0OC40LDE5MiwxNDguNAoJCQkgTTE5MiwxNDQuOGMtMTguNSwwLTMzLjUsMTUtMzMuNSwzMy41czE1LDMzLjUsMzMuNSwzMy41YzE4LjUsMCwzMy41LTE1LDMzLjUtMzMuNVMyMTAuNSwxNDQuOCwxOTIsMTQ0LjhMMTkyLDE0NC44eiIvPgoJPC9nPgo8L2c+Cjwvc3ZnPgo=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+                - pods
+                - podtemplates
+                - services
+                - endpoints
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - patch
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+                - clusterrolebindings
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+                - bind
+                - escalate
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - statefulsets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - apps
+              resourceNames:
+                - tigera-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.tigera.io
+              resources:
+                - '*'
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - patch
+                - delete
+                - watch
+            - apiGroups:
+                - scheduling.k8s.io
+              resources:
+                - priorityclasses
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - apiregistration.k8s.io
+              resources:
+                - apiservices
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks/status
+              verbs:
+                - get
+                - list
+                - update
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks
+                - infrastructures
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - hostnetwork
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - crd.projectcalico.org
+              resources:
+                - bgpconfigurations
+                - bgppeers
+                - felixconfigurations
+                - kubecontrollersconfigurations
+                - globalnetworkpolicies
+                - globalnetworksets
+                - hostendpoints
+                - ippools
+                - networkpolicies
+                - networksets
+              verbs:
+                - create
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+                - cronjobs
+              verbs:
+                - create
+                - update
+                - list
+                - watch
+          serviceAccountName: tigera-operator
+      deployments:
+        - name: tigera-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: tigera-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  k8s-app: tigera-operator
+                  name: tigera-operator
+              spec:
+                containers:
+                  - command:
+                      - operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: tigera-operator
+                      - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
+                        value: v1.5.2
+                    image: quay.io/tigera/operator@sha256:83ba32833b8284fa923d9818df3636ac717b6ad5650e904ee14367fdffe3b83c
+                    imagePullPolicy: IfNotPresent
+                    name: tigera-operator
+                    resources: {}
+                dnsPolicy: ClusterFirstWithHostNet
+                hostNetwork: true
+                serviceAccountName: tigera-operator
+                tolerations:
+                  - effect: NoExecute
+                    operator: Exists
+                  - effect: NoSchedule
+                    operator: Exists
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - networking
+    - security
+    - monitoring
+  links:
+    - name: Calico Introduction
+      url: https://docs.projectcalico.org/introduction/
+    - name: Install an OpenShift v4 cluster with Calico
+      url: https://docs.projectcalico.org/archive/v3.14/getting-started/openshift/installation
+  maintainers:
+    - email: maintainers@tigera.io
+      name: Project Calico Maintainers
+  maturity: stable
+  provider:
+    name: Tigera
+  version: 1.5.2
+  replaces: tigera-operator.v1.3.1

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-bgpconfiguration.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-bgpconfiguration.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-bgppeer.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-bgppeer.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-blockaffinity.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-blockaffinity.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-clusterinformation.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-clusterinformation.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-felixconfiguration.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-felixconfiguration.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-globalnetworkpolicy.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-globalnetworkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+    shortNames:
+    - gnp

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-globalnetworkset.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-globalnetworkset.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-hostendpoint.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-hostendpoint.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ipamblock.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ipamblock.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ipamconfig.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ipamconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMConfig
+    plural: ipamconfigs
+    singular: ipamconfig

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ipamhandle.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ipamhandle.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMHandle
+    plural: ipamhandles
+    singular: ipamhandle

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ippool.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-ippool.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-kubecontrollersconfiguration.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-kubecontrollersconfiguration.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: KubeControllersConfiguration
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-networkpolicy.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy

--- a/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-networkset.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/02-crd-networkset.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset

--- a/deploy/olm-catalog/tigera-operator/1.5.3/operator.tigera.io_installations_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/operator.tigera.io_installations_crd.yaml
@@ -1,0 +1,242 @@
+---
+# Source: tigera-operator/templates/crds/01-crd-installation.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: installations.operator.tigera.io
+  annotations:
+    "helm.sh/hook": "crd-install"
+spec:
+  group: operator.tigera.io
+  names:
+    kind: Installation
+    listKind: InstallationList
+    plural: installations
+    singular: installation
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the desired state for the Calico or Calico
+            Enterprise installation.
+          properties:
+            calicoNetwork:
+              description: CalicoNetwork specifies configuration options for Calico
+                provided pod networking.
+              properties:
+                hostPorts:
+                  description: 'HostPorts configures whether or not Calico will support
+                    Kubernetes HostPorts. Default: Enabled'
+                  enum:
+                  - Enabled
+                  - Disabled
+                  type: string
+                ipPools:
+                  description: IPPools contains a list of IP pools to use for allocating
+                    pod IP addresses. At most one IP pool may be specified. If omitted,
+                    a single pool will be configured when needed.
+                  items:
+                    properties:
+                      blockSize:
+                        description: 'BlockSize specifies the CIDR prefex length to
+                          use when allocating per-node IP blocks from the main IP
+                          pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
+                        format: int32
+                        type: integer
+                      cidr:
+                        description: CIDR contains the address range for the IP Pool
+                          in classless inter-domain routing format.
+                        type: string
+                      encapsulation:
+                        description: 'Encapsulation specifies the encapsulation type
+                          that will be used with the IP Pool. Default: IPIP'
+                        enum:
+                        - IPIPCrossSubnet
+                        - IPIP
+                        - VXLAN
+                        - VXLANCrossSubnet
+                        - None
+                        type: string
+                      natOutgoing:
+                        description: 'NATOutgoing specifies if NAT will be enabled
+                          or disabled for outgoing traffic. Default: Enabled'
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      nodeSelector:
+                        description: 'NodeSelector specifies the node selector that
+                          will be set for the IP Pool. Default: ''all()'''
+                        type: string
+                    required:
+                    - cidr
+                    type: object
+                  type: array
+                mtu:
+                  description: 'MTU specifies the maximum transmission unit to use
+                    for pods on the Calico network. Default: 1410'
+                  format: int32
+                  type: integer
+                nodeAddressAutodetectionV4:
+                  description: NodeAddressAutodetectionV4 specifies an approach to
+                    automatically detect node IPv4 addresses. If not specified, will
+                    use default auto-detection settings to acquire an IPv4 address
+                    for each node.
+                  properties:
+                    canReach:
+                      description: CanReach enables IP auto-detection based on which
+                        source address on the node is used to reach the specified
+                        IP or domain.
+                      type: string
+                    firstFound:
+                      description: FirstFound uses default interface matching parameters
+                        to select an interface, performing best-effort filtering based
+                        on well-known interface names.
+                      type: boolean
+                    interface:
+                      description: Interface enables IP auto-detection based on interfaces
+                        that match the given regex.
+                      type: string
+                    skipInterface:
+                      description: SkipInterface enables IP auto-detection based on
+                        interfaces that do not match the given regex.
+                      type: string
+                  type: object
+                nodeAddressAutodetectionV6:
+                  description: NodeAddressAutodetectionV6 specifies an approach to
+                    automatically detect node IPv4 addresses. If not specified, IPv6
+                    addresses will not be auto-detected.
+                  properties:
+                    canReach:
+                      description: CanReach enables IP auto-detection based on which
+                        source address on the node is used to reach the specified
+                        IP or domain.
+                      type: string
+                    firstFound:
+                      description: FirstFound uses default interface matching parameters
+                        to select an interface, performing best-effort filtering based
+                        on well-known interface names.
+                      type: boolean
+                    interface:
+                      description: Interface enables IP auto-detection based on interfaces
+                        that match the given regex.
+                      type: string
+                    skipInterface:
+                      description: SkipInterface enables IP auto-detection based on
+                        interfaces that do not match the given regex.
+                      type: string
+                  type: object
+              type: object
+            clusterManagementType:
+              description: 'How the cluster is managed. Valid values for this field
+                are: Standalone, Management, Managed. Standalone clusters are fully
+                self-contained installations of Calico Enterprise. Management clusters
+                provide a single view to manage any number of Managed clusters, which
+                are a lighter weight installation. Default: Standalone'
+              enum:
+              - Standalone
+              - Management
+              - Managed
+              type: string
+            controlPlaneNodeSelector:
+              additionalProperties:
+                type: string
+              description: ControlPlaneNodeSelector is used to select control plane
+                nodes on which to run specific Calico components. This currently only
+                applies to kube-controllers and the apiserver.
+              type: object
+            flexVolumePath:
+              description: FlexVolumePath optionally specifies a custom path for FlexVolume.
+                If not specified, FlexVolume will be enabled by default. If set to
+                'None', FlexVolume will be disabled. The default is based on the kubernetesProvider.
+              type: string
+            imagePath:
+              description: 'ImagePath allows for the path part of an image to be specified.
+                If specified then the specified value will be used as the image path
+                for each image. If not specified or empty, the default for each image
+                will be used.  Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`  This
+                option allows configuring the `<imagePath>` portion of the above format.'
+              type: string
+            imagePullSecrets:
+              description: ImagePullSecrets is an array of references to container
+                registry pull secrets to use. These are applied to all images to be
+                pulled.
+              items:
+                type: object
+              type: array
+            kubernetesProvider:
+              description: KubernetesProvider specifies a particular provider of the
+                Kubernetes platform and enables provider-specific configuration. If
+                the specified value is empty, the Operator will attempt to automatically
+                determine the current provider. If the specified value is not empty,
+                the Operator will still attempt auto-detection, but will additionally
+                compare the auto-detected value to the specified value to confirm
+                they match.
+              enum:
+              - ""
+              - EKS
+              - GKE
+              - AKS
+              - OpenShift
+              - DockerEnterprise
+              type: string
+            nodeMetricsPort:
+              description: NodeMetricsPort specifies which port calico/node serves
+                prometheus metrics on. By default, metrics are not enabled. If specified,
+                this overrides any FelixConfiguration resources which may exist. If
+                omitted, then prometheus metrics may still be configured through FelixConfiguration.
+              format: int32
+              type: integer
+            nodeUpdateStrategy:
+              description: NodeUpdateStrategy can be used to customize the desired
+                update strategy, such as the MaxUnavailable field.
+              type: object
+            registry:
+              description: 'Registry is the default Docker registry used for component
+                Docker images. If specified, all images will be pulled from this registry.
+                If not specified then the default registries will be used.  Image
+                format:    `<registry>/<imagePath>/<imageName>:<image-tag>`  This
+                option allows configuring the `<registry>` portion of the above format.'
+              type: string
+            variant:
+              description: 'Variant is the product to install - one of Calico or TigeraSecureEnterprise
+                Default: Calico'
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+        status:
+          description: Most recently observed state for the Calico or Calico Enterprise
+            installation.
+          properties:
+            variant:
+              description: Variant is the most recently observed installed variant
+                - one of Calico or TigeraSecureEnterprise
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+
+

--- a/deploy/olm-catalog/tigera-operator/1.5.3/operator.tigera.io_tigerastatuses_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/operator.tigera.io_tigerastatuses_crd.yaml
@@ -1,0 +1,94 @@
+---
+# Source: tigera-operator/templates/crds/01-crd-tigerastatus.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tigerastatuses.operator.tigera.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Available")].status
+    description: Whether the component running and stable.
+    name: Available
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Progressing")].status
+    description: Whether the component is processing changes.
+    name: Progressing
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Degraded")].status
+    description: Whether the component is degraded.
+    name: Degraded
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
+    description: The time the component's Available status last changed.
+    name: Since
+    type: date
+  group: operator.tigera.io
+  names:
+    kind: TigeraStatus
+    listKind: TigeraStatusList
+    plural: tigerastatuses
+    singular: tigerastatus
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions represents the latest observed set of conditions
+                for this component. A component may be one or more of Available, Progressing,
+                or Degraded.
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: The timestamp representing the start time for the
+                      current status.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Optionally, a detailed message providing additional
+                      context.
+                    type: string
+                  reason:
+                    description: A brief reason explaining the condition.
+                    type: string
+                  status:
+                    description: The status of the condition. May be True, False,
+                      or Unknown.
+                    type: string
+                  type:
+                    description: The type of condition. May be Available, Progressing,
+                      or Degraded.
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+
+

--- a/deploy/olm-catalog/tigera-operator/1.5.3/tigera-operator.v1.5.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.5.3/tigera-operator.v1.5.3.clusterserviceversion.yaml
@@ -1,0 +1,369 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.tigera.io/v1",
+          "kind": "Installation",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "variant": "Calico"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Logging & Tracing, Monitoring, Networking, Security
+    certified: "true"
+    description: An operator which manages the lifecycle of a Calico or Calico Enterprise installation on Kubernetes or OpenShift.
+    marketplace.openshift.io/action-text: Install-time Instructions
+    marketplace.openshift.io/remote-workflow: https://docs.projectcalico.org/archive/v3.14/getting-started/openshift/installation
+    operators.operatorframework.io/internal-objects: '["blockaffinities.crd.projectcalico.org","clusterinformations.crd.projectcalico.org","ipamblocks.crd.projectcalico.org","ipamconfigs.crd.projectcalico.org","ipamhandles.crd.projectcalico.org"]'
+    repository: https://github.com/tigera/operator
+    support: Tigera
+    containerImage: quay.io/tigera/operator:v1.5.3
+    createdAt: 2020-07-24T22:46:10.721139381Z
+  name: tigera-operator.v1.5.3
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: BGPConfiguration represents BGP specific configuration options for the cluster or a specific node.
+        displayName: BGPConfiguration
+        kind: BGPConfiguration
+        name: bgpconfigurations.crd.projectcalico.org
+        version: v1
+      - description: BGPPeer represents a remote BGP peer with which the node(s) in a Calico cluster will peer. Configuring BGP peers allows you to peer a Calico network with your datacenter fabric (e.g. ToR).
+        displayName: BGPPeer
+        kind: BGPPeer
+        name: bgppeers.crd.projectcalico.org
+        version: v1
+      - description: BlockAffinity maintains a block affinity's state.
+        displayName: BlockAffinity
+        kind: BlockAffinity
+        name: blockaffinities.crd.projectcalico.org
+        version: v1
+      - description: ClusterInformation contains the cluster specific information.
+        displayName: ClusterInformation
+        kind: ClusterInformation
+        name: clusterinformations.crd.projectcalico.org
+        version: v1
+      - description: FelixConfiguration represents Felix configuration options for the cluster.
+        displayName: FelixConfiguration
+        kind: FelixConfiguration
+        name: felixconfigurations.crd.projectcalico.org
+        version: v1
+      - description: GlobalNetworkPolicy represents an ordered set of rules which are applied to a collection of endpoints that match a label selector.
+        displayName: GlobalNetworkPolicy
+        kind: GlobalNetworkPolicy
+        name: globalnetworkpolicies.crd.projectcalico.org
+        version: v1
+      - description: GlobalNetworkSet represents an arbitrary set of IP subnetworks/CIDRs, allowing it to be matched by Calico policy. Network sets are useful for applying policy to traffic coming from (or going to) external, non-Calico, networks.
+        displayName: GlobalNetworkSet
+        kind: GlobalNetworkSet
+        name: globalnetworksets.crd.projectcalico.org
+        version: v1
+      - description: HostEndpoint represents one or more real or virtual interfaces attached to a host that is running Calico. It enforces Calico policy on the traffic that is entering or leaving the host’s default network namespace through those interfaces.
+        displayName: HostEndpoint
+        kind: HostEndpoint
+        name: hostendpoints.crd.projectcalico.org
+        version: v1
+      - description: Installation configures an installation of Calico or Calico Enterprise. At most one instance of this resource is supported. It must be named "default". The Installation API installs core networking and network policy components, and provides general install-time configuration.
+        kind: Installation
+        name: installations.operator.tigera.io
+        version: v1
+      - description: IPAMBlock contains information about a block for IP address assignment.
+        displayName: IPAMBlock
+        kind: IPAMBlock
+        name: ipamblocks.crd.projectcalico.org
+        version: v1
+      - description: IPAMConfig contains information about a block for IP address assignment.
+        displayName: IPAMConfig
+        kind: IPAMConfig
+        name: ipamconfigs.crd.projectcalico.org
+        version: v1
+      - description: IPAMHandle contains information about an IPAMHandle resource.
+        displayName: IPAMHandle
+        kind: IPAMHandle
+        name: ipamhandles.crd.projectcalico.org
+        version: v1
+      - kind: IPPool
+        name: ippools.crd.projectcalico.org
+        version: v1
+      - description: KubeControllersConfiguration represents configuration options for the Calico Kubernetes controllers.
+        displayName: KubeControllersConfiguration
+        kind: KubeControllersConfiguration
+        name: kubecontrollersconfigurations.crd.projectcalico.org
+        version: v1
+      - description: NetworkPolicy represents an ordered set of rules which are applied to a collection of endpoints that match a label selector.
+        displayName: NetworkPolicy
+        kind: NetworkPolicy
+        name: networkpolicies.crd.projectcalico.org
+        version: v1
+      - description: NetworkSet represents an arbitrary set of IP subnetworks/CIDRs, allowing it to be matched by Calico policy. Network sets are useful for applying policy to traffic coming from (or going to) external, non-Calico, networks.
+        displayName: NetworkSet
+        kind: NetworkSet
+        name: networksets.crd.projectcalico.org
+        version: v1
+      - description: TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
+        kind: TigeraStatus
+        name: tigerastatuses.operator.tigera.io
+        version: v1
+  description: 'An operator which manages the lifecycle of a Calico or Calico Enterprise installation on Kubernetes or OpenShift. Its goal is to make installation, upgrades, and ongoing lifecycle management of Calico and Calico Enterprise as simple and reliable as possible. **Important**: this operator should only be installed if the cluster was already provisioned with Calico.'
+  displayName: Tigera Operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAyMzQuMiAyMjQuMSIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjM0LjIgMjI0LjE7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDp1cmwoI1NWR0lEXzFfKTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6NC42ODQyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDF7ZmlsbDojMTczRjc0O30KCS5zdDJ7ZmlsbDojMDAyMTRDO30KCS5zdDN7ZmlsbDojNzU0QzI5O3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDR7ZmlsbDojNjAzOTEzO30KCS5zdDV7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDZ7ZmlsbDojRjc5NDFEO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjc2ODc7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0N3tmaWxsOiNGNDc3Mjk7fQoJLnN0OHtmaWxsOiNGRkZGRkY7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuNjkzNDtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0OXtmaWxsOiM3NTRDMjk7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuOTE5NDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxMHtmaWxsOiMyMzFGMjA7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuOTE5NDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxMXtmaWxsOiMzQzI0MTU7fQoJLnN0MTJ7ZmlsbDojRjc5NDFEO30KCS5zdDEze2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi45MTk0O3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDE0e2ZpbGw6bm9uZTt9Cgkuc3QxNXtmaWxsOiM2MDNEMTk7fQoJLnN0MTZ7ZmlsbDojNTczODE5O30KCS5zdDE3e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi42OTM0O3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxOHtmaWxsOiM1MzM0MTQ7fQoJLnN0MTl7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjc2ODc7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0MjB7ZmlsbDojRjc5NDFEO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDIxe2ZpbGw6IzIzMUYyMDt9Cgkuc3QyMntmaWxsOiNGRkZGRkY7fQoJLnN0MjN7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoxLjk0NjM7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0MjR7ZmlsbDojRTZFN0U4O30KCS5zdDI1e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi45MTk0O3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDI2e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi4yNzgyO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDI3e2ZpbGw6I0E3QTlBQzt9Cgkuc3QyOHtmaWxsOm5vbmU7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuNDM0NztzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QyOXtmaWxsOiM3NTRDMjk7fQoJLnN0MzB7ZmlsbDojRUY0MTM2O30KCS5zdDMxe2ZpbGw6bm9uZTtzdHJva2U6I0ZCQjA0MDtzdHJva2Utd2lkdGg6MS40MzEyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDMye2ZpbGw6I0ZCQjA0MDt9Cjwvc3R5bGU+CjxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfMV8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iMTEwLjYzMDQiIHkxPSIyLjgwMDIiIHgyPSIxMTAuNjMwNCIgeTI9IjIwNS45MDMxIj4KCTxzdG9wICBvZmZzZXQ9IjAiIHN0eWxlPSJzdG9wLWNvbG9yOiNGRkZGRkYiLz4KCTxzdG9wICBvZmZzZXQ9IjEiIHN0eWxlPSJzdG9wLWNvbG9yOiMwMDU0OUUiLz4KPC9saW5lYXJHcmFkaWVudD4KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTEwLjYiIGN5PSIxMTMiIHI9Ijk4LjciLz4KPHBhdGggY2xhc3M9InN0MSIgZD0iTTE1OC4xLDE3Ni42Yy00LjMsNi45LTIzLjgsMTIuMS00Ny4yLDEyLjFzLTQyLjgtNS4yLTQ3LjItMTIuMWMtNS42LDIuMi04LjksNC43LTguOSw3LjUKCWMwLDcuNywyNS4xLDEzLjksNTYsMTMuOXM1Ni02LjIsNTYtMTMuOUMxNjcsMTgxLjMsMTYzLjcsMTc4LjcsMTU4LjEsMTc2LjZ6Ii8+CjxwYXRoIGNsYXNzPSJzdDIiIGQ9Ik0xMTEsMTg4LjdjMjMuNCwwLDQyLjgtNS4yLDQ3LjItMTIuMWMtMTAtMy44LTI3LjMtNi40LTQ3LjItNi40cy0zNy4yLDIuNi00Ny4yLDYuNAoJQzY4LjEsMTgzLjQsODcuNiwxODguNywxMTEsMTg4Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDMiIGQ9Ik0xNTAuNiwxNDEuMmMwLDAsMy44LTMuNywxMC4yLTguMWMxNi40LTExLjEsMTEuOS0yOC41LDcuOS00Mi42Yy0yLjgtMTAuMSwxMC44LTEyLjgsMTYsMTYuNAoJYzUuMiwyOC43LTI2LjYsNTEuMi0zNS4xLDUxLjIiLz4KPHBhdGggY2xhc3M9InN0NCIgZD0iTTE3NC41LDg1LjJjMy40LDguMiwxMS44LDMxLjEsMC4yLDQ1LjdjLTExLjUsMTQuNS0xOS40LDEzLjktMTkuNCwxMy45bDEuMSwxMS4xYzEyLjMtNi4zLDMyLjYtMjUuNiwyOC40LTQ5CglDMTgyLDkxLjUsMTc4LjMsODYuNCwxNzQuNSw4NS4yeiIvPgo8cGF0aCBjbGFzcz0ic3Q1IiBkPSJNMTUwLjYsMTQxLjJjMCwwLDMuOC0zLjcsMTAuMi04LjFjMTYuNC0xMS4xLDExLjktMjguNSw3LjktNDIuNmMtMi44LTEwLjEsMTAuOC0xMi44LDE2LDE2LjQKCWM1LjIsMjguNy0yNi42LDUxLjItMzUuMSw1MS4yIi8+CjxwYXRoIGNsYXNzPSJzdDYiIGQ9Ik0xNTguNCwxNDIuM2MwLDI5LjctMjEuNiw0Ni40LTQ4LjEsNDYuNFM2Mi4yLDE3Miw2Mi4yLDE0Mi4zczIxLjYtNzYuMSw0OC4xLTc2LjFTMTU4LjQsMTEyLjYsMTU4LjQsMTQyLjN6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xMTAuMyw2Ni4yYy0wLjMsMC0wLjYsMC0xLDAuMWMyMC43LDEuMSw0NS40LDQ3LjgsNDUuNCw3NC45YzAsMjcuNS0yMC43LDQyLjgtNDYuMiw0Mi44CgljLTkuNSwwLTE4LjItMC4xLTI1LjQtMi4zYzcuNyw0LjYsMTcsNywyNy4xLDdjMjYuNiwwLDQ4LjEtMTYuNyw0OC4xLTQ2LjRDMTU4LjQsMTEyLjYsMTM2LjksNjYuMiwxMTAuMyw2Ni4yeiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTQ3LjUsMTA2LjhsLTcuNiw2LjdjMCwwLDguNi0xLjgsOC45LTMuNEMxNDkuMiwxMDguNiwxNDcuNSwxMDYuOCwxNDcuNSwxMDYuOHoiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTE0OS41LDExMi40bC04LjgsNi43YzAsMCw5LjktMS44LDEwLjMtMy40QzE1MS40LDExNC4yLDE0OS41LDExMi40LDE0OS41LDExMi40eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTUxLjUsMTE4LjNsLTEwLjMsNy44YzAsMCwxMS42LTIuMSwxMi4xLTMuOUMxNTMuOCwxMjAuNCwxNTEuNSwxMTguMywxNTEuNSwxMTguM3oiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTE1MS4xLDE2My45bC0xMS02LjdjMCwwLDYuMywxMCw4LjEsOS44UzE1MS4xLDE2My45LDE1MS4xLDE2My45eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTU1LjksMTU4LjJsLTEyLjMtNGMwLDAsOC40LDguMywxMC4xLDcuN0MxNTUuNSwxNjEuMywxNTUuOSwxNTguMiwxNTUuOSwxNTguMnoiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTcxLjEsMTA2LjhsOSw2LjdjMCwwLTEwLjEtMS44LTEwLjUtMy40QzY5LjEsMTA4LjYsNzEuMSwxMDYuOCw3MS4xLDEwNi44eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjguOCwxMTIuNGwxMC40LDYuN2MwLDAtMTEuOC0xLjgtMTIuMy0zLjRTNjguOCwxMTIuNCw2OC44LDExMi40eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjYuNCwxMTguM2wxMi4yLDcuOGMwLDAtMTMuOC0yLjEtMTQuMy0zLjlDNjMuNywxMjAuNCw2Ni40LDExOC4zLDY2LjQsMTE4LjN6Ii8+CjxwYXRoIGNsYXNzPSJzdDgiIGQ9Ik0xMzEuOSwxMzQuOWMwLDE0LjQtOC4xLDI3LTIyLjgsMjdzLTIyLjgtMTIuNi0yMi44LTI3czguMS0zNC45LDIyLjgtMzQuOVMxMzEuOSwxMjAuNSwxMzEuOSwxMzQuOXoiLz4KPHBhdGggY2xhc3M9InN0OSIgZD0iTTE1Mi43LDQ4LjdjLTAuMiwyLjQtNC43LTAuNy02LjIsMUwxMTUsMzAuNWMwLjgtMi4yLDEuOS00LjMsMy4yLTYuM2M2LjYtMTAuOSwyMC45LTIxLjksMjguMS0xMy45CglDMTUxLjEsMTUuNiwxNTMuOCwzNC43LDE1Mi43LDQ4Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDEwIiBkPSJNMTQyLjcsMzkuMmMtMC4xLDAuOC0xMy4zLTctMTMuMy03YzAuMy0wLjcsMC42LTEuNCwxLjEtMi4xYzIuMi0zLjYsNi45LTkuMiw5LjQtNgoJQzE0MC41LDI1LDE0My4xLDM0LjUsMTQyLjcsMzkuMnoiLz4KPHBhdGggY2xhc3M9InN0MTEiIGQ9Ik0xNDYuNywxMWwtNy42LDYuN2MwLDAsOC42LTEuOCw4LjktMy40UzE0Ni43LDExLDE0Ni43LDExeiIvPgo8cGF0aCBjbGFzcz0ic3QxMiIgZD0iTTY3LjIsNDkuN2MwLjIsMi40LDQuNy0wLjcsNi4yLDFsMzEuNS0xOS4yYy0wLjgtMi4yLTEuOS00LjMtMy4yLTYuM0M5NS4xLDE0LjIsODAuOCwzLjIsNzMuNywxMS4yCglDNjguOCwxNi42LDY2LjEsMzUuNyw2Ny4yLDQ5Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik03Mi4xLDE0LjNsOSw2LjdjMCwwLTEwLjEtMS44LTEwLjUtMy40QzcwLjEsMTYuMSw3Mi4xLDE0LjMsNzIuMSwxNC4zeiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjksMjAuNWw2LjgsNC44YzAsMC03LjctMS4zLTgtMi40QzY3LjUsMjEuOCw2OSwyMC41LDY5LDIwLjV6Ii8+CjxwYXRoIGNsYXNzPSJzdDEzIiBkPSJNNjcuMiw0OS43YzAuMiwyLjQsNC43LTAuNyw2LjIsMWwzMS41LTE5LjJjLTAuOC0yLjItMS45LTQuMy0zLjItNi4zQzk1LjEsMTQuMiw4MC44LDMuMiw3My43LDExLjIKCUM2OC44LDE2LjYsNjYuMSwzNS43LDY3LjIsNDkuN3oiLz4KPHBhdGggY2xhc3M9InN0MTAiIGQ9Ik03Ny4xLDQwLjJjMC4xLDAuOCwxMy4zLTcsMTMuMy03Yy0wLjMtMC43LTAuNi0xLjQtMS4xLTIuMWMtMi4yLTMuNi02LjktOS4yLTkuNC02CglDNzkuMywyNiw3Ni44LDM1LjUsNzcuMSw0MC4yeiIvPgo8cGF0aCBjbGFzcz0ic3QxNCIgZD0iTTExMC4zLDQ3LjRjLTAuNiwyNi4yLTkuNSw0OC41LTIyLjksNTcuM0MxMDAuOCw5NS45LDExMC4zLDczLjYsMTEwLjMsNDcuNHoiLz4KPGc+Cgk8cGF0aCBjbGFzcz0ic3QxNSIgZD0iTTEyMi45LDEwNy40YzEuMiwxLjUsMi4zLDMuMSwzLjIsNC45YzkuNS0yLjUsMTcuMS03LjIsMjEuNC0xMy4xYy0wLjMtMC43LTAuNy0xLjMtMS0yCgkJQzE0MC4xLDEwMi4xLDEzMiwxMDUuNywxMjIuOSwxMDcuNEMxMjIuOSwxMDcuNCwxMjIuOSwxMDcuNCwxMjIuOSwxMDcuNHoiLz4KCTxwYXRoIGNsYXNzPSJzdDE1IiBkPSJNOTIuMiwxMTEuOWMxLTEuNywyLTMuMywzLjItNC43Yy04LjItMS44LTE1LjYtNS4xLTIxLjYtOS41Yy0wLjQsMC43LTAuNywxLjUtMS4xLDIuMgoJCUM3Ni45LDEwNS4xLDgzLjgsMTA5LjQsOTIuMiwxMTEuOXoiLz4KCTxwYXRoIGNsYXNzPSJzdDE2IiBkPSJNMTA5LjksMTA4LjdjLTUsMC05LjktMC41LTE0LjUtMS42bDAsMGMtMS4yLDEuNC0yLjMsMy0zLjIsNC43YzAsMCwwLDAsMCwwYzUuNCwxLjYsMTEuNCwyLjUsMTcuNywyLjUKCQljNS44LDAsMTEuMi0wLjcsMTYuMi0yLjFjMCwwLDAsMCwwLDBjLTEtMS43LTItMy40LTMuMi00LjlDMTE4LjgsMTA4LjMsMTE0LjQsMTA4LjcsMTA5LjksMTA4Ljd6Ii8+CjwvZz4KPHBhdGggY2xhc3M9InN0MTciIGQ9Ik0xMzEuOSwxMzQuOWMwLDE0LjQtOC4xLDI3LTIyLjgsMjdzLTIyLjgtMTIuNi0yMi44LTI3czguMS0zNC45LDIyLjgtMzQuOVMxMzEuOSwxMjAuNSwxMzEuOSwxMzQuOXoiLz4KPHBhdGggY2xhc3M9InN0MTgiIGQ9Ik0xNTAuMyw5NC4xYy0xLjIsMS4xLTIuNCwyLjEtMy44LDMuMWMwLjMsMC43LDAuNywxLjMsMSwyQzE0OC43LDk3LjYsMTQ5LjcsOTUuOCwxNTAuMyw5NC4xeiIvPgo8cGF0aCBjbGFzcz0ic3QxOSIgZD0iTTE1OC40LDE0Mi4zYzAsMjkuNy0yMS42LDQ2LjQtNDguMSw0Ni40UzYyLjIsMTcyLDYyLjIsMTQyLjNzMjEuNi03Ni4xLDQ4LjEtNzYuMVMxNTguNCwxMTIuNiwxNTguNCwxNDIuM3oiCgkvPgo8cGF0aCBjbGFzcz0ic3QyMCIgZD0iTTE0Ni4xLDYxLjljMC02LjQsMy4zLTEyLjEsOC40LTE1LjhjLTkuNC0xMS0yNS43LTE4LjMtNDQuMi0xOC4zYy0wLjYsMC0xLjIsMC0xLjksMGMxLjUsNS44LDIsMTIuNSwxLjksMTkuNQoJYzAsMjYuMi05LjUsNDguNS0yMi45LDU3LjNjNi45LDIuNiwxNC43LDQsMjIuOSw0YzIzLjQsMCw0My4zLTExLjcsNTAuMi0yNy45QzE1Mi4xLDc3LjgsMTQ2LjEsNzAuNSwxNDYuMSw2MS45eiIvPgo8cGF0aCBjbGFzcz0ic3QzIiBkPSJNMTEwLjMsNDcuNGMwLTYuOC0wLjctMTMuNC0xLjktMTkuNWMtMjguMywwLjctNTEsMTguNS01MSw0MC40YzAsMTYuMSwxMi4yLDI5LjksMjkuOSwzNi41CglDMTAwLjgsOTUuOSwxMDkuNyw3My42LDExMC4zLDQ3LjR6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xNDIuOCw3OS40YzAtNS43LTQuMy0xMC4zLTkuNS0xMC4zYy0zLjgsMC03LDIuNC04LjYsNS44YzguMywyLjMsMTMuOSw2LjYsMTMuOSwxMi40YzAsMC4zLDAsMC41LTAuMSwwLjgKCUMxNDEuMSw4Ni4yLDE0Mi44LDgzLDE0Mi44LDc5LjR6Ii8+CjxwYXRoIGNsYXNzPSJzdDMiIGQ9Ik0xMDguNSwyNy44YzEuMiw2LjEsMS45LDEyLjcsMS45LDE5LjVDMTEwLjUsNDAuNCwxMTAsMzMuNywxMDguNSwyNy44eiIvPgo8cGF0aCBjbGFzcz0ic3Q5IiBkPSJNMTU0LjUsNDYuMWMtNS4xLDMuNy04LjQsOS40LTguNCwxNS44YzAsOC42LDYsMTYsMTQuNCwxOWMxLjctNCwyLjYtOC4yLDIuNi0xMi42CglDMTYzLjEsNjAuMSwxNTkuOSw1Mi40LDE1NC41LDQ2LjF6Ii8+CjxwYXRoIGNsYXNzPSJzdDExIiBkPSJNNjEuOCw1My41bDksNi43YzAsMC0xMC4xLTEuOC0xMC41LTMuNEM1OS44LDU1LjQsNjEuOCw1My41LDYxLjgsNTMuNXoiLz4KPHBhdGggY2xhc3M9InN0MTEiIGQ9Ik01OS41LDU5LjJsMTAuNCw2LjdjMCwwLTExLjgtMS44LTEyLjMtMy40QzU3LjIsNjEsNTkuNSw1OS4yLDU5LjUsNTkuMnoiLz4KPGVsbGlwc2UgdHJhbnNmb3JtPSJtYXRyaXgoMC45OTE5IC0wLjEyNyAwLjEyNyAwLjk5MTkgLTYuMjU3MSAxMi41NjM4KSIgY2xhc3M9InN0MjEiIGN4PSI5NS40IiBjeT0iNTUuNCIgcng9IjEyLjMiIHJ5PSIxMC42Ii8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuOTkxOSAtMC4xMjcgMC4xMjcgMC45OTE5IC02LjQ1MDYgMTIuNjQ0NSkiIGNsYXNzPSJzdDIyIiBjeD0iOTUuOSIgY3k9IjU2LjkiIHJ4PSI4LjkiIHJ5PSI3LjciLz4KPGVsbGlwc2UgdHJhbnNmb3JtPSJtYXRyaXgoMC45OTE5IC0wLjEyNjcgMC4xMjY3IDAuOTkxOSAtNi40ODU2IDEyLjYxNDkpIiBjbGFzcz0ic3QyMSIgY3g9Ijk1LjkiIGN5PSI1Ny4zIiByeD0iMy40IiByeT0iMyIvPgo8bGluZSBjbGFzcz0ic3QyMyIgeDE9Ijg1LjkiIHkxPSI0Ni42IiB4Mj0iODIuNSIgeTI9IjQ1LjMiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSI4OC42IiB5MT0iNDQuMyIgeDI9Ijg0LjUiIHkyPSI0MS40Ii8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuMTI3IC0wLjk5MTkgMC45OTE5IDAuMTI3IDU2LjM3NjMgMTc0Ljc1OTUpIiBjbGFzcz0ic3QyMSIgY3g9IjEyNy41IiBjeT0iNTUuNCIgcng9IjEwLjYiIHJ5PSIxMi4zIi8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuMTI3IC0wLjk5MTkgMC45OTE5IDAuMTI3IDU0LjM2MjkgMTc1LjU4ODMpIiBjbGFzcz0ic3QyMiIgY3g9IjEyNi45IiBjeT0iNTYuOSIgcng9IjcuNyIgcnk9IjguOSIvPgo8ZWxsaXBzZSB0cmFuc2Zvcm09Im1hdHJpeCgwLjEyNjcgLTAuOTkxOSAwLjk5MTkgMC4xMjY3IDU0LjAxNTkgMTc1Ljk1MDUpIiBjbGFzcz0ic3QyMSIgY3g9IjEyNi45IiBjeT0iNTcuMyIgcng9IjMiIHJ5PSIzLjQiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSIxMzciIHkxPSI0Ni42IiB4Mj0iMTQwLjQiIHkyPSI0NS4zIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iMTM0LjMiIHkxPSI0NC4zIiB4Mj0iMTM4LjQiIHkyPSI0MS40Ii8+CjxwYXRoIGNsYXNzPSJzdDIyIiBkPSJNMTM4LjYsODcuM2MwLDguNy0xMi43LDE1LjctMjguNCwxNS43cy0yOC40LTctMjguNC0xNS43czEyLjctMTQuMiwyOC40LTE0LjJTMTM4LjYsNzguNiwxMzguNiw4Ny4zeiIvPgo8cGF0aCBjbGFzcz0ic3QyNCIgZD0iTTExMC4zLDEwMEMxMDAsMTAwLDkwLjQsOTcuNCw4MS44LDg3LjNjMC43LDEwLjYsMTMuNiwxNS4zLDI4LjIsMTUuM2MxNS43LDAsMjctNiwyOC40LTE1LjMKCUMxMzAuMyw5Ni4xLDEyNC45LDk5LjksMTEwLjMsMTAweiIvPgo8cGF0aCBjbGFzcz0ic3QyMyIgZD0iTTkxLjQsODYuM2MzLjQsNi42LDEwLjksMTEuMSwxOS42LDExYzguNC0wLjEsMTUuNi00LjUsMTguOS0xMC45Ii8+CjxwYXRoIGNsYXNzPSJzdDI1IiBkPSJNMTM4LjYsODcuM2MwLDguNy0xMi43LDE1LjctMjguNCwxNS43cy0yOC40LTctMjguNC0xNS43czEyLjctMTQuMiwyOC40LTE0LjJTMTM4LjYsNzguNiwxMzguNiw4Ny4zeiIvPgo8bGluZSBjbGFzcz0ic3QyNiIgeDE9IjExMC42IiB5MT0iNzkiIHgyPSIxMTAuNiIgeTI9Ijk3LjkiLz4KPHBhdGggY2xhc3M9InN0MjEiIGQ9Ik0xMTksNzRjMCw0LjYtOC4zLDcuNC04LjMsNy40cy04LjMtMi44LTguMy03LjRzMy43LTQuMSw4LjMtNC4xUzExOSw2OS40LDExOSw3NHoiLz4KPGVsbGlwc2UgY2xhc3M9InN0MjciIGN4PSIxMTAuNiIgY3k9IjczIiByeD0iNS40IiByeT0iMC45Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xMzguOCwxNzAuMmMwLDQuMS0xLjksMjEuNS0xMi4zLDIwLjJjLTUuNi0wLjctMTMuNy05LjUtMTAuMy0xMS44YzMuNi0yLjQtMy42LTE0LjksMS4yLTExLjgKCUMxMjIuMiwxNjkuOSwxMzguOCwxNjYuMSwxMzguOCwxNzAuMnoiLz4KPHBhdGggY2xhc3M9InN0MjIiIGQ9Ik0xMzMuMiwxODUuNmMwLDQuMS0zLjksNS41LTkuOSw1LjVzLTExLTMuMy0xMS03LjRzMi43LTcuNSw3LjktNC4zQzEyNS4yLDE4Mi41LDEzMy4yLDE4MS41LDEzMy4yLDE4NS42eiIvPgo8cGF0aCBjbGFzcz0ic3QyNCIgZD0iTTEyMi42LDE4Ny4yYy0zLjgtMS40LTcuMi0zLjYtOS45LTYuM2MtMC4zLDAuNy0wLjQsMS4zLTAuNCwyLjFjMCw0LjUsNS4zLDguMSwxMS44LDguMWMzLjEsMCw1LjktMC44LDgtMi4yCglDMTI5LDE4OC45LDEyNS44LDE4OC40LDEyMi42LDE4Ny4yeiIvPgo8cGF0aCBjbGFzcz0ic3QyOCIgZD0iTTExNy41LDE2Ni44YzAuMSwzLjIsMC41LDYuMywxLjIsOWMtMy44LDEuNC02LjMsNC4xLTYuMyw3LjJjMCw0LjUsNS4zLDguMSwxMS44LDguMWM1LjMsMCw5LjgtMi40LDExLjMtNS43CgljMi00LjgsNC0xMC45LDUuMi0xOC44Ii8+CjxwYXRoIGNsYXNzPSJzdDI5IiBkPSJNODEsMTcwLjJjMCw0LjEsMS45LDIxLjUsMTIuMywyMC4yYzUuNi0wLjcsMTMuNy05LjUsMTAuMy0xMS44Yy0zLjYtMi40LDIuMi0xNC45LTIuNi0xMS44CglDOTYuMiwxNjkuOSw4MSwxNjYuMSw4MSwxNzAuMnoiLz4KPHBhdGggY2xhc3M9InN0MjIiIGQ9Ik04Ni42LDE4NS42YzAsNC4xLDMuOSw1LjUsOS45LDUuNWM2LjEsMCwxMS0zLjMsMTEtNy40cy0yLjctNy41LTcuOS00LjNDOTQuNiwxODIuNSw4Ni42LDE4MS41LDg2LjYsMTg1LjZ6IgoJLz4KPHBhdGggY2xhc3M9InN0MjQiIGQ9Ik05OC4yLDE4Ny42YzMuOC0xLjYsNy00LDkuNi02LjhjMC4zLDAuNiwwLjUsMS4zLDAuNSwyYzAuMiw0LjUtNC45LDguNC0xMS40LDguN2MtMy4xLDAuMi02LTAuNS04LjEtMS44CglDOTEuOSwxODkuNiw5NS4xLDE4OC45LDk4LjIsMTg3LjZ6Ii8+CjxwYXRoIGNsYXNzPSJzdDI4IiBkPSJNMTAyLjQsMTY2LjhjLTAuMSwzLjItMC41LDYuMy0xLjIsOWMzLjgsMS40LDYuMyw0LjEsNi4zLDcuMmMwLDQuNS01LjMsOC4xLTExLjgsOC4xYy01LjMsMC05LjgtMi40LTExLjMtNS43CgljLTItNC44LTQtMTAuOS01LjItMTguOCIvPgo8Y2lyY2xlIGNsYXNzPSJzdDI0IiBjeD0iMTI3LjciIGN5PSI4MiIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSIxMjQuOSIgY3k9Ijc4LjYiIHI9IjEuNCIvPgo8Y2lyY2xlIGNsYXNzPSJzdDI0IiBjeD0iMTI0IiBjeT0iODMuNSIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5My45IiBjeT0iODIuMiIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5Ny43IiBjeT0iODMuNSIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5Ny4xIiBjeT0iNzkiIHI9IjEuNCIvPgo8bGluZSBjbGFzcz0ic3QyMyIgeDE9IjEyOC43IiB5MT0iODIiIHgyPSIxNDguOSIgeTI9IjgyLjMiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSIxMjUuOSIgeTE9Ijc4LjUiIHgyPSIxNDQuOSIgeTI9IjcxIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iOTMuMiIgeTE9IjgyIiB4Mj0iNzMiIHkyPSI4Mi4zIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iOTYiIHkxPSI3OC41IiB4Mj0iNzciIHkyPSI3MSIvPgo8Zz4KCTxnPgoJCTxjaXJjbGUgY2xhc3M9InN0MzAiIGN4PSIxOTIiIGN5PSIxNzguMiIgcj0iMzAuNCIvPgoJCTxwYXRoIGNsYXNzPSJzdDMwIiBkPSJNMTkyLDE0OC40YzE2LjUsMCwyOS45LDEzLjQsMjkuOSwyOS45cy0xMy40LDI5LjktMjkuOSwyOS45cy0yOS45LTEzLjQtMjkuOS0yOS45UzE3NS41LDE0OC40LDE5MiwxNDguNAoJCQkgTTE5MiwxNDcuM2MtMTcuMSwwLTMxLDEzLjktMzEsMzFzMTMuOSwzMSwzMSwzMXMzMS0xMy45LDMxLTMxUzIwOS4xLDE0Ny4zLDE5MiwxNDcuM0wxOTIsMTQ3LjN6Ii8+Cgk8L2c+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE2NS41LDE2Ny44Yy0wLjEsMC4yLDEzLjYtMTYuNiwzMi4zLTE3LjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTYzLjUsMTczLjljMCwwLDE0LjYtMjIuMSwzOS4xLTIyLjEiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTYzLjUsMTc3LjhjMCwwLDE1LjYtMjYuNSw0Mi44LTIzLjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA0LjcsMTU2YzAsMCwxMy41LDYuMiwxMy41LDM0LjQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAwLjcsMTU1LjVjMCwwLDE1LDQuNSwxNS42LDM3LjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk4LjksMTU3Yy0yLjQtMC45LDE3LjEsNSwxNC45LDM5LjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk0LjMsMTU3YzAsMCwyMi44LDguOCwxNi41LDQzLjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkzLjQsMTU4LjVjMCwwLTEzLjQsMjQuOC0xMyw0NS4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE5MS4yLDE1Ny42YzAsMC0xMy43LDI1LTEzLjQsNDUuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTUuMywxNjAuMWMwLDAtMTEuNiwyMS4yLTEyLjUsNDQuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTkuMiwxNjIuM2MwLDAtMTIuOCwyMy42LTExLjcsNDMuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTcuMiwxNjEuMmMwLDAtMTMuMSwyNC43LTExLjksNDQuNiIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDAuOSwxNjMuOGMwLDAtMTIuNiwyMy40LTEwLjksNDMuMSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDUuNCwxNjkuN2MtMC45LTAuMi0zLjEtMC42LTQtMC44Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTIwOC4xLDE3Ny44Yy0xLjktMC42LTcuMy0yLjUtOS4yLTMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjIsMTgwLjVjLTIuOC0wLjktOC40LTMtMTEuMy0zLjQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjgsMTgzYy0zLjYtMS4zLTguMS0yLjgtMTEuOS0zLjIiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjgsMTg1LjVjLTQuMS0xLjYtOS4zLTMuMS0xMy41LTMuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDkuOCwxODhjLTMuNy0yLjItMTAtMy0xNC41LTMuOSIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxOTcuMiIgeTE9IjE4Ni4zIiB4Mj0iMTk0LjMiIHkyPSIxODcuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTkuNywxODdjMCwwLTYuMiwzLjYtNywzLjYiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAzLjQsMTg3LjdjMCwwLTkuMyw1LjYtMTAuNiw1LjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA1LjUsMTg4LjNjMCwwLTEwLjMsNy4zLTEyLjgsNy4yIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE4Ni44LDE1OC44YzAsMCwwLjcsMS4xLDEuMSwxLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTgxLjksMTYyYzAsMCwxLjksMy4yLDMsMy44Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ny44LDE2NWMwLDAsMy45LDUuMyw1LDUuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuNCwxNjYuNmMwLDAsMy43LDQuNiw1LjYsNi4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Mi4zLDE2OS4zYzAsMCw2LjMsNi44LDguMSw3LjEiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTcxLjEsMTcxLjVjMCwwLDYuMyw2LjcsNy42LDcuNCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzIuMSwxNzYuM2MwLDAtNS4xLDAuNy01LjcsMC42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3NCwxNzguMmMwLDAtOCwxLjEtOS42LDEuMSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzguNywxODEuOGMwLDAtMTEuNywxLjUtMTQuMywyLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc3LjgsMTg0LjFjMCwwLTEwLjMsMS42LTEyLjIsMi4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ni45LDE4N2MwLDAtOC4zLDEuMy0xMC42LDEuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuOSwxODkuNmMwLDAtOSwyLjEtOS41LDEuNiIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuNCwxOTEuOGMwLDAtNy42LDIuNS04LjEsMi4yIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ni40LDE5NC40YzAsMC01LDIuMS02LDIuMSIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNzYuNCIgeTE9IjE5Ny4zIiB4Mj0iMTcyLjEiIHkyPSIxOTkuMiIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNjMuNSIgeTE9IjE4MS44IiB4Mj0iMTc2LjQiIHkyPSIxNzkuOSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTEuMSwxNDkuMmMwLDAtMTMuMywxLjYtMjMuNiwxMy42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTIwNy41LDE1NS41YzAsMCwxMi42LDkuNCwxMi41LDMwLjgiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc5LjgsMTYzLjhjMCwwLDIuOSwzLjIsMy42LDQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc0LjksMTY4LjVjMCwwLDQuMyw0LjYsNS40LDUuNCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xODMuMSwxNjAuN2MwLDAsMi41LDMsMywzLjIiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTg0LjksMTYwLjFjMCwwLDEuNCwyLDEuOSwyLjIiLz4KCTxsaW5lIGNsYXNzPSJzdDMxIiB4MT0iMTY4LjMiIHkxPSIxNzQuNSIgeDI9IjE3MS4xIiB5Mj0iMTczLjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk5LjcsMTcyLjljMCwwLDcuNSwyLDguNCwyLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAwLjIsMTcwLjdjMCwwLDUuOCwxLjQsNi4yLDEuNyIvPgoJPGVsbGlwc2UgY2xhc3M9InN0MzIiIGN4PSIyMDMuMiIgY3k9IjE2Ny4zIiByeD0iMC42IiByeT0iMC41Ii8+Cgk8ZWxsaXBzZSBjbGFzcz0ic3QzMiIgY3g9IjE4OSIgY3k9IjE1OCIgcng9IjAuOCIgcnk9IjAuNCIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNzQiIHkxPSIyMDAuNSIgeDI9IjE3NS44IiB5Mj0iMTk5LjgiLz4KCQoJCTxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuODE2OSAtMC41NzY3IDAuNTc2NyAwLjgxNjkgLTg0LjM2NTggMTM4LjcyNDIpIiBjbGFzcz0ic3QzMiIgY3g9IjE3Ni4zIiBjeT0iMjAyLjMiIHJ4PSIwLjkiIHJ5PSIwLjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkyLDE5OC4yYzAsMCwxMy44LTYuMywxNi04LjciLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkxLjUsMjAxLjZjMCwwLDE2LjEtNy4yLDE4LjMtMTAuOSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTEuNSwyMDQuMWMwLDAsMTcuMi04LjMsMTguMy0xMC42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE5MiwyMDUuOGMwLDAsMTYuNi02LjcsMTcuNy05LjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk0LjMsMjA3YzAsMCwxNC4yLTUuNSwxNC45LTYuOCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMTAuNywxNTZjMC0wLjIsNy41LDQuNiwxMC41LDIzLjMiLz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDIxIiBkPSJNMTkyLDE0OC40YzE2LjUsMCwyOS45LDEzLjQsMjkuOSwyOS45cy0xMy40LDI5LjktMjkuOSwyOS45cy0yOS45LTEzLjQtMjkuOS0yOS45UzE3NS41LDE0OC40LDE5MiwxNDguNAoJCQkgTTE5MiwxNDQuOGMtMTguNSwwLTMzLjUsMTUtMzMuNSwzMy41czE1LDMzLjUsMzMuNSwzMy41YzE4LjUsMCwzMy41LTE1LDMzLjUtMzMuNVMyMTAuNSwxNDQuOCwxOTIsMTQ0LjhMMTkyLDE0NC44eiIvPgoJPC9nPgo8L2c+Cjwvc3ZnPgo=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+                - pods
+                - podtemplates
+                - services
+                - endpoints
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - patch
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+                - clusterrolebindings
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+                - bind
+                - escalate
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - statefulsets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - apps
+              resourceNames:
+                - tigera-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.tigera.io
+              resources:
+                - '*'
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - patch
+                - delete
+                - watch
+            - apiGroups:
+                - scheduling.k8s.io
+              resources:
+                - priorityclasses
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - apiregistration.k8s.io
+              resources:
+                - apiservices
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks/status
+              verbs:
+                - get
+                - list
+                - update
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks
+                - infrastructures
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - hostnetwork
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - crd.projectcalico.org
+              resources:
+                - bgpconfigurations
+                - bgppeers
+                - felixconfigurations
+                - kubecontrollersconfigurations
+                - globalnetworkpolicies
+                - globalnetworksets
+                - hostendpoints
+                - ippools
+                - networkpolicies
+                - networksets
+              verbs:
+                - create
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+                - cronjobs
+              verbs:
+                - create
+                - update
+                - list
+                - watch
+          serviceAccountName: tigera-operator
+      deployments:
+        - name: tigera-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: tigera-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  k8s-app: tigera-operator
+                  name: tigera-operator
+              spec:
+                containers:
+                  - command:
+                      - operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: tigera-operator
+                      - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
+                        value: v1.5.3
+                    image: quay.io/tigera/operator@sha256:ebb3e42326062259b27a02bd72f91e78d510f18807dfefb29c6707d3357e6fdc
+                    imagePullPolicy: IfNotPresent
+                    name: tigera-operator
+                    resources: {}
+                dnsPolicy: ClusterFirstWithHostNet
+                hostNetwork: true
+                serviceAccountName: tigera-operator
+                tolerations:
+                  - effect: NoExecute
+                    operator: Exists
+                  - effect: NoSchedule
+                    operator: Exists
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - networking
+    - security
+    - monitoring
+  links:
+    - name: Calico Introduction
+      url: https://docs.projectcalico.org/introduction/
+    - name: Install an OpenShift v4 cluster with Calico
+      url: https://docs.projectcalico.org/archive/v3.14/getting-started/openshift/installation
+  maintainers:
+    - email: maintainers@tigera.io
+      name: Project Calico Maintainers
+  maturity: stable
+  provider:
+    name: Tigera
+  version: 1.5.3
+  replaces: tigera-operator.v1.5.2

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgpconfigurations.yaml
@@ -1,0 +1,85 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: BGPConfiguration contains the configuration for any BGP routing.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPConfigurationSpec contains the values of the BGP configuration.
+            properties:
+              asNumber:
+                description: 'ASNumber is the default AS number used by a node. [Default:
+                  64512]'
+                format: int32
+                type: integer
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: INFO]'
+                type: string
+              nodeToNodeMeshEnabled:
+                description: 'NodeToNodeMeshEnabled sets whether full node to node
+                  BGP mesh is enabled. [Default: true]'
+                type: boolean
+              serviceClusterIPs:
+                description: ServiceClusterIPs are the CIDR blocks from which service
+                  cluster IPs are allocated. If specified, Calico will advertise these
+                  blocks, as well as any cluster IPs within them.
+                items:
+                  description: ServiceClusterIPBlock represents a single whitelisted
+                    CIDR block for ClusterIPs.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+              serviceExternalIPs:
+                description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                  Service External IPs. Kubernetes Service ExternalIPs will only be
+                  advertised if they are within one of these blocks.
+                items:
+                  description: ServiceExternalIPBlock represents a single whitelisted
+                    CIDR External IP block.
+                  properties:
+                    cidr:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgpconfigurations.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,68 +13,69 @@ spec:
     plural: bgpconfigurations
     singular: bgpconfiguration
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        description: BGPConfiguration contains the configuration for any BGP routing.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BGPConfigurationSpec contains the values of the BGP configuration.
-            properties:
-              asNumber:
-                description: 'ASNumber is the default AS number used by a node. [Default:
-                  64512]'
-                format: int32
-                type: integer
-              logSeverityScreen:
-                description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: INFO]'
-                type: string
-              nodeToNodeMeshEnabled:
-                description: 'NodeToNodeMeshEnabled sets whether full node to node
-                  BGP mesh is enabled. [Default: true]'
-                type: boolean
-              serviceClusterIPs:
-                description: ServiceClusterIPs are the CIDR blocks from which service
-                  cluster IPs are allocated. If specified, Calico will advertise these
-                  blocks, as well as any cluster IPs within them.
-                items:
-                  description: ServiceClusterIPBlock represents a single whitelisted
-                    CIDR block for ClusterIPs.
-                  properties:
-                    cidr:
-                      type: string
-                  type: object
-                type: array
-              serviceExternalIPs:
-                description: ServiceExternalIPs are the CIDR blocks for Kubernetes
-                  Service External IPs. Kubernetes Service ExternalIPs will only be
-                  advertised if they are within one of these blocks.
-                items:
-                  description: ServiceExternalIPBlock represents a single whitelisted
-                    CIDR External IP block.
-                  properties:
-                    cidr:
-                      type: string
-                  type: object
-                type: array
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      description: BGPConfiguration contains the configuration for any BGP routing.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BGPConfigurationSpec contains the values of the BGP configuration.
+          properties:
+            asNumber:
+              description: 'ASNumber is the default AS number used by a node. [Default:
+                64512]'
+              format: int32
+              type: integer
+            logSeverityScreen:
+              description: 'LogSeverityScreen is the log severity above which logs
+                are sent to the stdout. [Default: INFO]'
+              type: string
+            nodeToNodeMeshEnabled:
+              description: 'NodeToNodeMeshEnabled sets whether full node to node
+                BGP mesh is enabled. [Default: true]'
+              type: boolean
+            serviceClusterIPs:
+              description: ServiceClusterIPs are the CIDR blocks from which service
+                cluster IPs are allocated. If specified, Calico will advertise these
+                blocks, as well as any cluster IPs within them.
+              items:
+                description: ServiceClusterIPBlock represents a single whitelisted
+                  CIDR block for ClusterIPs.
+                properties:
+                  cidr:
+                    type: string
+                type: object
+              type: array
+            serviceExternalIPs:
+              description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                Service External IPs. Kubernetes Service ExternalIPs will only be
+                advertised if they are within one of these blocks.
+              items:
+                description: ServiceExternalIPBlock represents a single whitelisted
+                  CIDR External IP block.
+                properties:
+                  cidr:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgppeers.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgppeers.yaml
@@ -1,0 +1,75 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: bgppeers.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    singular: bgppeer
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec contains the specification for a BGPPeer resource.
+            properties:
+              asNumber:
+                description: The AS Number of the peer.
+                format: int32
+                type: integer
+              node:
+                description: The node name identifying the Calico node instance that
+                  is peering with this peer. If this is not set, this represents a
+                  global peer, i.e. a peer that peers with every node in the deployment.
+                type: string
+              nodeSelector:
+                description: Selector for the nodes that should have this peering.  When
+                  this is set, the Node field must be empty.
+                type: string
+              peerIP:
+                description: The IP address of the peer.
+                type: string
+              peerSelector:
+                description: Selector for the remote nodes to peer with.  When this
+                  is set, the PeerIP and ASNumber fields must be empty.  For each
+                  peering between the local node and selected remote nodes, we configure
+                  an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                  and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                  remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
+                  or the global default if that is not set.
+                type: string
+            required:
+            - asNumber
+            - peerIP
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgppeers.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_bgppeers.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,58 +13,59 @@ spec:
     plural: bgppeers
     singular: bgppeer
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BGPPeerSpec contains the specification for a BGPPeer resource.
-            properties:
-              asNumber:
-                description: The AS Number of the peer.
-                format: int32
-                type: integer
-              node:
-                description: The node name identifying the Calico node instance that
-                  is peering with this peer. If this is not set, this represents a
-                  global peer, i.e. a peer that peers with every node in the deployment.
-                type: string
-              nodeSelector:
-                description: Selector for the nodes that should have this peering.  When
-                  this is set, the Node field must be empty.
-                type: string
-              peerIP:
-                description: The IP address of the peer.
-                type: string
-              peerSelector:
-                description: Selector for the remote nodes to peer with.  When this
-                  is set, the PeerIP and ASNumber fields must be empty.  For each
-                  peering between the local node and selected remote nodes, we configure
-                  an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
-                  and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
-                  remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
-                  or the global default if that is not set.
-                type: string
-            required:
-            - asNumber
-            - peerIP
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BGPPeerSpec contains the specification for a BGPPeer resource.
+          properties:
+            asNumber:
+              description: The AS Number of the peer.
+              format: int32
+              type: integer
+            node:
+              description: The node name identifying the Calico node instance that
+                is peering with this peer. If this is not set, this represents a
+                global peer, i.e. a peer that peers with every node in the deployment.
+              type: string
+            nodeSelector:
+              description: Selector for the nodes that should have this peering.  When
+                this is set, the Node field must be empty.
+              type: string
+            peerIP:
+              description: The IP address of the peer.
+              type: string
+            peerSelector:
+              description: Selector for the remote nodes to peer with.  When this
+                is set, the PeerIP and ASNumber fields must be empty.  For each
+                peering between the local node and selected remote nodes, we configure
+                an IPv4 peering if both ends have NodeBGPSpec.IPv4Address specified,
+                and an IPv6 peering if both ends have NodeBGPSpec.IPv6Address specified.  The
+                remote AS number comes from the remote node’s NodeBGPSpec.ASNumber,
+                or the global default if that is not set.
+              type: string
+          required:
+          - asNumber
+          - peerIP
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_blockaffinities.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_blockaffinities.yaml
@@ -1,0 +1,64 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BlockAffinity
+    listKind: BlockAffinityList
+    plural: blockaffinities
+    singular: blockaffinity
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BlockAffinitySpec contains the specification for a BlockAffinity
+              resource.
+            properties:
+              cidr:
+                type: string
+              deleted:
+                description: Deleted indicates that this block affinity is being deleted.
+                  This field is a string for compatibility with older releases that
+                  mistakenly treat this field as a string.
+                type: string
+              node:
+                type: string
+              state:
+                type: string
+            required:
+            - cidr
+            - deleted
+            - node
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_blockaffinities.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_blockaffinities.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,47 +13,48 @@ spec:
     plural: blockaffinities
     singular: blockaffinity
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BlockAffinitySpec contains the specification for a BlockAffinity
-              resource.
-            properties:
-              cidr:
-                type: string
-              deleted:
-                description: Deleted indicates that this block affinity is being deleted.
-                  This field is a string for compatibility with older releases that
-                  mistakenly treat this field as a string.
-                type: string
-              node:
-                type: string
-              state:
-                type: string
-            required:
-            - cidr
-            - deleted
-            - node
-            - state
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BlockAffinitySpec contains the specification for a BlockAffinity
+            resource.
+          properties:
+            cidr:
+              type: string
+            deleted:
+              description: Deleted indicates that this block affinity is being deleted.
+                This field is a string for compatibility with older releases that
+                mistakenly treat this field as a string.
+              type: string
+            node:
+              type: string
+            state:
+              type: string
+          required:
+          - cidr
+          - deleted
+          - node
+          - state
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_clusterinformations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_clusterinformations.yaml
@@ -1,0 +1,67 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInformation contains the cluster specific information.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInformationSpec contains the values of describing
+              the cluster.
+            properties:
+              calicoVersion:
+                description: CalicoVersion is the version of Calico that the cluster
+                  is running
+                type: string
+              clusterGUID:
+                description: ClusterGUID is the GUID of the cluster
+                type: string
+              clusterType:
+                description: ClusterType describes the type of the cluster
+                type: string
+              datastoreReady:
+                description: DatastoreReady is used during significant datastore migrations
+                  to signal to components such as Felix that it should wait before
+                  accessing the datastore.
+                type: boolean
+              variant:
+                description: Variant declares which variant of Calico should be active.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_clusterinformations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_clusterinformations.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,50 +13,51 @@ spec:
     plural: clusterinformations
     singular: clusterinformation
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ClusterInformation contains the cluster specific information.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterInformationSpec contains the values of describing
-              the cluster.
-            properties:
-              calicoVersion:
-                description: CalicoVersion is the version of Calico that the cluster
-                  is running
-                type: string
-              clusterGUID:
-                description: ClusterGUID is the GUID of the cluster
-                type: string
-              clusterType:
-                description: ClusterType describes the type of the cluster
-                type: string
-              datastoreReady:
-                description: DatastoreReady is used during significant datastore migrations
-                  to signal to components such as Felix that it should wait before
-                  accessing the datastore.
-                type: boolean
-              variant:
-                description: Variant declares which variant of Calico should be active.
-                type: string
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      description: ClusterInformation contains the cluster specific information.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ClusterInformationSpec contains the values of describing
+            the cluster.
+          properties:
+            calicoVersion:
+              description: CalicoVersion is the version of Calico that the cluster
+                is running
+              type: string
+            clusterGUID:
+              description: ClusterGUID is the GUID of the cluster
+              type: string
+            clusterType:
+              description: ClusterType describes the type of the cluster
+              type: string
+            datastoreReady:
+              description: DatastoreReady is used during significant datastore migrations
+                to signal to components such as Felix that it should wait before
+                accessing the datastore.
+              type: boolean
+            variant:
+              description: Variant declares which variant of Calico should be active.
+              type: string
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_felixconfigurations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_felixconfigurations.yaml
@@ -1,0 +1,514 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Felix Configuration contains the configuration for Felix.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FelixConfigurationSpec contains the values of the Felix configuration.
+            properties:
+              bpfConnectTimeLoadBalancingEnabled:
+                description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                  controls whether Felix installs the connection-time load balancer.  The
+                  connect-time load balancer is required for the host to be able to
+                  reach Kubernetes services and it improves the performance of pod-to-service
+                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  true]'
+                type: boolean
+              bpfDataIfacePattern:
+                description: 'BPFDataIfacePattern is a regular expression that controls
+                  which interfaces Felix should attach BPF programs to in order to
+                  catch traffic to/from the network.  This needs to match the interfaces
+                  that Calico workload traffic flows over as well as any interfaces
+                  that handle incoming traffic to nodeports and services from outside
+                  the cluster.  It should not match the workload interfaces (usually
+                  named cali...). [Default: ^(en.*|eth.*|tunl0$)]'
+                type: string
+              bpfDisableUnprivileged:
+                description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                  users cannot access Calico''s BPF maps and cannot insert their own
+                  BPF programs to interfere with Calico''s. [Default: true]'
+                type: boolean
+              bpfEnabled:
+                description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                  [Default: false]'
+                type: boolean
+              bpfExternalServiceMode:
+                description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                  from outside the cluster to services (node ports and cluster IPs)
+                  are forwarded to remote workloads.  If set to "Tunnel" then both
+                  request and response traffic is tunneled to the remote node.  If
+                  set to "DSR", the request traffic is tunneled but the response traffic
+                  is sent directly from the remote node.  In "DSR" mode, the remote
+                  node appears to use the IP of the ingress node; this requires a
+                  permissive L2 network.  [Default: Tunnel]'
+                type: string
+              bpfKubeProxyEndpointSlicesEnabled:
+                description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                  whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                type: boolean
+              bpfKubeProxyIptablesCleanupEnabled:
+                description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                  true]'
+                type: boolean
+              bpfKubeProxyMinSyncPeriod:
+                description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                  minimum time between updates to the dataplane for Felix''s embedded
+                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfLogLevel:
+                description: 'BPFLogLevel controls the log level of the BPF programs
+                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                  logs are emitted to the BPF trace pipe, accessible with the command
+                  `tc exec bpf debug`. [Default: Off].'
+                type: string
+              chainInsertMode:
+                description: 'ChainInsertMode controls whether Felix hooks the kernel’s
+                  top-level iptables chains by inserting a rule at the top of the
+                  chain or by appending a rule at the bottom. insert is the safe default
+                  since it prevents Calico’s rules from being bypassed. If you switch
+                  to append mode, be sure that the other rules in the chains signal
+                  acceptance by falling through to the Calico rules, otherwise the
+                  Calico policy will be bypassed. [Default: insert]'
+                type: string
+              dataplaneDriver:
+                type: string
+              debugDisableLogDropping:
+                type: boolean
+              debugMemoryProfilePath:
+                type: string
+              debugSimulateCalcGraphHangAfter:
+                type: string
+              debugSimulateDataplaneHangAfter:
+                type: string
+              defaultEndpointToHostAction:
+                description: 'DefaultEndpointToHostAction controls what happens to
+                  traffic that goes from a workload endpoint to the host itself (after
+                  the traffic hits the endpoint egress policy). By default Calico
+                  blocks traffic from workload endpoints to the host itself with an
+                  iptables “DROP” action. If you want to allow some or all traffic
+                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                  RETURN if you have your own rules in the iptables “INPUT” chain;
+                  Calico will insert its rules at the top of that chain, then “RETURN”
+                  packets to the “INPUT” chain once it has completed processing workload
+                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                  from workloads after processing workload endpoint egress policy.
+                  [Default: Drop]'
+                type: string
+              deviceRouteProtocol:
+                description: This defines the route protocol added to programmed device
+                  routes, by default this will be RTPROT_BOOT when left blank.
+                type: integer
+              deviceRouteSourceAddress:
+                description: This is the source address to use on programmed device
+                  routes. By default the source address is left blank, leaving the
+                  kernel to choose the source address used.
+                type: string
+              disableConntrackInvalidCheck:
+                type: boolean
+              endpointReportingDelay:
+                type: string
+              endpointReportingEnabled:
+                type: boolean
+              externalNodesList:
+                description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                  which may source tunnel traffic and have the tunneled traffic be
+                  accepted at calico nodes.
+                items:
+                  type: string
+                type: array
+              failsafeInboundHostPorts:
+                description: 'FailsafeInboundHostPorts is a comma-delimited list of
+                  UDP/TCP ports that Felix will allow incoming traffic to host endpoints
+                  on irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. Each
+                  port should be specified as tcp:<port-number> or udp:<port-number>.
+                  For back-compatibility, if the protocol is not specified, it defaults
+                  to “tcp”. To disable all inbound host ports, use the value none.
+                  The default value allows ssh access and DHCP. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                items:
+                  description: ProtoPort is combination of protocol and port, both
+                    must be specified.
+                  properties:
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              failsafeOutboundHostPorts:
+                description: 'FailsafeOutboundHostPorts is a comma-delimited list
+                  of UDP/TCP ports that Felix will allow outgoing traffic from host
+                  endpoints to irrespective of the security policy. This is useful
+                  to avoid accidentally cutting off a host with incorrect configuration.
+                  Each port should be specified as tcp:<port-number> or udp:<port-number>.
+                  For back-compatibility, if the protocol is not specified, it defaults
+                  to “tcp”. To disable all outbound host ports, use the value none.
+                  The default value opens etcd’s standard ports to ensure that Felix
+                  does not get cut off from etcd as well as allowing DHCP and DNS.
+                  [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667,
+                  udp:53, udp:67]'
+                items:
+                  description: ProtoPort is combination of protocol and port, both
+                    must be specified.
+                  properties:
+                    port:
+                      type: integer
+                    protocol:
+                      type: string
+                  required:
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              genericXDPEnabled:
+                description: 'GenericXDPEnabled enables Generic XDP so network cards
+                  that don''t support XDP offload or driver modes can use XDP. This
+                  is not recommended since it doesn''t provide better performance
+                  than iptables. [Default: false]'
+                type: boolean
+              healthEnabled:
+                type: boolean
+              healthHost:
+                type: string
+              healthPort:
+                type: integer
+              interfaceExclude:
+                description: 'InterfaceExclude is a comma-separated list of interfaces
+                  that Felix should exclude when monitoring for host endpoints. The
+                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                  interface, which is used internally by kube-proxy. If you want to
+                  exclude multiple interface names using a single value, the list
+                  supports regular expressions. For regular expressions you must wrap
+                  the value with ''/''. For example having values ''/^kube/,veth1''
+                  will exclude all interfaces that begin with ''kube'' and also the
+                  interface ''veth1''. [Default: kube-ipvs0]'
+                type: string
+              interfacePrefix:
+                description: 'InterfacePrefix is the interface name prefix that identifies
+                  workload endpoints and so distinguishes them from host endpoint
+                  interfaces. Note: in environments other than bare metal, the orchestrators
+                  configure this appropriately. For example our Kubernetes and Docker
+                  integrations set the ‘cali’ value, and our OpenStack integration
+                  sets the ‘tap’ value. [Default: cali]'
+                type: string
+              ipipEnabled:
+                type: boolean
+              ipipMTU:
+                description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              ipsetsRefreshInterval:
+                description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                  all iptables state to ensure that no other process has accidentally
+                  broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
+                  90s]'
+                type: string
+              iptablesBackend:
+                description: IptablesBackend specifies which backend of iptables will
+                  be used. The default is legacy.
+                type: string
+              iptablesFilterAllowAction:
+                type: string
+              iptablesLockFilePath:
+                description: 'IptablesLockFilePath is the location of the iptables
+                  lock file. You may need to change this if the lock file is not in
+                  its standard location (for example if you have mapped it into Felix’s
+                  container at a different path). [Default: /run/xtables.lock]'
+                type: string
+              iptablesLockProbeInterval:
+                description: 'IptablesLockProbeInterval is the time that Felix will
+                  wait between attempts to acquire the iptables lock if it is not
+                  available. Lower values make Felix more responsive when the lock
+                  is contended, but use more CPU. [Default: 50ms]'
+                type: string
+              iptablesLockTimeout:
+                description: 'IptablesLockTimeout is the time that Felix will wait
+                  for the iptables lock, or 0, to disable. To use this feature, Felix
+                  must share the iptables lock file with all other processes that
+                  also take the lock. When running Felix inside a container, this
+                  requires the /run directory of the host to be mounted into the calico/node
+                  or calico/felix container. [Default: 0s disabled]'
+                type: string
+              iptablesMangleAllowAction:
+                type: string
+              iptablesMarkMask:
+                description: 'IptablesMarkMask is the mask that Felix selects its
+                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                  at least 8 bits set, none of which clash with any other mark bits
+                  in use on the system. [Default: 0xff000000]'
+                format: int32
+                type: integer
+              iptablesNATOutgoingInterfaceFilter:
+                type: string
+              iptablesPostWriteCheckInterval:
+                description: 'IptablesPostWriteCheckInterval is the period after Felix
+                  has done a write to the dataplane that it schedules an extra read
+                  back in order to check the write was not clobbered by another process.
+                  This should only occur if another application on the system doesn’t
+                  respect the iptables lock. [Default: 1s]'
+                type: string
+              iptablesRefreshInterval:
+                description: 'IptablesRefreshInterval is the period at which Felix
+                  re-checks the IP sets in the dataplane to ensure that no other process
+                  has accidentally broken Calico’s rules. Set to 0 to disable IP sets
+                  refresh. Note: the default for this value is lower than the other
+                  refresh intervals as a workaround for a Linux kernel bug that was
+                  fixed in kernel version 4.11. If you are using v4.11 or greater
+                  you may want to set this to, a higher value to reduce Felix CPU
+                  usage. [Default: 10s]'
+                type: string
+              ipv6Support:
+                type: boolean
+              kubeNodePortRanges:
+                description: 'KubeNodePortRanges holds list of port ranges used for
+                  service node ports. Only used if felix detects kube-proxy running
+                  in ipvs mode. Felix uses these ranges to separate host and workload
+                  traffic. [Default: 30000:32767].'
+                items:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                type: array
+              logFilePath:
+                description: 'LogFilePath is the full path to the Felix log. Set to
+                  none to disable file logging. [Default: /var/log/calico/felix.log]'
+                type: string
+              logPrefix:
+                description: 'LogPrefix is the log prefix that Felix uses when rendering
+                  LOG rules. [Default: calico-packet]'
+                type: string
+              logSeverityFile:
+                description: 'LogSeverityFile is the log severity above which logs
+                  are sent to the log file. [Default: Info]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+              logSeveritySys:
+                description: 'LogSeveritySys is the log severity above which logs
+                  are sent to the syslog. Set to None for no logging to syslog. [Default:
+                  Info]'
+                type: string
+              maxIpsetSize:
+                type: integer
+              metadataAddr:
+                description: 'MetadataAddr is the IP address or domain name of the
+                  server that can answer VM queries for cloud-init metadata. In OpenStack,
+                  this corresponds to the machine running nova-api (or in Ubuntu,
+                  nova-api-metadata). A value of none (case insensitive) means that
+                  Felix should not set up any NAT rule for the metadata path. [Default:
+                  127.0.0.1]'
+                type: string
+              metadataPort:
+                description: 'MetadataPort is the port of the metadata server. This,
+                  combined with global.MetadataAddr (if not ‘None’), is used to set
+                  up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  In most cases this should not need to be changed [Default: 8775].'
+                type: integer
+              natOutgoingAddress:
+                description: NATOutgoingAddress specifies an address to use when performing
+                  source NAT for traffic in a natOutgoing pool that is leaving the
+                  network. By default the address used is an address on the interface
+                  the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                type: string
+              natPortRange:
+                anyOf:
+                - type: integer
+                - type: string
+                description: NATPortRange specifies the range of ports that is used
+                  for port mapping when doing outgoing NAT. When unset the default
+                  behavior of the network stack is used.
+                pattern: ^.*
+                x-kubernetes-int-or-string: true
+              netlinkTimeout:
+                type: string
+              openstackRegion:
+                description: 'OpenstackRegion is the name of the region that a particular
+                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                  this must be configured somehow for each Felix (here in the datamodel,
+                  or in felix.cfg or the environment on each compute node), and must
+                  match the [calico] openstack_region value configured in neutron.conf
+                  on each node. [Default: Empty]'
+                type: string
+              policySyncPathPrefix:
+                description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                  policy changes to external services, like Application layer policy.
+                  [Default: Empty]'
+                type: string
+              prometheusGoMetricsEnabled:
+                description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              prometheusMetricsEnabled:
+                description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                  server in Felix if set to true. [Default: false]'
+                type: boolean
+              prometheusMetricsHost:
+                description: 'PrometheusMetricsHost is the host that the Prometheus
+                  metrics server should bind to. [Default: empty]'
+                type: string
+              prometheusMetricsPort:
+                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. [Default: 9091]'
+                type: integer
+              prometheusProcessMetricsEnabled:
+                description: 'PrometheusProcessMetricsEnabled disables process metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                type: boolean
+              removeExternalRoutes:
+                description: Whether or not to remove device routes that have not
+                  been programmed by Felix. Disabling this will allow external applications
+                  to also add device routes. This is enabled by default which means
+                  we will remove externally added routes.
+                type: boolean
+              reportingInterval:
+                description: 'ReportingInterval is the interval at which Felix reports
+                  its status into the datastore or 0 to disable. Must be non-zero
+                  in OpenStack deployments. [Default: 30s]'
+                type: string
+              reportingTTL:
+                description: 'ReportingTTL is the time-to-live setting for process-wide
+                  status reports. [Default: 90s]'
+                type: string
+              routeRefreshInterval:
+                description: 'RouterefreshInterval is the period at which Felix re-checks
+                  the routes in the dataplane to ensure that no other process has
+                  accidentally broken Calico’s rules. Set to 0 to disable route refresh.
+                  [Default: 90s]'
+                type: string
+              routeSource:
+                description: 'RouteSource configures where Felix gets its routing
+                  information. - WorkloadIPs: use workload endpoints to construct
+                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                type: string
+              routeTableRange:
+                description: Calico programs additional Linux route tables for various
+                  purposes.  RouteTableRange specifies the indices of the route tables
+                  that Calico should use.
+                properties:
+                  max:
+                    type: integer
+                  min:
+                    type: integer
+                required:
+                - max
+                - min
+                type: object
+              sidecarAccelerationEnabled:
+                description: 'SidecarAccelerationEnabled enables experimental sidecar
+                  acceleration [Default: false]'
+                type: boolean
+              usageReportingEnabled:
+                description: 'UsageReportingEnabled reports anonymous Calico version
+                  number and cluster size to projectcalico.org. Logs warnings returned
+                  by the usage server. For example, if a significant security vulnerability
+                  has been discovered in the version of Calico being used. [Default:
+                  true]'
+                type: boolean
+              usageReportingInitialDelay:
+                description: 'UsageReportingInitialDelay controls the minimum delay
+                  before Felix makes a report. [Default: 300s]'
+                type: string
+              usageReportingInterval:
+                description: 'UsageReportingInterval controls the interval at which
+                  Felix makes reports. [Default: 86400s]'
+                type: string
+              useInternalDataplaneDriver:
+                type: boolean
+              vxlanEnabled:
+                type: boolean
+              vxlanMTU:
+                description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                type: integer
+              vxlanPort:
+                type: integer
+              vxlanVNI:
+                type: integer
+              wireguardEnabled:
+                description: 'WireguardEnabled controls whether Wireguard is enabled.
+                  [Default: false]'
+                type: boolean
+              wireguardInterfaceName:
+                description: 'WireguardInterfaceName specifies the name to use for
+                  the Wireguard interface. [Default: wg.calico]'
+                type: string
+              wireguardListeningPort:
+                description: 'WireguardListeningPort controls the listening port used
+                  by Wireguard. [Default: 51820]'
+                type: integer
+              wireguardMTU:
+                description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                  See Configuring MTU [Default: 1420]'
+                type: integer
+              wireguardRoutingRulePriority:
+                description: 'WireguardRoutingRulePriority controls the priority value
+                  to use for the Wireguard routing rule. [Default: 99]'
+                type: integer
+              xdpEnabled:
+                description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                  incoming deny rules. [Default: true]'
+                type: boolean
+              xdpRefreshInterval:
+                description: 'XDPRefreshInterval is the period at which Felix re-checks
+                  all XDP state to ensure that no other process has accidentally broken
+                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                  refresh. [Default: 90s]'
+                type: string
+            required:
+            - bpfLogLevel
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_felixconfigurations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_felixconfigurations.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,497 +13,498 @@ spec:
     plural: felixconfigurations
     singular: felixconfiguration
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Felix Configuration contains the configuration for Felix.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: FelixConfigurationSpec contains the values of the Felix configuration.
-            properties:
-              bpfConnectTimeLoadBalancingEnabled:
-                description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
-                  controls whether Felix installs the connection-time load balancer.  The
-                  connect-time load balancer is required for the host to be able to
-                  reach Kubernetes services and it improves the performance of pod-to-service
-                  connections.  The only reason to disable it is for debugging purposes.  [Default:
-                  true]'
-                type: boolean
-              bpfDataIfacePattern:
-                description: 'BPFDataIfacePattern is a regular expression that controls
-                  which interfaces Felix should attach BPF programs to in order to
-                  catch traffic to/from the network.  This needs to match the interfaces
-                  that Calico workload traffic flows over as well as any interfaces
-                  that handle incoming traffic to nodeports and services from outside
-                  the cluster.  It should not match the workload interfaces (usually
-                  named cali...). [Default: ^(en.*|eth.*|tunl0$)]'
+    served: true
+    storage: true
+  validation:
+    openAPIV3Schema:
+      description: Felix Configuration contains the configuration for Felix.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FelixConfigurationSpec contains the values of the Felix configuration.
+          properties:
+            bpfConnectTimeLoadBalancingEnabled:
+              description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                controls whether Felix installs the connection-time load balancer.  The
+                connect-time load balancer is required for the host to be able to
+                reach Kubernetes services and it improves the performance of pod-to-service
+                connections.  The only reason to disable it is for debugging purposes.  [Default:
+                true]'
+              type: boolean
+            bpfDataIfacePattern:
+              description: 'BPFDataIfacePattern is a regular expression that controls
+                which interfaces Felix should attach BPF programs to in order to
+                catch traffic to/from the network.  This needs to match the interfaces
+                that Calico workload traffic flows over as well as any interfaces
+                that handle incoming traffic to nodeports and services from outside
+                the cluster.  It should not match the workload interfaces (usually
+                named cali...). [Default: ^(en.*|eth.*|tunl0$)]'
+              type: string
+            bpfDisableUnprivileged:
+              description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                users cannot access Calico''s BPF maps and cannot insert their own
+                BPF programs to interfere with Calico''s. [Default: true]'
+              type: boolean
+            bpfEnabled:
+              description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                [Default: false]'
+              type: boolean
+            bpfExternalServiceMode:
+              description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                from outside the cluster to services (node ports and cluster IPs)
+                are forwarded to remote workloads.  If set to "Tunnel" then both
+                request and response traffic is tunneled to the remote node.  If
+                set to "DSR", the request traffic is tunneled but the response traffic
+                is sent directly from the remote node.  In "DSR" mode, the remote
+                node appears to use the IP of the ingress node; this requires a
+                permissive L2 network.  [Default: Tunnel]'
+              type: string
+            bpfKubeProxyEndpointSlicesEnabled:
+              description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+              type: boolean
+            bpfKubeProxyIptablesCleanupEnabled:
+              description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                true]'
+              type: boolean
+            bpfKubeProxyMinSyncPeriod:
+              description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                minimum time between updates to the dataplane for Felix''s embedded
+                kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+              type: string
+            bpfLogLevel:
+              description: 'BPFLogLevel controls the log level of the BPF programs
+                when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                logs are emitted to the BPF trace pipe, accessible with the command
+                `tc exec bpf debug`. [Default: Off].'
+              type: string
+            chainInsertMode:
+              description: 'ChainInsertMode controls whether Felix hooks the kernel’s
+                top-level iptables chains by inserting a rule at the top of the
+                chain or by appending a rule at the bottom. insert is the safe default
+                since it prevents Calico’s rules from being bypassed. If you switch
+                to append mode, be sure that the other rules in the chains signal
+                acceptance by falling through to the Calico rules, otherwise the
+                Calico policy will be bypassed. [Default: insert]'
+              type: string
+            dataplaneDriver:
+              type: string
+            debugDisableLogDropping:
+              type: boolean
+            debugMemoryProfilePath:
+              type: string
+            debugSimulateCalcGraphHangAfter:
+              type: string
+            debugSimulateDataplaneHangAfter:
+              type: string
+            defaultEndpointToHostAction:
+              description: 'DefaultEndpointToHostAction controls what happens to
+                traffic that goes from a workload endpoint to the host itself (after
+                the traffic hits the endpoint egress policy). By default Calico
+                blocks traffic from workload endpoints to the host itself with an
+                iptables “DROP” action. If you want to allow some or all traffic
+                from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                RETURN if you have your own rules in the iptables “INPUT” chain;
+                Calico will insert its rules at the top of that chain, then “RETURN”
+                packets to the “INPUT” chain once it has completed processing workload
+                endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                from workloads after processing workload endpoint egress policy.
+                [Default: Drop]'
+              type: string
+            deviceRouteProtocol:
+              description: This defines the route protocol added to programmed device
+                routes, by default this will be RTPROT_BOOT when left blank.
+              type: integer
+            deviceRouteSourceAddress:
+              description: This is the source address to use on programmed device
+                routes. By default the source address is left blank, leaving the
+                kernel to choose the source address used.
+              type: string
+            disableConntrackInvalidCheck:
+              type: boolean
+            endpointReportingDelay:
+              type: string
+            endpointReportingEnabled:
+              type: boolean
+            externalNodesList:
+              description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                which may source tunnel traffic and have the tunneled traffic be
+                accepted at calico nodes.
+              items:
                 type: string
-              bpfDisableUnprivileged:
-                description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
-                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
-                  users cannot access Calico''s BPF maps and cannot insert their own
-                  BPF programs to interfere with Calico''s. [Default: true]'
-                type: boolean
-              bpfEnabled:
-                description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
-                  [Default: false]'
-                type: boolean
-              bpfExternalServiceMode:
-                description: 'BPFExternalServiceMode in BPF mode, controls how connections
-                  from outside the cluster to services (node ports and cluster IPs)
-                  are forwarded to remote workloads.  If set to "Tunnel" then both
-                  request and response traffic is tunneled to the remote node.  If
-                  set to "DSR", the request traffic is tunneled but the response traffic
-                  is sent directly from the remote node.  In "DSR" mode, the remote
-                  node appears to use the IP of the ingress node; this requires a
-                  permissive L2 network.  [Default: Tunnel]'
-                type: string
-              bpfKubeProxyEndpointSlicesEnabled:
-                description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
-                  whether Felix's embedded kube-proxy accepts EndpointSlices or not.
-                type: boolean
-              bpfKubeProxyIptablesCleanupEnabled:
-                description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
-                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
-                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
-                  true]'
-                type: boolean
-              bpfKubeProxyMinSyncPeriod:
-                description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
-                  minimum time between updates to the dataplane for Felix''s embedded
-                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
-                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
-                type: string
-              bpfLogLevel:
-                description: 'BPFLogLevel controls the log level of the BPF programs
-                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
-                  logs are emitted to the BPF trace pipe, accessible with the command
-                  `tc exec bpf debug`. [Default: Off].'
-                type: string
-              chainInsertMode:
-                description: 'ChainInsertMode controls whether Felix hooks the kernel’s
-                  top-level iptables chains by inserting a rule at the top of the
-                  chain or by appending a rule at the bottom. insert is the safe default
-                  since it prevents Calico’s rules from being bypassed. If you switch
-                  to append mode, be sure that the other rules in the chains signal
-                  acceptance by falling through to the Calico rules, otherwise the
-                  Calico policy will be bypassed. [Default: insert]'
-                type: string
-              dataplaneDriver:
-                type: string
-              debugDisableLogDropping:
-                type: boolean
-              debugMemoryProfilePath:
-                type: string
-              debugSimulateCalcGraphHangAfter:
-                type: string
-              debugSimulateDataplaneHangAfter:
-                type: string
-              defaultEndpointToHostAction:
-                description: 'DefaultEndpointToHostAction controls what happens to
-                  traffic that goes from a workload endpoint to the host itself (after
-                  the traffic hits the endpoint egress policy). By default Calico
-                  blocks traffic from workload endpoints to the host itself with an
-                  iptables “DROP” action. If you want to allow some or all traffic
-                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
-                  RETURN if you have your own rules in the iptables “INPUT” chain;
-                  Calico will insert its rules at the top of that chain, then “RETURN”
-                  packets to the “INPUT” chain once it has completed processing workload
-                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
-                  from workloads after processing workload endpoint egress policy.
-                  [Default: Drop]'
-                type: string
-              deviceRouteProtocol:
-                description: This defines the route protocol added to programmed device
-                  routes, by default this will be RTPROT_BOOT when left blank.
-                type: integer
-              deviceRouteSourceAddress:
-                description: This is the source address to use on programmed device
-                  routes. By default the source address is left blank, leaving the
-                  kernel to choose the source address used.
-                type: string
-              disableConntrackInvalidCheck:
-                type: boolean
-              endpointReportingDelay:
-                type: string
-              endpointReportingEnabled:
-                type: boolean
-              externalNodesList:
-                description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
-                  which may source tunnel traffic and have the tunneled traffic be
-                  accepted at calico nodes.
-                items:
-                  type: string
-                type: array
-              failsafeInboundHostPorts:
-                description: 'FailsafeInboundHostPorts is a comma-delimited list of
-                  UDP/TCP ports that Felix will allow incoming traffic to host endpoints
-                  on irrespective of the security policy. This is useful to avoid
-                  accidentally cutting off a host with incorrect configuration. Each
-                  port should be specified as tcp:<port-number> or udp:<port-number>.
-                  For back-compatibility, if the protocol is not specified, it defaults
-                  to “tcp”. To disable all inbound host ports, use the value none.
-                  The default value allows ssh access and DHCP. [Default: tcp:22,
-                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
-                items:
-                  description: ProtoPort is combination of protocol and port, both
-                    must be specified.
-                  properties:
-                    port:
-                      type: integer
-                    protocol:
-                      type: string
-                  required:
-                  - port
-                  - protocol
-                  type: object
-                type: array
-              failsafeOutboundHostPorts:
-                description: 'FailsafeOutboundHostPorts is a comma-delimited list
-                  of UDP/TCP ports that Felix will allow outgoing traffic from host
-                  endpoints to irrespective of the security policy. This is useful
-                  to avoid accidentally cutting off a host with incorrect configuration.
-                  Each port should be specified as tcp:<port-number> or udp:<port-number>.
-                  For back-compatibility, if the protocol is not specified, it defaults
-                  to “tcp”. To disable all outbound host ports, use the value none.
-                  The default value opens etcd’s standard ports to ensure that Felix
-                  does not get cut off from etcd as well as allowing DHCP and DNS.
-                  [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667,
-                  udp:53, udp:67]'
-                items:
-                  description: ProtoPort is combination of protocol and port, both
-                    must be specified.
-                  properties:
-                    port:
-                      type: integer
-                    protocol:
-                      type: string
-                  required:
-                  - port
-                  - protocol
-                  type: object
-                type: array
-              genericXDPEnabled:
-                description: 'GenericXDPEnabled enables Generic XDP so network cards
-                  that don''t support XDP offload or driver modes can use XDP. This
-                  is not recommended since it doesn''t provide better performance
-                  than iptables. [Default: false]'
-                type: boolean
-              healthEnabled:
-                type: boolean
-              healthHost:
-                type: string
-              healthPort:
-                type: integer
-              interfaceExclude:
-                description: 'InterfaceExclude is a comma-separated list of interfaces
-                  that Felix should exclude when monitoring for host endpoints. The
-                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
-                  interface, which is used internally by kube-proxy. If you want to
-                  exclude multiple interface names using a single value, the list
-                  supports regular expressions. For regular expressions you must wrap
-                  the value with ''/''. For example having values ''/^kube/,veth1''
-                  will exclude all interfaces that begin with ''kube'' and also the
-                  interface ''veth1''. [Default: kube-ipvs0]'
-                type: string
-              interfacePrefix:
-                description: 'InterfacePrefix is the interface name prefix that identifies
-                  workload endpoints and so distinguishes them from host endpoint
-                  interfaces. Note: in environments other than bare metal, the orchestrators
-                  configure this appropriately. For example our Kubernetes and Docker
-                  integrations set the ‘cali’ value, and our OpenStack integration
-                  sets the ‘tap’ value. [Default: cali]'
-                type: string
-              ipipEnabled:
-                type: boolean
-              ipipMTU:
-                description: 'IPIPMTU is the MTU to set on the tunnel device. See
-                  Configuring MTU [Default: 1440]'
-                type: integer
-              ipsetsRefreshInterval:
-                description: 'IpsetsRefreshInterval is the period at which Felix re-checks
-                  all iptables state to ensure that no other process has accidentally
-                  broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
-                  90s]'
-                type: string
-              iptablesBackend:
-                description: IptablesBackend specifies which backend of iptables will
-                  be used. The default is legacy.
-                type: string
-              iptablesFilterAllowAction:
-                type: string
-              iptablesLockFilePath:
-                description: 'IptablesLockFilePath is the location of the iptables
-                  lock file. You may need to change this if the lock file is not in
-                  its standard location (for example if you have mapped it into Felix’s
-                  container at a different path). [Default: /run/xtables.lock]'
-                type: string
-              iptablesLockProbeInterval:
-                description: 'IptablesLockProbeInterval is the time that Felix will
-                  wait between attempts to acquire the iptables lock if it is not
-                  available. Lower values make Felix more responsive when the lock
-                  is contended, but use more CPU. [Default: 50ms]'
-                type: string
-              iptablesLockTimeout:
-                description: 'IptablesLockTimeout is the time that Felix will wait
-                  for the iptables lock, or 0, to disable. To use this feature, Felix
-                  must share the iptables lock file with all other processes that
-                  also take the lock. When running Felix inside a container, this
-                  requires the /run directory of the host to be mounted into the calico/node
-                  or calico/felix container. [Default: 0s disabled]'
-                type: string
-              iptablesMangleAllowAction:
-                type: string
-              iptablesMarkMask:
-                description: 'IptablesMarkMask is the mask that Felix selects its
-                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
-                  at least 8 bits set, none of which clash with any other mark bits
-                  in use on the system. [Default: 0xff000000]'
-                format: int32
-                type: integer
-              iptablesNATOutgoingInterfaceFilter:
-                type: string
-              iptablesPostWriteCheckInterval:
-                description: 'IptablesPostWriteCheckInterval is the period after Felix
-                  has done a write to the dataplane that it schedules an extra read
-                  back in order to check the write was not clobbered by another process.
-                  This should only occur if another application on the system doesn’t
-                  respect the iptables lock. [Default: 1s]'
-                type: string
-              iptablesRefreshInterval:
-                description: 'IptablesRefreshInterval is the period at which Felix
-                  re-checks the IP sets in the dataplane to ensure that no other process
-                  has accidentally broken Calico’s rules. Set to 0 to disable IP sets
-                  refresh. Note: the default for this value is lower than the other
-                  refresh intervals as a workaround for a Linux kernel bug that was
-                  fixed in kernel version 4.11. If you are using v4.11 or greater
-                  you may want to set this to, a higher value to reduce Felix CPU
-                  usage. [Default: 10s]'
-                type: string
-              ipv6Support:
-                type: boolean
-              kubeNodePortRanges:
-                description: 'KubeNodePortRanges holds list of port ranges used for
-                  service node ports. Only used if felix detects kube-proxy running
-                  in ipvs mode. Felix uses these ranges to separate host and workload
-                  traffic. [Default: 30000:32767].'
-                items:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^.*
-                  x-kubernetes-int-or-string: true
-                type: array
-              logFilePath:
-                description: 'LogFilePath is the full path to the Felix log. Set to
-                  none to disable file logging. [Default: /var/log/calico/felix.log]'
-                type: string
-              logPrefix:
-                description: 'LogPrefix is the log prefix that Felix uses when rendering
-                  LOG rules. [Default: calico-packet]'
-                type: string
-              logSeverityFile:
-                description: 'LogSeverityFile is the log severity above which logs
-                  are sent to the log file. [Default: Info]'
-                type: string
-              logSeverityScreen:
-                description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: Info]'
-                type: string
-              logSeveritySys:
-                description: 'LogSeveritySys is the log severity above which logs
-                  are sent to the syslog. Set to None for no logging to syslog. [Default:
-                  Info]'
-                type: string
-              maxIpsetSize:
-                type: integer
-              metadataAddr:
-                description: 'MetadataAddr is the IP address or domain name of the
-                  server that can answer VM queries for cloud-init metadata. In OpenStack,
-                  this corresponds to the machine running nova-api (or in Ubuntu,
-                  nova-api-metadata). A value of none (case insensitive) means that
-                  Felix should not set up any NAT rule for the metadata path. [Default:
-                  127.0.0.1]'
-                type: string
-              metadataPort:
-                description: 'MetadataPort is the port of the metadata server. This,
-                  combined with global.MetadataAddr (if not ‘None’), is used to set
-                  up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
-                  In most cases this should not need to be changed [Default: 8775].'
-                type: integer
-              natOutgoingAddress:
-                description: NATOutgoingAddress specifies an address to use when performing
-                  source NAT for traffic in a natOutgoing pool that is leaving the
-                  network. By default the address used is an address on the interface
-                  the traffic is leaving on (ie it uses the iptables MASQUERADE target)
-                type: string
-              natPortRange:
+              type: array
+            failsafeInboundHostPorts:
+              description: 'FailsafeInboundHostPorts is a comma-delimited list of
+                UDP/TCP ports that Felix will allow incoming traffic to host endpoints
+                on irrespective of the security policy. This is useful to avoid
+                accidentally cutting off a host with incorrect configuration. Each
+                port should be specified as tcp:<port-number> or udp:<port-number>.
+                For back-compatibility, if the protocol is not specified, it defaults
+                to “tcp”. To disable all inbound host ports, use the value none.
+                The default value allows ssh access and DHCP. [Default: tcp:22,
+                udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+              items:
+                description: ProtoPort is combination of protocol and port, both
+                  must be specified.
+                properties:
+                  port:
+                    type: integer
+                  protocol:
+                    type: string
+                required:
+                - port
+                - protocol
+                type: object
+              type: array
+            failsafeOutboundHostPorts:
+              description: 'FailsafeOutboundHostPorts is a comma-delimited list
+                of UDP/TCP ports that Felix will allow outgoing traffic from host
+                endpoints to irrespective of the security policy. This is useful
+                to avoid accidentally cutting off a host with incorrect configuration.
+                Each port should be specified as tcp:<port-number> or udp:<port-number>.
+                For back-compatibility, if the protocol is not specified, it defaults
+                to “tcp”. To disable all outbound host ports, use the value none.
+                The default value opens etcd’s standard ports to ensure that Felix
+                does not get cut off from etcd as well as allowing DHCP and DNS.
+                [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667,
+                udp:53, udp:67]'
+              items:
+                description: ProtoPort is combination of protocol and port, both
+                  must be specified.
+                properties:
+                  port:
+                    type: integer
+                  protocol:
+                    type: string
+                required:
+                - port
+                - protocol
+                type: object
+              type: array
+            genericXDPEnabled:
+              description: 'GenericXDPEnabled enables Generic XDP so network cards
+                that don''t support XDP offload or driver modes can use XDP. This
+                is not recommended since it doesn''t provide better performance
+                than iptables. [Default: false]'
+              type: boolean
+            healthEnabled:
+              type: boolean
+            healthHost:
+              type: string
+            healthPort:
+              type: integer
+            interfaceExclude:
+              description: 'InterfaceExclude is a comma-separated list of interfaces
+                that Felix should exclude when monitoring for host endpoints. The
+                default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                interface, which is used internally by kube-proxy. If you want to
+                exclude multiple interface names using a single value, the list
+                supports regular expressions. For regular expressions you must wrap
+                the value with ''/''. For example having values ''/^kube/,veth1''
+                will exclude all interfaces that begin with ''kube'' and also the
+                interface ''veth1''. [Default: kube-ipvs0]'
+              type: string
+            interfacePrefix:
+              description: 'InterfacePrefix is the interface name prefix that identifies
+                workload endpoints and so distinguishes them from host endpoint
+                interfaces. Note: in environments other than bare metal, the orchestrators
+                configure this appropriately. For example our Kubernetes and Docker
+                integrations set the ‘cali’ value, and our OpenStack integration
+                sets the ‘tap’ value. [Default: cali]'
+              type: string
+            ipipEnabled:
+              type: boolean
+            ipipMTU:
+              description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                Configuring MTU [Default: 1440]'
+              type: integer
+            ipsetsRefreshInterval:
+              description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                all iptables state to ensure that no other process has accidentally
+                broken Calico’s rules. Set to 0 to disable iptables refresh. [Default:
+                90s]'
+              type: string
+            iptablesBackend:
+              description: IptablesBackend specifies which backend of iptables will
+                be used. The default is legacy.
+              type: string
+            iptablesFilterAllowAction:
+              type: string
+            iptablesLockFilePath:
+              description: 'IptablesLockFilePath is the location of the iptables
+                lock file. You may need to change this if the lock file is not in
+                its standard location (for example if you have mapped it into Felix’s
+                container at a different path). [Default: /run/xtables.lock]'
+              type: string
+            iptablesLockProbeInterval:
+              description: 'IptablesLockProbeInterval is the time that Felix will
+                wait between attempts to acquire the iptables lock if it is not
+                available. Lower values make Felix more responsive when the lock
+                is contended, but use more CPU. [Default: 50ms]'
+              type: string
+            iptablesLockTimeout:
+              description: 'IptablesLockTimeout is the time that Felix will wait
+                for the iptables lock, or 0, to disable. To use this feature, Felix
+                must share the iptables lock file with all other processes that
+                also take the lock. When running Felix inside a container, this
+                requires the /run directory of the host to be mounted into the calico/node
+                or calico/felix container. [Default: 0s disabled]'
+              type: string
+            iptablesMangleAllowAction:
+              type: string
+            iptablesMarkMask:
+              description: 'IptablesMarkMask is the mask that Felix selects its
+                IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                at least 8 bits set, none of which clash with any other mark bits
+                in use on the system. [Default: 0xff000000]'
+              format: int32
+              type: integer
+            iptablesNATOutgoingInterfaceFilter:
+              type: string
+            iptablesPostWriteCheckInterval:
+              description: 'IptablesPostWriteCheckInterval is the period after Felix
+                has done a write to the dataplane that it schedules an extra read
+                back in order to check the write was not clobbered by another process.
+                This should only occur if another application on the system doesn’t
+                respect the iptables lock. [Default: 1s]'
+              type: string
+            iptablesRefreshInterval:
+              description: 'IptablesRefreshInterval is the period at which Felix
+                re-checks the IP sets in the dataplane to ensure that no other process
+                has accidentally broken Calico’s rules. Set to 0 to disable IP sets
+                refresh. Note: the default for this value is lower than the other
+                refresh intervals as a workaround for a Linux kernel bug that was
+                fixed in kernel version 4.11. If you are using v4.11 or greater
+                you may want to set this to, a higher value to reduce Felix CPU
+                usage. [Default: 10s]'
+              type: string
+            ipv6Support:
+              type: boolean
+            kubeNodePortRanges:
+              description: 'KubeNodePortRanges holds list of port ranges used for
+                service node ports. Only used if felix detects kube-proxy running
+                in ipvs mode. Felix uses these ranges to separate host and workload
+                traffic. [Default: 30000:32767].'
+              items:
                 anyOf:
                 - type: integer
                 - type: string
-                description: NATPortRange specifies the range of ports that is used
-                  for port mapping when doing outgoing NAT. When unset the default
-                  behavior of the network stack is used.
                 pattern: ^.*
                 x-kubernetes-int-or-string: true
-              netlinkTimeout:
-                type: string
-              openstackRegion:
-                description: 'OpenstackRegion is the name of the region that a particular
-                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
-                  this must be configured somehow for each Felix (here in the datamodel,
-                  or in felix.cfg or the environment on each compute node), and must
-                  match the [calico] openstack_region value configured in neutron.conf
-                  on each node. [Default: Empty]'
-                type: string
-              policySyncPathPrefix:
-                description: 'PolicySyncPathPrefix is used to by Felix to communicate
-                  policy changes to external services, like Application layer policy.
-                  [Default: Empty]'
-                type: string
-              prometheusGoMetricsEnabled:
-                description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
-                  collection, which the Prometheus client does by default, when set
-                  to false. This reduces the number of metrics reported, reducing
-                  Prometheus load. [Default: true]'
-                type: boolean
-              prometheusMetricsEnabled:
-                description: 'PrometheusMetricsEnabled enables the Prometheus metrics
-                  server in Felix if set to true. [Default: false]'
-                type: boolean
-              prometheusMetricsHost:
-                description: 'PrometheusMetricsHost is the host that the Prometheus
-                  metrics server should bind to. [Default: empty]'
-                type: string
-              prometheusMetricsPort:
-                description: 'PrometheusMetricsPort is the TCP port that the Prometheus
-                  metrics server should bind to. [Default: 9091]'
-                type: integer
-              prometheusProcessMetricsEnabled:
-                description: 'PrometheusProcessMetricsEnabled disables process metrics
-                  collection, which the Prometheus client does by default, when set
-                  to false. This reduces the number of metrics reported, reducing
-                  Prometheus load. [Default: true]'
-                type: boolean
-              removeExternalRoutes:
-                description: Whether or not to remove device routes that have not
-                  been programmed by Felix. Disabling this will allow external applications
-                  to also add device routes. This is enabled by default which means
-                  we will remove externally added routes.
-                type: boolean
-              reportingInterval:
-                description: 'ReportingInterval is the interval at which Felix reports
-                  its status into the datastore or 0 to disable. Must be non-zero
-                  in OpenStack deployments. [Default: 30s]'
-                type: string
-              reportingTTL:
-                description: 'ReportingTTL is the time-to-live setting for process-wide
-                  status reports. [Default: 90s]'
-                type: string
-              routeRefreshInterval:
-                description: 'RouterefreshInterval is the period at which Felix re-checks
-                  the routes in the dataplane to ensure that no other process has
-                  accidentally broken Calico’s rules. Set to 0 to disable route refresh.
-                  [Default: 90s]'
-                type: string
-              routeSource:
-                description: 'RouteSource configures where Felix gets its routing
-                  information. - WorkloadIPs: use workload endpoints to construct
-                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
-                type: string
-              routeTableRange:
-                description: Calico programs additional Linux route tables for various
-                  purposes.  RouteTableRange specifies the indices of the route tables
-                  that Calico should use.
-                properties:
-                  max:
-                    type: integer
-                  min:
-                    type: integer
-                required:
-                - max
-                - min
-                type: object
-              sidecarAccelerationEnabled:
-                description: 'SidecarAccelerationEnabled enables experimental sidecar
-                  acceleration [Default: false]'
-                type: boolean
-              usageReportingEnabled:
-                description: 'UsageReportingEnabled reports anonymous Calico version
-                  number and cluster size to projectcalico.org. Logs warnings returned
-                  by the usage server. For example, if a significant security vulnerability
-                  has been discovered in the version of Calico being used. [Default:
-                  true]'
-                type: boolean
-              usageReportingInitialDelay:
-                description: 'UsageReportingInitialDelay controls the minimum delay
-                  before Felix makes a report. [Default: 300s]'
-                type: string
-              usageReportingInterval:
-                description: 'UsageReportingInterval controls the interval at which
-                  Felix makes reports. [Default: 86400s]'
-                type: string
-              useInternalDataplaneDriver:
-                type: boolean
-              vxlanEnabled:
-                type: boolean
-              vxlanMTU:
-                description: 'VXLANMTU is the MTU to set on the tunnel device. See
-                  Configuring MTU [Default: 1440]'
-                type: integer
-              vxlanPort:
-                type: integer
-              vxlanVNI:
-                type: integer
-              wireguardEnabled:
-                description: 'WireguardEnabled controls whether Wireguard is enabled.
-                  [Default: false]'
-                type: boolean
-              wireguardInterfaceName:
-                description: 'WireguardInterfaceName specifies the name to use for
-                  the Wireguard interface. [Default: wg.calico]'
-                type: string
-              wireguardListeningPort:
-                description: 'WireguardListeningPort controls the listening port used
-                  by Wireguard. [Default: 51820]'
-                type: integer
-              wireguardMTU:
-                description: 'WireguardMTU controls the MTU on the Wireguard interface.
-                  See Configuring MTU [Default: 1420]'
-                type: integer
-              wireguardRoutingRulePriority:
-                description: 'WireguardRoutingRulePriority controls the priority value
-                  to use for the Wireguard routing rule. [Default: 99]'
-                type: integer
-              xdpEnabled:
-                description: 'XDPEnabled enables XDP acceleration for suitable untracked
-                  incoming deny rules. [Default: true]'
-                type: boolean
-              xdpRefreshInterval:
-                description: 'XDPRefreshInterval is the period at which Felix re-checks
-                  all XDP state to ensure that no other process has accidentally broken
-                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
-                  refresh. [Default: 90s]'
-                type: string
-            required:
-            - bpfLogLevel
-            type: object
-        type: object
-    served: true
-    storage: true
+              type: array
+            logFilePath:
+              description: 'LogFilePath is the full path to the Felix log. Set to
+                none to disable file logging. [Default: /var/log/calico/felix.log]'
+              type: string
+            logPrefix:
+              description: 'LogPrefix is the log prefix that Felix uses when rendering
+                LOG rules. [Default: calico-packet]'
+              type: string
+            logSeverityFile:
+              description: 'LogSeverityFile is the log severity above which logs
+                are sent to the log file. [Default: Info]'
+              type: string
+            logSeverityScreen:
+              description: 'LogSeverityScreen is the log severity above which logs
+                are sent to the stdout. [Default: Info]'
+              type: string
+            logSeveritySys:
+              description: 'LogSeveritySys is the log severity above which logs
+                are sent to the syslog. Set to None for no logging to syslog. [Default:
+                Info]'
+              type: string
+            maxIpsetSize:
+              type: integer
+            metadataAddr:
+              description: 'MetadataAddr is the IP address or domain name of the
+                server that can answer VM queries for cloud-init metadata. In OpenStack,
+                this corresponds to the machine running nova-api (or in Ubuntu,
+                nova-api-metadata). A value of none (case insensitive) means that
+                Felix should not set up any NAT rule for the metadata path. [Default:
+                127.0.0.1]'
+              type: string
+            metadataPort:
+              description: 'MetadataPort is the port of the metadata server. This,
+                combined with global.MetadataAddr (if not ‘None’), is used to set
+                up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                In most cases this should not need to be changed [Default: 8775].'
+              type: integer
+            natOutgoingAddress:
+              description: NATOutgoingAddress specifies an address to use when performing
+                source NAT for traffic in a natOutgoing pool that is leaving the
+                network. By default the address used is an address on the interface
+                the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+              type: string
+            natPortRange:
+              anyOf:
+              - type: integer
+              - type: string
+              description: NATPortRange specifies the range of ports that is used
+                for port mapping when doing outgoing NAT. When unset the default
+                behavior of the network stack is used.
+              pattern: ^.*
+              x-kubernetes-int-or-string: true
+            netlinkTimeout:
+              type: string
+            openstackRegion:
+              description: 'OpenstackRegion is the name of the region that a particular
+                Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                this must be configured somehow for each Felix (here in the datamodel,
+                or in felix.cfg or the environment on each compute node), and must
+                match the [calico] openstack_region value configured in neutron.conf
+                on each node. [Default: Empty]'
+              type: string
+            policySyncPathPrefix:
+              description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                policy changes to external services, like Application layer policy.
+                [Default: Empty]'
+              type: string
+            prometheusGoMetricsEnabled:
+              description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                collection, which the Prometheus client does by default, when set
+                to false. This reduces the number of metrics reported, reducing
+                Prometheus load. [Default: true]'
+              type: boolean
+            prometheusMetricsEnabled:
+              description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                server in Felix if set to true. [Default: false]'
+              type: boolean
+            prometheusMetricsHost:
+              description: 'PrometheusMetricsHost is the host that the Prometheus
+                metrics server should bind to. [Default: empty]'
+              type: string
+            prometheusMetricsPort:
+              description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                metrics server should bind to. [Default: 9091]'
+              type: integer
+            prometheusProcessMetricsEnabled:
+              description: 'PrometheusProcessMetricsEnabled disables process metrics
+                collection, which the Prometheus client does by default, when set
+                to false. This reduces the number of metrics reported, reducing
+                Prometheus load. [Default: true]'
+              type: boolean
+            removeExternalRoutes:
+              description: Whether or not to remove device routes that have not
+                been programmed by Felix. Disabling this will allow external applications
+                to also add device routes. This is enabled by default which means
+                we will remove externally added routes.
+              type: boolean
+            reportingInterval:
+              description: 'ReportingInterval is the interval at which Felix reports
+                its status into the datastore or 0 to disable. Must be non-zero
+                in OpenStack deployments. [Default: 30s]'
+              type: string
+            reportingTTL:
+              description: 'ReportingTTL is the time-to-live setting for process-wide
+                status reports. [Default: 90s]'
+              type: string
+            routeRefreshInterval:
+              description: 'RouterefreshInterval is the period at which Felix re-checks
+                the routes in the dataplane to ensure that no other process has
+                accidentally broken Calico’s rules. Set to 0 to disable route refresh.
+                [Default: 90s]'
+              type: string
+            routeSource:
+              description: 'RouteSource configures where Felix gets its routing
+                information. - WorkloadIPs: use workload endpoints to construct
+                routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+              type: string
+            routeTableRange:
+              description: Calico programs additional Linux route tables for various
+                purposes.  RouteTableRange specifies the indices of the route tables
+                that Calico should use.
+              properties:
+                max:
+                  type: integer
+                min:
+                  type: integer
+              required:
+              - max
+              - min
+              type: object
+            sidecarAccelerationEnabled:
+              description: 'SidecarAccelerationEnabled enables experimental sidecar
+                acceleration [Default: false]'
+              type: boolean
+            usageReportingEnabled:
+              description: 'UsageReportingEnabled reports anonymous Calico version
+                number and cluster size to projectcalico.org. Logs warnings returned
+                by the usage server. For example, if a significant security vulnerability
+                has been discovered in the version of Calico being used. [Default:
+                true]'
+              type: boolean
+            usageReportingInitialDelay:
+              description: 'UsageReportingInitialDelay controls the minimum delay
+                before Felix makes a report. [Default: 300s]'
+              type: string
+            usageReportingInterval:
+              description: 'UsageReportingInterval controls the interval at which
+                Felix makes reports. [Default: 86400s]'
+              type: string
+            useInternalDataplaneDriver:
+              type: boolean
+            vxlanEnabled:
+              type: boolean
+            vxlanMTU:
+              description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                Configuring MTU [Default: 1440]'
+              type: integer
+            vxlanPort:
+              type: integer
+            vxlanVNI:
+              type: integer
+            wireguardEnabled:
+              description: 'WireguardEnabled controls whether Wireguard is enabled.
+                [Default: false]'
+              type: boolean
+            wireguardInterfaceName:
+              description: 'WireguardInterfaceName specifies the name to use for
+                the Wireguard interface. [Default: wg.calico]'
+              type: string
+            wireguardListeningPort:
+              description: 'WireguardListeningPort controls the listening port used
+                by Wireguard. [Default: 51820]'
+              type: integer
+            wireguardMTU:
+              description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                See Configuring MTU [Default: 1420]'
+              type: integer
+            wireguardRoutingRulePriority:
+              description: 'WireguardRoutingRulePriority controls the priority value
+                to use for the Wireguard routing rule. [Default: 99]'
+              type: integer
+            xdpEnabled:
+              description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                incoming deny rules. [Default: true]'
+              type: boolean
+            xdpRefreshInterval:
+              description: 'XDPRefreshInterval is the period at which Felix re-checks
+                all XDP state to ensure that no other process has accidentally broken
+                Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                refresh. [Default: 90s]'
+              type: string
+          required:
+          - bpfLogLevel
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,757 +13,758 @@ spec:
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              applyOnForward:
-                description: ApplyOnForward indicates to apply the rules in this policy
-                  on forward traffic.
-                type: boolean
-              doNotTrack:
-                description: DoNotTrack indicates whether packets matched by the rules
-                  in this policy should go through the data plane's connection tracking,
-                  such as Linux conntrack.  If True, the rules in this policy are
-                  applied before any data plane connection tracking, and packets allowed
-                  by this policy are marked as not to be tracked.
-                type: boolean
-              egress:
-                description: The ordered set of egress rules.  Each rule contains
-                  a set of packet match criteria and a corresponding action to apply.
-                items:
-                  description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                  properties:
-                    action:
-                      type: string
-                    destination:
-                      description: Destination contains the match criteria that apply
-                        to destination entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                    http:
-                      description: HTTP contains match criteria that apply to HTTP
-                        requests.
-                      properties:
-                        methods:
-                          description: Methods is an optional field that restricts
-                            the rule to apply only to HTTP requests that use one of
-                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                            methods are OR'd together.
-                          items:
-                            type: string
-                          type: array
-                        paths:
-                          description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                          items:
-                            description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    icmp:
-                      description: ICMP is an optional field that restricts the rule
-                        to apply to a specific type and code of ICMP traffic.  This
-                        should only be specified if the Protocol field is set to "ICMP"
-                        or "ICMPv6".
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    ipVersion:
-                      description: IPVersion is an optional field that restricts the
-                        rule to only match a specific IP version.
-                      type: integer
-                    metadata:
-                      description: Metadata contains additional information for this
-                        rule
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations is a set of key value pairs that
-                            give extra information about the rule
-                          type: object
-                      type: object
-                    notICMP:
-                      description: NotICMP is the negated version of the ICMP field.
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    notProtocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: NotProtocol is the negated version of the Protocol
-                        field.
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    protocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    source:
-                      description: Source contains the match criteria that apply to
-                        source entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                  required:
-                  - action
-                  type: object
-                type: array
-              ingress:
-                description: The ordered set of ingress rules.  Each rule contains
-                  a set of packet match criteria and a corresponding action to apply.
-                items:
-                  description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                  properties:
-                    action:
-                      type: string
-                    destination:
-                      description: Destination contains the match criteria that apply
-                        to destination entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                    http:
-                      description: HTTP contains match criteria that apply to HTTP
-                        requests.
-                      properties:
-                        methods:
-                          description: Methods is an optional field that restricts
-                            the rule to apply only to HTTP requests that use one of
-                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                            methods are OR'd together.
-                          items:
-                            type: string
-                          type: array
-                        paths:
-                          description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                          items:
-                            description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    icmp:
-                      description: ICMP is an optional field that restricts the rule
-                        to apply to a specific type and code of ICMP traffic.  This
-                        should only be specified if the Protocol field is set to "ICMP"
-                        or "ICMPv6".
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    ipVersion:
-                      description: IPVersion is an optional field that restricts the
-                        rule to only match a specific IP version.
-                      type: integer
-                    metadata:
-                      description: Metadata contains additional information for this
-                        rule
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations is a set of key value pairs that
-                            give extra information about the rule
-                          type: object
-                      type: object
-                    notICMP:
-                      description: NotICMP is the negated version of the ICMP field.
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    notProtocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: NotProtocol is the negated version of the Protocol
-                        field.
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    protocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    source:
-                      description: Source contains the match criteria that apply to
-                        source entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                  required:
-                  - action
-                  type: object
-                type: array
-              namespaceSelector:
-                description: NamespaceSelector is an optional field for an expression
-                  used to select a pod based on namespaces.
-                type: string
-              order:
-                description: Order is an optional field that specifies the order in
-                  which the policy is applied. Policies with higher "order" are applied
-                  after those with lower order.  If the order is omitted, it may be
-                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                  with identical order will be applied in alphanumerical order based
-                  on the Policy "Name".
-                type: number
-              preDNAT:
-                description: PreDNAT indicates to apply the rules in this policy before
-                  any DNAT.
-                type: boolean
-              selector:
-                description: "The selector is an expression used to pick pick out
-                  the endpoints that the policy should be applied to. \n Selector
-                  expressions follow this syntax: \n \tlabel == \"string_literal\"
-                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                  \  ->  not equal; also matches if label is not present \tlabel in
-                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                  or the empty selector -> matches all endpoints. \n Label names are
-                  allowed to contain alphanumerics, -, _ and /. String literals are
-                  more permissive but they do not support escape characters. \n Examples
-                  (with made-up labels): \n \ttype == \"webserver\" && deployment
-                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                  \"dev\" \t! has(label_name)"
-                type: string
-              serviceAccountSelector:
-                description: ServiceAccountSelector is an optional field for an expression
-                  used to select a pod based on service accounts.
-                type: string
-              types:
-                description: "Types indicates whether this policy applies to ingress,
-                  or to egress, or to both.  When not explicitly specified (and so
-                  the value on creation is empty or nil), Calico defaults Types according
-                  to what Ingress and Egress rules are present in the policy.  The
-                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
-                  (including the case where there are   also no Ingress rules) \n
-                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
-                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
-                  both Ingress and Egress rules. \n When the policy is read back again,
-                  Types will always be one of these values, never empty or nil."
-                items:
-                  description: PolicyType enumerates the possible values of the PolicySpec
-                    Types field.
-                  type: string
-                type: array
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            applyOnForward:
+              description: ApplyOnForward indicates to apply the rules in this policy
+                on forward traffic.
+              type: boolean
+            doNotTrack:
+              description: DoNotTrack indicates whether packets matched by the rules
+                in this policy should go through the data plane's connection tracking,
+                such as Linux conntrack.  If True, the rules in this policy are
+                applied before any data plane connection tracking, and packets allowed
+                by this policy are marked as not to be tracked.
+              type: boolean
+            egress:
+              description: The ordered set of egress rules.  Each rule contains
+                a set of packet match criteria and a corresponding action to apply.
+              items:
+                description: "A Rule encapsulates a set of match criteria and an
+                  action.  Both selector-based security Policy and security Profiles
+                  reference rules - separated out as a list of rules for both ingress
+                  and egress packet matching. \n Each positive match criteria has
+                  a negated version, prefixed with ”Not”. All the match criteria
+                  within a rule must be satisfied for a packet to match. A single
+                  rule can contain the positive and negative version of a match
+                  and both must be satisfied for the rule to match."
+                properties:
+                  action:
+                    type: string
+                  destination:
+                    description: Destination contains the match criteria that apply
+                      to destination entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                  http:
+                    description: HTTP contains match criteria that apply to HTTP
+                      requests.
+                    properties:
+                      methods:
+                        description: Methods is an optional field that restricts
+                          the rule to apply only to HTTP requests that use one of
+                          the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                          methods are OR'd together.
+                        items:
+                          type: string
+                        type: array
+                      paths:
+                        description: 'Paths is an optional field that restricts
+                          the rule to apply to HTTP requests that use one of the
+                          listed HTTP Paths. Multiple paths are OR''d together.
+                          e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                          ONLY specify either a `exact` or a `prefix` match. The
+                          validator will check for it.'
+                        items:
+                          description: 'HTTPPath specifies an HTTP path to match.
+                            It may be either of the form: exact: <path>: which matches
+                            the path exactly or prefix: <path-prefix>: which matches
+                            the path prefix'
+                          properties:
+                            exact:
+                              type: string
+                            prefix:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  icmp:
+                    description: ICMP is an optional field that restricts the rule
+                      to apply to a specific type and code of ICMP traffic.  This
+                      should only be specified if the Protocol field is set to "ICMP"
+                      or "ICMPv6".
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  ipVersion:
+                    description: IPVersion is an optional field that restricts the
+                      rule to only match a specific IP version.
+                    type: integer
+                  metadata:
+                    description: Metadata contains additional information for this
+                      rule
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a set of key value pairs that
+                          give extra information about the rule
+                        type: object
+                    type: object
+                  notICMP:
+                    description: NotICMP is the negated version of the ICMP field.
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  notProtocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NotProtocol is the negated version of the Protocol
+                      field.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  protocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: "Protocol is an optional field that restricts the
+                      rule to only apply to traffic of a specific IP protocol. Required
+                      if any of the EntityRules contain Ports (because ports only
+                      apply to certain protocols). \n Must be one of these string
+                      values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                      \"UDPLite\" or an integer in the range 1-255."
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  source:
+                    description: Source contains the match criteria that apply to
+                      source entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - action
+                type: object
+              type: array
+            ingress:
+              description: The ordered set of ingress rules.  Each rule contains
+                a set of packet match criteria and a corresponding action to apply.
+              items:
+                description: "A Rule encapsulates a set of match criteria and an
+                  action.  Both selector-based security Policy and security Profiles
+                  reference rules - separated out as a list of rules for both ingress
+                  and egress packet matching. \n Each positive match criteria has
+                  a negated version, prefixed with ”Not”. All the match criteria
+                  within a rule must be satisfied for a packet to match. A single
+                  rule can contain the positive and negative version of a match
+                  and both must be satisfied for the rule to match."
+                properties:
+                  action:
+                    type: string
+                  destination:
+                    description: Destination contains the match criteria that apply
+                      to destination entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                  http:
+                    description: HTTP contains match criteria that apply to HTTP
+                      requests.
+                    properties:
+                      methods:
+                        description: Methods is an optional field that restricts
+                          the rule to apply only to HTTP requests that use one of
+                          the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                          methods are OR'd together.
+                        items:
+                          type: string
+                        type: array
+                      paths:
+                        description: 'Paths is an optional field that restricts
+                          the rule to apply to HTTP requests that use one of the
+                          listed HTTP Paths. Multiple paths are OR''d together.
+                          e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                          ONLY specify either a `exact` or a `prefix` match. The
+                          validator will check for it.'
+                        items:
+                          description: 'HTTPPath specifies an HTTP path to match.
+                            It may be either of the form: exact: <path>: which matches
+                            the path exactly or prefix: <path-prefix>: which matches
+                            the path prefix'
+                          properties:
+                            exact:
+                              type: string
+                            prefix:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  icmp:
+                    description: ICMP is an optional field that restricts the rule
+                      to apply to a specific type and code of ICMP traffic.  This
+                      should only be specified if the Protocol field is set to "ICMP"
+                      or "ICMPv6".
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  ipVersion:
+                    description: IPVersion is an optional field that restricts the
+                      rule to only match a specific IP version.
+                    type: integer
+                  metadata:
+                    description: Metadata contains additional information for this
+                      rule
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a set of key value pairs that
+                          give extra information about the rule
+                        type: object
+                    type: object
+                  notICMP:
+                    description: NotICMP is the negated version of the ICMP field.
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  notProtocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NotProtocol is the negated version of the Protocol
+                      field.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  protocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: "Protocol is an optional field that restricts the
+                      rule to only apply to traffic of a specific IP protocol. Required
+                      if any of the EntityRules contain Ports (because ports only
+                      apply to certain protocols). \n Must be one of these string
+                      values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                      \"UDPLite\" or an integer in the range 1-255."
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  source:
+                    description: Source contains the match criteria that apply to
+                      source entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - action
+                type: object
+              type: array
+            namespaceSelector:
+              description: NamespaceSelector is an optional field for an expression
+                used to select a pod based on namespaces.
+              type: string
+            order:
+              description: Order is an optional field that specifies the order in
+                which the policy is applied. Policies with higher "order" are applied
+                after those with lower order.  If the order is omitted, it may be
+                considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                with identical order will be applied in alphanumerical order based
+                on the Policy "Name".
+              type: number
+            preDNAT:
+              description: PreDNAT indicates to apply the rules in this policy before
+                any DNAT.
+              type: boolean
+            selector:
+              description: "The selector is an expression used to pick pick out
+                the endpoints that the policy should be applied to. \n Selector
+                expressions follow this syntax: \n \tlabel == \"string_literal\"
+                \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                \  ->  not equal; also matches if label is not present \tlabel in
+                { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                or the empty selector -> matches all endpoints. \n Label names are
+                allowed to contain alphanumerics, -, _ and /. String literals are
+                more permissive but they do not support escape characters. \n Examples
+                (with made-up labels): \n \ttype == \"webserver\" && deployment
+                == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                \"dev\" \t! has(label_name)"
+              type: string
+            serviceAccountSelector:
+              description: ServiceAccountSelector is an optional field for an expression
+                used to select a pod based on service accounts.
+              type: string
+            types:
+              description: "Types indicates whether this policy applies to ingress,
+                or to egress, or to both.  When not explicitly specified (and so
+                the value on creation is empty or nil), Calico defaults Types according
+                to what Ingress and Egress rules are present in the policy.  The
+                default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                (including the case where there are   also no Ingress rules) \n
+                - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                both Ingress and Egress rules. \n When the policy is read back again,
+                Types will always be one of these values, never empty or nil."
+              items:
+                description: PolicyType enumerates the possible values of the PolicySpec
+                  Types field.
+                type: string
+              type: array
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -1,0 +1,774 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              applyOnForward:
+                description: ApplyOnForward indicates to apply the rules in this policy
+                  on forward traffic.
+                type: boolean
+              doNotTrack:
+                description: DoNotTrack indicates whether packets matched by the rules
+                  in this policy should go through the data plane's connection tracking,
+                  such as Linux conntrack.  If True, the rules in this policy are
+                  applied before any data plane connection tracking, and packets allowed
+                  by this policy are marked as not to be tracked.
+                type: boolean
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector is an optional field for an expression
+                  used to select a pod based on namespaces.
+                type: string
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              preDNAT:
+                description: PreDNAT indicates to apply the rules in this policy before
+                  any DNAT.
+                type: boolean
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworksets.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworksets.yaml
@@ -1,0 +1,56 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+          that share labels to allow rules to refer to them via selectors.  The labels
+          of GlobalNetworkSet are not namespaced.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworksets.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_globalnetworksets.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,39 +13,40 @@ spec:
     plural: globalnetworksets
     singular: globalnetworkset
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
-          that share labels to allow rules to refer to them via selectors.  The labels
-          of GlobalNetworkSet are not namespaced.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: GlobalNetworkSetSpec contains the specification for a NetworkSet
-              resource.
-            properties:
-              nets:
-                description: The list of IP networks that belong to this set.
-                items:
-                  type: string
-                type: array
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+        that share labels to allow rules to refer to them via selectors.  The labels
+        of GlobalNetworkSet are not namespaced.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+            resource.
+          properties:
+            nets:
+              description: The list of IP networks that belong to this set.
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_hostendpoints.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_hostendpoints.yaml
@@ -1,0 +1,111 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HostEndpointSpec contains the specification for a HostEndpoint
+              resource.
+            properties:
+              expectedIPs:
+                description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                  If \"InterfaceName\" is not present, Calico will look for an interface
+                  matching any of the IPs in the list and apply policy to that. Note:
+                  \tWhen using the selector match criteria in an ingress or egress
+                  security Policy \tor Profile, Calico converts the selector into
+                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                  is used for that purpose. (If only the interface \tname is specified,
+                  Calico does not learn the IPs of the interface for use in match
+                  \tcriteria.)"
+                items:
+                  type: string
+                type: array
+              interfaceName:
+                description: "Either \"*\", or the name of a specific Linux interface
+                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                  governs all traffic to, from or through the default network namespace
+                  of the host named by the \"Node\" field; entering and leaving that
+                  namespace via any interface, including those from/to non-host-networked
+                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                  only governs traffic that enters or leaves the host through the
+                  specific interface named by InterfaceName, or - when InterfaceName
+                  is empty - through the specific interface that has one of the IPs
+                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                  one expected IP must be specified.  Only external interfaces (such
+                  as “eth0”) are supported here; it isn't possible for a HostEndpoint
+                  to protect traffic through a specific local workload interface.
+                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                  initially just pre-DNAT policy.  Please check Calico documentation
+                  for the latest position."
+                type: string
+              node:
+                description: The node name identifying the Calico node instance.
+                type: string
+              ports:
+                description: Ports contains the endpoint's named ports, which may
+                  be referenced in security policy rules.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                type: array
+              profiles:
+                description: A list of identifiers of security Profile objects that
+                  apply to this endpoint. Each profile is applied in the order that
+                  they appear in this list.  Profile rules are applied after the selector-based
+                  security policy.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_hostendpoints.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_hostendpoints.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,94 +13,95 @@ spec:
     plural: hostendpoints
     singular: hostendpoint
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: HostEndpointSpec contains the specification for a HostEndpoint
-              resource.
-            properties:
-              expectedIPs:
-                description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
-                  If \"InterfaceName\" is not present, Calico will look for an interface
-                  matching any of the IPs in the list and apply policy to that. Note:
-                  \tWhen using the selector match criteria in an ingress or egress
-                  security Policy \tor Profile, Calico converts the selector into
-                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
-                  is used for that purpose. (If only the interface \tname is specified,
-                  Calico does not learn the IPs of the interface for use in match
-                  \tcriteria.)"
-                items:
-                  type: string
-                type: array
-              interfaceName:
-                description: "Either \"*\", or the name of a specific Linux interface
-                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
-                  governs all traffic to, from or through the default network namespace
-                  of the host named by the \"Node\" field; entering and leaving that
-                  namespace via any interface, including those from/to non-host-networked
-                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
-                  only governs traffic that enters or leaves the host through the
-                  specific interface named by InterfaceName, or - when InterfaceName
-                  is empty - through the specific interface that has one of the IPs
-                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
-                  one expected IP must be specified.  Only external interfaces (such
-                  as “eth0”) are supported here; it isn't possible for a HostEndpoint
-                  to protect traffic through a specific local workload interface.
-                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
-                  initially just pre-DNAT policy.  Please check Calico documentation
-                  for the latest position."
-                type: string
-              node:
-                description: The node name identifying the Calico node instance.
-                type: string
-              ports:
-                description: Ports contains the endpoint's named ports, which may
-                  be referenced in security policy rules.
-                items:
-                  properties:
-                    name:
-                      type: string
-                    port:
-                      type: integer
-                    protocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                  required:
-                  - name
-                  - port
-                  - protocol
-                  type: object
-                type: array
-              profiles:
-                description: A list of identifiers of security Profile objects that
-                  apply to this endpoint. Each profile is applied in the order that
-                  they appear in this list.  Profile rules are applied after the selector-based
-                  security policy.
-                items:
-                  type: string
-                type: array
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: HostEndpointSpec contains the specification for a HostEndpoint
+            resource.
+          properties:
+            expectedIPs:
+              description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                If \"InterfaceName\" is not present, Calico will look for an interface
+                matching any of the IPs in the list and apply policy to that. Note:
+                \tWhen using the selector match criteria in an ingress or egress
+                security Policy \tor Profile, Calico converts the selector into
+                a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                is used for that purpose. (If only the interface \tname is specified,
+                Calico does not learn the IPs of the interface for use in match
+                \tcriteria.)"
+              items:
+                type: string
+              type: array
+            interfaceName:
+              description: "Either \"*\", or the name of a specific Linux interface
+                to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                governs all traffic to, from or through the default network namespace
+                of the host named by the \"Node\" field; entering and leaving that
+                namespace via any interface, including those from/to non-host-networked
+                local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                only governs traffic that enters or leaves the host through the
+                specific interface named by InterfaceName, or - when InterfaceName
+                is empty - through the specific interface that has one of the IPs
+                in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                one expected IP must be specified.  Only external interfaces (such
+                as “eth0”) are supported here; it isn't possible for a HostEndpoint
+                to protect traffic through a specific local workload interface.
+                \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                initially just pre-DNAT policy.  Please check Calico documentation
+                for the latest position."
+              type: string
+            node:
+              description: The node name identifying the Calico node instance.
+              type: string
+            ports:
+              description: Ports contains the endpoint's named ports, which may
+                be referenced in security policy rules.
+              items:
+                properties:
+                  name:
+                    type: string
+                  port:
+                    type: integer
+                  protocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                - protocol
+                type: object
+              type: array
+            profiles:
+              description: A list of identifiers of security Profile objects that
+                apply to this endpoint. Each profile is applied in the order that
+                they appear in this list.  Profile rules are applied after the selector-based
+                security policy.
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamblocks.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamblocks.yaml
@@ -1,0 +1,85 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMBlock
+    listKind: IPAMBlockList
+    plural: ipamblocks
+    singular: ipamblock
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMBlockSpec contains the specification for an IPAMBlock
+              resource.
+            properties:
+              affinity:
+                type: string
+              allocations:
+                items:
+                  type: integer
+                  # TODO: This nullable is manually added in. We should update controller-gen
+                  # to handle []*int properly itself.
+                  nullable: true
+                type: array
+              attributes:
+                items:
+                  properties:
+                    handle_id:
+                      type: string
+                    secondary:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
+              cidr:
+                type: string
+              deleted:
+                type: boolean
+              strictAffinity:
+                type: boolean
+              unallocated:
+                items:
+                  type: integer
+                type: array
+            required:
+            - allocations
+            - attributes
+            - cidr
+            - deleted
+            - strictAffinity
+            - unallocated
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamblocks.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamblocks.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,68 +13,69 @@ spec:
     plural: ipamblocks
     singular: ipamblock
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPAMBlockSpec contains the specification for an IPAMBlock
-              resource.
-            properties:
-              affinity:
-                type: string
-              allocations:
-                items:
-                  type: integer
-                  # TODO: This nullable is manually added in. We should update controller-gen
-                  # to handle []*int properly itself.
-                  nullable: true
-                type: array
-              attributes:
-                items:
-                  properties:
-                    handle_id:
-                      type: string
-                    secondary:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  type: object
-                type: array
-              cidr:
-                type: string
-              deleted:
-                type: boolean
-              strictAffinity:
-                type: boolean
-              unallocated:
-                items:
-                  type: integer
-                type: array
-            required:
-            - allocations
-            - attributes
-            - cidr
-            - deleted
-            - strictAffinity
-            - unallocated
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IPAMBlockSpec contains the specification for an IPAMBlock
+            resource.
+          properties:
+            affinity:
+              type: string
+            allocations:
+              items:
+                type: integer
+                # TODO: This nullable is manually added in. We should update controller-gen
+                # to handle []*int properly itself.
+                nullable: true
+              type: array
+            attributes:
+              items:
+                properties:
+                  handle_id:
+                    type: string
+                  secondary:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              type: array
+            cidr:
+              type: string
+            deleted:
+              type: boolean
+            strictAffinity:
+              type: boolean
+            unallocated:
+              items:
+                type: integer
+              type: array
+          required:
+          - allocations
+          - attributes
+          - cidr
+          - deleted
+          - strictAffinity
+          - unallocated
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamconfigs.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamconfigs.yaml
@@ -1,0 +1,55 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMConfig
+    listKind: IPAMConfigList
+    plural: ipamconfigs
+    singular: ipamconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMConfigSpec contains the specification for an IPAMConfig
+              resource.
+            properties:
+              autoAllocateBlocks:
+                type: boolean
+              strictAffinity:
+                type: boolean
+            required:
+            - autoAllocateBlocks
+            - strictAffinity
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamconfigs.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamconfigs.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,38 +13,39 @@ spec:
     plural: ipamconfigs
     singular: ipamconfig
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPAMConfigSpec contains the specification for an IPAMConfig
-              resource.
-            properties:
-              autoAllocateBlocks:
-                type: boolean
-              strictAffinity:
-                type: boolean
-            required:
-            - autoAllocateBlocks
-            - strictAffinity
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IPAMConfigSpec contains the specification for an IPAMConfig
+            resource.
+          properties:
+            autoAllocateBlocks:
+              type: boolean
+            strictAffinity:
+              type: boolean
+          required:
+          - autoAllocateBlocks
+          - strictAffinity
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamhandles.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamhandles.yaml
@@ -1,0 +1,57 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPAMHandle
+    listKind: IPAMHandleList
+    plural: ipamhandles
+    singular: ipamhandle
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAMHandleSpec contains the specification for an IPAMHandle
+              resource.
+            properties:
+              block:
+                additionalProperties:
+                  type: integer
+                type: object
+              handleID:
+                type: string
+            required:
+            - block
+            - handleID
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamhandles.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ipamhandles.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,40 +13,41 @@ spec:
     plural: ipamhandles
     singular: ipamhandle
   scope: Cluster
+  version: v1 
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPAMHandleSpec contains the specification for an IPAMHandle
-              resource.
-            properties:
-              block:
-                additionalProperties:
-                  type: integer
-                type: object
-              handleID:
-                type: string
-            required:
-            - block
-            - handleID
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IPAMHandleSpec contains the specification for an IPAMHandle
+            resource.
+          properties:
+            block:
+              additionalProperties:
+                type: integer
+              type: object
+            handleID:
+              type: string
+          required:
+          - block
+          - handleID
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ippools.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ippools.yaml
@@ -1,0 +1,102 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec contains the specification for an IPPool resource.
+            properties:
+              blockSize:
+                description: The block size to use for IP address assignments from
+                  this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                type: integer
+              cidr:
+                description: The pool CIDR.
+                type: string
+              disabled:
+                description: When disabled is true, Calico IPAM will not assign addresses
+                  from this pool.
+                type: boolean
+              ipip:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                properties:
+                  enabled:
+                    description: When enabled is true, ipip tunneling will be used
+                      to deliver packets to destinations within this pool.
+                    type: boolean
+                  mode:
+                    description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                      mode of "always" will also use IPIP tunneling for routing to
+                      destination IP addresses within this pool.  A mode of "cross-subnet"
+                      will only use IPIP tunneling when the destination node is on
+                      a different subnet to the originating node.  The default value
+                      (if not specified) is "always".
+                    type: string
+                type: object
+              ipipMode:
+                description: Contains configuration for IPIP tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. IPIP tunelling
+                  is disabled).
+                type: string
+              nat-outgoing:
+                description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                type: boolean
+              natOutgoing:
+                description: When nat-outgoing is true, packets sent from Calico networked
+                  containers in this pool to destinations outside of this pool will
+                  be masqueraded.
+                type: boolean
+              nodeSelector:
+                description: Allows IPPool to allocate for a specific node by label
+                  selector.
+                type: string
+              vxlanMode:
+                description: Contains configuration for VXLAN tunneling for this pool.
+                  If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                  tunelling is disabled).
+                type: string
+            required:
+            - cidr
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ippools.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_ippools.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,85 +13,86 @@ spec:
     plural: ippools
     singular: ippool
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPPoolSpec contains the specification for an IPPool resource.
-            properties:
-              blockSize:
-                description: The block size to use for IP address assignments from
-                  this pool. Defaults to 26 for IPv4 and 112 for IPv6.
-                type: integer
-              cidr:
-                description: The pool CIDR.
-                type: string
-              disabled:
-                description: When disabled is true, Calico IPAM will not assign addresses
-                  from this pool.
-                type: boolean
-              ipip:
-                description: 'Deprecated: this field is only used for APIv1 backwards
-                  compatibility. Setting this field is not allowed, this field is
-                  for internal use only.'
-                properties:
-                  enabled:
-                    description: When enabled is true, ipip tunneling will be used
-                      to deliver packets to destinations within this pool.
-                    type: boolean
-                  mode:
-                    description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
-                      mode of "always" will also use IPIP tunneling for routing to
-                      destination IP addresses within this pool.  A mode of "cross-subnet"
-                      will only use IPIP tunneling when the destination node is on
-                      a different subnet to the originating node.  The default value
-                      (if not specified) is "always".
-                    type: string
-                type: object
-              ipipMode:
-                description: Contains configuration for IPIP tunneling for this pool.
-                  If not specified, then this is defaulted to "Never" (i.e. IPIP tunelling
-                  is disabled).
-                type: string
-              nat-outgoing:
-                description: 'Deprecated: this field is only used for APIv1 backwards
-                  compatibility. Setting this field is not allowed, this field is
-                  for internal use only.'
-                type: boolean
-              natOutgoing:
-                description: When nat-outgoing is true, packets sent from Calico networked
-                  containers in this pool to destinations outside of this pool will
-                  be masqueraded.
-                type: boolean
-              nodeSelector:
-                description: Allows IPPool to allocate for a specific node by label
-                  selector.
-                type: string
-              vxlanMode:
-                description: Contains configuration for VXLAN tunneling for this pool.
-                  If not specified, then this is defaulted to "Never" (i.e. VXLAN
-                  tunelling is disabled).
-                type: string
-            required:
-            - cidr
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IPPoolSpec contains the specification for an IPPool resource.
+          properties:
+            blockSize:
+              description: The block size to use for IP address assignments from
+                this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+              type: integer
+            cidr:
+              description: The pool CIDR.
+              type: string
+            disabled:
+              description: When disabled is true, Calico IPAM will not assign addresses
+                from this pool.
+              type: boolean
+            ipip:
+              description: 'Deprecated: this field is only used for APIv1 backwards
+                compatibility. Setting this field is not allowed, this field is
+                for internal use only.'
+              properties:
+                enabled:
+                  description: When enabled is true, ipip tunneling will be used
+                    to deliver packets to destinations within this pool.
+                  type: boolean
+                mode:
+                  description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                    mode of "always" will also use IPIP tunneling for routing to
+                    destination IP addresses within this pool.  A mode of "cross-subnet"
+                    will only use IPIP tunneling when the destination node is on
+                    a different subnet to the originating node.  The default value
+                    (if not specified) is "always".
+                  type: string
+              type: object
+            ipipMode:
+              description: Contains configuration for IPIP tunneling for this pool.
+                If not specified, then this is defaulted to "Never" (i.e. IPIP tunelling
+                is disabled).
+              type: string
+            nat-outgoing:
+              description: 'Deprecated: this field is only used for APIv1 backwards
+                compatibility. Setting this field is not allowed, this field is
+                for internal use only.'
+              type: boolean
+            natOutgoing:
+              description: When nat-outgoing is true, packets sent from Calico networked
+                containers in this pool to destinations outside of this pool will
+                be masqueraded.
+              type: boolean
+            nodeSelector:
+              description: Allows IPPool to allocate for a specific node by label
+                selector.
+              type: string
+            vxlanMode:
+              description: Contains configuration for VXLAN tunneling for this pool.
+                If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                tunelling is disabled).
+              type: string
+          required:
+          - cidr
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -1,0 +1,226 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: kubecontrollersconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: KubeControllersConfiguration
+    listKind: KubeControllersConfigurationList
+    plural: kubecontrollersconfigurations
+    singular: kubecontrollersconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeControllersConfigurationSpec contains the values of the
+              Kubernetes controllers configuration.
+            properties:
+              controllers:
+                description: Controllers enables and configures individual Kubernetes
+                  controllers
+                properties:
+                  namespace:
+                    description: Namespace enables and configures the namespace controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  node:
+                    description: Node enables and configures the node controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      hostEndpoint:
+                        description: HostEndpoint controls syncing nodes to host endpoints.
+                          Disabled by default, set to nil to disable.
+                        properties:
+                          autoCreate:
+                            description: 'AutoCreate enables automatic creation of
+                              host endpoints for every node. [Default: Disabled]'
+                            type: string
+                        type: object
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                      syncLabels:
+                        description: 'SyncLabels controls whether to copy Kubernetes
+                          node labels to Calico nodes. [Default: Enabled]'
+                        type: string
+                    type: object
+                  policy:
+                    description: Policy enables and configures the policy controller.
+                      Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  serviceAccount:
+                    description: ServiceAccount enables and configures the service
+                      account controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                  workloadEndpoint:
+                    description: WorkloadEndpoint enables and configures the workload
+                      endpoint controller. Enabled by default, set to nil to disable.
+                    properties:
+                      reconcilerPeriod:
+                        description: 'ReconcilerPeriod is the period to perform reconciliation
+                          with the Calico datastore. [Default: 5m]'
+                        type: string
+                    type: object
+                type: object
+              etcdV3CompactionPeriod:
+                description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                  compaction requests. Set to 0 to disable. [Default: 10m]'
+                type: string
+              healthChecks:
+                description: 'HealthChecks enables or disables support for health
+                  checks [Default: Enabled]'
+                type: string
+              logSeverityScreen:
+                description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                type: string
+            required:
+            - controllers
+            type: object
+          status:
+            description: KubeControllersConfigurationStatus represents the status
+              of the configuration. It's useful for admins to be able to see the actual
+              config that was applied, which can be modified by environment variables
+              on the kube-controllers process.
+            properties:
+              environmentVars:
+                additionalProperties:
+                  type: string
+                description: EnvironmentVars contains the environment variables on
+                  the kube-controllers that influenced the RunningConfig.
+                type: object
+              runningConfig:
+                description: RunningConfig contains the effective config that is running
+                  in the kube-controllers pod, after merging the API resource with
+                  any environment variables.
+                properties:
+                  controllers:
+                    description: Controllers enables and configures individual Kubernetes
+                      controllers
+                    properties:
+                      namespace:
+                        description: Namespace enables and configures the namespace
+                          controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      node:
+                        description: Node enables and configures the node controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          hostEndpoint:
+                            description: HostEndpoint controls syncing nodes to host
+                              endpoints. Disabled by default, set to nil to disable.
+                            properties:
+                              autoCreate:
+                                description: 'AutoCreate enables automatic creation
+                                  of host endpoints for every node. [Default: Disabled]'
+                                type: string
+                            type: object
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                          syncLabels:
+                            description: 'SyncLabels controls whether to copy Kubernetes
+                              node labels to Calico nodes. [Default: Enabled]'
+                            type: string
+                        type: object
+                      policy:
+                        description: Policy enables and configures the policy controller.
+                          Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      serviceAccount:
+                        description: ServiceAccount enables and configures the service
+                          account controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                      workloadEndpoint:
+                        description: WorkloadEndpoint enables and configures the workload
+                          endpoint controller. Enabled by default, set to nil to disable.
+                        properties:
+                          reconcilerPeriod:
+                            description: 'ReconcilerPeriod is the period to perform
+                              reconciliation with the Calico datastore. [Default:
+                              5m]'
+                            type: string
+                        type: object
+                    type: object
+                  etcdV3CompactionPeriod:
+                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                      compaction requests. Set to 0 to disable. [Default: 10m]'
+                    type: string
+                  healthChecks:
+                    description: 'HealthChecks enables or disables support for health
+                      checks [Default: Enabled]'
+                    type: string
+                  logSeverityScreen:
+                    description: 'LogSeverityScreen is the log severity above which
+                      logs are sent to the stdout. [Default: Info]'
+                    type: string
+                required:
+                - controllers
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,209 +13,210 @@ spec:
     plural: kubecontrollersconfigurations
     singular: kubecontrollersconfiguration
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: KubeControllersConfigurationSpec contains the values of the
-              Kubernetes controllers configuration.
-            properties:
-              controllers:
-                description: Controllers enables and configures individual Kubernetes
-                  controllers
-                properties:
-                  namespace:
-                    description: Namespace enables and configures the namespace controller.
-                      Enabled by default, set to nil to disable.
-                    properties:
-                      reconcilerPeriod:
-                        description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                        type: string
-                    type: object
-                  node:
-                    description: Node enables and configures the node controller.
-                      Enabled by default, set to nil to disable.
-                    properties:
-                      hostEndpoint:
-                        description: HostEndpoint controls syncing nodes to host endpoints.
-                          Disabled by default, set to nil to disable.
-                        properties:
-                          autoCreate:
-                            description: 'AutoCreate enables automatic creation of
-                              host endpoints for every node. [Default: Disabled]'
-                            type: string
-                        type: object
-                      reconcilerPeriod:
-                        description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                        type: string
-                      syncLabels:
-                        description: 'SyncLabels controls whether to copy Kubernetes
-                          node labels to Calico nodes. [Default: Enabled]'
-                        type: string
-                    type: object
-                  policy:
-                    description: Policy enables and configures the policy controller.
-                      Enabled by default, set to nil to disable.
-                    properties:
-                      reconcilerPeriod:
-                        description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                        type: string
-                    type: object
-                  serviceAccount:
-                    description: ServiceAccount enables and configures the service
-                      account controller. Enabled by default, set to nil to disable.
-                    properties:
-                      reconcilerPeriod:
-                        description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                        type: string
-                    type: object
-                  workloadEndpoint:
-                    description: WorkloadEndpoint enables and configures the workload
-                      endpoint controller. Enabled by default, set to nil to disable.
-                    properties:
-                      reconcilerPeriod:
-                        description: 'ReconcilerPeriod is the period to perform reconciliation
-                          with the Calico datastore. [Default: 5m]'
-                        type: string
-                    type: object
-                type: object
-              etcdV3CompactionPeriod:
-                description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                  compaction requests. Set to 0 to disable. [Default: 10m]'
-                type: string
-              healthChecks:
-                description: 'HealthChecks enables or disables support for health
-                  checks [Default: Enabled]'
-                type: string
-              logSeverityScreen:
-                description: 'LogSeverityScreen is the log severity above which logs
-                  are sent to the stdout. [Default: Info]'
-                type: string
-            required:
-            - controllers
-            type: object
-          status:
-            description: KubeControllersConfigurationStatus represents the status
-              of the configuration. It's useful for admins to be able to see the actual
-              config that was applied, which can be modified by environment variables
-              on the kube-controllers process.
-            properties:
-              environmentVars:
-                additionalProperties:
-                  type: string
-                description: EnvironmentVars contains the environment variables on
-                  the kube-controllers that influenced the RunningConfig.
-                type: object
-              runningConfig:
-                description: RunningConfig contains the effective config that is running
-                  in the kube-controllers pod, after merging the API resource with
-                  any environment variables.
-                properties:
-                  controllers:
-                    description: Controllers enables and configures individual Kubernetes
-                      controllers
-                    properties:
-                      namespace:
-                        description: Namespace enables and configures the namespace
-                          controller. Enabled by default, set to nil to disable.
-                        properties:
-                          reconcilerPeriod:
-                            description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                            type: string
-                        type: object
-                      node:
-                        description: Node enables and configures the node controller.
-                          Enabled by default, set to nil to disable.
-                        properties:
-                          hostEndpoint:
-                            description: HostEndpoint controls syncing nodes to host
-                              endpoints. Disabled by default, set to nil to disable.
-                            properties:
-                              autoCreate:
-                                description: 'AutoCreate enables automatic creation
-                                  of host endpoints for every node. [Default: Disabled]'
-                                type: string
-                            type: object
-                          reconcilerPeriod:
-                            description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                            type: string
-                          syncLabels:
-                            description: 'SyncLabels controls whether to copy Kubernetes
-                              node labels to Calico nodes. [Default: Enabled]'
-                            type: string
-                        type: object
-                      policy:
-                        description: Policy enables and configures the policy controller.
-                          Enabled by default, set to nil to disable.
-                        properties:
-                          reconcilerPeriod:
-                            description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                            type: string
-                        type: object
-                      serviceAccount:
-                        description: ServiceAccount enables and configures the service
-                          account controller. Enabled by default, set to nil to disable.
-                        properties:
-                          reconcilerPeriod:
-                            description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                            type: string
-                        type: object
-                      workloadEndpoint:
-                        description: WorkloadEndpoint enables and configures the workload
-                          endpoint controller. Enabled by default, set to nil to disable.
-                        properties:
-                          reconcilerPeriod:
-                            description: 'ReconcilerPeriod is the period to perform
-                              reconciliation with the Calico datastore. [Default:
-                              5m]'
-                            type: string
-                        type: object
-                    type: object
-                  etcdV3CompactionPeriod:
-                    description: 'EtcdV3CompactionPeriod is the period between etcdv3
-                      compaction requests. Set to 0 to disable. [Default: 10m]'
-                    type: string
-                  healthChecks:
-                    description: 'HealthChecks enables or disables support for health
-                      checks [Default: Enabled]'
-                    type: string
-                  logSeverityScreen:
-                    description: 'LogSeverityScreen is the log severity above which
-                      logs are sent to the stdout. [Default: Info]'
-                    type: string
-                required:
-                - controllers
-                type: object
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeControllersConfigurationSpec contains the values of the
+            Kubernetes controllers configuration.
+          properties:
+            controllers:
+              description: Controllers enables and configures individual Kubernetes
+                controllers
+              properties:
+                namespace:
+                  description: Namespace enables and configures the namespace controller.
+                    Enabled by default, set to nil to disable.
+                  properties:
+                    reconcilerPeriod:
+                      description: 'ReconcilerPeriod is the period to perform reconciliation
+                        with the Calico datastore. [Default: 5m]'
+                      type: string
+                  type: object
+                node:
+                  description: Node enables and configures the node controller.
+                    Enabled by default, set to nil to disable.
+                  properties:
+                    hostEndpoint:
+                      description: HostEndpoint controls syncing nodes to host endpoints.
+                        Disabled by default, set to nil to disable.
+                      properties:
+                        autoCreate:
+                          description: 'AutoCreate enables automatic creation of
+                            host endpoints for every node. [Default: Disabled]'
+                          type: string
+                      type: object
+                    reconcilerPeriod:
+                      description: 'ReconcilerPeriod is the period to perform reconciliation
+                        with the Calico datastore. [Default: 5m]'
+                      type: string
+                    syncLabels:
+                      description: 'SyncLabels controls whether to copy Kubernetes
+                        node labels to Calico nodes. [Default: Enabled]'
+                      type: string
+                  type: object
+                policy:
+                  description: Policy enables and configures the policy controller.
+                    Enabled by default, set to nil to disable.
+                  properties:
+                    reconcilerPeriod:
+                      description: 'ReconcilerPeriod is the period to perform reconciliation
+                        with the Calico datastore. [Default: 5m]'
+                      type: string
+                  type: object
+                serviceAccount:
+                  description: ServiceAccount enables and configures the service
+                    account controller. Enabled by default, set to nil to disable.
+                  properties:
+                    reconcilerPeriod:
+                      description: 'ReconcilerPeriod is the period to perform reconciliation
+                        with the Calico datastore. [Default: 5m]'
+                      type: string
+                  type: object
+                workloadEndpoint:
+                  description: WorkloadEndpoint enables and configures the workload
+                    endpoint controller. Enabled by default, set to nil to disable.
+                  properties:
+                    reconcilerPeriod:
+                      description: 'ReconcilerPeriod is the period to perform reconciliation
+                        with the Calico datastore. [Default: 5m]'
+                      type: string
+                  type: object
+              type: object
+            etcdV3CompactionPeriod:
+              description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                compaction requests. Set to 0 to disable. [Default: 10m]'
+              type: string
+            healthChecks:
+              description: 'HealthChecks enables or disables support for health
+                checks [Default: Enabled]'
+              type: string
+            logSeverityScreen:
+              description: 'LogSeverityScreen is the log severity above which logs
+                are sent to the stdout. [Default: Info]'
+              type: string
+          required:
+          - controllers
+          type: object
+        status:
+          description: KubeControllersConfigurationStatus represents the status
+            of the configuration. It's useful for admins to be able to see the actual
+            config that was applied, which can be modified by environment variables
+            on the kube-controllers process.
+          properties:
+            environmentVars:
+              additionalProperties:
+                type: string
+              description: EnvironmentVars contains the environment variables on
+                the kube-controllers that influenced the RunningConfig.
+              type: object
+            runningConfig:
+              description: RunningConfig contains the effective config that is running
+                in the kube-controllers pod, after merging the API resource with
+                any environment variables.
+              properties:
+                controllers:
+                  description: Controllers enables and configures individual Kubernetes
+                    controllers
+                  properties:
+                    namespace:
+                      description: Namespace enables and configures the namespace
+                        controller. Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description: 'ReconcilerPeriod is the period to perform
+                            reconciliation with the Calico datastore. [Default:
+                            5m]'
+                          type: string
+                      type: object
+                    node:
+                      description: Node enables and configures the node controller.
+                        Enabled by default, set to nil to disable.
+                      properties:
+                        hostEndpoint:
+                          description: HostEndpoint controls syncing nodes to host
+                            endpoints. Disabled by default, set to nil to disable.
+                          properties:
+                            autoCreate:
+                              description: 'AutoCreate enables automatic creation
+                                of host endpoints for every node. [Default: Disabled]'
+                              type: string
+                          type: object
+                        reconcilerPeriod:
+                          description: 'ReconcilerPeriod is the period to perform
+                            reconciliation with the Calico datastore. [Default:
+                            5m]'
+                          type: string
+                        syncLabels:
+                          description: 'SyncLabels controls whether to copy Kubernetes
+                            node labels to Calico nodes. [Default: Enabled]'
+                          type: string
+                      type: object
+                    policy:
+                      description: Policy enables and configures the policy controller.
+                        Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description: 'ReconcilerPeriod is the period to perform
+                            reconciliation with the Calico datastore. [Default:
+                            5m]'
+                          type: string
+                      type: object
+                    serviceAccount:
+                      description: ServiceAccount enables and configures the service
+                        account controller. Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description: 'ReconcilerPeriod is the period to perform
+                            reconciliation with the Calico datastore. [Default:
+                            5m]'
+                          type: string
+                      type: object
+                    workloadEndpoint:
+                      description: WorkloadEndpoint enables and configures the workload
+                        endpoint controller. Enabled by default, set to nil to disable.
+                      properties:
+                        reconcilerPeriod:
+                          description: 'ReconcilerPeriod is the period to perform
+                            reconciliation with the Calico datastore. [Default:
+                            5m]'
+                          type: string
+                      type: object
+                  type: object
+                etcdV3CompactionPeriod:
+                  description: 'EtcdV3CompactionPeriod is the period between etcdv3
+                    compaction requests. Set to 0 to disable. [Default: 10m]'
+                  type: string
+                healthChecks:
+                  description: 'HealthChecks enables or disables support for health
+                    checks [Default: Enabled]'
+                  type: string
+                logSeverityScreen:
+                  description: 'LogSeverityScreen is the log severity above which
+                    logs are sent to the stdout. [Default: Info]'
+                  type: string
+              required:
+              - controllers
+              type: object
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networkpolicies.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networkpolicies.yaml
@@ -1,0 +1,755 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with ”Not”. All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel’s iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and Selector are defined on the same rule, then only workload
+                            endpoints that are matched by both selectors will be selected
+                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                            implies that the Selector is limited to selecting only
+                            workload endpoints in the same namespace as the NetworkPolicy.
+                            \n For NetworkPolicy, `global()` NamespaceSelector implies
+                            that the Selector is limited to selecting only GlobalNetworkSet
+                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                            NamespaceSelector implies the Selector applies to workload
+                            endpoints across all namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label “my_label”. \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label “my_label”.
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networkpolicies.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networkpolicies.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,738 +13,739 @@ spec:
     plural: networkpolicies
     singular: networkpolicy
   scope: Namespaced
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              egress:
-                description: The ordered set of egress rules.  Each rule contains
-                  a set of packet match criteria and a corresponding action to apply.
-                items:
-                  description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                  properties:
-                    action:
-                      type: string
-                    destination:
-                      description: Destination contains the match criteria that apply
-                        to destination entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                    http:
-                      description: HTTP contains match criteria that apply to HTTP
-                        requests.
-                      properties:
-                        methods:
-                          description: Methods is an optional field that restricts
-                            the rule to apply only to HTTP requests that use one of
-                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                            methods are OR'd together.
-                          items:
-                            type: string
-                          type: array
-                        paths:
-                          description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                          items:
-                            description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    icmp:
-                      description: ICMP is an optional field that restricts the rule
-                        to apply to a specific type and code of ICMP traffic.  This
-                        should only be specified if the Protocol field is set to "ICMP"
-                        or "ICMPv6".
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    ipVersion:
-                      description: IPVersion is an optional field that restricts the
-                        rule to only match a specific IP version.
-                      type: integer
-                    metadata:
-                      description: Metadata contains additional information for this
-                        rule
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations is a set of key value pairs that
-                            give extra information about the rule
-                          type: object
-                      type: object
-                    notICMP:
-                      description: NotICMP is the negated version of the ICMP field.
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    notProtocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: NotProtocol is the negated version of the Protocol
-                        field.
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    protocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    source:
-                      description: Source contains the match criteria that apply to
-                        source entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                  required:
-                  - action
-                  type: object
-                type: array
-              ingress:
-                description: The ordered set of ingress rules.  Each rule contains
-                  a set of packet match criteria and a corresponding action to apply.
-                items:
-                  description: "A Rule encapsulates a set of match criteria and an
-                    action.  Both selector-based security Policy and security Profiles
-                    reference rules - separated out as a list of rules for both ingress
-                    and egress packet matching. \n Each positive match criteria has
-                    a negated version, prefixed with ”Not”. All the match criteria
-                    within a rule must be satisfied for a packet to match. A single
-                    rule can contain the positive and negative version of a match
-                    and both must be satisfied for the rule to match."
-                  properties:
-                    action:
-                      type: string
-                    destination:
-                      description: Destination contains the match criteria that apply
-                        to destination entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                    http:
-                      description: HTTP contains match criteria that apply to HTTP
-                        requests.
-                      properties:
-                        methods:
-                          description: Methods is an optional field that restricts
-                            the rule to apply only to HTTP requests that use one of
-                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
-                            methods are OR'd together.
-                          items:
-                            type: string
-                          type: array
-                        paths:
-                          description: 'Paths is an optional field that restricts
-                            the rule to apply to HTTP requests that use one of the
-                            listed HTTP Paths. Multiple paths are OR''d together.
-                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
-                            ONLY specify either a `exact` or a `prefix` match. The
-                            validator will check for it.'
-                          items:
-                            description: 'HTTPPath specifies an HTTP path to match.
-                              It may be either of the form: exact: <path>: which matches
-                              the path exactly or prefix: <path-prefix>: which matches
-                              the path prefix'
-                            properties:
-                              exact:
-                                type: string
-                              prefix:
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    icmp:
-                      description: ICMP is an optional field that restricts the rule
-                        to apply to a specific type and code of ICMP traffic.  This
-                        should only be specified if the Protocol field is set to "ICMP"
-                        or "ICMPv6".
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    ipVersion:
-                      description: IPVersion is an optional field that restricts the
-                        rule to only match a specific IP version.
-                      type: integer
-                    metadata:
-                      description: Metadata contains additional information for this
-                        rule
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations is a set of key value pairs that
-                            give extra information about the rule
-                          type: object
-                      type: object
-                    notICMP:
-                      description: NotICMP is the negated version of the ICMP field.
-                      properties:
-                        code:
-                          description: Match on a specific ICMP code.  If specified,
-                            the Type value must also be specified. This is a technical
-                            limitation imposed by the kernel’s iptables firewall,
-                            which Calico uses to enforce the rule.
-                          type: integer
-                        type:
-                          description: Match on a specific ICMP type.  For example
-                            a value of 8 refers to ICMP Echo Request (i.e. pings).
-                          type: integer
-                      type: object
-                    notProtocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: NotProtocol is the negated version of the Protocol
-                        field.
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    protocol:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: "Protocol is an optional field that restricts the
-                        rule to only apply to traffic of a specific IP protocol. Required
-                        if any of the EntityRules contain Ports (because ports only
-                        apply to certain protocols). \n Must be one of these string
-                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
-                        \"UDPLite\" or an integer in the range 1-255."
-                      pattern: ^.*
-                      x-kubernetes-int-or-string: true
-                    source:
-                      description: Source contains the match criteria that apply to
-                        source entity.
-                      properties:
-                        namespaceSelector:
-                          description: "NamespaceSelector is an optional field that
-                            contains a selector expression. Only traffic that originates
-                            from (or terminates at) endpoints within the selected
-                            namespaces will be matched. When both NamespaceSelector
-                            and Selector are defined on the same rule, then only workload
-                            endpoints that are matched by both selectors will be selected
-                            by the rule. \n For NetworkPolicy, an empty NamespaceSelector
-                            implies that the Selector is limited to selecting only
-                            workload endpoints in the same namespace as the NetworkPolicy.
-                            \n For NetworkPolicy, `global()` NamespaceSelector implies
-                            that the Selector is limited to selecting only GlobalNetworkSet
-                            or HostEndpoint. \n For GlobalNetworkPolicy, an empty
-                            NamespaceSelector implies the Selector applies to workload
-                            endpoints across all namespaces."
-                          type: string
-                        nets:
-                          description: Nets is an optional field that restricts the
-                            rule to only apply to traffic that originates from (or
-                            terminates at) IP addresses in any of the given subnets.
-                          items:
-                            type: string
-                          type: array
-                        notNets:
-                          description: NotNets is the negated version of the Nets
-                            field.
-                          items:
-                            type: string
-                          type: array
-                        notPorts:
-                          description: NotPorts is the negated version of the Ports
-                            field. Since only some protocols have ports, if any ports
-                            are specified it requires the Protocol match in the Rule
-                            to be set to "TCP" or "UDP".
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        notSelector:
-                          description: NotSelector is the negated version of the Selector
-                            field.  See Selector field for subtleties with negated
-                            selectors.
-                          type: string
-                        ports:
-                          description: "Ports is an optional field that restricts
-                            the rule to only apply to traffic that has a source (destination)
-                            port that matches one of these ranges/values. This value
-                            is a list of integers or strings that represent ranges
-                            of ports. \n Since only some protocols have ports, if
-                            any ports are specified it requires the Protocol match
-                            in the Rule to be set to \"TCP\" or \"UDP\"."
-                          items:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^.*
-                            x-kubernetes-int-or-string: true
-                          type: array
-                        selector:
-                          description: "Selector is an optional field that contains
-                            a selector expression (see Policy for sample syntax).
-                            \ Only traffic that originates from (terminates at) endpoints
-                            matching the selector will be matched. \n Note that: in
-                            addition to the negated version of the Selector (see NotSelector
-                            below), the selector expression syntax itself supports
-                            negation.  The two types of negation are subtly different.
-                            One negates the set of matched endpoints, the other negates
-                            the whole match: \n \tSelector = \"!has(my_label)\" matches
-                            packets that are from other Calico-controlled \tendpoints
-                            that do not have the label “my_label”. \n \tNotSelector
-                            = \"has(my_label)\" matches packets that are not from
-                            Calico-controlled \tendpoints that do have the label “my_label”.
-                            \n The effect is that the latter will accept packets from
-                            non-Calico sources whereas the former is limited to packets
-                            from Calico-controlled endpoints."
-                          type: string
-                        serviceAccounts:
-                          description: ServiceAccounts is an optional field that restricts
-                            the rule to only apply to traffic that originates from
-                            (or terminates at) a pod running as a matching service
-                            account.
-                          properties:
-                            names:
-                              description: Names is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account whose name is in the list.
-                              items:
-                                type: string
-                              type: array
-                            selector:
-                              description: Selector is an optional field that restricts
-                                the rule to only apply to traffic that originates
-                                from (or terminates at) a pod running as a service
-                                account that matches the given label selector. If
-                                both Names and Selector are specified then they are
-                                AND'ed.
-                              type: string
-                          type: object
-                      type: object
-                  required:
-                  - action
-                  type: object
-                type: array
-              order:
-                description: Order is an optional field that specifies the order in
-                  which the policy is applied. Policies with higher "order" are applied
-                  after those with lower order.  If the order is omitted, it may be
-                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
-                  with identical order will be applied in alphanumerical order based
-                  on the Policy "Name".
-                type: number
-              selector:
-                description: "The selector is an expression used to pick pick out
-                  the endpoints that the policy should be applied to. \n Selector
-                  expressions follow this syntax: \n \tlabel == \"string_literal\"
-                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
-                  \  ->  not equal; also matches if label is not present \tlabel in
-                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
-                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
-                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
-                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
-                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
-                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
-                  or the empty selector -> matches all endpoints. \n Label names are
-                  allowed to contain alphanumerics, -, _ and /. String literals are
-                  more permissive but they do not support escape characters. \n Examples
-                  (with made-up labels): \n \ttype == \"webserver\" && deployment
-                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
-                  \"dev\" \t! has(label_name)"
-                type: string
-              serviceAccountSelector:
-                description: ServiceAccountSelector is an optional field for an expression
-                  used to select a pod based on service accounts.
-                type: string
-              types:
-                description: "Types indicates whether this policy applies to ingress,
-                  or to egress, or to both.  When not explicitly specified (and so
-                  the value on creation is empty or nil), Calico defaults Types according
-                  to what Ingress and Egress are present in the policy.  The default
-                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
-                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
-                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
-                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
-                  \n When the policy is read back again, Types will always be one
-                  of these values, never empty or nil."
-                items:
-                  description: PolicyType enumerates the possible values of the PolicySpec
-                    Types field.
-                  type: string
-                type: array
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            egress:
+              description: The ordered set of egress rules.  Each rule contains
+                a set of packet match criteria and a corresponding action to apply.
+              items:
+                description: "A Rule encapsulates a set of match criteria and an
+                  action.  Both selector-based security Policy and security Profiles
+                  reference rules - separated out as a list of rules for both ingress
+                  and egress packet matching. \n Each positive match criteria has
+                  a negated version, prefixed with ”Not”. All the match criteria
+                  within a rule must be satisfied for a packet to match. A single
+                  rule can contain the positive and negative version of a match
+                  and both must be satisfied for the rule to match."
+                properties:
+                  action:
+                    type: string
+                  destination:
+                    description: Destination contains the match criteria that apply
+                      to destination entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                  http:
+                    description: HTTP contains match criteria that apply to HTTP
+                      requests.
+                    properties:
+                      methods:
+                        description: Methods is an optional field that restricts
+                          the rule to apply only to HTTP requests that use one of
+                          the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                          methods are OR'd together.
+                        items:
+                          type: string
+                        type: array
+                      paths:
+                        description: 'Paths is an optional field that restricts
+                          the rule to apply to HTTP requests that use one of the
+                          listed HTTP Paths. Multiple paths are OR''d together.
+                          e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                          ONLY specify either a `exact` or a `prefix` match. The
+                          validator will check for it.'
+                        items:
+                          description: 'HTTPPath specifies an HTTP path to match.
+                            It may be either of the form: exact: <path>: which matches
+                            the path exactly or prefix: <path-prefix>: which matches
+                            the path prefix'
+                          properties:
+                            exact:
+                              type: string
+                            prefix:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  icmp:
+                    description: ICMP is an optional field that restricts the rule
+                      to apply to a specific type and code of ICMP traffic.  This
+                      should only be specified if the Protocol field is set to "ICMP"
+                      or "ICMPv6".
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  ipVersion:
+                    description: IPVersion is an optional field that restricts the
+                      rule to only match a specific IP version.
+                    type: integer
+                  metadata:
+                    description: Metadata contains additional information for this
+                      rule
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a set of key value pairs that
+                          give extra information about the rule
+                        type: object
+                    type: object
+                  notICMP:
+                    description: NotICMP is the negated version of the ICMP field.
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  notProtocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NotProtocol is the negated version of the Protocol
+                      field.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  protocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: "Protocol is an optional field that restricts the
+                      rule to only apply to traffic of a specific IP protocol. Required
+                      if any of the EntityRules contain Ports (because ports only
+                      apply to certain protocols). \n Must be one of these string
+                      values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                      \"UDPLite\" or an integer in the range 1-255."
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  source:
+                    description: Source contains the match criteria that apply to
+                      source entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - action
+                type: object
+              type: array
+            ingress:
+              description: The ordered set of ingress rules.  Each rule contains
+                a set of packet match criteria and a corresponding action to apply.
+              items:
+                description: "A Rule encapsulates a set of match criteria and an
+                  action.  Both selector-based security Policy and security Profiles
+                  reference rules - separated out as a list of rules for both ingress
+                  and egress packet matching. \n Each positive match criteria has
+                  a negated version, prefixed with ”Not”. All the match criteria
+                  within a rule must be satisfied for a packet to match. A single
+                  rule can contain the positive and negative version of a match
+                  and both must be satisfied for the rule to match."
+                properties:
+                  action:
+                    type: string
+                  destination:
+                    description: Destination contains the match criteria that apply
+                      to destination entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                  http:
+                    description: HTTP contains match criteria that apply to HTTP
+                      requests.
+                    properties:
+                      methods:
+                        description: Methods is an optional field that restricts
+                          the rule to apply only to HTTP requests that use one of
+                          the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                          methods are OR'd together.
+                        items:
+                          type: string
+                        type: array
+                      paths:
+                        description: 'Paths is an optional field that restricts
+                          the rule to apply to HTTP requests that use one of the
+                          listed HTTP Paths. Multiple paths are OR''d together.
+                          e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                          ONLY specify either a `exact` or a `prefix` match. The
+                          validator will check for it.'
+                        items:
+                          description: 'HTTPPath specifies an HTTP path to match.
+                            It may be either of the form: exact: <path>: which matches
+                            the path exactly or prefix: <path-prefix>: which matches
+                            the path prefix'
+                          properties:
+                            exact:
+                              type: string
+                            prefix:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  icmp:
+                    description: ICMP is an optional field that restricts the rule
+                      to apply to a specific type and code of ICMP traffic.  This
+                      should only be specified if the Protocol field is set to "ICMP"
+                      or "ICMPv6".
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  ipVersion:
+                    description: IPVersion is an optional field that restricts the
+                      rule to only match a specific IP version.
+                    type: integer
+                  metadata:
+                    description: Metadata contains additional information for this
+                      rule
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a set of key value pairs that
+                          give extra information about the rule
+                        type: object
+                    type: object
+                  notICMP:
+                    description: NotICMP is the negated version of the ICMP field.
+                    properties:
+                      code:
+                        description: Match on a specific ICMP code.  If specified,
+                          the Type value must also be specified. This is a technical
+                          limitation imposed by the kernel’s iptables firewall,
+                          which Calico uses to enforce the rule.
+                        type: integer
+                      type:
+                        description: Match on a specific ICMP type.  For example
+                          a value of 8 refers to ICMP Echo Request (i.e. pings).
+                        type: integer
+                    type: object
+                  notProtocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: NotProtocol is the negated version of the Protocol
+                      field.
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  protocol:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: "Protocol is an optional field that restricts the
+                      rule to only apply to traffic of a specific IP protocol. Required
+                      if any of the EntityRules contain Ports (because ports only
+                      apply to certain protocols). \n Must be one of these string
+                      values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                      \"UDPLite\" or an integer in the range 1-255."
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  source:
+                    description: Source contains the match criteria that apply to
+                      source entity.
+                    properties:
+                      namespaceSelector:
+                        description: "NamespaceSelector is an optional field that
+                          contains a selector expression. Only traffic that originates
+                          from (or terminates at) endpoints within the selected
+                          namespaces will be matched. When both NamespaceSelector
+                          and Selector are defined on the same rule, then only workload
+                          endpoints that are matched by both selectors will be selected
+                          by the rule. \n For NetworkPolicy, an empty NamespaceSelector
+                          implies that the Selector is limited to selecting only
+                          workload endpoints in the same namespace as the NetworkPolicy.
+                          \n For NetworkPolicy, `global()` NamespaceSelector implies
+                          that the Selector is limited to selecting only GlobalNetworkSet
+                          or HostEndpoint. \n For GlobalNetworkPolicy, an empty
+                          NamespaceSelector implies the Selector applies to workload
+                          endpoints across all namespaces."
+                        type: string
+                      nets:
+                        description: Nets is an optional field that restricts the
+                          rule to only apply to traffic that originates from (or
+                          terminates at) IP addresses in any of the given subnets.
+                        items:
+                          type: string
+                        type: array
+                      notNets:
+                        description: NotNets is the negated version of the Nets
+                          field.
+                        items:
+                          type: string
+                        type: array
+                      notPorts:
+                        description: NotPorts is the negated version of the Ports
+                          field. Since only some protocols have ports, if any ports
+                          are specified it requires the Protocol match in the Rule
+                          to be set to "TCP" or "UDP".
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      notSelector:
+                        description: NotSelector is the negated version of the Selector
+                          field.  See Selector field for subtleties with negated
+                          selectors.
+                        type: string
+                      ports:
+                        description: "Ports is an optional field that restricts
+                          the rule to only apply to traffic that has a source (destination)
+                          port that matches one of these ranges/values. This value
+                          is a list of integers or strings that represent ranges
+                          of ports. \n Since only some protocols have ports, if
+                          any ports are specified it requires the Protocol match
+                          in the Rule to be set to \"TCP\" or \"UDP\"."
+                        items:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^.*
+                          x-kubernetes-int-or-string: true
+                        type: array
+                      selector:
+                        description: "Selector is an optional field that contains
+                          a selector expression (see Policy for sample syntax).
+                          \ Only traffic that originates from (terminates at) endpoints
+                          matching the selector will be matched. \n Note that: in
+                          addition to the negated version of the Selector (see NotSelector
+                          below), the selector expression syntax itself supports
+                          negation.  The two types of negation are subtly different.
+                          One negates the set of matched endpoints, the other negates
+                          the whole match: \n \tSelector = \"!has(my_label)\" matches
+                          packets that are from other Calico-controlled \tendpoints
+                          that do not have the label “my_label”. \n \tNotSelector
+                          = \"has(my_label)\" matches packets that are not from
+                          Calico-controlled \tendpoints that do have the label “my_label”.
+                          \n The effect is that the latter will accept packets from
+                          non-Calico sources whereas the former is limited to packets
+                          from Calico-controlled endpoints."
+                        type: string
+                      serviceAccounts:
+                        description: ServiceAccounts is an optional field that restricts
+                          the rule to only apply to traffic that originates from
+                          (or terminates at) a pod running as a matching service
+                          account.
+                        properties:
+                          names:
+                            description: Names is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account whose name is in the list.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: Selector is an optional field that restricts
+                              the rule to only apply to traffic that originates
+                              from (or terminates at) a pod running as a service
+                              account that matches the given label selector. If
+                              both Names and Selector are specified then they are
+                              AND'ed.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - action
+                type: object
+              type: array
+            order:
+              description: Order is an optional field that specifies the order in
+                which the policy is applied. Policies with higher "order" are applied
+                after those with lower order.  If the order is omitted, it may be
+                considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                with identical order will be applied in alphanumerical order based
+                on the Policy "Name".
+              type: number
+            selector:
+              description: "The selector is an expression used to pick pick out
+                the endpoints that the policy should be applied to. \n Selector
+                expressions follow this syntax: \n \tlabel == \"string_literal\"
+                \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                \  ->  not equal; also matches if label is not present \tlabel in
+                { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                or the empty selector -> matches all endpoints. \n Label names are
+                allowed to contain alphanumerics, -, _ and /. String literals are
+                more permissive but they do not support escape characters. \n Examples
+                (with made-up labels): \n \ttype == \"webserver\" && deployment
+                == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                \"dev\" \t! has(label_name)"
+              type: string
+            serviceAccountSelector:
+              description: ServiceAccountSelector is an optional field for an expression
+                used to select a pod based on service accounts.
+              type: string
+            types:
+              description: "Types indicates whether this policy applies to ingress,
+                or to egress, or to both.  When not explicitly specified (and so
+                the value on creation is empty or nil), Calico defaults Types according
+                to what Ingress and Egress are present in the policy.  The default
+                is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                \n When the policy is read back again, Types will always be one
+                of these values, never empty or nil."
+              items:
+                description: PolicyType enumerates the possible values of the PolicySpec
+                  Types field.
+                type: string
+              type: array
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networksets.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networksets.yaml
@@ -1,0 +1,54 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: networksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkSet
+    listKind: NetworkSetList
+    plural: networksets
+    singular: networkset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkSetSpec contains the specification for a NetworkSet
+              resource.
+            properties:
+              nets:
+                description: The list of IP networks that belong to this set.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networksets.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/crd.projectcalico.org_networksets.yaml
@@ -1,6 +1,4 @@
-
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,37 +13,38 @@ spec:
     plural: networksets
     singular: networkset
   scope: Namespaced
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: NetworkSetSpec contains the specification for a NetworkSet
-              resource.
-            properties:
-              nets:
-                description: The list of IP networks that belong to this set.
-                items:
-                  type: string
-                type: array
-            type: object
-        type: object
     served: true
     storage: true
+  validation:
+    openAPIV3Schema:
+      description: NetworkSet is the Namespaced-equivalent of the GlobalNetworkSet.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: NetworkSetSpec contains the specification for a NetworkSet
+            resource.
+          properties:
+            nets:
+              description: The list of IP networks that belong to this set.
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_installations_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_installations_crd.yaml
@@ -1,0 +1,342 @@
+---
+# Source: tigera-operator/templates/crds/operator.tigera.io_installations_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: installations.operator.tigera.io
+spec:
+  group: operator.tigera.io
+  names:
+    kind: Installation
+    listKind: InstallationList
+    plural: installations
+    singular: installation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Installation configures an installation of Calico or Calico Enterprise.
+          At most one instance of this resource is supported. It must be named "default".
+          The Installation API installs core networking and network policy components,
+          and provides general install-time configuration.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired state for the Calico or Calico
+              Enterprise installation.
+            properties:
+              calicoNetwork:
+                description: CalicoNetwork specifies configuration options for Calico
+                  provided pod networking.
+                properties:
+                  hostPorts:
+                    description: 'HostPorts configures whether or not Calico will
+                      support Kubernetes HostPorts. Default: Enabled'
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  ipPools:
+                    description: IPPools contains a list of IP pools to use for allocating
+                      pod IP addresses. At most one IP pool may be specified. If omitted,
+                      a single pool will be configured when needed.
+                    items:
+                      properties:
+                        blockSize:
+                          description: 'BlockSize specifies the CIDR prefex length
+                            to use when allocating per-node IP blocks from the main
+                            IP pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
+                          format: int32
+                          type: integer
+                        cidr:
+                          description: CIDR contains the address range for the IP
+                            Pool in classless inter-domain routing format.
+                          type: string
+                        encapsulation:
+                          description: 'Encapsulation specifies the encapsulation
+                            type that will be used with the IP Pool. Default: IPIP'
+                          enum:
+                          - IPIPCrossSubnet
+                          - IPIP
+                          - VXLAN
+                          - VXLANCrossSubnet
+                          - None
+                          type: string
+                        natOutgoing:
+                          description: 'NATOutgoing specifies if NAT will be enabled
+                            or disabled for outgoing traffic. Default: Enabled'
+                          enum:
+                          - Enabled
+                          - Disabled
+                          type: string
+                        nodeSelector:
+                          description: 'NodeSelector specifies the node selector that
+                            will be set for the IP Pool. Default: ''all()'''
+                          type: string
+                      required:
+                      - cidr
+                      type: object
+                    type: array
+                  mtu:
+                    description: 'MTU specifies the maximum transmission unit to use
+                      for pods on the Calico network. Default: 1410'
+                    format: int32
+                    type: integer
+                  multiInterfaceMode:
+                    description: 'MultiInterfaceMode configures what will configure
+                      multiple interface per pod. Only valid for Calico Enterprise
+                      installations. Default: None'
+                    enum:
+                    - None
+                    - Multus
+                    type: string
+                  nodeAddressAutodetectionV4:
+                    description: NodeAddressAutodetectionV4 specifies an approach
+                      to automatically detect node IPv4 addresses. If not specified,
+                      will use default auto-detection settings to acquire an IPv4
+                      address for each node.
+                    properties:
+                      canReach:
+                        description: CanReach enables IP auto-detection based on which
+                          source address on the node is used to reach the specified
+                          IP or domain.
+                        type: string
+                      firstFound:
+                        description: FirstFound uses default interface matching parameters
+                          to select an interface, performing best-effort filtering
+                          based on well-known interface names.
+                        type: boolean
+                      interface:
+                        description: Interface enables IP auto-detection based on
+                          interfaces that match the given regex.
+                        type: string
+                      skipInterface:
+                        description: SkipInterface enables IP auto-detection based
+                          on interfaces that do not match the given regex.
+                        type: string
+                    type: object
+                  nodeAddressAutodetectionV6:
+                    description: NodeAddressAutodetectionV6 specifies an approach
+                      to automatically detect node IPv4 addresses. If not specified,
+                      IPv6 addresses will not be auto-detected.
+                    properties:
+                      canReach:
+                        description: CanReach enables IP auto-detection based on which
+                          source address on the node is used to reach the specified
+                          IP or domain.
+                        type: string
+                      firstFound:
+                        description: FirstFound uses default interface matching parameters
+                          to select an interface, performing best-effort filtering
+                          based on well-known interface names.
+                        type: boolean
+                      interface:
+                        description: Interface enables IP auto-detection based on
+                          interfaces that match the given regex.
+                        type: string
+                      skipInterface:
+                        description: SkipInterface enables IP auto-detection based
+                          on interfaces that do not match the given regex.
+                        type: string
+                    type: object
+                type: object
+              clusterManagementType:
+                description: 'How the cluster is managed. Valid values for this field
+                  are: Standalone, Management, Managed. Standalone clusters are fully
+                  self-contained installations of Calico Enterprise. Management clusters
+                  provide a single view to manage any number of Managed clusters,
+                  which are a lighter weight installation. This option is applicable
+                  only when variant is TigeraSecureEnterprise. Default: Standalone'
+                enum:
+                - Standalone
+                - Management
+                - Managed
+                type: string
+              componentResources:
+                description: ComponentResources can be used to customize the resource
+                  requirements for each component.
+                items:
+                  description: The ComponentResource struct associates a ResourceRequirements
+                    with a component by name
+                  properties:
+                    componentName:
+                      description: ComponentName CRD enum
+                      enum:
+                      - Node
+                      - Typha
+                      - KubeControllers
+                      type: string
+                    resourceRequirements:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                  required:
+                  - componentName
+                  - resourceRequirements
+                  type: object
+                type: array
+              controlPlaneNodeSelector:
+                additionalProperties:
+                  type: string
+                description: ControlPlaneNodeSelector is used to select control plane
+                  nodes on which to run specific Calico components. This currently
+                  only applies to kube-controllers and the apiserver.
+                type: object
+              flexVolumePath:
+                description: FlexVolumePath optionally specifies a custom path for
+                  FlexVolume. If not specified, FlexVolume will be enabled by default.
+                  If set to 'None', FlexVolume will be disabled. The default is based
+                  on the kubernetesProvider.
+                type: string
+              imagePath:
+                description: "ImagePath allows for the path part of an image to be
+                  specified. If specified then the specified value will be used as
+                  the image path for each image. If not specified or empty, the default
+                  for each image will be used. \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                  \n This option allows configuring the `<imagePath>` portion of the
+                  above format."
+                type: string
+              imagePullSecrets:
+                description: ImagePullSecrets is an array of references to container
+                  registry pull secrets to use. These are applied to all images to
+                  be pulled.
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
+              kubernetesProvider:
+                description: KubernetesProvider specifies a particular provider of
+                  the Kubernetes platform and enables provider-specific configuration.
+                  If the specified value is empty, the Operator will attempt to automatically
+                  determine the current provider. If the specified value is not empty,
+                  the Operator will still attempt auto-detection, but will additionally
+                  compare the auto-detected value to the specified value to confirm
+                  they match.
+                enum:
+                - EKS
+                - GKE
+                - AKS
+                - OpenShift
+                - DockerEnterprise
+                type: string
+              nodeMetricsPort:
+                description: NodeMetricsPort specifies which port calico/node serves
+                  prometheus metrics on. By default, metrics are not enabled. If specified,
+                  this overrides any FelixConfiguration resources which may exist.
+                  If omitted, then prometheus metrics may still be configured through
+                  FelixConfiguration.
+                format: int32
+                type: integer
+              nodeUpdateStrategy:
+                description: NodeUpdateStrategy can be used to customize the desired
+                  update strategy, such as the MaxUnavailable field.
+                properties:
+                  rollingUpdate:
+                    description: 'Rolling update config params. Present only if type
+                      = "RollingUpdate". --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
+                      See https://github.com/kubernetes/kubernetes/issues/35345'
+                    properties:
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of DaemonSet pods that can
+                          be unavailable during the update. Value can be an absolute
+                          number (ex: 5) or a percentage of total number of DaemonSet
+                          pods at the start of the update (ex: 10%). Absolute number
+                          is calculated from percentage by rounding up. This cannot
+                          be 0. Default value is 1. Example: when this is set to 30%,
+                          at most 30% of the total number of nodes that should be
+                          running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time.
+                          The update starts by stopping at most 30% of those DaemonSet
+                          pods and then brings up new DaemonSet pods in their place.
+                          Once the new pods are available, it then proceeds onto other
+                          DaemonSet pods, thus ensuring that at least 70% of original
+                          number of DaemonSet pods are available at all times during
+                          the update.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of daemon set update. Can be "RollingUpdate"
+                      or "OnDelete". Default is RollingUpdate.
+                    type: string
+                type: object
+              registry:
+                description: "Registry is the default Docker registry used for component
+                  Docker images. If specified, all images will be pulled from this
+                  registry. If not specified then the default registries will be used.
+                  \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                  \n This option allows configuring the `<registry>` portion of the
+                  above format."
+                type: string
+              variant:
+                description: 'Variant is the product to install - one of Calico or
+                  TigeraSecureEnterprise Default: Calico'
+                enum:
+                - Calico
+                - TigeraSecureEnterprise
+                type: string
+            type: object
+          status:
+            description: Most recently observed state for the Calico or Calico Enterprise
+              installation.
+            properties:
+              variant:
+                description: Variant is the most recently observed installed variant
+                  - one of Calico or TigeraSecureEnterprise
+                enum:
+                - Calico
+                - TigeraSecureEnterprise
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+

--- a/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_installations_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_installations_crd.yaml
@@ -1,6 +1,4 @@
----
-# Source: tigera-operator/templates/crds/operator.tigera.io_installations_crd.yaml
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: installations.operator.tigera.io
@@ -12,331 +10,332 @@ spec:
     plural: installations
     singular: installation
   scope: Cluster
+  version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Installation configures an installation of Calico or Calico Enterprise.
-          At most one instance of this resource is supported. It must be named "default".
-          The Installation API installs core networking and network policy components,
-          and provides general install-time configuration.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Specification of the desired state for the Calico or Calico
-              Enterprise installation.
-            properties:
-              calicoNetwork:
-                description: CalicoNetwork specifies configuration options for Calico
-                  provided pod networking.
-                properties:
-                  hostPorts:
-                    description: 'HostPorts configures whether or not Calico will
-                      support Kubernetes HostPorts. Default: Enabled'
-                    enum:
-                    - Enabled
-                    - Disabled
-                    type: string
-                  ipPools:
-                    description: IPPools contains a list of IP pools to use for allocating
-                      pod IP addresses. At most one IP pool may be specified. If omitted,
-                      a single pool will be configured when needed.
-                    items:
-                      properties:
-                        blockSize:
-                          description: 'BlockSize specifies the CIDR prefex length
-                            to use when allocating per-node IP blocks from the main
-                            IP pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
-                          format: int32
-                          type: integer
-                        cidr:
-                          description: CIDR contains the address range for the IP
-                            Pool in classless inter-domain routing format.
-                          type: string
-                        encapsulation:
-                          description: 'Encapsulation specifies the encapsulation
-                            type that will be used with the IP Pool. Default: IPIP'
-                          enum:
-                          - IPIPCrossSubnet
-                          - IPIP
-                          - VXLAN
-                          - VXLANCrossSubnet
-                          - None
-                          type: string
-                        natOutgoing:
-                          description: 'NATOutgoing specifies if NAT will be enabled
-                            or disabled for outgoing traffic. Default: Enabled'
-                          enum:
-                          - Enabled
-                          - Disabled
-                          type: string
-                        nodeSelector:
-                          description: 'NodeSelector specifies the node selector that
-                            will be set for the IP Pool. Default: ''all()'''
-                          type: string
-                      required:
-                      - cidr
-                      type: object
-                    type: array
-                  mtu:
-                    description: 'MTU specifies the maximum transmission unit to use
-                      for pods on the Calico network. Default: 1410'
-                    format: int32
-                    type: integer
-                  multiInterfaceMode:
-                    description: 'MultiInterfaceMode configures what will configure
-                      multiple interface per pod. Only valid for Calico Enterprise
-                      installations. Default: None'
-                    enum:
-                    - None
-                    - Multus
-                    type: string
-                  nodeAddressAutodetectionV4:
-                    description: NodeAddressAutodetectionV4 specifies an approach
-                      to automatically detect node IPv4 addresses. If not specified,
-                      will use default auto-detection settings to acquire an IPv4
-                      address for each node.
-                    properties:
-                      canReach:
-                        description: CanReach enables IP auto-detection based on which
-                          source address on the node is used to reach the specified
-                          IP or domain.
-                        type: string
-                      firstFound:
-                        description: FirstFound uses default interface matching parameters
-                          to select an interface, performing best-effort filtering
-                          based on well-known interface names.
-                        type: boolean
-                      interface:
-                        description: Interface enables IP auto-detection based on
-                          interfaces that match the given regex.
-                        type: string
-                      skipInterface:
-                        description: SkipInterface enables IP auto-detection based
-                          on interfaces that do not match the given regex.
-                        type: string
-                    type: object
-                  nodeAddressAutodetectionV6:
-                    description: NodeAddressAutodetectionV6 specifies an approach
-                      to automatically detect node IPv4 addresses. If not specified,
-                      IPv6 addresses will not be auto-detected.
-                    properties:
-                      canReach:
-                        description: CanReach enables IP auto-detection based on which
-                          source address on the node is used to reach the specified
-                          IP or domain.
-                        type: string
-                      firstFound:
-                        description: FirstFound uses default interface matching parameters
-                          to select an interface, performing best-effort filtering
-                          based on well-known interface names.
-                        type: boolean
-                      interface:
-                        description: Interface enables IP auto-detection based on
-                          interfaces that match the given regex.
-                        type: string
-                      skipInterface:
-                        description: SkipInterface enables IP auto-detection based
-                          on interfaces that do not match the given regex.
-                        type: string
-                    type: object
-                type: object
-              clusterManagementType:
-                description: 'How the cluster is managed. Valid values for this field
-                  are: Standalone, Management, Managed. Standalone clusters are fully
-                  self-contained installations of Calico Enterprise. Management clusters
-                  provide a single view to manage any number of Managed clusters,
-                  which are a lighter weight installation. This option is applicable
-                  only when variant is TigeraSecureEnterprise. Default: Standalone'
-                enum:
-                - Standalone
-                - Management
-                - Managed
-                type: string
-              componentResources:
-                description: ComponentResources can be used to customize the resource
-                  requirements for each component.
-                items:
-                  description: The ComponentResource struct associates a ResourceRequirements
-                    with a component by name
-                  properties:
-                    componentName:
-                      description: ComponentName CRD enum
-                      enum:
-                      - Node
-                      - Typha
-                      - KubeControllers
-                      type: string
-                    resourceRequirements:
-                      description: ResourceRequirements describes the compute resource
-                        requirements.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                  required:
-                  - componentName
-                  - resourceRequirements
-                  type: object
-                type: array
-              controlPlaneNodeSelector:
-                additionalProperties:
-                  type: string
-                description: ControlPlaneNodeSelector is used to select control plane
-                  nodes on which to run specific Calico components. This currently
-                  only applies to kube-controllers and the apiserver.
-                type: object
-              flexVolumePath:
-                description: FlexVolumePath optionally specifies a custom path for
-                  FlexVolume. If not specified, FlexVolume will be enabled by default.
-                  If set to 'None', FlexVolume will be disabled. The default is based
-                  on the kubernetesProvider.
-                type: string
-              imagePath:
-                description: "ImagePath allows for the path part of an image to be
-                  specified. If specified then the specified value will be used as
-                  the image path for each image. If not specified or empty, the default
-                  for each image will be used. \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
-                  \n This option allows configuring the `<imagePath>` portion of the
-                  above format."
-                type: string
-              imagePullSecrets:
-                description: ImagePullSecrets is an array of references to container
-                  registry pull secrets to use. These are applied to all images to
-                  be pulled.
-                items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                type: array
-              kubernetesProvider:
-                description: KubernetesProvider specifies a particular provider of
-                  the Kubernetes platform and enables provider-specific configuration.
-                  If the specified value is empty, the Operator will attempt to automatically
-                  determine the current provider. If the specified value is not empty,
-                  the Operator will still attempt auto-detection, but will additionally
-                  compare the auto-detected value to the specified value to confirm
-                  they match.
-                enum:
-                - EKS
-                - GKE
-                - AKS
-                - OpenShift
-                - DockerEnterprise
-                type: string
-              nodeMetricsPort:
-                description: NodeMetricsPort specifies which port calico/node serves
-                  prometheus metrics on. By default, metrics are not enabled. If specified,
-                  this overrides any FelixConfiguration resources which may exist.
-                  If omitted, then prometheus metrics may still be configured through
-                  FelixConfiguration.
-                format: int32
-                type: integer
-              nodeUpdateStrategy:
-                description: NodeUpdateStrategy can be used to customize the desired
-                  update strategy, such as the MaxUnavailable field.
-                properties:
-                  rollingUpdate:
-                    description: 'Rolling update config params. Present only if type
-                      = "RollingUpdate". --- TODO: Update this to follow our convention
-                      for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
-                      See https://github.com/kubernetes/kubernetes/issues/35345'
-                    properties:
-                      maxUnavailable:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: 'The maximum number of DaemonSet pods that can
-                          be unavailable during the update. Value can be an absolute
-                          number (ex: 5) or a percentage of total number of DaemonSet
-                          pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This cannot
-                          be 0. Default value is 1. Example: when this is set to 30%,
-                          at most 30% of the total number of nodes that should be
-                          running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their pods stopped for an update at any given time.
-                          The update starts by stopping at most 30% of those DaemonSet
-                          pods and then brings up new DaemonSet pods in their place.
-                          Once the new pods are available, it then proceeds onto other
-                          DaemonSet pods, thus ensuring that at least 70% of original
-                          number of DaemonSet pods are available at all times during
-                          the update.'
-                        x-kubernetes-int-or-string: true
-                    type: object
-                  type:
-                    description: Type of daemon set update. Can be "RollingUpdate"
-                      or "OnDelete". Default is RollingUpdate.
-                    type: string
-                type: object
-              registry:
-                description: "Registry is the default Docker registry used for component
-                  Docker images. If specified, all images will be pulled from this
-                  registry. If not specified then the default registries will be used.
-                  \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
-                  \n This option allows configuring the `<registry>` portion of the
-                  above format."
-                type: string
-              variant:
-                description: 'Variant is the product to install - one of Calico or
-                  TigeraSecureEnterprise Default: Calico'
-                enum:
-                - Calico
-                - TigeraSecureEnterprise
-                type: string
-            type: object
-          status:
-            description: Most recently observed state for the Calico or Calico Enterprise
-              installation.
-            properties:
-              variant:
-                description: Variant is the most recently observed installed variant
-                  - one of Calico or TigeraSecureEnterprise
-                enum:
-                - Calico
-                - TigeraSecureEnterprise
-                type: string
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+  validation:
+    openAPIV3Schema:
+      description: Installation configures an installation of Calico or Calico Enterprise.
+        At most one instance of this resource is supported. It must be named "default".
+        The Installation API installs core networking and network policy components,
+        and provides general install-time configuration.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the desired state for the Calico or Calico
+            Enterprise installation.
+          properties:
+            calicoNetwork:
+              description: CalicoNetwork specifies configuration options for Calico
+                provided pod networking.
+              properties:
+                hostPorts:
+                  description: 'HostPorts configures whether or not Calico will
+                    support Kubernetes HostPorts. Default: Enabled'
+                  enum:
+                  - Enabled
+                  - Disabled
+                  type: string
+                ipPools:
+                  description: IPPools contains a list of IP pools to use for allocating
+                    pod IP addresses. At most one IP pool may be specified. If omitted,
+                    a single pool will be configured when needed.
+                  items:
+                    properties:
+                      blockSize:
+                        description: 'BlockSize specifies the CIDR prefex length
+                          to use when allocating per-node IP blocks from the main
+                          IP pool CIDR. Default: 26 (IPv4), 122 (IPv6)'
+                        format: int32
+                        type: integer
+                      cidr:
+                        description: CIDR contains the address range for the IP
+                          Pool in classless inter-domain routing format.
+                        type: string
+                      encapsulation:
+                        description: 'Encapsulation specifies the encapsulation
+                          type that will be used with the IP Pool. Default: IPIP'
+                        enum:
+                        - IPIPCrossSubnet
+                        - IPIP
+                        - VXLAN
+                        - VXLANCrossSubnet
+                        - None
+                        type: string
+                      natOutgoing:
+                        description: 'NATOutgoing specifies if NAT will be enabled
+                          or disabled for outgoing traffic. Default: Enabled'
+                        enum:
+                        - Enabled
+                        - Disabled
+                        type: string
+                      nodeSelector:
+                        description: 'NodeSelector specifies the node selector that
+                          will be set for the IP Pool. Default: ''all()'''
+                        type: string
+                    required:
+                    - cidr
+                    type: object
+                  type: array
+                mtu:
+                  description: 'MTU specifies the maximum transmission unit to use
+                    for pods on the Calico network. Default: 1410'
+                  format: int32
+                  type: integer
+                multiInterfaceMode:
+                  description: 'MultiInterfaceMode configures what will configure
+                    multiple interface per pod. Only valid for Calico Enterprise
+                    installations. Default: None'
+                  enum:
+                  - None
+                  - Multus
+                  type: string
+                nodeAddressAutodetectionV4:
+                  description: NodeAddressAutodetectionV4 specifies an approach
+                    to automatically detect node IPv4 addresses. If not specified,
+                    will use default auto-detection settings to acquire an IPv4
+                    address for each node.
+                  properties:
+                    canReach:
+                      description: CanReach enables IP auto-detection based on which
+                        source address on the node is used to reach the specified
+                        IP or domain.
+                      type: string
+                    firstFound:
+                      description: FirstFound uses default interface matching parameters
+                        to select an interface, performing best-effort filtering
+                        based on well-known interface names.
+                      type: boolean
+                    interface:
+                      description: Interface enables IP auto-detection based on
+                        interfaces that match the given regex.
+                      type: string
+                    skipInterface:
+                      description: SkipInterface enables IP auto-detection based
+                        on interfaces that do not match the given regex.
+                      type: string
+                  type: object
+                nodeAddressAutodetectionV6:
+                  description: NodeAddressAutodetectionV6 specifies an approach
+                    to automatically detect node IPv4 addresses. If not specified,
+                    IPv6 addresses will not be auto-detected.
+                  properties:
+                    canReach:
+                      description: CanReach enables IP auto-detection based on which
+                        source address on the node is used to reach the specified
+                        IP or domain.
+                      type: string
+                    firstFound:
+                      description: FirstFound uses default interface matching parameters
+                        to select an interface, performing best-effort filtering
+                        based on well-known interface names.
+                      type: boolean
+                    interface:
+                      description: Interface enables IP auto-detection based on
+                        interfaces that match the given regex.
+                      type: string
+                    skipInterface:
+                      description: SkipInterface enables IP auto-detection based
+                        on interfaces that do not match the given regex.
+                      type: string
+                  type: object
+              type: object
+            clusterManagementType:
+              description: 'How the cluster is managed. Valid values for this field
+                are: Standalone, Management, Managed. Standalone clusters are fully
+                self-contained installations of Calico Enterprise. Management clusters
+                provide a single view to manage any number of Managed clusters,
+                which are a lighter weight installation. This option is applicable
+                only when variant is TigeraSecureEnterprise. Default: Standalone'
+              enum:
+              - Standalone
+              - Management
+              - Managed
+              type: string
+            componentResources:
+              description: ComponentResources can be used to customize the resource
+                requirements for each component.
+              items:
+                description: The ComponentResource struct associates a ResourceRequirements
+                  with a component by name
+                properties:
+                  componentName:
+                    description: ComponentName CRD enum
+                    enum:
+                    - Node
+                    - Typha
+                    - KubeControllers
+                    type: string
+                  resourceRequirements:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. More info:
+                          https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - componentName
+                - resourceRequirements
+                type: object
+              type: array
+            controlPlaneNodeSelector:
+              additionalProperties:
+                type: string
+              description: ControlPlaneNodeSelector is used to select control plane
+                nodes on which to run specific Calico components. This currently
+                only applies to kube-controllers and the apiserver.
+              type: object
+            flexVolumePath:
+              description: FlexVolumePath optionally specifies a custom path for
+                FlexVolume. If not specified, FlexVolume will be enabled by default.
+                If set to 'None', FlexVolume will be disabled. The default is based
+                on the kubernetesProvider.
+              type: string
+            imagePath:
+              description: "ImagePath allows for the path part of an image to be
+                specified. If specified then the specified value will be used as
+                the image path for each image. If not specified or empty, the default
+                for each image will be used. \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                \n This option allows configuring the `<imagePath>` portion of the
+                above format."
+              type: string
+            imagePullSecrets:
+              description: ImagePullSecrets is an array of references to container
+                registry pull secrets to use. These are applied to all images to
+                be pulled.
+              items:
+                description: LocalObjectReference contains enough information to
+                  let you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              type: array
+            kubernetesProvider:
+              description: KubernetesProvider specifies a particular provider of
+                the Kubernetes platform and enables provider-specific configuration.
+                If the specified value is empty, the Operator will attempt to automatically
+                determine the current provider. If the specified value is not empty,
+                the Operator will still attempt auto-detection, but will additionally
+                compare the auto-detected value to the specified value to confirm
+                they match.
+              enum:
+              - EKS
+              - GKE
+              - AKS
+              - OpenShift
+              - DockerEnterprise
+              type: string
+            nodeMetricsPort:
+              description: NodeMetricsPort specifies which port calico/node serves
+                prometheus metrics on. By default, metrics are not enabled. If specified,
+                this overrides any FelixConfiguration resources which may exist.
+                If omitted, then prometheus metrics may still be configured through
+                FelixConfiguration.
+              format: int32
+              type: integer
+            nodeUpdateStrategy:
+              description: NodeUpdateStrategy can be used to customize the desired
+                update strategy, such as the MaxUnavailable field.
+              properties:
+                rollingUpdate:
+                  description: 'Rolling update config params. Present only if type
+                    = "RollingUpdate". --- TODO: Update this to follow our convention
+                    for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
+                    See https://github.com/kubernetes/kubernetes/issues/35345'
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'The maximum number of DaemonSet pods that can
+                        be unavailable during the update. Value can be an absolute
+                        number (ex: 5) or a percentage of total number of DaemonSet
+                        pods at the start of the update (ex: 10%). Absolute number
+                        is calculated from percentage by rounding up. This cannot
+                        be 0. Default value is 1. Example: when this is set to 30%,
+                        at most 30% of the total number of nodes that should be
+                        running the daemon pod (i.e. status.desiredNumberScheduled)
+                        can have their pods stopped for an update at any given time.
+                        The update starts by stopping at most 30% of those DaemonSet
+                        pods and then brings up new DaemonSet pods in their place.
+                        Once the new pods are available, it then proceeds onto other
+                        DaemonSet pods, thus ensuring that at least 70% of original
+                        number of DaemonSet pods are available at all times during
+                        the update.'
+                      x-kubernetes-int-or-string: true
+                  type: object
+                type:
+                  description: Type of daemon set update. Can be "RollingUpdate"
+                    or "OnDelete". Default is RollingUpdate.
+                  type: string
+              type: object
+            registry:
+              description: "Registry is the default Docker registry used for component
+                Docker images. If specified, all images will be pulled from this
+                registry. If not specified then the default registries will be used.
+                \n Image format:    `<registry>/<imagePath>/<imageName>:<image-tag>`
+                \n This option allows configuring the `<registry>` portion of the
+                above format."
+              type: string
+            variant:
+              description: 'Variant is the product to install - one of Calico or
+                TigeraSecureEnterprise Default: Calico'
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+        status:
+          description: Most recently observed state for the Calico or Calico Enterprise
+            installation.
+          properties:
+            variant:
+              description: Variant is the most recently observed installed variant
+                - one of Calico or TigeraSecureEnterprise
+              enum:
+              - Calico
+              - TigeraSecureEnterprise
+              type: string
+          type: object
+      type: object
+  subresources:
+    status: {}
 
 

--- a/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_tigerastatuses_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_tigerastatuses_crd.yaml
@@ -1,6 +1,4 @@
----
-# Source: tigera-operator/templates/crds/operator.tigera.io_tigerastatuses_crd.yaml
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: tigerastatuses.operator.tigera.io
@@ -12,88 +10,89 @@ spec:
     plural: tigerastatuses
     singular: tigerastatus
   scope: Cluster
+  version: v1
   versions:
-  - additionalPrinterColumns:
-    - description: Whether the component running and stable.
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Whether the component is processing changes.
-      jsonPath: .status.conditions[?(@.type=='Progressing')].status
-      name: Progressing
-      type: string
-    - description: Whether the component is degraded.
-      jsonPath: .status.conditions[?(@.type=='Degraded')].status
-      name: Degraded
-      type: string
-    - description: The time the component's Available status last changed.
-      jsonPath: .status.conditions[?(@.type=='Available')].lastTransitionTime
-      name: Since
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: TigeraStatus represents the most recently observed status for
-          Calico or a Calico Enterprise functional area.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            type: object
-          status:
-            description: TigeraStatusStatus defines the observed state of TigeraStatus
-            properties:
-              conditions:
-                description: Conditions represents the latest observed set of conditions
-                  for this component. A component may be one or more of Available,
-                  Progressing, or Degraded.
-                items:
-                  description: TigeraStatusCondition represents a condition attached
-                    to a particular component.
-                  properties:
-                    lastTransitionTime:
-                      description: The timestamp representing the start time for the
-                        current status.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Optionally, a detailed message providing additional
-                        context.
-                      type: string
-                    reason:
-                      description: A brief reason explaining the condition.
-                      type: string
-                    status:
-                      description: The status of the condition. May be True, False,
-                        or Unknown.
-                      type: string
-                    type:
-                      description: The type of condition. May be Available, Progressing,
-                        or Degraded.
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - status
-                  - type
-                  type: object
-                type: array
-            required:
-            - conditions
-            type: object
-        type: object
+  - name: v1
     served: true
     storage: true
-    subresources:
-      status: {}
+  additionalPrinterColumns:
+  - description: Whether the component running and stable.
+    JSONPath: .status.conditions[?(@.type=='Available')].status
+    name: Available
+    type: string
+  - description: Whether the component is processing changes.
+    JSONPath: .status.conditions[?(@.type=='Progressing')].status
+    name: Progressing
+    type: string
+  - description: Whether the component is degraded.
+    JSONPath: .status.conditions[?(@.type=='Degraded')].status
+    name: Degraded
+    type: string
+  - description: The time the component's Available status last changed.
+    JSONPath: .status.conditions[?(@.type=='Available')].lastTransitionTime
+    name: Since
+    type: date
+  validation:
+    openAPIV3Schema:
+      description: TigeraStatus represents the most recently observed status for
+        Calico or a Calico Enterprise functional area.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          description: TigeraStatusStatus defines the observed state of TigeraStatus
+          properties:
+            conditions:
+              description: Conditions represents the latest observed set of conditions
+                for this component. A component may be one or more of Available,
+                Progressing, or Degraded.
+              items:
+                description: TigeraStatusCondition represents a condition attached
+                  to a particular component.
+                properties:
+                  lastTransitionTime:
+                    description: The timestamp representing the start time for the
+                      current status.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Optionally, a detailed message providing additional
+                      context.
+                    type: string
+                  reason:
+                    description: A brief reason explaining the condition.
+                    type: string
+                  status:
+                    description: The status of the condition. May be True, False,
+                      or Unknown.
+                    type: string
+                  type:
+                    description: The type of condition. May be Available, Progressing,
+                      or Degraded.
+                    type: string
+                required:
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+      type: object
+  subresources:
+    status: {}
 
 

--- a/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_tigerastatuses_crd.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/operator.tigera.io_tigerastatuses_crd.yaml
@@ -1,0 +1,99 @@
+---
+# Source: tigera-operator/templates/crds/operator.tigera.io_tigerastatuses_crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tigerastatuses.operator.tigera.io
+spec:
+  group: operator.tigera.io
+  names:
+    kind: TigeraStatus
+    listKind: TigeraStatusList
+    plural: tigerastatuses
+    singular: tigerastatus
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Whether the component running and stable.
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Whether the component is processing changes.
+      jsonPath: .status.conditions[?(@.type=='Progressing')].status
+      name: Progressing
+      type: string
+    - description: Whether the component is degraded.
+      jsonPath: .status.conditions[?(@.type=='Degraded')].status
+      name: Degraded
+      type: string
+    - description: The time the component's Available status last changed.
+      jsonPath: .status.conditions[?(@.type=='Available')].lastTransitionTime
+      name: Since
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: TigeraStatus represents the most recently observed status for
+          Calico or a Calico Enterprise functional area.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+          status:
+            description: TigeraStatusStatus defines the observed state of TigeraStatus
+            properties:
+              conditions:
+                description: Conditions represents the latest observed set of conditions
+                  for this component. A component may be one or more of Available,
+                  Progressing, or Degraded.
+                items:
+                  description: TigeraStatusCondition represents a condition attached
+                    to a particular component.
+                  properties:
+                    lastTransitionTime:
+                      description: The timestamp representing the start time for the
+                        current status.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Optionally, a detailed message providing additional
+                        context.
+                      type: string
+                    reason:
+                      description: A brief reason explaining the condition.
+                      type: string
+                    status:
+                      description: The status of the condition. May be True, False,
+                        or Unknown.
+                      type: string
+                    type:
+                      description: The type of condition. May be Available, Progressing,
+                        or Degraded.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+

--- a/deploy/olm-catalog/tigera-operator/1.7.3/tigera-operator.v1.7.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/tigera-operator/1.7.3/tigera-operator.v1.7.3.clusterserviceversion.yaml
@@ -1,0 +1,369 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.tigera.io/v1",
+          "kind": "Installation",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "variant": "Calico"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Logging & Tracing, Monitoring, Networking, Security
+    certified: "true"
+    description: An operator which manages the lifecycle of a Calico or Calico Enterprise installation on Kubernetes or OpenShift.
+    marketplace.openshift.io/action-text: Install-time Instructions
+    marketplace.openshift.io/remote-workflow: https://docs.projectcalico.org/archive/v3.15/getting-started/openshift/installation
+    operators.operatorframework.io/internal-objects: '["blockaffinities.crd.projectcalico.org","clusterinformations.crd.projectcalico.org","ipamblocks.crd.projectcalico.org","ipamconfigs.crd.projectcalico.org","ipamhandles.crd.projectcalico.org"]'
+    repository: https://github.com/tigera/operator
+    support: Tigera
+    containerImage: quay.io/tigera/operator:v1.7.3
+    createdAt: 2020-08-07T22:44:11.830727552Z
+  name: tigera-operator.v1.7.3
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: BGPConfiguration represents BGP specific configuration options for the cluster or a specific node.
+        displayName: BGPConfiguration
+        kind: BGPConfiguration
+        name: bgpconfigurations.crd.projectcalico.org
+        version: v1
+      - description: BGPPeer represents a remote BGP peer with which the node(s) in a Calico cluster will peer. Configuring BGP peers allows you to peer a Calico network with your datacenter fabric (e.g. ToR).
+        displayName: BGPPeer
+        kind: BGPPeer
+        name: bgppeers.crd.projectcalico.org
+        version: v1
+      - description: BlockAffinity maintains a block affinity's state.
+        displayName: BlockAffinity
+        kind: BlockAffinity
+        name: blockaffinities.crd.projectcalico.org
+        version: v1
+      - description: ClusterInformation contains the cluster specific information.
+        displayName: ClusterInformation
+        kind: ClusterInformation
+        name: clusterinformations.crd.projectcalico.org
+        version: v1
+      - description: FelixConfiguration represents Felix configuration options for the cluster.
+        displayName: FelixConfiguration
+        kind: FelixConfiguration
+        name: felixconfigurations.crd.projectcalico.org
+        version: v1
+      - description: GlobalNetworkPolicy represents an ordered set of rules which are applied to a collection of endpoints that match a label selector.
+        displayName: GlobalNetworkPolicy
+        kind: GlobalNetworkPolicy
+        name: globalnetworkpolicies.crd.projectcalico.org
+        version: v1
+      - description: GlobalNetworkSet represents an arbitrary set of IP subnetworks/CIDRs, allowing it to be matched by Calico policy. Network sets are useful for applying policy to traffic coming from (or going to) external, non-Calico, networks.
+        displayName: GlobalNetworkSet
+        kind: GlobalNetworkSet
+        name: globalnetworksets.crd.projectcalico.org
+        version: v1
+      - description: HostEndpoint represents one or more real or virtual interfaces attached to a host that is running Calico. It enforces Calico policy on the traffic that is entering or leaving the host’s default network namespace through those interfaces.
+        displayName: HostEndpoint
+        kind: HostEndpoint
+        name: hostendpoints.crd.projectcalico.org
+        version: v1
+      - description: Installation configures an installation of Calico or Calico Enterprise. At most one instance of this resource is supported. It must be named "default". The Installation API installs core networking and network policy components, and provides general install-time configuration.
+        kind: Installation
+        name: installations.operator.tigera.io
+        version: v1
+      - description: IPAMBlock contains information about a block for IP address assignment.
+        displayName: IPAMBlock
+        kind: IPAMBlock
+        name: ipamblocks.crd.projectcalico.org
+        version: v1
+      - description: IPAMConfig contains information about a block for IP address assignment.
+        displayName: IPAMConfig
+        kind: IPAMConfig
+        name: ipamconfigs.crd.projectcalico.org
+        version: v1
+      - description: IPAMHandle contains information about an IPAMHandle resource.
+        displayName: IPAMHandle
+        kind: IPAMHandle
+        name: ipamhandles.crd.projectcalico.org
+        version: v1
+      - kind: IPPool
+        name: ippools.crd.projectcalico.org
+        version: v1
+      - description: KubeControllersConfiguration represents configuration options for the Calico Kubernetes controllers.
+        displayName: KubeControllersConfiguration
+        kind: KubeControllersConfiguration
+        name: kubecontrollersconfigurations.crd.projectcalico.org
+        version: v1
+      - description: NetworkPolicy represents an ordered set of rules which are applied to a collection of endpoints that match a label selector.
+        displayName: NetworkPolicy
+        kind: NetworkPolicy
+        name: networkpolicies.crd.projectcalico.org
+        version: v1
+      - description: NetworkSet represents an arbitrary set of IP subnetworks/CIDRs, allowing it to be matched by Calico policy. Network sets are useful for applying policy to traffic coming from (or going to) external, non-Calico, networks.
+        displayName: NetworkSet
+        kind: NetworkSet
+        name: networksets.crd.projectcalico.org
+        version: v1
+      - description: TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
+        kind: TigeraStatus
+        name: tigerastatuses.operator.tigera.io
+        version: v1
+  description: 'An operator which manages the lifecycle of a Calico or Calico Enterprise installation on Kubernetes or OpenShift. Its goal is to make installation, upgrades, and ongoing lifecycle management of Calico and Calico Enterprise as simple and reliable as possible. **Important**: this operator should only be installed if the cluster was already provisioned with Calico.'
+  displayName: Tigera Operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAyMzQuMiAyMjQuMSIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjM0LjIgMjI0LjE7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDp1cmwoI1NWR0lEXzFfKTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6NC42ODQyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDF7ZmlsbDojMTczRjc0O30KCS5zdDJ7ZmlsbDojMDAyMTRDO30KCS5zdDN7ZmlsbDojNzU0QzI5O3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDR7ZmlsbDojNjAzOTEzO30KCS5zdDV7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDZ7ZmlsbDojRjc5NDFEO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjc2ODc7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0N3tmaWxsOiNGNDc3Mjk7fQoJLnN0OHtmaWxsOiNGRkZGRkY7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuNjkzNDtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0OXtmaWxsOiM3NTRDMjk7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuOTE5NDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxMHtmaWxsOiMyMzFGMjA7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuOTE5NDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxMXtmaWxsOiMzQzI0MTU7fQoJLnN0MTJ7ZmlsbDojRjc5NDFEO30KCS5zdDEze2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi45MTk0O3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDE0e2ZpbGw6bm9uZTt9Cgkuc3QxNXtmaWxsOiM2MDNEMTk7fQoJLnN0MTZ7ZmlsbDojNTczODE5O30KCS5zdDE3e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi42OTM0O3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QxOHtmaWxsOiM1MzM0MTQ7fQoJLnN0MTl7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjc2ODc7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0MjB7ZmlsbDojRjc5NDFEO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoyLjkxOTQ7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDIxe2ZpbGw6IzIzMUYyMDt9Cgkuc3QyMntmaWxsOiNGRkZGRkY7fQoJLnN0MjN7ZmlsbDpub25lO3N0cm9rZTojMjMxRjIwO3N0cm9rZS13aWR0aDoxLjk0NjM7c3Ryb2tlLWxpbmVjYXA6cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7fQoJLnN0MjR7ZmlsbDojRTZFN0U4O30KCS5zdDI1e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi45MTk0O3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDI2e2ZpbGw6bm9uZTtzdHJva2U6IzIzMUYyMDtzdHJva2Utd2lkdGg6Mi4yNzgyO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDI3e2ZpbGw6I0E3QTlBQzt9Cgkuc3QyOHtmaWxsOm5vbmU7c3Ryb2tlOiMyMzFGMjA7c3Ryb2tlLXdpZHRoOjIuNDM0NztzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3QyOXtmaWxsOiM3NTRDMjk7fQoJLnN0MzB7ZmlsbDojRUY0MTM2O30KCS5zdDMxe2ZpbGw6bm9uZTtzdHJva2U6I0ZCQjA0MDtzdHJva2Utd2lkdGg6MS40MzEyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDMye2ZpbGw6I0ZCQjA0MDt9Cjwvc3R5bGU+CjxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfMV8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iMTEwLjYzMDQiIHkxPSIyLjgwMDIiIHgyPSIxMTAuNjMwNCIgeTI9IjIwNS45MDMxIj4KCTxzdG9wICBvZmZzZXQ9IjAiIHN0eWxlPSJzdG9wLWNvbG9yOiNGRkZGRkYiLz4KCTxzdG9wICBvZmZzZXQ9IjEiIHN0eWxlPSJzdG9wLWNvbG9yOiMwMDU0OUUiLz4KPC9saW5lYXJHcmFkaWVudD4KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTEwLjYiIGN5PSIxMTMiIHI9Ijk4LjciLz4KPHBhdGggY2xhc3M9InN0MSIgZD0iTTE1OC4xLDE3Ni42Yy00LjMsNi45LTIzLjgsMTIuMS00Ny4yLDEyLjFzLTQyLjgtNS4yLTQ3LjItMTIuMWMtNS42LDIuMi04LjksNC43LTguOSw3LjUKCWMwLDcuNywyNS4xLDEzLjksNTYsMTMuOXM1Ni02LjIsNTYtMTMuOUMxNjcsMTgxLjMsMTYzLjcsMTc4LjcsMTU4LjEsMTc2LjZ6Ii8+CjxwYXRoIGNsYXNzPSJzdDIiIGQ9Ik0xMTEsMTg4LjdjMjMuNCwwLDQyLjgtNS4yLDQ3LjItMTIuMWMtMTAtMy44LTI3LjMtNi40LTQ3LjItNi40cy0zNy4yLDIuNi00Ny4yLDYuNAoJQzY4LjEsMTgzLjQsODcuNiwxODguNywxMTEsMTg4Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDMiIGQ9Ik0xNTAuNiwxNDEuMmMwLDAsMy44LTMuNywxMC4yLTguMWMxNi40LTExLjEsMTEuOS0yOC41LDcuOS00Mi42Yy0yLjgtMTAuMSwxMC44LTEyLjgsMTYsMTYuNAoJYzUuMiwyOC43LTI2LjYsNTEuMi0zNS4xLDUxLjIiLz4KPHBhdGggY2xhc3M9InN0NCIgZD0iTTE3NC41LDg1LjJjMy40LDguMiwxMS44LDMxLjEsMC4yLDQ1LjdjLTExLjUsMTQuNS0xOS40LDEzLjktMTkuNCwxMy45bDEuMSwxMS4xYzEyLjMtNi4zLDMyLjYtMjUuNiwyOC40LTQ5CglDMTgyLDkxLjUsMTc4LjMsODYuNCwxNzQuNSw4NS4yeiIvPgo8cGF0aCBjbGFzcz0ic3Q1IiBkPSJNMTUwLjYsMTQxLjJjMCwwLDMuOC0zLjcsMTAuMi04LjFjMTYuNC0xMS4xLDExLjktMjguNSw3LjktNDIuNmMtMi44LTEwLjEsMTAuOC0xMi44LDE2LDE2LjQKCWM1LjIsMjguNy0yNi42LDUxLjItMzUuMSw1MS4yIi8+CjxwYXRoIGNsYXNzPSJzdDYiIGQ9Ik0xNTguNCwxNDIuM2MwLDI5LjctMjEuNiw0Ni40LTQ4LjEsNDYuNFM2Mi4yLDE3Miw2Mi4yLDE0Mi4zczIxLjYtNzYuMSw0OC4xLTc2LjFTMTU4LjQsMTEyLjYsMTU4LjQsMTQyLjN6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xMTAuMyw2Ni4yYy0wLjMsMC0wLjYsMC0xLDAuMWMyMC43LDEuMSw0NS40LDQ3LjgsNDUuNCw3NC45YzAsMjcuNS0yMC43LDQyLjgtNDYuMiw0Mi44CgljLTkuNSwwLTE4LjItMC4xLTI1LjQtMi4zYzcuNyw0LjYsMTcsNywyNy4xLDdjMjYuNiwwLDQ4LjEtMTYuNyw0OC4xLTQ2LjRDMTU4LjQsMTEyLjYsMTM2LjksNjYuMiwxMTAuMyw2Ni4yeiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTQ3LjUsMTA2LjhsLTcuNiw2LjdjMCwwLDguNi0xLjgsOC45LTMuNEMxNDkuMiwxMDguNiwxNDcuNSwxMDYuOCwxNDcuNSwxMDYuOHoiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTE0OS41LDExMi40bC04LjgsNi43YzAsMCw5LjktMS44LDEwLjMtMy40QzE1MS40LDExNC4yLDE0OS41LDExMi40LDE0OS41LDExMi40eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTUxLjUsMTE4LjNsLTEwLjMsNy44YzAsMCwxMS42LTIuMSwxMi4xLTMuOUMxNTMuOCwxMjAuNCwxNTEuNSwxMTguMywxNTEuNSwxMTguM3oiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTE1MS4xLDE2My45bC0xMS02LjdjMCwwLDYuMywxMCw4LjEsOS44UzE1MS4xLDE2My45LDE1MS4xLDE2My45eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTU1LjksMTU4LjJsLTEyLjMtNGMwLDAsOC40LDguMywxMC4xLDcuN0MxNTUuNSwxNjEuMywxNTUuOSwxNTguMiwxNTUuOSwxNTguMnoiLz4KPHBhdGggY2xhc3M9InN0NyIgZD0iTTcxLjEsMTA2LjhsOSw2LjdjMCwwLTEwLjEtMS44LTEwLjUtMy40QzY5LjEsMTA4LjYsNzEuMSwxMDYuOCw3MS4xLDEwNi44eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjguOCwxMTIuNGwxMC40LDYuN2MwLDAtMTEuOC0xLjgtMTIuMy0zLjRTNjguOCwxMTIuNCw2OC44LDExMi40eiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjYuNCwxMTguM2wxMi4yLDcuOGMwLDAtMTMuOC0yLjEtMTQuMy0zLjlDNjMuNywxMjAuNCw2Ni40LDExOC4zLDY2LjQsMTE4LjN6Ii8+CjxwYXRoIGNsYXNzPSJzdDgiIGQ9Ik0xMzEuOSwxMzQuOWMwLDE0LjQtOC4xLDI3LTIyLjgsMjdzLTIyLjgtMTIuNi0yMi44LTI3czguMS0zNC45LDIyLjgtMzQuOVMxMzEuOSwxMjAuNSwxMzEuOSwxMzQuOXoiLz4KPHBhdGggY2xhc3M9InN0OSIgZD0iTTE1Mi43LDQ4LjdjLTAuMiwyLjQtNC43LTAuNy02LjIsMUwxMTUsMzAuNWMwLjgtMi4yLDEuOS00LjMsMy4yLTYuM2M2LjYtMTAuOSwyMC45LTIxLjksMjguMS0xMy45CglDMTUxLjEsMTUuNiwxNTMuOCwzNC43LDE1Mi43LDQ4Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDEwIiBkPSJNMTQyLjcsMzkuMmMtMC4xLDAuOC0xMy4zLTctMTMuMy03YzAuMy0wLjcsMC42LTEuNCwxLjEtMi4xYzIuMi0zLjYsNi45LTkuMiw5LjQtNgoJQzE0MC41LDI1LDE0My4xLDM0LjUsMTQyLjcsMzkuMnoiLz4KPHBhdGggY2xhc3M9InN0MTEiIGQ9Ik0xNDYuNywxMWwtNy42LDYuN2MwLDAsOC42LTEuOCw4LjktMy40UzE0Ni43LDExLDE0Ni43LDExeiIvPgo8cGF0aCBjbGFzcz0ic3QxMiIgZD0iTTY3LjIsNDkuN2MwLjIsMi40LDQuNy0wLjcsNi4yLDFsMzEuNS0xOS4yYy0wLjgtMi4yLTEuOS00LjMtMy4yLTYuM0M5NS4xLDE0LjIsODAuOCwzLjIsNzMuNywxMS4yCglDNjguOCwxNi42LDY2LjEsMzUuNyw2Ny4yLDQ5Ljd6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik03Mi4xLDE0LjNsOSw2LjdjMCwwLTEwLjEtMS44LTEwLjUtMy40QzcwLjEsMTYuMSw3Mi4xLDE0LjMsNzIuMSwxNC4zeiIvPgo8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNNjksMjAuNWw2LjgsNC44YzAsMC03LjctMS4zLTgtMi40QzY3LjUsMjEuOCw2OSwyMC41LDY5LDIwLjV6Ii8+CjxwYXRoIGNsYXNzPSJzdDEzIiBkPSJNNjcuMiw0OS43YzAuMiwyLjQsNC43LTAuNyw2LjIsMWwzMS41LTE5LjJjLTAuOC0yLjItMS45LTQuMy0zLjItNi4zQzk1LjEsMTQuMiw4MC44LDMuMiw3My43LDExLjIKCUM2OC44LDE2LjYsNjYuMSwzNS43LDY3LjIsNDkuN3oiLz4KPHBhdGggY2xhc3M9InN0MTAiIGQ9Ik03Ny4xLDQwLjJjMC4xLDAuOCwxMy4zLTcsMTMuMy03Yy0wLjMtMC43LTAuNi0xLjQtMS4xLTIuMWMtMi4yLTMuNi02LjktOS4yLTkuNC02CglDNzkuMywyNiw3Ni44LDM1LjUsNzcuMSw0MC4yeiIvPgo8cGF0aCBjbGFzcz0ic3QxNCIgZD0iTTExMC4zLDQ3LjRjLTAuNiwyNi4yLTkuNSw0OC41LTIyLjksNTcuM0MxMDAuOCw5NS45LDExMC4zLDczLjYsMTEwLjMsNDcuNHoiLz4KPGc+Cgk8cGF0aCBjbGFzcz0ic3QxNSIgZD0iTTEyMi45LDEwNy40YzEuMiwxLjUsMi4zLDMuMSwzLjIsNC45YzkuNS0yLjUsMTcuMS03LjIsMjEuNC0xMy4xYy0wLjMtMC43LTAuNy0xLjMtMS0yCgkJQzE0MC4xLDEwMi4xLDEzMiwxMDUuNywxMjIuOSwxMDcuNEMxMjIuOSwxMDcuNCwxMjIuOSwxMDcuNCwxMjIuOSwxMDcuNHoiLz4KCTxwYXRoIGNsYXNzPSJzdDE1IiBkPSJNOTIuMiwxMTEuOWMxLTEuNywyLTMuMywzLjItNC43Yy04LjItMS44LTE1LjYtNS4xLTIxLjYtOS41Yy0wLjQsMC43LTAuNywxLjUtMS4xLDIuMgoJCUM3Ni45LDEwNS4xLDgzLjgsMTA5LjQsOTIuMiwxMTEuOXoiLz4KCTxwYXRoIGNsYXNzPSJzdDE2IiBkPSJNMTA5LjksMTA4LjdjLTUsMC05LjktMC41LTE0LjUtMS42bDAsMGMtMS4yLDEuNC0yLjMsMy0zLjIsNC43YzAsMCwwLDAsMCwwYzUuNCwxLjYsMTEuNCwyLjUsMTcuNywyLjUKCQljNS44LDAsMTEuMi0wLjcsMTYuMi0yLjFjMCwwLDAsMCwwLDBjLTEtMS43LTItMy40LTMuMi00LjlDMTE4LjgsMTA4LjMsMTE0LjQsMTA4LjcsMTA5LjksMTA4Ljd6Ii8+CjwvZz4KPHBhdGggY2xhc3M9InN0MTciIGQ9Ik0xMzEuOSwxMzQuOWMwLDE0LjQtOC4xLDI3LTIyLjgsMjdzLTIyLjgtMTIuNi0yMi44LTI3czguMS0zNC45LDIyLjgtMzQuOVMxMzEuOSwxMjAuNSwxMzEuOSwxMzQuOXoiLz4KPHBhdGggY2xhc3M9InN0MTgiIGQ9Ik0xNTAuMyw5NC4xYy0xLjIsMS4xLTIuNCwyLjEtMy44LDMuMWMwLjMsMC43LDAuNywxLjMsMSwyQzE0OC43LDk3LjYsMTQ5LjcsOTUuOCwxNTAuMyw5NC4xeiIvPgo8cGF0aCBjbGFzcz0ic3QxOSIgZD0iTTE1OC40LDE0Mi4zYzAsMjkuNy0yMS42LDQ2LjQtNDguMSw0Ni40UzYyLjIsMTcyLDYyLjIsMTQyLjNzMjEuNi03Ni4xLDQ4LjEtNzYuMVMxNTguNCwxMTIuNiwxNTguNCwxNDIuM3oiCgkvPgo8cGF0aCBjbGFzcz0ic3QyMCIgZD0iTTE0Ni4xLDYxLjljMC02LjQsMy4zLTEyLjEsOC40LTE1LjhjLTkuNC0xMS0yNS43LTE4LjMtNDQuMi0xOC4zYy0wLjYsMC0xLjIsMC0xLjksMGMxLjUsNS44LDIsMTIuNSwxLjksMTkuNQoJYzAsMjYuMi05LjUsNDguNS0yMi45LDU3LjNjNi45LDIuNiwxNC43LDQsMjIuOSw0YzIzLjQsMCw0My4zLTExLjcsNTAuMi0yNy45QzE1Mi4xLDc3LjgsMTQ2LjEsNzAuNSwxNDYuMSw2MS45eiIvPgo8cGF0aCBjbGFzcz0ic3QzIiBkPSJNMTEwLjMsNDcuNGMwLTYuOC0wLjctMTMuNC0xLjktMTkuNWMtMjguMywwLjctNTEsMTguNS01MSw0MC40YzAsMTYuMSwxMi4yLDI5LjksMjkuOSwzNi41CglDMTAwLjgsOTUuOSwxMDkuNyw3My42LDExMC4zLDQ3LjR6Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xNDIuOCw3OS40YzAtNS43LTQuMy0xMC4zLTkuNS0xMC4zYy0zLjgsMC03LDIuNC04LjYsNS44YzguMywyLjMsMTMuOSw2LjYsMTMuOSwxMi40YzAsMC4zLDAsMC41LTAuMSwwLjgKCUMxNDEuMSw4Ni4yLDE0Mi44LDgzLDE0Mi44LDc5LjR6Ii8+CjxwYXRoIGNsYXNzPSJzdDMiIGQ9Ik0xMDguNSwyNy44YzEuMiw2LjEsMS45LDEyLjcsMS45LDE5LjVDMTEwLjUsNDAuNCwxMTAsMzMuNywxMDguNSwyNy44eiIvPgo8cGF0aCBjbGFzcz0ic3Q5IiBkPSJNMTU0LjUsNDYuMWMtNS4xLDMuNy04LjQsOS40LTguNCwxNS44YzAsOC42LDYsMTYsMTQuNCwxOWMxLjctNCwyLjYtOC4yLDIuNi0xMi42CglDMTYzLjEsNjAuMSwxNTkuOSw1Mi40LDE1NC41LDQ2LjF6Ii8+CjxwYXRoIGNsYXNzPSJzdDExIiBkPSJNNjEuOCw1My41bDksNi43YzAsMC0xMC4xLTEuOC0xMC41LTMuNEM1OS44LDU1LjQsNjEuOCw1My41LDYxLjgsNTMuNXoiLz4KPHBhdGggY2xhc3M9InN0MTEiIGQ9Ik01OS41LDU5LjJsMTAuNCw2LjdjMCwwLTExLjgtMS44LTEyLjMtMy40QzU3LjIsNjEsNTkuNSw1OS4yLDU5LjUsNTkuMnoiLz4KPGVsbGlwc2UgdHJhbnNmb3JtPSJtYXRyaXgoMC45OTE5IC0wLjEyNyAwLjEyNyAwLjk5MTkgLTYuMjU3MSAxMi41NjM4KSIgY2xhc3M9InN0MjEiIGN4PSI5NS40IiBjeT0iNTUuNCIgcng9IjEyLjMiIHJ5PSIxMC42Ii8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuOTkxOSAtMC4xMjcgMC4xMjcgMC45OTE5IC02LjQ1MDYgMTIuNjQ0NSkiIGNsYXNzPSJzdDIyIiBjeD0iOTUuOSIgY3k9IjU2LjkiIHJ4PSI4LjkiIHJ5PSI3LjciLz4KPGVsbGlwc2UgdHJhbnNmb3JtPSJtYXRyaXgoMC45OTE5IC0wLjEyNjcgMC4xMjY3IDAuOTkxOSAtNi40ODU2IDEyLjYxNDkpIiBjbGFzcz0ic3QyMSIgY3g9Ijk1LjkiIGN5PSI1Ny4zIiByeD0iMy40IiByeT0iMyIvPgo8bGluZSBjbGFzcz0ic3QyMyIgeDE9Ijg1LjkiIHkxPSI0Ni42IiB4Mj0iODIuNSIgeTI9IjQ1LjMiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSI4OC42IiB5MT0iNDQuMyIgeDI9Ijg0LjUiIHkyPSI0MS40Ii8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuMTI3IC0wLjk5MTkgMC45OTE5IDAuMTI3IDU2LjM3NjMgMTc0Ljc1OTUpIiBjbGFzcz0ic3QyMSIgY3g9IjEyNy41IiBjeT0iNTUuNCIgcng9IjEwLjYiIHJ5PSIxMi4zIi8+CjxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuMTI3IC0wLjk5MTkgMC45OTE5IDAuMTI3IDU0LjM2MjkgMTc1LjU4ODMpIiBjbGFzcz0ic3QyMiIgY3g9IjEyNi45IiBjeT0iNTYuOSIgcng9IjcuNyIgcnk9IjguOSIvPgo8ZWxsaXBzZSB0cmFuc2Zvcm09Im1hdHJpeCgwLjEyNjcgLTAuOTkxOSAwLjk5MTkgMC4xMjY3IDU0LjAxNTkgMTc1Ljk1MDUpIiBjbGFzcz0ic3QyMSIgY3g9IjEyNi45IiBjeT0iNTcuMyIgcng9IjMiIHJ5PSIzLjQiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSIxMzciIHkxPSI0Ni42IiB4Mj0iMTQwLjQiIHkyPSI0NS4zIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iMTM0LjMiIHkxPSI0NC4zIiB4Mj0iMTM4LjQiIHkyPSI0MS40Ii8+CjxwYXRoIGNsYXNzPSJzdDIyIiBkPSJNMTM4LjYsODcuM2MwLDguNy0xMi43LDE1LjctMjguNCwxNS43cy0yOC40LTctMjguNC0xNS43czEyLjctMTQuMiwyOC40LTE0LjJTMTM4LjYsNzguNiwxMzguNiw4Ny4zeiIvPgo8cGF0aCBjbGFzcz0ic3QyNCIgZD0iTTExMC4zLDEwMEMxMDAsMTAwLDkwLjQsOTcuNCw4MS44LDg3LjNjMC43LDEwLjYsMTMuNiwxNS4zLDI4LjIsMTUuM2MxNS43LDAsMjctNiwyOC40LTE1LjMKCUMxMzAuMyw5Ni4xLDEyNC45LDk5LjksMTEwLjMsMTAweiIvPgo8cGF0aCBjbGFzcz0ic3QyMyIgZD0iTTkxLjQsODYuM2MzLjQsNi42LDEwLjksMTEuMSwxOS42LDExYzguNC0wLjEsMTUuNi00LjUsMTguOS0xMC45Ii8+CjxwYXRoIGNsYXNzPSJzdDI1IiBkPSJNMTM4LjYsODcuM2MwLDguNy0xMi43LDE1LjctMjguNCwxNS43cy0yOC40LTctMjguNC0xNS43czEyLjctMTQuMiwyOC40LTE0LjJTMTM4LjYsNzguNiwxMzguNiw4Ny4zeiIvPgo8bGluZSBjbGFzcz0ic3QyNiIgeDE9IjExMC42IiB5MT0iNzkiIHgyPSIxMTAuNiIgeTI9Ijk3LjkiLz4KPHBhdGggY2xhc3M9InN0MjEiIGQ9Ik0xMTksNzRjMCw0LjYtOC4zLDcuNC04LjMsNy40cy04LjMtMi44LTguMy03LjRzMy43LTQuMSw4LjMtNC4xUzExOSw2OS40LDExOSw3NHoiLz4KPGVsbGlwc2UgY2xhc3M9InN0MjciIGN4PSIxMTAuNiIgY3k9IjczIiByeD0iNS40IiByeT0iMC45Ii8+CjxwYXRoIGNsYXNzPSJzdDciIGQ9Ik0xMzguOCwxNzAuMmMwLDQuMS0xLjksMjEuNS0xMi4zLDIwLjJjLTUuNi0wLjctMTMuNy05LjUtMTAuMy0xMS44YzMuNi0yLjQtMy42LTE0LjksMS4yLTExLjgKCUMxMjIuMiwxNjkuOSwxMzguOCwxNjYuMSwxMzguOCwxNzAuMnoiLz4KPHBhdGggY2xhc3M9InN0MjIiIGQ9Ik0xMzMuMiwxODUuNmMwLDQuMS0zLjksNS41LTkuOSw1LjVzLTExLTMuMy0xMS03LjRzMi43LTcuNSw3LjktNC4zQzEyNS4yLDE4Mi41LDEzMy4yLDE4MS41LDEzMy4yLDE4NS42eiIvPgo8cGF0aCBjbGFzcz0ic3QyNCIgZD0iTTEyMi42LDE4Ny4yYy0zLjgtMS40LTcuMi0zLjYtOS45LTYuM2MtMC4zLDAuNy0wLjQsMS4zLTAuNCwyLjFjMCw0LjUsNS4zLDguMSwxMS44LDguMWMzLjEsMCw1LjktMC44LDgtMi4yCglDMTI5LDE4OC45LDEyNS44LDE4OC40LDEyMi42LDE4Ny4yeiIvPgo8cGF0aCBjbGFzcz0ic3QyOCIgZD0iTTExNy41LDE2Ni44YzAuMSwzLjIsMC41LDYuMywxLjIsOWMtMy44LDEuNC02LjMsNC4xLTYuMyw3LjJjMCw0LjUsNS4zLDguMSwxMS44LDguMWM1LjMsMCw5LjgtMi40LDExLjMtNS43CgljMi00LjgsNC0xMC45LDUuMi0xOC44Ii8+CjxwYXRoIGNsYXNzPSJzdDI5IiBkPSJNODEsMTcwLjJjMCw0LjEsMS45LDIxLjUsMTIuMywyMC4yYzUuNi0wLjcsMTMuNy05LjUsMTAuMy0xMS44Yy0zLjYtMi40LDIuMi0xNC45LTIuNi0xMS44CglDOTYuMiwxNjkuOSw4MSwxNjYuMSw4MSwxNzAuMnoiLz4KPHBhdGggY2xhc3M9InN0MjIiIGQ9Ik04Ni42LDE4NS42YzAsNC4xLDMuOSw1LjUsOS45LDUuNWM2LjEsMCwxMS0zLjMsMTEtNy40cy0yLjctNy41LTcuOS00LjNDOTQuNiwxODIuNSw4Ni42LDE4MS41LDg2LjYsMTg1LjZ6IgoJLz4KPHBhdGggY2xhc3M9InN0MjQiIGQ9Ik05OC4yLDE4Ny42YzMuOC0xLjYsNy00LDkuNi02LjhjMC4zLDAuNiwwLjUsMS4zLDAuNSwyYzAuMiw0LjUtNC45LDguNC0xMS40LDguN2MtMy4xLDAuMi02LTAuNS04LjEtMS44CglDOTEuOSwxODkuNiw5NS4xLDE4OC45LDk4LjIsMTg3LjZ6Ii8+CjxwYXRoIGNsYXNzPSJzdDI4IiBkPSJNMTAyLjQsMTY2LjhjLTAuMSwzLjItMC41LDYuMy0xLjIsOWMzLjgsMS40LDYuMyw0LjEsNi4zLDcuMmMwLDQuNS01LjMsOC4xLTExLjgsOC4xYy01LjMsMC05LjgtMi40LTExLjMtNS43CgljLTItNC44LTQtMTAuOS01LjItMTguOCIvPgo8Y2lyY2xlIGNsYXNzPSJzdDI0IiBjeD0iMTI3LjciIGN5PSI4MiIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSIxMjQuOSIgY3k9Ijc4LjYiIHI9IjEuNCIvPgo8Y2lyY2xlIGNsYXNzPSJzdDI0IiBjeD0iMTI0IiBjeT0iODMuNSIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5My45IiBjeT0iODIuMiIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5Ny43IiBjeT0iODMuNSIgcj0iMS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MjQiIGN4PSI5Ny4xIiBjeT0iNzkiIHI9IjEuNCIvPgo8bGluZSBjbGFzcz0ic3QyMyIgeDE9IjEyOC43IiB5MT0iODIiIHgyPSIxNDguOSIgeTI9IjgyLjMiLz4KPGxpbmUgY2xhc3M9InN0MjMiIHgxPSIxMjUuOSIgeTE9Ijc4LjUiIHgyPSIxNDQuOSIgeTI9IjcxIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iOTMuMiIgeTE9IjgyIiB4Mj0iNzMiIHkyPSI4Mi4zIi8+CjxsaW5lIGNsYXNzPSJzdDIzIiB4MT0iOTYiIHkxPSI3OC41IiB4Mj0iNzciIHkyPSI3MSIvPgo8Zz4KCTxnPgoJCTxjaXJjbGUgY2xhc3M9InN0MzAiIGN4PSIxOTIiIGN5PSIxNzguMiIgcj0iMzAuNCIvPgoJCTxwYXRoIGNsYXNzPSJzdDMwIiBkPSJNMTkyLDE0OC40YzE2LjUsMCwyOS45LDEzLjQsMjkuOSwyOS45cy0xMy40LDI5LjktMjkuOSwyOS45cy0yOS45LTEzLjQtMjkuOS0yOS45UzE3NS41LDE0OC40LDE5MiwxNDguNAoJCQkgTTE5MiwxNDcuM2MtMTcuMSwwLTMxLDEzLjktMzEsMzFzMTMuOSwzMSwzMSwzMXMzMS0xMy45LDMxLTMxUzIwOS4xLDE0Ny4zLDE5MiwxNDcuM0wxOTIsMTQ3LjN6Ii8+Cgk8L2c+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE2NS41LDE2Ny44Yy0wLjEsMC4yLDEzLjYtMTYuNiwzMi4zLTE3LjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTYzLjUsMTczLjljMCwwLDE0LjYtMjIuMSwzOS4xLTIyLjEiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTYzLjUsMTc3LjhjMCwwLDE1LjYtMjYuNSw0Mi44LTIzLjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA0LjcsMTU2YzAsMCwxMy41LDYuMiwxMy41LDM0LjQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAwLjcsMTU1LjVjMCwwLDE1LDQuNSwxNS42LDM3LjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk4LjksMTU3Yy0yLjQtMC45LDE3LjEsNSwxNC45LDM5LjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk0LjMsMTU3YzAsMCwyMi44LDguOCwxNi41LDQzLjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkzLjQsMTU4LjVjMCwwLTEzLjQsMjQuOC0xMyw0NS4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE5MS4yLDE1Ny42YzAsMC0xMy43LDI1LTEzLjQsNDUuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTUuMywxNjAuMWMwLDAtMTEuNiwyMS4yLTEyLjUsNDQuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTkuMiwxNjIuM2MwLDAtMTIuOCwyMy42LTExLjcsNDMuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTcuMiwxNjEuMmMwLDAtMTMuMSwyNC43LTExLjksNDQuNiIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDAuOSwxNjMuOGMwLDAtMTIuNiwyMy40LTEwLjksNDMuMSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDUuNCwxNjkuN2MtMC45LTAuMi0zLjEtMC42LTQtMC44Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTIwOC4xLDE3Ny44Yy0xLjktMC42LTcuMy0yLjUtOS4yLTMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjIsMTgwLjVjLTIuOC0wLjktOC40LTMtMTEuMy0zLjQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjgsMTgzYy0zLjYtMS4zLTguMS0yLjgtMTEuOS0zLjIiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA5LjgsMTg1LjVjLTQuMS0xLjYtOS4zLTMuMS0xMy41LTMuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMDkuOCwxODhjLTMuNy0yLjItMTAtMy0xNC41LTMuOSIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxOTcuMiIgeTE9IjE4Ni4zIiB4Mj0iMTk0LjMiIHkyPSIxODcuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTkuNywxODdjMCwwLTYuMiwzLjYtNywzLjYiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAzLjQsMTg3LjdjMCwwLTkuMyw1LjYtMTAuNiw1LjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjA1LjUsMTg4LjNjMCwwLTEwLjMsNy4zLTEyLjgsNy4yIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE4Ni44LDE1OC44YzAsMCwwLjcsMS4xLDEuMSwxLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTgxLjksMTYyYzAsMCwxLjksMy4yLDMsMy44Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ny44LDE2NWMwLDAsMy45LDUuMyw1LDUuNyIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuNCwxNjYuNmMwLDAsMy43LDQuNiw1LjYsNi4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Mi4zLDE2OS4zYzAsMCw2LjMsNi44LDguMSw3LjEiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTcxLjEsMTcxLjVjMCwwLDYuMyw2LjcsNy42LDcuNCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzIuMSwxNzYuM2MwLDAtNS4xLDAuNy01LjcsMC42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3NCwxNzguMmMwLDAtOCwxLjEtOS42LDEuMSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzguNywxODEuOGMwLDAtMTEuNywxLjUtMTQuMywyLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc3LjgsMTg0LjFjMCwwLTEwLjMsMS42LTEyLjIsMi4zIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ni45LDE4N2MwLDAtOC4zLDEuMy0xMC42LDEuNSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuOSwxODkuNmMwLDAtOSwyLjEtOS41LDEuNiIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xNzYuNCwxOTEuOGMwLDAtNy42LDIuNS04LjEsMi4yIi8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE3Ni40LDE5NC40YzAsMC01LDIuMS02LDIuMSIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNzYuNCIgeTE9IjE5Ny4zIiB4Mj0iMTcyLjEiIHkyPSIxOTkuMiIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNjMuNSIgeTE9IjE4MS44IiB4Mj0iMTc2LjQiIHkyPSIxNzkuOSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTEuMSwxNDkuMmMwLDAtMTMuMywxLjYtMjMuNiwxMy42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTIwNy41LDE1NS41YzAsMCwxMi42LDkuNCwxMi41LDMwLjgiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc5LjgsMTYzLjhjMCwwLDIuOSwzLjIsMy42LDQiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTc0LjksMTY4LjVjMCwwLDQuMyw0LjYsNS40LDUuNCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xODMuMSwxNjAuN2MwLDAsMi41LDMsMywzLjIiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTg0LjksMTYwLjFjMCwwLDEuNCwyLDEuOSwyLjIiLz4KCTxsaW5lIGNsYXNzPSJzdDMxIiB4MT0iMTY4LjMiIHkxPSIxNzQuNSIgeDI9IjE3MS4xIiB5Mj0iMTczLjkiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk5LjcsMTcyLjljMCwwLDcuNSwyLDguNCwyLjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMjAwLjIsMTcwLjdjMCwwLDUuOCwxLjQsNi4yLDEuNyIvPgoJPGVsbGlwc2UgY2xhc3M9InN0MzIiIGN4PSIyMDMuMiIgY3k9IjE2Ny4zIiByeD0iMC42IiByeT0iMC41Ii8+Cgk8ZWxsaXBzZSBjbGFzcz0ic3QzMiIgY3g9IjE4OSIgY3k9IjE1OCIgcng9IjAuOCIgcnk9IjAuNCIvPgoJPGxpbmUgY2xhc3M9InN0MzEiIHgxPSIxNzQiIHkxPSIyMDAuNSIgeDI9IjE3NS44IiB5Mj0iMTk5LjgiLz4KCQoJCTxlbGxpcHNlIHRyYW5zZm9ybT0ibWF0cml4KDAuODE2OSAtMC41NzY3IDAuNTc2NyAwLjgxNjkgLTg0LjM2NTggMTM4LjcyNDIpIiBjbGFzcz0ic3QzMiIgY3g9IjE3Ni4zIiBjeT0iMjAyLjMiIHJ4PSIwLjkiIHJ5PSIwLjUiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkyLDE5OC4yYzAsMCwxMy44LTYuMywxNi04LjciLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTkxLjUsMjAxLjZjMCwwLDE2LjEtNy4yLDE4LjMtMTAuOSIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0xOTEuNSwyMDQuMWMwLDAsMTcuMi04LjMsMTguMy0xMC42Ii8+Cgk8cGF0aCBjbGFzcz0ic3QzMSIgZD0iTTE5MiwyMDUuOGMwLDAsMTYuNi02LjcsMTcuNy05LjMiLz4KCTxwYXRoIGNsYXNzPSJzdDMxIiBkPSJNMTk0LjMsMjA3YzAsMCwxNC4yLTUuNSwxNC45LTYuOCIvPgoJPHBhdGggY2xhc3M9InN0MzEiIGQ9Ik0yMTAuNywxNTZjMC0wLjIsNy41LDQuNiwxMC41LDIzLjMiLz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDIxIiBkPSJNMTkyLDE0OC40YzE2LjUsMCwyOS45LDEzLjQsMjkuOSwyOS45cy0xMy40LDI5LjktMjkuOSwyOS45cy0yOS45LTEzLjQtMjkuOS0yOS45UzE3NS41LDE0OC40LDE5MiwxNDguNAoJCQkgTTE5MiwxNDQuOGMtMTguNSwwLTMzLjUsMTUtMzMuNSwzMy41czE1LDMzLjUsMzMuNSwzMy41YzE4LjUsMCwzMy41LTE1LDMzLjUtMzMuNVMyMTAuNSwxNDQuOCwxOTIsMTQ0LjhMMTkyLDE0NC44eiIvPgoJPC9nPgo8L2c+Cjwvc3ZnPgo=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+                - pods
+                - podtemplates
+                - services
+                - endpoints
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - patch
+                - list
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+                - clusterrolebindings
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+                - bind
+                - escalate
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - statefulsets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - apps
+              resourceNames:
+                - tigera-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.tigera.io
+              resources:
+                - '*'
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - patch
+                - delete
+                - watch
+            - apiGroups:
+                - scheduling.k8s.io
+              resources:
+                - priorityclasses
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - apiregistration.k8s.io
+              resources:
+                - apiservices
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks/status
+              verbs:
+                - get
+                - list
+                - update
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - networks
+                - infrastructures
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - delete
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - hostnetwork
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - crd.projectcalico.org
+              resources:
+                - bgpconfigurations
+                - bgppeers
+                - felixconfigurations
+                - kubecontrollersconfigurations
+                - globalnetworkpolicies
+                - globalnetworksets
+                - hostendpoints
+                - ippools
+                - networkpolicies
+                - networksets
+              verbs:
+                - create
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+                - cronjobs
+              verbs:
+                - create
+                - update
+                - list
+                - watch
+          serviceAccountName: tigera-operator
+      deployments:
+        - name: tigera-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: tigera-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  k8s-app: tigera-operator
+                  name: tigera-operator
+              spec:
+                containers:
+                  - command:
+                      - operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: tigera-operator
+                      - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
+                        value: v1.7.3
+                    image: quay.io/tigera/operator@sha256:ebe3bf3a6cd29cd2f570232e187fe95d138119e589ec8fcbd8e4e98a377d5dff
+                    imagePullPolicy: IfNotPresent
+                    name: tigera-operator
+                    resources: {}
+                dnsPolicy: ClusterFirstWithHostNet
+                hostNetwork: true
+                serviceAccountName: tigera-operator
+                tolerations:
+                  - effect: NoExecute
+                    operator: Exists
+                  - effect: NoSchedule
+                    operator: Exists
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - networking
+    - security
+    - monitoring
+  links:
+    - name: Calico Introduction
+      url: https://docs.projectcalico.org/introduction/
+    - name: Install an OpenShift v4 cluster with Calico
+      url: https://docs.projectcalico.org/archive/v3.15/getting-started/openshift/installation
+  maintainers:
+    - email: maintainers@tigera.io
+      name: Project Calico Maintainers
+  maturity: stable
+  provider:
+    name: Tigera
+  version: 1.7.3
+  replaces: tigera-operator.v1.5.3

--- a/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
+++ b/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: tigera-operator.v1.3.1
+- currentCSV: tigera-operator.v1.5.2
   name: stable
 defaultChannel: stable
 packageName: tigera-operator

--- a/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
+++ b/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
@@ -1,0 +1,5 @@
+channels:
+- currentCSV: tigera-operator.v1.3.1
+  name: stable
+defaultChannel: stable
+packageName: tigera-operator

--- a/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
+++ b/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: tigera-operator.v1.5.3
+- currentCSV: tigera-operator.v1.7.3
   name: stable
 defaultChannel: stable
 packageName: tigera-operator

--- a/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
+++ b/deploy/olm-catalog/tigera-operator/tigera-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: tigera-operator.v1.5.2
+- currentCSV: tigera-operator.v1.5.3
   name: stable
 defaultChannel: stable
 packageName: tigera-operator


### PR DESCRIPTION
## Description

This PR adds the original v1.3.1 CSV and the most recent v1.5.2, v1.5.3 and v1.7.3 CSV's generated with `make gen-csv` and `make gen-bundle`.

However, the v1.7.3 csv has been modified outside of the make targets mentioned above. 4a98598 changes the crds to use apiextensions.k8s.io/v1beta1 so that the bundle will pass upstream validation tests.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
