### PR TITLE
Allow access to packet capture resource

### DIFF
--- a/deploy/crds/enterprise/02-crd-packetcapture.yaml
+++ b/deploy/crds/enterprise/02-crd-packetcapture.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: packetcaptures.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: PacketCapture
+    plural: packetcaptures
+    singular: packetcapture
+

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -331,6 +331,7 @@ func (c *apiServerComponent) apiServiceAccountClusterRole() *rbacv1.ClusterRole 
 				"blockaffinities",
 				"remoteclusterconfigurations",
 				"managedclusters",
+				"packetcaptures",
 			},
 			Verbs: []string{"*"},
 		},

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -270,6 +270,7 @@ func (c *typhaComponent) typhaRole() *rbacv1.ClusterRole {
 					"stagedkubernetesnetworkpolicies",
 					"stagednetworkpolicies",
 					"tiers",
+					"packetcaptures",
 				},
 				Verbs: []string{"get", "list", "watch"},
 			},


### PR DESCRIPTION
## Description

Allow the api-server and typha to access packetcapture resource.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
