### PR TITLE
Ensure the kubernetes.io/os annotation is set to linux if it's not already set

### DIFF
--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -17,8 +17,12 @@ package utils_test
 import (
 	"context"
 
-	ocsv1 "github.com/openshift/api/security/v1"
+	apps "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta "k8s.io/api/batch/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ocsv1 "github.com/openshift/api/security/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -32,7 +36,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+)
+
+const (
+	fakeComponentAnnotationKey   = "tigera.io/annotation-should-be"
+	fakeComponentAnnotationValue = "present"
 )
 
 var log = logf.Log.WithName("test_utils_logger")
@@ -44,7 +54,6 @@ var _ = Describe("Component handler tests", func() {
 		ctx      context.Context
 		scheme   *runtime.Scheme
 		sm       status.StatusManager
-		fc       render.Component
 		handler  utils.ComponentHandler
 	)
 
@@ -55,11 +64,12 @@ var _ = Describe("Component handler tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(v1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(apps.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(batchv1beta.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 
 		c = fake.NewFakeClientWithScheme(scheme)
 		ctx = context.Background()
 		sm = status.New(c, "fake-component")
-		fc = &fakeComponent{}
 
 		// We need to provide something to handler even though it seems to be unused..
 		instance = &operatorv1.Manager{
@@ -68,7 +78,19 @@ var _ = Describe("Component handler tests", func() {
 		}
 		handler = utils.NewComponentHandler(log, c, scheme, instance)
 	})
+
 	It("merges annotations and reconciles only operator added annotations", func() {
+		fc := newFakeComponent(
+			&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+					Annotations: map[string]string{
+						fakeComponentAnnotationKey: fakeComponentAnnotationValue,
+					},
+				},
+			},
+		)
+
 		err := handler.CreateOrUpdate(ctx, fc, sm)
 		Expect(err).To(BeNil())
 
@@ -160,15 +182,156 @@ var _ = Describe("Component handler tests", func() {
 		c.Get(ctx, nsKey, ns)
 		Expect(ns.GetAnnotations()).To(Equal(expectedAnnotations))
 	})
-})
 
-const (
-	fakeComponentAnnotationKey   = "tigera.io/annotation-should-be"
-	fakeComponentAnnotationValue = "present"
-)
+	FDescribeTable("ensuring pod annotations", func(component render.Component, key client.ObjectKey, obj runtime.Object, expectedNodeSelectors map[string]string) {
+		Expect(handler.CreateOrUpdate(ctx, component, sm)).ShouldNot(HaveOccurred())
+		Expect(c.Get(ctx, key, obj)).ShouldNot(HaveOccurred())
+
+		var nodeSelectors map[string]string
+		switch obj.(type) {
+		case *apps.Deployment:
+			nodeSelectors = obj.(*apps.Deployment).Spec.Template.Spec.NodeSelector
+		case *apps.DaemonSet:
+			nodeSelectors = obj.(*apps.DaemonSet).Spec.Template.Spec.NodeSelector
+		case *apps.StatefulSet:
+			nodeSelectors = obj.(*apps.StatefulSet).Spec.Template.Spec.NodeSelector
+		case *batchv1beta.CronJob:
+			nodeSelectors = obj.(*batchv1beta.CronJob).Spec.JobTemplate.Spec.Template.Spec.NodeSelector
+		default:
+			return
+		}
+
+		Expect(nodeSelectors).Should(Equal(expectedNodeSelectors))
+	},
+		TableEntry{
+			Description: "sets the required annotations for a deployment when their not set",
+			Parameters: []interface{}{
+				newFakeComponent(&apps.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								NodeSelector: map[string]string{},
+							},
+						},
+					},
+				}), client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "sets the required annotations for a daemonset when their not set",
+			Parameters: []interface{}{
+				newFakeComponent(&apps.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset"},
+					Spec: apps.DaemonSetSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								NodeSelector: map[string]string{},
+							},
+						},
+					},
+				}), client.ObjectKey{Name: "test-daemonset"}, &apps.DaemonSet{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "sets the required annotations for a statefulset when their not set",
+			Parameters: []interface{}{
+				newFakeComponent(&apps.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset"},
+					Spec: apps.StatefulSetSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								NodeSelector: map[string]string{},
+							},
+						},
+					},
+				}), client.ObjectKey{Name: "test-statefulset"}, &apps.StatefulSet{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "sets the required annotations for a cronjob when their not set",
+			Parameters: []interface{}{
+				newFakeComponent(&batchv1beta.CronJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-cronjob"},
+					Spec: batchv1beta.CronJobSpec{
+						JobTemplate: batchv1beta.JobTemplateSpec{
+							Spec: batchv1.JobSpec{
+								Template: v1.PodTemplateSpec{
+									Spec: v1.PodSpec{
+										NodeSelector: map[string]string{},
+									},
+								},
+							},
+						},
+					},
+				}), client.ObjectKey{Name: "test-cronjob"}, &batchv1beta.CronJob{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "leaves the required annotations alone if they're already set",
+			Parameters: []interface{}{
+				newFakeComponent(&apps.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								NodeSelector: map[string]string{
+									"kubernetes.io/os": "windows",
+								},
+							},
+						},
+					},
+				}), client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				map[string]string{
+					"kubernetes.io/os": "windows",
+				},
+			},
+		},
+		TableEntry{
+			Description: "leaves other annotations alone and sets the required ones",
+			Parameters: []interface{}{
+				newFakeComponent(&apps.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+					Spec: apps.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								NodeSelector: map[string]string{
+									"kubernetes.io/foo": "bar",
+								},
+							},
+						},
+					},
+				}), client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				map[string]string{
+					"kubernetes.io/foo": "bar",
+					"kubernetes.io/os":  "linux",
+				},
+			},
+		},
+	)
+})
 
 // A fake component that only returns ready and always creates the "test-namespace" Namespace.
 type fakeComponent struct {
+	objs []runtime.Object
+}
+
+func newFakeComponent(objs ...runtime.Object) render.Component {
+	return &fakeComponent{
+		objs: objs,
+	}
 }
 
 func (c *fakeComponent) Ready() bool {
@@ -176,15 +339,5 @@ func (c *fakeComponent) Ready() bool {
 }
 
 func (c *fakeComponent) Objects() ([]runtime.Object, []runtime.Object) {
-	objsToCreate := []runtime.Object{
-		&v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-namespace",
-				Annotations: map[string]string{
-					fakeComponentAnnotationKey: fakeComponentAnnotationValue,
-				},
-			},
-		},
-	}
-	return objsToCreate, nil
+	return c.objs, nil
 }


### PR DESCRIPTION
## Description

This fixes the issue where fluentd / curator will get scheduled on none linux pods.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
