### PR TITLE
Run the node's init containers as privileged

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -605,12 +605,16 @@ func (c *nodeComponent) cniContainer() v1.Container {
 		image = components.GetReference(components.ComponentTigeraCNI, c.cr.Spec.Registry, c.cr.Spec.ImagePath)
 	}
 
+	t := true
 	return v1.Container{
 		Name:         "install-cni",
 		Image:        image,
 		Command:      []string{"/install-cni.sh"},
 		Env:          cniEnv,
 		VolumeMounts: cniVolumeMounts,
+		SecurityContext: &v1.SecurityContext{
+			Privileged: &t,
+		},
 	}
 }
 
@@ -621,10 +625,14 @@ func (c *nodeComponent) flexVolumeContainer() v1.Container {
 		{MountPath: "/host/driver", Name: "flexvol-driver-host"},
 	}
 
+	t := true
 	return v1.Container{
 		Name:         "flexvol-driver",
 		Image:        components.GetReference(components.ComponentFlexVolume, c.cr.Spec.Registry, c.cr.Spec.ImagePath),
 		VolumeMounts: flexVolumeMounts,
+		SecurityContext: &v1.SecurityContext{
+			Privileged: &t,
+		},
 	}
 }
 


### PR DESCRIPTION
## Description
This is related to the fixes that were made as part of https://github.com/projectcalico/calico/pull/2738/

The fixes are in the docs manifests but not in the ones rendered by the operator.

Note that this fix is already in `master` and `release-v1.9` as part of the the [PSP work](https://github.com/tigera/operator/pull/666/files#diff-f07b6f8fff13d0b84bc1bb5aa5d256ebR658-R660).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
