### PR TITLE
Degrade Calico status on typha autoscale issues

### DIFF
--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tigera/operator/pkg/controller/status"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/tigera/operator/pkg/common"
@@ -50,8 +52,11 @@ const (
 //  2000              8
 //  2000+            10
 type typhaAutoscaler struct {
-	client     client.Client
-	syncPeriod time.Duration
+	client         client.Client
+	syncPeriod     time.Duration
+	statusManager  status.StatusManager
+	triggerRunChan chan chan error
+	isDegradedChan chan chan bool
 }
 
 type typhaAutoscalerOption func(*typhaAutoscaler)
@@ -65,10 +70,14 @@ func typhaAutoscalerPeriod(syncPeriod time.Duration) typhaAutoscalerOption {
 
 // newTyphaAutoscaler creates a new Typha autoscaler, optionally applying any options to the default autoscaler instance.
 // The default sync period is 2 minutes.
-func newTyphaAutoscaler(client client.Client, options ...typhaAutoscalerOption) *typhaAutoscaler {
-	ta := new(typhaAutoscaler)
-	ta.client = client
-	ta.syncPeriod = defaultTyphaAutoscalerSyncPeriod
+func newTyphaAutoscaler(client client.Client, statusManager status.StatusManager, options ...typhaAutoscalerOption) *typhaAutoscaler {
+	ta := &typhaAutoscaler{
+		client:         client,
+		statusManager:  statusManager,
+		syncPeriod:     defaultTyphaAutoscalerSyncPeriod,
+		triggerRunChan: make(chan chan error),
+		isDegradedChan: make(chan chan bool),
+	}
 
 	for _, option := range options {
 		option(ta)
@@ -99,27 +108,89 @@ func (t *typhaAutoscaler) getExpectedReplicas(nodes int) int {
 	return 10
 }
 
-// run starts the Typha autoscaler, updating the Typha deployment's replica count every sync period.
-func (t *typhaAutoscaler) run() {
-	ticker := time.NewTicker(t.syncPeriod)
+// start starts the Typha autoscaler, updating the Typha deployment's replica count every sync period. The triggerRunChan
+// can be used to trigger an auto scale run immediately, while the isDegradedChan can be used to get the degraded status
+// of the last run. The triggerRun and isDegraded functions should be used instead of instead of access these channels directly.
+func (t *typhaAutoscaler) start() {
 	go func() {
+		degraded := false
+		ticker := time.NewTicker(t.syncPeriod)
+		defer ticker.Stop()
+
+		if err := t.autoscaleReplicas(); err != nil {
+			degraded = true
+			typhaLog.Error(err, "Failed to autoscale typha")
+			t.statusManager.SetDegraded("Failed to autoscale typha", err.Error())
+		}
+
+		// Autoscale on start up then do it again every tick.
 		for {
 			select {
 			case <-ticker.C:
-				expectedNodes, err := t.getNumberOfNodes()
-				if err != nil {
-					typhaLog.Error(err, "Could not get number of nodes")
-					continue
-				}
-				expectedReplicas := t.getExpectedReplicas(expectedNodes)
-				err = t.updateReplicas(int32(expectedReplicas))
+				if err := t.autoscaleReplicas(); err != nil {
+					degraded = true
+					typhaLog.Error(err, "Failed to autoscale typha")
 
-				if err != nil && !apierrors.IsNotFound(err) {
-					typhaLog.Error(err, "Could not scale Typha deployment")
+					// Since this run was triggered by the ticker we need to degrade the tigera status now.
+					t.statusManager.SetDegraded("Failed to autoscale typha", err.Error())
+				} else {
+					degraded = false
 				}
+			case errCh := <-t.triggerRunChan:
+				if err := t.autoscaleReplicas(); err != nil {
+					degraded = true
+
+					// Return the error so the "caller" can decided what to do with the error
+					errCh <- err
+				} else {
+					degraded = false
+				}
+
+				close(errCh)
+
+				ticker.Stop()
+				ticker = time.NewTicker(t.syncPeriod)
+			case boolCh := <-t.isDegradedChan:
+				boolCh <- degraded
+				close(boolCh)
 			}
 		}
 	}()
+}
+
+func (t *typhaAutoscaler) triggerRun() error {
+	errChan := make(chan error)
+	t.triggerRunChan <- errChan
+
+	return <-errChan
+}
+
+// isDegraded checks if the last run autoscale run failed and returns true if it did and false otherwise.
+func (t *typhaAutoscaler) isDegraded() bool {
+	boolChan := make(chan bool)
+	t.isDegradedChan <- boolChan
+
+	return <-boolChan
+}
+
+// autoscaleReplicas calculates the number of typha pods that should be running and scales the typha deployment accordingly
+func (t *typhaAutoscaler) autoscaleReplicas() error {
+	allSchedulableNodes, linuxNodes, err := t.getNodeCounts()
+	if err != nil {
+		return fmt.Errorf("could not get number of nodes: %w", err)
+	}
+	expectedReplicas := t.getExpectedReplicas(allSchedulableNodes)
+	if linuxNodes < expectedReplicas {
+		return fmt.Errorf("not enough linux nodes to schedule typha pods on, require %d and have %d", expectedReplicas, linuxNodes)
+	}
+
+	err = t.updateReplicas(int32(expectedReplicas))
+
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("could not scale Typha deployment: %w", err)
+	}
+
+	return nil
 }
 
 // updateReplicas updates the Typha deployment to the expected replicas if the current replica count differs.
@@ -147,10 +218,33 @@ func (t *typhaAutoscaler) updateReplicas(expectedReplicas int32) error {
 	return t.client.Update(context.Background(), typha)
 }
 
-// getNumberOfNodes returns the count of schedulable nodes.
-func (t *typhaAutoscaler) getNumberOfNodes() (int, error) {
+// getNodeCounts returns the number of all the schedulable nodes and the number of the schedulable linux nodes. The linux
+// node count is needed because typha pods can only be scheduled on linux nodes, however, nodes of other os types (i.e. windows)
+// still need to use typha.
+func (t *typhaAutoscaler) getNodeCounts() (int, int, error) {
 	nodes := corev1.NodeList{}
+	// We only want to count linux nodes
 	err := t.client.List(context.Background(), &nodes)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	linuxNodes := 0
+	schedulable := 0
+	for _, n := range nodes.Items {
+		if !n.Spec.Unschedulable {
+			schedulable++
+			if n.Labels["kubernetes.io/os"] == "linux" {
+				linuxNodes++
+			}
+		}
+	}
+	return schedulable, linuxNodes, nil
+}
+
+func (t *typhaAutoscaler) getSchedulableNodeCount(listOptions ...client.ListOption) (int, error) {
+	nodes := corev1.NodeList{}
+	err := t.client.List(context.Background(), &nodes, listOptions...)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/tigera/operator/pkg/controller/status"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/tigera/operator/test"
@@ -31,36 +33,42 @@ import (
 
 var _ = Describe("Test typha autoscaler ", func() {
 	var c client.Client
-	ctx := context.Background()
+	var statusManager *status.MockStatus
 
-	calicoSystemNs := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "calico-system",
-		},
-	}
+	var ctx context.Context
+
 	BeforeEach(func() {
 		c = fake.NewFakeClientWithScheme(scheme.Scheme)
-		err := c.Create(ctx, calicoSystemNs)
+		err := c.Create(ctx, &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "calico-system",
+			},
+		})
 		Expect(err).NotTo(HaveOccurred())
+		statusManager = new(status.MockStatus)
+
+		ctx = context.Background()
 	})
 
 	It("should get the correct number of nodes", func() {
-		n1 := createNode(c, "node1")
-		_ = createNode(c, "node2")
+		n1 := createNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		_ = createNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"})
 
-		ta := newTyphaAutoscaler(c)
-		n, err := ta.getNumberOfNodes()
+		ta := newTyphaAutoscaler(c, statusManager)
+		schedulableNodes, linuxNodes, err := ta.getNodeCounts()
 		Expect(err).To(BeNil())
-		Expect(n).To(Equal(2))
+		Expect(schedulableNodes).To(Equal(2))
+		Expect(linuxNodes).To(Equal(2))
 
 		n1.Spec.Unschedulable = true
 		err = c.Update(ctx, n1)
 		Expect(err).To(BeNil())
 
-		n, err = ta.getNumberOfNodes()
+		schedulableNodes, linuxNodes, err = ta.getNodeCounts()
 		Expect(err).To(BeNil())
-		Expect(n).To(Equal(1))
+		Expect(schedulableNodes).To(Equal(1))
+		Expect(linuxNodes).To(Equal(1))
 	})
 
 	It("should scale the Typha up and down in response to the number of schedulable nodes", func() {
@@ -77,16 +85,16 @@ var _ = Describe("Test typha autoscaler ", func() {
 		Expect(err).To(BeNil())
 
 		// Create a few nodes
-		_ = createNode(c, "node1")
-		_ = createNode(c, "node2")
+		_ = createNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		_ = createNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"})
 
 		// Create the autoscaler and run it
-		ta := newTyphaAutoscaler(c, typhaAutoscalerPeriod(10*time.Millisecond))
-		ta.run()
+		ta := newTyphaAutoscaler(c, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
+		ta.start()
 
 		verifyTyphaReplicas(c, 2)
 
-		n3 := createNode(c, "node3")
+		n3 := createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux"})
 		verifyTyphaReplicas(c, 3)
 
 		// Verify that making a node unschedulable updates replicas.
@@ -95,12 +103,45 @@ var _ = Describe("Test typha autoscaler ", func() {
 		Expect(err).To(BeNil())
 		verifyTyphaReplicas(c, 2)
 	})
+	It("should be degraded if there's not enough linux nodes", func() {
+		typhaMeta := metav1.ObjectMeta{
+			Name:      "calico-typha",
+			Namespace: "calico-system",
+		}
+		// Create a typha deployment
+		typha := &appsv1.Deployment{
+			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+			ObjectMeta: typhaMeta,
+		}
+		err := c.Create(ctx, typha)
+		Expect(err).To(BeNil())
+
+		statusManager.On("SetDegraded", "Failed to autoscale typha", "not enough linux nodes to schedule typha pods on, require 4 and have 2")
+
+		// Create a few nodes
+		_ = createNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		_ = createNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"})
+		_ = createNode(c, "node3", map[string]string{"kubernetes.io/os": "window"})
+		_ = createNode(c, "node4", map[string]string{"kubernetes.io/os": "window"})
+
+		// Create the autoscaler and run it
+		ta := newTyphaAutoscaler(c, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
+		ta.start()
+
+		// This blocks until the first run is done.
+		ta.isDegraded()
+
+		statusManager.AssertExpectations(GinkgoT())
+	})
 })
 
-func createNode(c client.Client, name string) *corev1.Node {
+func createNode(c client.Client, name string, labels map[string]string) *corev1.Node {
 	node := &corev1.Node{
-		TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
 	}
 	err := c.Create(context.Background(), node)
 	Expect(err).To(BeNil())


### PR DESCRIPTION
This commit ties the Calico tigera status to the typha autoscalar, degrading the status if there's an issue.

An error check that has been added is to make sure that there are enough linux nodes available to schedule the required typha pods on, and now if there's not, an error is logged and the Calico tigera status is set to degraded

If the auto scalar degraded the status, the core controller will see it if it reconciles and trigger the autoscalar run immediately. If this run fails the controller will set the degraded status again and try to re reconcile later. Note the the ticker in typha is reset if the run is triggered by the controller.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
