### PR TITLE
Fix incorrect EKS detection

### DIFF
--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -141,8 +141,12 @@ func isDockerEE(c kubernetes.Interface) (bool, error) {
 // we use for other platforms in autodetectFromGroup.
 func isEKS(c kubernetes.Interface) (bool, error) {
 	cm, err := c.CoreV1().ConfigMaps("kube-system").Get("eks-certificates-controller", metav1.GetOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
+
 	return (cm != nil), nil
 }


### PR DESCRIPTION
## Description

I incorrectly assumed that a nil would be returned from the Get when there was no ConfigMap. Comparing the "real" code with the Fake version does show a difference in behavior. [Real](https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/configmap.go#L67) vs [Fake](https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/fake/fake_configmap.go#L44)
This also explains why our UTs did not catch this.

This PR fixes the incorrect code.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
