### PR TITLE
Fix error with non-calico CNI and IPPool migration

### DIFF
--- a/pkg/controller/migration/convert/network_test.go
+++ b/pkg/controller/migration/convert/network_test.go
@@ -608,6 +608,20 @@ var _ = Describe("Convert network tests", func() {
 				NATOutgoing:   operatorv1.NATOutgoingEnabled,
 			}}))
 		})
+		It("should handle no pools", func() {
+			ds := emptyNodeSpec()
+			ds.Spec.Template.Spec.InitContainers = nil
+			ds.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+				{Name: "CALICO_NETWORKING_BACKEND", Value: "none"},
+				{Name: "FELIX_INTERFACEPREFIX", Value: "eni"},
+				{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"},
+			}
+
+			c := fake.NewFakeClientWithScheme(scheme, ds)
+			cfg := operatorv1.Installation{}
+			err := Convert(ctx, c, &cfg)
+			Expect(err).NotTo(HaveOccurred())
+		})
 		DescribeTable("should pick v4 default pool", func(envcidr, expectcidr string) {
 			ds := emptyNodeSpec()
 			ds.Spec.Template.Spec.InitContainers[0].Env = []corev1.EnvVar{{


### PR DESCRIPTION
## Description

This fixes a panic when migrating non-Calico CNI because there was no CalicoNetwork in the installation resource.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
