### PR TITLE
[v1.9] Backport KUBERNETES_SERVICE_HOST/PORT override (#700)

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -57,6 +57,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+var k8sEndpoint render.K8sServiceEndpoint
+
+func init() {
+	// We read whatever is in the variable. We would read "" if they were not set.
+	// We decide at the point of usage what to do with the values.
+	k8sEndpoint = render.K8sServiceEndpoint{
+		Host: os.Getenv("KUBERNETES_SERVICE_HOST"),
+		Port: os.Getenv("KUBERNETES_SERVICE_PORT"),
+	}
+}
+
 var log = logf.Log.WithName("controller_installation")
 var openshiftNetworkConfig = "cluster"
 
@@ -686,6 +697,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	// Render the desired Calico components based on our configuration and then
 	// create or update them.
 	calico, err := render.Calico(
+		k8sEndpoint,
 		instance,
 		logStorageExists,
 		managementCluster,

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -371,3 +371,23 @@ func basePodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
 		},
 	}
 }
+
+// K8sServiceEndpoint is the Host/Port of the K8s endpoint.
+type K8sServiceEndpoint struct {
+	Host string
+	Port string
+}
+
+// EnvVars returns a slice of v1.EnvVars KUBERNETES_SERVICE_HOST/PORT if the Host and Port
+// of the K8sServiceEndpoint were set. It returns a nil slice if either was empty as both
+// need to be set.
+func (k8s K8sServiceEndpoint) EnvVars() []v1.EnvVar {
+	if k8s.Host == "" || k8s.Port == "" {
+		return nil
+	}
+
+	return []v1.EnvVar{
+		{Name: "KUBERNETES_SERVICE_HOST", Value: k8s.Host},
+		{Name: "KUBERNETES_SERVICE_PORT", Value: k8s.Port},
+	}
+}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -425,7 +425,7 @@ var _ = Describe("Node rendering tests", func() {
 		defaultInstance.Spec.KubernetesProvider = operator.ProviderEKS
 		defaultInstance.Spec.CalicoNetwork.BGP = &disabled
 		defaultInstance.Spec.CalicoNetwork.IPPools[0].Encapsulation = operator.EncapsulationVXLAN
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -46,6 +46,8 @@ var _ = Describe("Node rendering tests", func() {
 	one := intstr.FromInt(1)
 	defaultNumExpectedResources := 6
 
+	k8sServiceEp := render.K8sServiceEndpoint{}
+
 	BeforeEach(func() {
 		ff := true
 		hp := operator.HostPortsEnabled
@@ -91,7 +93,7 @@ var _ = Describe("Node rendering tests", func() {
 		}
 
 		defaultInstance.Spec.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -314,7 +316,7 @@ var _ = Describe("Node rendering tests", func() {
 		}
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -645,7 +647,7 @@ var _ = Describe("Node rendering tests", func() {
 			},
 		}
 
-		component := render.Node(amazonVPCInstalllation, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, amazonVPCInstalllation, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(5))
 
@@ -816,7 +818,7 @@ var _ = Describe("Node rendering tests", func() {
 
 		defaultInstance.Spec.FlexVolumePath = "/etc/kubernetes/kubelet-plugins/volume/exec/"
 		defaultInstance.Spec.KubernetesProvider = operator.ProviderOpenShift
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -949,7 +951,7 @@ var _ = Describe("Node rendering tests", func() {
 
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		defaultInstance.Spec.KubernetesProvider = operator.ProviderOpenShift
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -1062,7 +1064,7 @@ var _ = Describe("Node rendering tests", func() {
 			"template-1.yaml": "dataforTemplate1 that is not used here",
 		}
 		defaultInstance.Spec.KubernetesProvider = operator.ProviderOpenShift
-		component := render.Node(defaultInstance, bt, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, bt, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -1103,7 +1105,7 @@ var _ = Describe("Node rendering tests", func() {
 		It("should support canReach", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.CanReach = "1.1.1.1"
-			component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+			component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(defaultNumExpectedResources))
 
@@ -1118,7 +1120,7 @@ var _ = Describe("Node rendering tests", func() {
 		It("should support interface regex", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.Interface = "eth*"
-			component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+			component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(defaultNumExpectedResources))
 
@@ -1133,7 +1135,7 @@ var _ = Describe("Node rendering tests", func() {
 		It("should support skip-interface regex", func() {
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.FirstFound = nil
 			defaultInstance.Spec.CalicoNetwork.NodeAddressAutodetectionV4.SkipInterface = "eth*"
-			component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+			component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(defaultNumExpectedResources))
 
@@ -1148,7 +1150,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should include updates needed for the core upgrade", func() {
 		defaultInstance.Spec.KubernetesProvider = operator.ProviderOpenShift
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, true)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, true)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(defaultNumExpectedResources-1), fmt.Sprintf("resources are %v", resources))
 
@@ -1183,7 +1185,7 @@ var _ = Describe("Node rendering tests", func() {
 		func(pool operator.IPPool, expect map[string]string) {
 			// Provider does not matter for IPPool configuration
 			defaultInstance.Spec.CalicoNetwork.IPPools = []operator.IPPool{pool}
-			component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+			component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 			resources, _ := component.Objects()
 			Expect(len(resources)).To(Equal(defaultNumExpectedResources))
 
@@ -1310,7 +1312,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should not enable prometheus metrics if NodeMetricsPort is nil", func() {
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		defaultInstance.Spec.NodeMetricsPort = nil
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(defaultNumExpectedResources + 1))
 
@@ -1330,7 +1332,7 @@ var _ = Describe("Node rendering tests", func() {
 		var nodeMetricsPort int32 = 1234
 		defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
 		defaultInstance.Spec.NodeMetricsPort = &nodeMetricsPort
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(defaultNumExpectedResources + 1))
 
@@ -1354,7 +1356,7 @@ var _ = Describe("Node rendering tests", func() {
 
 	It("should not render a FlexVolume container if FlexVolumePath is set to None", func() {
 		defaultInstance.Spec.FlexVolumePath = "None"
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(defaultNumExpectedResources))
 
@@ -1368,7 +1370,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should render MaxUnavailable if a custom value was set", func() {
 		two := intstr.FromInt(2)
 		defaultInstance.Spec.NodeUpdateStrategy.RollingUpdate.MaxUnavailable = &two
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(defaultNumExpectedResources))
 
@@ -1399,7 +1401,7 @@ var _ = Describe("Node rendering tests", func() {
 		defaultInstance.Spec.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		hpd := operator.HostPortsDisabled
 		defaultInstance.Spec.CalicoNetwork.HostPorts = &hpd
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -1480,7 +1482,7 @@ var _ = Describe("Node rendering tests", func() {
 	It("should render a proper 'allow_ip_forwarding' container setting in the cni config", func() {
 		cif := operator.ContainerIPForwardingEnabled
 		defaultInstance.Spec.CalicoNetwork.ContainerIPForwarding = &cif
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(defaultNumExpectedResources))
 
@@ -1521,7 +1523,7 @@ var _ = Describe("Node rendering tests", func() {
 		seccompProf := "localhost/calico-node-v1"
 		defaultInstance.ObjectMeta.Annotations = make(map[string]string)
 		defaultInstance.ObjectMeta.Annotations["tech-preview.operator.tigera.io/node-apparmor-profile"] = seccompProf
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 
 		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -1539,7 +1541,7 @@ var _ = Describe("Node rendering tests", func() {
 				PodSecurityGroupID:   "sg-podsgid",
 			},
 		}
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, aci, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, aci, false)
 		resources, _ := component.Objects()
 
 		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -1575,7 +1577,7 @@ var _ = Describe("Node rendering tests", func() {
 			},
 		}
 
-		component := render.Node(defaultInstance, nil, typhaNodeTLS, nil, false)
+		component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 
 		dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
@@ -1590,6 +1592,46 @@ var _ = Describe("Node rendering tests", func() {
 			}
 		}
 		Expect(passed).To(Equal(true))
+	})
+
+	Context("with k8s overrides set", func() {
+		It("should override k8s endpoints", func() {
+			k8sServiceEp := render.K8sServiceEndpoint{
+				Host: "k8shost",
+				Port: "1234",
+			}
+			component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
+			resources, _ := component.Objects()
+			Expect(len(resources)).To(Equal(defaultNumExpectedResources))
+
+			dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+			ds := dsResource.(*apps.DaemonSet)
+
+			// FIXME update gomega to include ContainElements
+			Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "k8shost"},
+			))
+			Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "1234"},
+			))
+
+			var cni v1.Container
+
+			for _, c := range ds.Spec.Template.Spec.InitContainers {
+				if c.Name == "install-cni" {
+					cni = c
+					break
+				}
+			}
+			Expect(cni).NotTo(BeNil())
+
+			Expect(cni.Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "k8shost"},
+			))
+			Expect(cni.Env).To(ContainElement(
+				v1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "1234"},
+			))
+		})
 	})
 })
 

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -60,6 +60,7 @@ type TyphaNodeTLS struct {
 }
 
 func Calico(
+	k8sServiceEp K8sServiceEndpoint,
 	cr *operator.Installation,
 	logStorageExists bool,
 	managementCluster *operator.ManagementCluster,
@@ -134,6 +135,7 @@ func Calico(
 	}
 
 	return calicoRenderer{
+		k8sServiceEp:                k8sServiceEp,
 		installation:                cr,
 		logStorageExists:            logStorageExists,
 		managementCluster:           managementCluster,
@@ -208,6 +210,7 @@ func createTLS() (*TyphaNodeTLS, error) {
 }
 
 type calicoRenderer struct {
+	k8sServiceEp                K8sServiceEndpoint
 	installation                *operator.Installation
 	logStorageExists            bool
 	managementCluster           *operator.ManagementCluster
@@ -230,8 +233,8 @@ func (r calicoRenderer) Render() []Component {
 	components = appendNotNil(components, Namespaces(r.installation.Spec.KubernetesProvider == operator.ProviderOpenShift, r.pullSecrets))
 	components = appendNotNil(components, ConfigMaps(r.tlsConfigMaps))
 	components = appendNotNil(components, Secrets(r.tlsSecrets))
-	components = appendNotNil(components, Typha(r.installation, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade))
-	components = appendNotNil(components, Node(r.installation, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade))
+	components = appendNotNil(components, Typha(r.k8sServiceEp, r.installation, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade))
+	components = appendNotNil(components, Node(r.k8sServiceEp, r.installation, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade))
 	components = appendNotNil(components, KubeControllers(r.installation, r.logStorageExists, r.managementCluster, r.managementClusterConnection, r.managerInternalTLSecret, r.authentication))
 	return components
 }

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Rendering tests", func() {
 	var typhaNodeTLS *render.TyphaNodeTLS
 	one := intstr.FromInt(1)
 	miMode := operator.MultiInterfaceModeNone
+	k8sServiceEp := render.K8sServiceEndpoint{}
 
 	BeforeEach(func() {
 		// Initialize a default instance to use. Each test can override this to its
@@ -82,7 +83,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 5 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment, PodSecurityPolicy)
 		// - 1 namespace
 		// - 1 PriorityClass
-		c, err := render.Calico(instance, false, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false)
+		c, err := render.Calico(k8sServiceEp, instance, false, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(6 + 4 + 2 + 7 + 5 + 1 + 1))
 	})
@@ -95,7 +96,7 @@ var _ = Describe("Rendering tests", func() {
 		var nodeMetricsPort int32 = 9081
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		instance.Spec.NodeMetricsPort = &nodeMetricsPort
-		c, err := render.Calico(instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false)
+		c, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(((6 + 4 + 2 + 7 + 5 + 1) + 1 + 1)))
 	})
@@ -110,7 +111,7 @@ var _ = Describe("Rendering tests", func() {
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		instance.Spec.NodeMetricsPort = &nodeMetricsPort
 
-		c, err := render.Calico(instance, true, &operator.ManagementCluster{}, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false)
+		c, err := render.Calico(k8sServiceEp, instance, true, &operator.ManagementCluster{}, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 
 		expectedResources := []struct {

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -45,12 +45,14 @@ const (
 
 // Typha creates the typha daemonset and other resources for the daemonset to operate normally.
 func Typha(
+	k8sServiceEp K8sServiceEndpoint,
 	installation *operator.Installation,
 	tnTLS *TyphaNodeTLS,
 	aci *operator.AmazonCloudIntegration,
 	migrationNeeded bool,
 ) Component {
 	return &typhaComponent{
+		k8sServiceEp:       k8sServiceEp,
 		installation:       installation,
 		typhaNodeTLS:       tnTLS,
 		amazonCloudInt:     aci,
@@ -59,6 +61,7 @@ func Typha(
 }
 
 type typhaComponent struct {
+	k8sServiceEp       K8sServiceEndpoint
 	installation       *operator.Installation
 	typhaNodeTLS       *TyphaNodeTLS
 	amazonCloudInt     *operator.AmazonCloudIntegration
@@ -492,6 +495,7 @@ func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
 	}
 
 	typhaEnv = append(typhaEnv, GetTigeraSecurityGroupEnvVariables(c.amazonCloudInt)...)
+	typhaEnv = append(typhaEnv, c.k8sServiceEp.EnvVars()...)
 
 	return typhaEnv
 }

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Typha rendering tests", func() {
 	var installation *operator.Installation
 	var registry string
 	var typhaNodeTLS *render.TyphaNodeTLS
+	k8sServiceEp := render.K8sServiceEndpoint{}
 	BeforeEach(func() {
 		registry = "test.registry.com/org"
 		// Initialize a default installation to use. Each test can override this to its
@@ -69,7 +70,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
-		component := render.Typha(installation, typhaNodeTLS, nil, false)
+		component := render.Typha(k8sServiceEp, installation, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -108,7 +109,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
-		component := render.Typha(installation, typhaNodeTLS, nil, true)
+		component := render.Typha(k8sServiceEp, installation, typhaNodeTLS, nil, true)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -150,7 +151,7 @@ var _ = Describe("Typha rendering tests", func() {
 				PodSecurityGroupID:   "sg-podsgid",
 			},
 		}
-		component := render.Typha(installation, typhaNodeTLS, aci, true)
+		component := render.Typha(k8sServiceEp, installation, typhaNodeTLS, aci, true)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -189,7 +190,7 @@ var _ = Describe("Typha rendering tests", func() {
 			},
 		}
 
-		component := render.Typha(installation, typhaNodeTLS, nil, false)
+		component := render.Typha(k8sServiceEp, installation, typhaNodeTLS, nil, false)
 		resources, _ := component.Objects()
 
 		depResource := GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Backport #700 

forward KUBERNETES_SERVICE_HOST/PORT to node ds

If there is no kube-proxy (or it is to be removed), e.g. when we enable
BPF, we need to override the KUBERNETES_SERVICE_HOST/PORT for operator
so that it can access k8s. The same setting needs to be forwarded to
other components like felix and cni.

(cherry picked from commit 8f0732fa1be6e86c7d5360dea425f56ac69478f8)

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
