### PR TITLE
switch to use the controller runtime logger

### DIFF
--- a/pkg/controller/migration/convert/cni.go
+++ b/pkg/controller/migration/convert/cni.go
@@ -5,14 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"reflect"
 	"strings"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("migration_convert")
 
 // Used to parse the IPAM section out of the full CNI configuration
 type CNIHostLocalIPAM struct {
@@ -50,7 +52,7 @@ func loadCNI(c *components) error {
 	if cntnr == nil {
 		// It is valid to not have an install-cni container in the cases
 		// of non Calico CNI so nothing more to do in that case.
-		log.Print("no install-cni container detected on node")
+		log.Info("no install-cni container detected on node")
 		return nil
 	}
 
@@ -59,7 +61,7 @@ func loadCNI(c *components) error {
 		return err
 	}
 	if cniConfig == nil {
-		log.Print("no CNI_NETWORK_CONFIG detected on node")
+		log.Info("no CNI_NETWORK_CONFIG detected on node")
 		return nil
 	}
 

--- a/pkg/controller/migration/convert/cni.go
+++ b/pkg/controller/migration/convert/cni.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 // Used to parse the IPAM section out of the full CNI configuration

--- a/pkg/controller/migration/convert/cni.go
+++ b/pkg/controller/migration/convert/cni.go
@@ -14,8 +14,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var log = logf.Log.WithName("migration_convert")
-
 // Used to parse the IPAM section out of the full CNI configuration
 type CNIHostLocalIPAM struct {
 	IPAM json.RawMessage `json:"ipam"`

--- a/pkg/controller/migration/convert/convert.go
+++ b/pkg/controller/migration/convert/convert.go
@@ -6,12 +6,10 @@ package convert
 import (
 	"context"
 	"fmt"
-	"log"
-
-	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 
 	"github.com/containernetworking/cni/libcni"
 	calicocni "github.com/projectcalico/cni-plugin/pkg/types"
+	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -88,7 +86,7 @@ func getComponents(ctx context.Context, client client.Client) (*components, erro
 		if !errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get kube-controllers deployment: %v", err)
 		}
-		log.Print("did not detect kube-controllers")
+		log.Info("did not detect kube-controllers")
 		kc = nil
 	}
 
@@ -101,7 +99,7 @@ func getComponents(ctx context.Context, client client.Client) (*components, erro
 			return nil, fmt.Errorf("failed to get typha deployment: %v", err)
 		}
 		// typha is optional, so just log.
-		log.Print("did not detect typha")
+		log.Info("did not detect typha")
 		t = nil
 	}
 
@@ -128,7 +126,7 @@ func Convert(ctx context.Context, client client.Client, install *operatorv1.Inst
 	comps, err := getComponents(ctx, client)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			log.Print("no existing install found: ", err)
+			log.Error(err, "no existing install found: %v", err)
 			return nil
 		}
 		return err

--- a/pkg/controller/migration/convert/convert.go
+++ b/pkg/controller/migration/convert/convert.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var log = logf.Log.WithName("migration_convert")

--- a/pkg/controller/migration/convert/convert.go
+++ b/pkg/controller/migration/convert/convert.go
@@ -20,6 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var log = logf.Log.WithName("migration_convert")
+
 var ctx = context.Background()
 
 // Installation represents the configuration pulled from the existing install.


### PR DESCRIPTION
## Description
Converted a few legacy loggers to use the controller-runtime logger

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
