### PR TITLE
Refactor CNI into package, remove dependency on projectcalico/cni-plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,16 @@ go 1.12
 require (
 	github.com/cloudflare/cfssl v1.4.1
 	github.com/containernetworking/cni v0.8.0
-	github.com/containernetworking/plugins v0.8.6
 	github.com/elastic/cloud-on-k8s v0.0.0-20200526192013-f13b6d26a186
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
 	github.com/hashicorp/go-version v1.2.0
-	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/openshift/api v3.9.1-0.20190927182313-d4a64ec2cbd8+incompatible
 	github.com/openshift/library-go v0.0.0-20190924092619-a8c1174d4ee7
 	github.com/operator-framework/operator-sdk v0.18.1
 	github.com/pkg/errors v0.8.1
-	github.com/projectcalico/cni-plugin v3.8.9+incompatible
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	github.com/tigera/api v0.0.0-20200311151854-a6d8502444cd

--- a/pkg/controller/migration/cni/calicotypes.go
+++ b/pkg/controller/migration/cni/calicotypes.go
@@ -14,16 +14,13 @@ type CalicoConf struct {
 		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
 		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
 	} `json:"ipam,omitempty"`
-	// Args                 Args   `json:"args"`
-	MTU                  int    `json:"mtu"`
-	Nodename             string `json:"nodename"`
-	NodenameFileOptional bool   `json:"nodename_file_optional"`
-	DatastoreType        string `json:"datastore_type"`
-	EtcdEndpoints        string `json:"etcd_endpoints"`
-	EtcdDiscoverySrv     string `json:"etcd_discovery_srv"`
-	LogLevel             string `json:"log_level"`
-	// Policy               Policy `json:"policy"`
-	// Kubernetes           Kubernetes        `json:"kubernetes"`
+	MTU                  int               `json:"mtu"`
+	Nodename             string            `json:"nodename"`
+	NodenameFileOptional bool              `json:"nodename_file_optional"`
+	DatastoreType        string            `json:"datastore_type"`
+	EtcdEndpoints        string            `json:"etcd_endpoints"`
+	EtcdDiscoverySrv     string            `json:"etcd_discovery_srv"`
+	LogLevel             string            `json:"log_level"`
 	FeatureControl       FeatureControl    `json:"feature_control"`
 	EtcdScheme           string            `json:"etcd_scheme"`
 	EtcdKeyFile          string            `json:"etcd_key_file"`

--- a/pkg/controller/migration/cni/calicotypes.go
+++ b/pkg/controller/migration/cni/calicotypes.go
@@ -1,0 +1,46 @@
+package cni
+
+// CalicoConf stores the common network config for Calico CNI plugin
+type CalicoConf struct {
+	CNIVersion string `json:"cniVersion,omitempty"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	IPAM       struct {
+		Name       string
+		Type       string   `json:"type"`
+		Subnet     string   `json:"subnet"`
+		AssignIpv4 *string  `json:"assign_ipv4"`
+		AssignIpv6 *string  `json:"assign_ipv6"`
+		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
+		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
+	} `json:"ipam,omitempty"`
+	// Args                 Args   `json:"args"`
+	MTU                  int    `json:"mtu"`
+	Nodename             string `json:"nodename"`
+	NodenameFileOptional bool   `json:"nodename_file_optional"`
+	DatastoreType        string `json:"datastore_type"`
+	EtcdEndpoints        string `json:"etcd_endpoints"`
+	EtcdDiscoverySrv     string `json:"etcd_discovery_srv"`
+	LogLevel             string `json:"log_level"`
+	// Policy               Policy `json:"policy"`
+	// Kubernetes           Kubernetes        `json:"kubernetes"`
+	FeatureControl       FeatureControl    `json:"feature_control"`
+	EtcdScheme           string            `json:"etcd_scheme"`
+	EtcdKeyFile          string            `json:"etcd_key_file"`
+	EtcdCertFile         string            `json:"etcd_cert_file"`
+	EtcdCaCertFile       string            `json:"etcd_ca_cert_file"`
+	ContainerSettings    ContainerSettings `json:"container_settings,omitempty"`
+	IncludeDefaultRoutes bool              `json:"include_default_routes,omitempty"`
+}
+
+// ContainerSettings contains configuration options
+// to be configured inside the container namespace.
+type ContainerSettings struct {
+	AllowIPForwarding bool `json:"allow_ip_forwarding"`
+}
+
+// FeatureControl is a struct which controls which features are enabled in Calico.
+type FeatureControl struct {
+	IPAddrsNoIpam bool `json:"ip_addrs_no_ipam"`
+	FloatingIPs   bool `json:"floating_ips"`
+}

--- a/pkg/controller/migration/cni/cni.go
+++ b/pkg/controller/migration/cni/cni.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
-	calicocni "github.com/projectcalico/cni-plugin/pkg/types"
 )
 
 type NetworkComponents struct {
 	ConfigName          string
-	CalicoConfig        *calicocni.NetConf
+	CalicoConfig        *CalicoConf
 	HostLocalIPAMConfig *HostLocalIPAMConfig
 
 	// other CNI plugins in the conflist.

--- a/pkg/controller/migration/cni/cni_test.go
+++ b/pkg/controller/migration/cni/cni_test.go
@@ -1,10 +1,7 @@
-package convert
+package cni
 
 import (
 	"fmt"
-
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -38,50 +35,26 @@ const cniTemplate = `{
 		"capabilities": {"bandwidth": true}
 	  }
 	]
-  }`
+}`
 
 var defaultCNI = fmt.Sprintf(cniTemplate, `{"type": "calico-ipam"}`)
 
 var _ = Describe("CNI", func() {
-	It("should load cni from correct fields on calico-node", func() {
-		ds := emptyNodeSpec()
-		ds.Spec.Template.Spec.InitContainers[0].Env = []corev1.EnvVar{
-			{
-				Name:  "CNI_NETWORK_CONFIG",
-				Value: defaultCNI,
-			},
-		}
-
-		cli := fake.NewFakeClient(ds, emptyKubeControllerSpec())
-		c := components{
-			node: CheckedDaemonSet{
-				DaemonSet:   *ds,
-				checkedVars: map[string]checkedFields{},
-			},
-			client: cli,
-		}
-
-		nc, err := loadCNI(&c)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(nc.calicoCNIConfig).ToNot(BeNil())
-		Expect(nc.calicoCNIConfig.IPAM.Type).To(Equal("calico-ipam"), fmt.Sprintf("Got %+v", c.calicoCNIConfig))
-	})
-
 	It("should unmarshal a valid cni conf list", func() {
 		_, err := unmarshalCNIConfList(defaultCNI)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should parse basic calico cni", func() {
-		c, err := parseCNIConfig(defaultCNI)
+		c, err := Parse(defaultCNI)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(c.calicoCNIConfig).ToNot(BeNil())
+		Expect(c.CalicoConfig).ToNot(BeNil())
 		// check that any field was unmarshaled correctly.
-		Expect(c.calicoCNIConfig.IPAM.Type).To(Equal("calico-ipam"), fmt.Sprintf("Got %+v", c.calicoCNIConfig))
+		Expect(c.CalicoConfig.IPAM.Type).To(Equal("calico-ipam"), fmt.Sprintf("Got %+v", c.CalicoConfig))
 	})
 
 	It("should parse ranges and routes", func() {
-		cni := fmt.Sprintf(cniTemplate, `{
+		c, err := Parse(fmt.Sprintf(cniTemplate, `{
 			"type": "host-local",
 			"ranges": [
                 [
@@ -95,20 +68,18 @@ var _ = Describe("CNI", func() {
                 { "dst": "0.0.0.0/0" },
                 { "dst": "2001:db8::/96" }
             ]
-        }`)
-		c, err := parseCNIConfig(cni)
+        }`))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(c.calicoCNIConfig).ToNot(BeNil())
-		Expect(c.calicoCNIConfig.IPAM.Type).To(Equal("host-local"), fmt.Sprintf("Got %+v", c.calicoCNIConfig))
-		Expect(c.hostLocalIPAMConfig.Ranges).To(HaveLen(2))
-		Expect(c.hostLocalIPAMConfig.Routes).To(HaveLen(2))
+		Expect(c.CalicoConfig).ToNot(BeNil())
+		Expect(c.CalicoConfig.IPAM.Type).To(Equal("host-local"), fmt.Sprintf("Got %+v", c.CalicoConfig))
+		Expect(c.HostLocalIPAMConfig.Ranges).To(HaveLen(2))
+		Expect(c.HostLocalIPAMConfig.Routes).To(HaveLen(2))
 	})
 	It("should raise error if IPAM with unknown field is detected", func() {
-		cni := fmt.Sprintf(cniTemplate, `{
+		_, err := Parse(fmt.Sprintf(cniTemplate, `{
 			"type": "host-local",
 			"unknown": "whocares"
-          }`)
-		_, err := parseCNIConfig(cni)
+        }`))
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/controller/migration/convert/convert.go
+++ b/pkg/controller/migration/convert/convert.go
@@ -7,9 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containernetworking/cni/libcni"
-	calicocni "github.com/projectcalico/cni-plugin/pkg/types"
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/migration/cni"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,16 +35,7 @@ type components struct {
 	// client is used to resolve spec fields that reference other data sources
 	client client.Client
 
-	networkComponents
-}
-
-type networkComponents struct {
-	cniConfigName       string
-	calicoCNIConfig     *calicocni.NetConf
-	hostLocalIPAMConfig *HostLocalIPAMConfig
-
-	// other CNI plugins in the conflist.
-	pluginCNIConfig map[string]*libcni.NetworkConfig
+	cni cni.NetworkComponents
 }
 
 // getComponents loads the main calico components into structs for later parsing.
@@ -106,19 +96,19 @@ func getComponents(ctx context.Context, client client.Client) (*components, erro
 
 	// do some upfront processing of CNI by loading it into comps
 	var err error
-	comps.networkComponents, err = loadCNI(comps)
+	comps.cni, err = loadCNI(comps)
 
 	return comps, err
 }
 
 // loadCNI pulls the CNI network config from it's env var source within components
 // and then returns the parsed data.
-func loadCNI(comps *components) (networkComponents, error) {
-	nc := networkComponents{}
+func loadCNI(comps *components) (nc cni.NetworkComponents, err error) {
 	// do some upfront processing of CNI by loading it into comps
 	c := getContainer(comps.node.Spec.Template.Spec, containerInstallCNI)
 	if c == nil {
-		return nc, nil
+		log.V(5).Info("no install-cni container found on calico-node")
+		return
 	}
 
 	cniConfig, err := comps.node.getEnv(ctx, comps.client, containerInstallCNI, "CNI_NETWORK_CONFIG")
@@ -126,7 +116,8 @@ func loadCNI(comps *components) (networkComponents, error) {
 		return nc, err
 	}
 	if cniConfig != nil {
-		nc, err = parseCNIConfig(*cniConfig)
+		log.V(5).Info("no env var CNI_NETWORK_CONFIG found on calico-node")
+		nc, err = cni.Parse(*cniConfig)
 	}
 
 	return nc, err

--- a/pkg/controller/migration/convert/convert_test.go
+++ b/pkg/controller/migration/convert/convert_test.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -174,6 +175,53 @@ var _ = Describe("Parser", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
 			Expect(*cfg.Spec.NodeMetricsPort).To(Equal(int32(7777)))
+		})
+	})
+
+	Context("CNI", func() {
+		var _ = Describe("CNI", func() {
+			It("should load cni from correct fields on calico-node", func() {
+				ds := emptyNodeSpec()
+				ds.Spec.Template.Spec.InitContainers[0].Env = []corev1.EnvVar{
+					{
+						Name: "CNI_NETWORK_CONFIG",
+						Value: `{
+							"name": "k8s-pod-network",
+							"cniVersion": "0.3.1",
+							"plugins": [
+							  {
+								"type": "calico",
+								"log_level": "info",
+								"datastore_type": "kubernetes",
+								"nodename": "__KUBERNETES_NODE_NAME__",
+								"mtu": __CNI_MTU__,
+								"ipam": {"type": "calico-ipam"},
+								"policy": {
+									"type": "k8s"
+								},
+								"kubernetes": {
+									"kubeconfig": "__KUBECONFIG_FILEPATH__"
+								}
+							  }
+							]
+						}`,
+					},
+				}
+
+				cli := fake.NewFakeClient(ds, emptyKubeControllerSpec())
+				c := components{
+					node: CheckedDaemonSet{
+						DaemonSet:   *ds,
+						checkedVars: map[string]checkedFields{},
+					},
+					client: cli,
+				}
+
+				nc, err := loadCNI(&c)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nc.CalicoConfig).ToNot(BeNil())
+				Expect(nc.CalicoConfig.IPAM.Type).To(Equal("calico-ipam"), fmt.Sprintf("Got %+v", c.cni.CalicoConfig))
+			})
 		})
 	})
 })

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -106,7 +106,7 @@ func handleCore(c *components, install *operatorv1.Installation) error {
 	if v == nil || v.HostPath == nil || v.HostPath.Path != "/run/xtables.lock" {
 		return ErrIncompatibleCluster{"expected calico-node to have volume 'xtables-lock' with hostPath '/run/xtables.lock"}
 	}
-	if c.calicoCNIConfig != nil {
+	if c.cni.CalicoConfig != nil {
 		v = getVolume(c.node.Spec.Template.Spec, "cni-bin-dir")
 		if v == nil || v.HostPath == nil || v.HostPath.Path != "/opt/cni/bin" {
 			return ErrIncompatibleCluster{"expected calico-node to have volume 'cni-bin-dir' with hostPath '/opt/cni/bin'"}

--- a/pkg/controller/migration/convert/mtu.go
+++ b/pkg/controller/migration/convert/mtu.go
@@ -32,8 +32,8 @@ func handleMTU(c *components, install *operatorv1.Installation) error {
 		curMTU, curMTUSrc = mtu, src
 	}
 
-	if c.calicoCNIConfig != nil {
-		if c.calicoCNIConfig.MTU == -1 {
+	if c.cni.CalicoConfig != nil {
+		if c.cni.CalicoConfig.MTU == -1 {
 			// if MTU is -1, we assume it was us who replaced it when doing initial CNI
 			// config loading. We need to pull it from the correct source
 			var src = "CNI_MTU"
@@ -57,7 +57,7 @@ func handleMTU(c *components, install *operatorv1.Installation) error {
 		} else {
 			// user must have hardcoded their CNI instead of using the cni templating engine.
 			// use the hardcoded value.
-			mtu := int32(c.calicoCNIConfig.MTU)
+			mtu := int32(c.cni.CalicoConfig.MTU)
 			if curMTU != nil && *curMTU != mtu {
 				return ErrIncompatibleCluster{fmt.Sprintf("mtu '%d' specified in CNI config does not match mtu %s=%d", mtu, curMTUSrc, *curMTU)}
 			}

--- a/pkg/controller/migration/convert/mtu_test.go
+++ b/pkg/controller/migration/convert/mtu_test.go
@@ -1,8 +1,8 @@
 package convert
 
 import (
-	"github.com/projectcalico/cni-plugin/pkg/types"
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/migration/cni"
 	v1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -27,7 +27,7 @@ var _ = Describe("mtu handler", func() {
 	})
 
 	It("should read mtu from cni config", func() {
-		comps.cni.CalicoConfig = &types.NetConf{
+		comps.cni.CalicoConfig = &cni.CalicoConf{
 			MTU: 1234,
 		}
 		err := handleMTU(&comps, i)
@@ -71,7 +71,7 @@ var _ = Describe("mtu handler", func() {
 			Name:  "FELIX_IPINIPMTU",
 			Value: "1324",
 		}}
-		comps.cni.CalicoConfig = &types.NetConf{
+		comps.cni.CalicoConfig = &cni.CalicoConf{
 			MTU: 1234,
 		}
 		err := handleMTU(&comps, i)

--- a/pkg/controller/migration/convert/mtu_test.go
+++ b/pkg/controller/migration/convert/mtu_test.go
@@ -27,7 +27,7 @@ var _ = Describe("mtu handler", func() {
 	})
 
 	It("should read mtu from cni config", func() {
-		comps.calicoCNIConfig = &types.NetConf{
+		comps.cni.CalicoConfig = &types.NetConf{
 			MTU: 1234,
 		}
 		err := handleMTU(&comps, i)
@@ -71,7 +71,7 @@ var _ = Describe("mtu handler", func() {
 			Name:  "FELIX_IPINIPMTU",
 			Value: "1324",
 		}}
-		comps.calicoCNIConfig = &types.NetConf{
+		comps.cni.CalicoConfig = &types.NetConf{
 			MTU: 1234,
 		}
 		err := handleMTU(&comps, i)

--- a/pkg/controller/migration/convert/network.go
+++ b/pkg/controller/migration/convert/network.go
@@ -12,6 +12,7 @@ import (
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	operatorv1 "github.com/tigera/operator/pkg/apis/operator/v1"
 	v1 "github.com/tigera/operator/pkg/apis/operator/v1"
+	"github.com/tigera/operator/pkg/controller/migration/cni"
 	"github.com/tigera/operator/pkg/render"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -49,7 +50,7 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 
 	errCtx := fmt.Sprintf("detected %s CNI plugin", plugin)
 
-	if c.calicoCNIConfig == nil {
+	if c.cni.CalicoConfig == nil {
 		return ErrIncompatibleCluster{fmt.Sprintf("%s, required Calico cni config was not found ", errCtx)}
 	}
 
@@ -71,26 +72,26 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 		return err
 	}
 
-	switch c.calicoCNIConfig.IPAM.Type {
+	switch c.cni.CalicoConfig.IPAM.Type {
 	case "calico-ipam":
 		install.Spec.CNI.IPAM.Type = operatorv1.IPAMPluginCalico
 
-		if err := subhandleCalicoIPAM(netBackend, *c.calicoCNIConfig, install); err != nil {
+		if err := subhandleCalicoIPAM(netBackend, *c.cni.CalicoConfig, install); err != nil {
 			return ErrIncompatibleCluster{fmt.Sprintf("%s and IPAM calico-ipam, %s", errCtx, err.Error())}
 		}
 	case "host-local":
 		install.Spec.CNI.IPAM.Type = operatorv1.IPAMPluginHostLocal
 
-		if c.hostLocalIPAMConfig == nil {
+		if c.cni.HostLocalIPAMConfig == nil {
 			return ErrIncompatibleCluster{fmt.Sprintf("%s and IPAM host-local, but no IPAM configuration available", errCtx)}
 		}
 
-		if err := subhandleHostLocalIPAM(netBackend, *c.hostLocalIPAMConfig, install); err != nil {
+		if err := subhandleHostLocalIPAM(netBackend, *c.cni.HostLocalIPAMConfig, install); err != nil {
 			return ErrIncompatibleCluster{fmt.Sprintf("%s and IPAM plugin %s, %s",
-				errCtx, c.calicoCNIConfig.IPAM.Type, err.Error())}
+				errCtx, c.cni.CalicoConfig.IPAM.Type, err.Error())}
 		}
 	default:
-		return ErrIncompatibleCluster{fmt.Sprintf("%s, unrecognized IPAM plugin %s, expected calico-ipam or host-local", errCtx, c.calicoCNIConfig.IPAM.Type)}
+		return ErrIncompatibleCluster{fmt.Sprintf("%s, unrecognized IPAM plugin %s, expected calico-ipam or host-local", errCtx, c.cni.CalicoConfig.IPAM.Type)}
 	}
 
 	// IP
@@ -118,7 +119,7 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 	}
 
 	// CNI portmap plugin
-	if _, ok := c.pluginCNIConfig["portmap"]; ok {
+	if _, ok := c.cni.Plugins["portmap"]; ok {
 		hp := v1.HostPortsEnabled
 		install.Spec.CalicoNetwork.HostPorts = &hp
 	} else {
@@ -126,18 +127,18 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 		install.Spec.CalicoNetwork.HostPorts = &hp
 	}
 
-	if c.cniConfigName != "k8s-pod-network" {
-		return ErrIncompatibleCluster{fmt.Sprintf("%s, only 'k8s-pod-network' is supported as CNI name, found %s", errCtx, c.cniConfigName)}
+	if c.cni.ConfigName != "k8s-pod-network" {
+		return ErrIncompatibleCluster{fmt.Sprintf("%s, only 'k8s-pod-network' is supported as CNI name, found %s", errCtx, c.cni.ConfigName)}
 	}
 
 	// Other CNI features
-	if c.calicoCNIConfig.FeatureControl.FloatingIPs {
+	if c.cni.CalicoConfig.FeatureControl.FloatingIPs {
 		return ErrIncompatibleCluster{errCtx + ", floating IPs not supported"}
 	}
-	if c.calicoCNIConfig.FeatureControl.IPAddrsNoIpam {
+	if c.cni.CalicoConfig.FeatureControl.IPAddrsNoIpam {
 		return ErrIncompatibleCluster{errCtx + ", IpAddrsNoIpam not supported"}
 	}
-	if c.calicoCNIConfig.ContainerSettings.AllowIPForwarding {
+	if c.cni.CalicoConfig.ContainerSettings.AllowIPForwarding {
 		return ErrIncompatibleCluster{errCtx + ", AllowIPForwarding not supported"}
 	}
 
@@ -204,7 +205,7 @@ func subhandleCalicoIPAM(netBackend string, cnicfg calicocni.NetConf, install *o
 	}
 
 	// ignored fields:
-	//   - c.calicoCNIConfig.IPAM.Name
+	//   - c.cni.CalicoCNIConfig.IPAM.Name
 
 	invalidFields := []string{}
 	if cnicfg.IPAM.Subnet != "" {
@@ -229,7 +230,7 @@ func subhandleCalicoIPAM(netBackend string, cnicfg calicocni.NetConf, install *o
 // The function tries to collect all the errors and report one message.
 // If there are no errors and the config can be added to the passed in 'install'
 // then nil is returned.
-func subhandleHostLocalIPAM(netBackend string, ipamcfg HostLocalIPAMConfig, install *operatorv1.Installation) error {
+func subhandleHostLocalIPAM(netBackend string, ipamcfg cni.HostLocalIPAMConfig, install *operatorv1.Installation) error {
 	switch netBackend {
 	case "bird":
 		install.Spec.CalicoNetwork.BGP = operatorv1.BGPOptionPtr(operatorv1.BGPEnabled)
@@ -277,7 +278,7 @@ func subhandleHostLocalIPAM(netBackend string, ipamcfg HostLocalIPAMConfig, inst
 }
 
 // checkRange checks the fields in r for invalid values for HostLocal IPAM configuration.
-func checkRange(prefix string, r Range) []string {
+func checkRange(prefix string, r cni.Range) []string {
 	bf := []string{}
 	if r.Subnet != "" {
 		if r.Subnet != "usePodCidr" {
@@ -512,8 +513,8 @@ func handleIPPools(c *components, install *operatorv1.Installation) error {
 	}
 
 	// If IPAM is calico then check that the assign_ipv* fields match the IPPools that have been detected
-	if c.calicoCNIConfig != nil && c.calicoCNIConfig.IPAM.Type == "calico-ipam" {
-		if c.calicoCNIConfig.IPAM.AssignIpv4 == nil || strings.ToLower(*c.calicoCNIConfig.IPAM.AssignIpv4) == "true" {
+	if c.cni.CalicoConfig != nil && c.cni.CalicoConfig.IPAM.Type == "calico-ipam" {
+		if c.cni.CalicoConfig.IPAM.AssignIpv4 == nil || strings.ToLower(*c.cni.CalicoConfig.IPAM.AssignIpv4) == "true" {
 			if v4pool == nil {
 				return ErrIncompatibleCluster{"CNI config indicates assign_ipv4 true but there were no valid V4 pools found"}
 			}
@@ -522,7 +523,7 @@ func handleIPPools(c *components, install *operatorv1.Installation) error {
 				return ErrIncompatibleCluster{"CNI config indicates assig_ipv4 false but a V4 pool was found"}
 			}
 		}
-		if c.calicoCNIConfig.IPAM.AssignIpv6 != nil && strings.ToLower(*c.calicoCNIConfig.IPAM.AssignIpv6) == "true" {
+		if c.cni.CalicoConfig.IPAM.AssignIpv6 != nil && strings.ToLower(*c.cni.CalicoConfig.IPAM.AssignIpv6) == "true" {
 			if v6pool == nil {
 				return ErrIncompatibleCluster{"CNI config indicates assign_ipv6 true but there were no valid V6 pools found"}
 			}

--- a/pkg/controller/migration/convert/network.go
+++ b/pkg/controller/migration/convert/network.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strings"
 
-	calicocni "github.com/projectcalico/cni-plugin/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
@@ -194,7 +193,7 @@ func getNetworkingBackend(node CheckedDaemonSet, client client.Client) (string, 
 // The function tries to collect all the errors and report one message.
 // If there are no errors and the config can be added to the passed in 'install'
 // then nil is returned.
-func subhandleCalicoIPAM(netBackend string, cnicfg calicocni.NetConf, install *operatorv1.Installation) error {
+func subhandleCalicoIPAM(netBackend string, cnicfg cni.CalicoConf, install *operatorv1.Installation) error {
 	switch netBackend {
 	case "bird":
 		install.Spec.CalicoNetwork.BGP = operatorv1.BGPOptionPtr(operatorv1.BGPEnabled)


### PR DESCRIPTION
## Description

Changes:
- Moved CNI into own package
- Moved the various network fields into a new `NetworkComponents` struct instead of having them directly in the main Components struct.
- Updated main cni Parsing function to accept a string instead of the entire components struct, allowing for more isolated testing without having to initialize an entire components struct.
- Improved templating in the cni tests so the same main template can be used across all tests.
- Copied used types from projectcalico/cni-plugin, removing dependency on it


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
