### PR TITLE
Add SupportedOSTypes function to Components

### DIFF
--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -17,8 +17,12 @@ package utils_test
 import (
 	"context"
 
-	ocsv1 "github.com/openshift/api/security/v1"
+	apps "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta "k8s.io/api/batch/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ocsv1 "github.com/openshift/api/security/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -32,7 +36,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+)
+
+const (
+	fakeComponentAnnotationKey   = "tigera.io/annotation-should-be"
+	fakeComponentAnnotationValue = "present"
 )
 
 var log = logf.Log.WithName("test_utils_logger")
@@ -44,7 +54,6 @@ var _ = Describe("Component handler tests", func() {
 		ctx      context.Context
 		scheme   *runtime.Scheme
 		sm       status.StatusManager
-		fc       render.Component
 		handler  utils.ComponentHandler
 	)
 
@@ -55,11 +64,12 @@ var _ = Describe("Component handler tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(v1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(apps.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(batchv1beta.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 
 		c = fake.NewFakeClientWithScheme(scheme)
 		ctx = context.Background()
 		sm = status.New(c, "fake-component")
-		fc = &fakeComponent{}
 
 		// We need to provide something to handler even though it seems to be unused..
 		instance = &operatorv1.Manager{
@@ -68,7 +78,20 @@ var _ = Describe("Component handler tests", func() {
 		}
 		handler = utils.NewComponentHandler(log, c, scheme, instance)
 	})
+
 	It("merges annotations and reconciles only operator added annotations", func() {
+		fc := &fakeComponent{
+			supportedOSType: render.OSTypeLinux,
+			objs: []runtime.Object{&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+					Annotations: map[string]string{
+						fakeComponentAnnotationKey: fakeComponentAnnotationValue,
+					},
+				},
+			}},
+		}
+
 		err := handler.CreateOrUpdate(ctx, fc, sm)
 		Expect(err).To(BeNil())
 
@@ -160,15 +183,146 @@ var _ = Describe("Component handler tests", func() {
 		c.Get(ctx, nsKey, ns)
 		Expect(ns.GetAnnotations()).To(Equal(expectedAnnotations))
 	})
-})
 
-const (
-	fakeComponentAnnotationKey   = "tigera.io/annotation-should-be"
-	fakeComponentAnnotationValue = "present"
-)
+	DescribeTable("ensuring os node selectors", func(component render.Component, key client.ObjectKey, obj runtime.Object, expectedNodeSelectors map[string]string) {
+		Expect(handler.CreateOrUpdate(ctx, component, sm)).ShouldNot(HaveOccurred())
+		Expect(c.Get(ctx, key, obj)).ShouldNot(HaveOccurred())
+
+		var nodeSelectors map[string]string
+		switch obj.(type) {
+		case *apps.Deployment:
+			nodeSelectors = obj.(*apps.Deployment).Spec.Template.Spec.NodeSelector
+		case *apps.DaemonSet:
+			nodeSelectors = obj.(*apps.DaemonSet).Spec.Template.Spec.NodeSelector
+		case *apps.StatefulSet:
+			nodeSelectors = obj.(*apps.StatefulSet).Spec.Template.Spec.NodeSelector
+		case *batchv1beta.CronJob:
+			nodeSelectors = obj.(*batchv1beta.CronJob).Spec.JobTemplate.Spec.Template.Spec.NodeSelector
+		default:
+			return
+		}
+
+		Expect(nodeSelectors).Should(Equal(expectedNodeSelectors))
+	},
+		TableEntry{
+			Description: "sets the required annotations for a deployment when their not set",
+			Parameters: []interface{}{
+				&fakeComponent{
+					supportedOSType: render.OSTypeLinux,
+					objs: []runtime.Object{&apps.Deployment{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+						Spec: apps.DeploymentSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									NodeSelector: map[string]string{},
+								},
+							},
+						}},
+					},
+				}, client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "sets the required annotations for a daemonset when their not set",
+			Parameters: []interface{}{
+				&fakeComponent{
+					supportedOSType: render.OSTypeLinux,
+					objs: []runtime.Object{&apps.DaemonSet{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset"},
+						Spec: apps.DaemonSetSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									NodeSelector: map[string]string{},
+								},
+							},
+						}},
+					},
+				}, client.ObjectKey{Name: "test-daemonset"}, &apps.DaemonSet{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "sets the required annotations for a statefulset when their not set",
+			Parameters: []interface{}{
+				&fakeComponent{
+					supportedOSType: render.OSTypeLinux,
+					objs: []runtime.Object{&apps.StatefulSet{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset"},
+						Spec: apps.StatefulSetSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									NodeSelector: map[string]string{},
+								},
+							},
+						}},
+					},
+				}, client.ObjectKey{Name: "test-statefulset"}, &apps.StatefulSet{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "sets the required annotations for a cronjob when their not set",
+			Parameters: []interface{}{
+				&fakeComponent{
+					supportedOSType: render.OSTypeLinux,
+					objs: []runtime.Object{&batchv1beta.CronJob{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-cronjob"},
+						Spec: batchv1beta.CronJobSpec{
+							JobTemplate: batchv1beta.JobTemplateSpec{
+								Spec: batchv1.JobSpec{
+									Template: v1.PodTemplateSpec{
+										Spec: v1.PodSpec{
+											NodeSelector: map[string]string{},
+										},
+									},
+								},
+							},
+						}},
+					},
+				}, client.ObjectKey{Name: "test-cronjob"}, &batchv1beta.CronJob{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "leaves other annotations alone and sets the required ones",
+			Parameters: []interface{}{
+				&fakeComponent{
+					supportedOSType: render.OSTypeLinux,
+					objs: []runtime.Object{&apps.Deployment{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+						Spec: apps.DeploymentSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									NodeSelector: map[string]string{
+										"kubernetes.io/foo": "bar",
+									},
+								},
+							},
+						},
+					}},
+				}, client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				map[string]string{
+					"kubernetes.io/foo": "bar",
+					"kubernetes.io/os":  "linux",
+				},
+			},
+		},
+	)
+})
 
 // A fake component that only returns ready and always creates the "test-namespace" Namespace.
 type fakeComponent struct {
+	objs            []runtime.Object
+	supportedOSType render.OSType
 }
 
 func (c *fakeComponent) Ready() bool {
@@ -176,15 +330,9 @@ func (c *fakeComponent) Ready() bool {
 }
 
 func (c *fakeComponent) Objects() ([]runtime.Object, []runtime.Object) {
-	objsToCreate := []runtime.Object{
-		&v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-namespace",
-				Annotations: map[string]string{
-					fakeComponentAnnotationKey: fakeComponentAnnotationValue,
-				},
-			},
-		},
-	}
-	return objsToCreate, nil
+	return c.objs, nil
+}
+
+func (c *fakeComponent) SupportedOSType() render.OSType {
+	return c.supportedOSType
 }

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -54,6 +54,10 @@ type amazonCloudIntegrationComponent struct {
 	openshift              bool
 }
 
+func (c *amazonCloudIntegrationComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 type AmazonCredential struct {
 	KeyId     []byte
 	KeySecret []byte

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -102,6 +102,10 @@ type apiServerComponent struct {
 	isManagement                bool
 }
 
+func (c *apiServerComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *apiServerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		createNamespace(APIServerNamespace, c.openshift),
@@ -598,10 +602,8 @@ func (c *apiServerComponent) apiServer() *appsv1.Deployment {
 					Annotations: c.tlsAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					DNSPolicy: dnsPolicy,
-					NodeSelector: map[string]string{
-						"kubernetes.io/os": "linux",
-					},
+					DNSPolicy:          dnsPolicy,
+					NodeSelector:       c.installation.Spec.ControlPlaneNodeSelector,
 					HostNetwork:        hostNetwork,
 					ServiceAccountName: "tigera-apiserver",
 					Tolerations:        c.tolerations(),
@@ -614,11 +616,6 @@ func (c *apiServerComponent) apiServer() *appsv1.Deployment {
 				},
 			},
 		},
-	}
-
-	// Add the ControlPlaneNodeSelector to our Deployment if one was specified.
-	for k, v := range c.installation.Spec.ControlPlaneNodeSelector {
-		d.Spec.Template.Spec.NodeSelector[k] = v
 	}
 
 	return d

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -143,8 +143,6 @@ var _ = Describe("API server rendering tests", func() {
 		Expect(d.Spec.Template.Labels).To(HaveKeyWithValue("apiserver", "true"))
 		Expect(d.Spec.Template.Labels).To(HaveKeyWithValue("k8s-app", "tigera-apiserver"))
 
-		Expect(len(d.Spec.Template.Spec.NodeSelector)).To(Equal(1))
-		Expect(d.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("kubernetes.io/os", "linux"))
 		Expect(d.Spec.Template.Spec.ServiceAccountName).To(Equal("tigera-apiserver"))
 
 		expectedTolerations := []corev1.Toleration{

--- a/pkg/render/aws-securitygroup-setup.go
+++ b/pkg/render/aws-securitygroup-setup.go
@@ -34,6 +34,10 @@ type awsSGSetupComponent struct {
 	installcr   *operator.Installation
 }
 
+func (c *awsSGSetupComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *awsSGSetupComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	return []runtime.Object{
 		c.serviceAccount(),

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -39,7 +39,13 @@ import (
 const (
 	Optional                   = true
 	DefaultCertificateDuration = 100 * 365 * 24 * time.Hour
+
+	OSTypeAny   OSType = "any"
+	OSTypeLinux OSType = "linux"
 )
+
+// This type helps ensure that we only use defined os types
+type OSType string
 
 var log = logf.Log.WithName("render")
 

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -106,6 +106,10 @@ type complianceComponent struct {
 	managementClusterConnection *operatorv1.ManagementClusterConnection
 }
 
+func (c *complianceComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *complianceComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	complianceObjs := append(
 		[]runtime.Object{createNamespace(ComplianceNamespace, c.openshift)},
@@ -344,9 +348,6 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 			},
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector: map[string]string{
-				"kubernetes.io/os": "linux",
-			},
 			ServiceAccountName: "tigera-compliance-controller",
 			Tolerations: []corev1.Toleration{
 				{
@@ -473,7 +474,6 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 				},
 			},
 			Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-				NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 				ServiceAccountName: "tigera-compliance-reporter",
 				Tolerations: []corev1.Toleration{
 					{
@@ -643,7 +643,6 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 			Annotations: complianceAnnotations(c),
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 			ServiceAccountName: "tigera-compliance-server",
 			Tolerations: []corev1.Toleration{
 				{
@@ -865,7 +864,6 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 			},
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 			ServiceAccountName: "tigera-compliance-snapshotter",
 			Tolerations: []corev1.Toleration{
 				{
@@ -1014,7 +1012,6 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 			},
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector:       map[string]string{"kubernetes.io/os": "linux"},
 			ServiceAccountName: "tigera-compliance-benchmarker",
 			HostPID:            true,
 			Tolerations: []corev1.Toleration{
@@ -1247,7 +1244,7 @@ func (c *complianceComponent) complianceGlobalReportNetworkAccess() *v3.GlobalRe
 `,
 				},
 			},
-			IncludeEndpointData: true,
+			IncludeEndpointData:        true,
 			IncludeEndpointFlowLogData: true,
 			UISummaryTemplate: v3.ReportTemplate{
 				Name: "ui-summary.json",

--- a/pkg/render/configmap.go
+++ b/pkg/render/configmap.go
@@ -27,6 +27,10 @@ type configMapComponent struct {
 	configMaps []*corev1.ConfigMap
 }
 
+func (c *configMapComponent) SupportedOSType() OSType {
+	return OSTypeAny
+}
+
 func (c *configMapComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{}
 	for _, cm := range c.configMaps {

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -121,6 +121,10 @@ type fluentdComponent struct {
 	installation    *operatorv1.Installation
 }
 
+func (c *fluentdComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *fluentdComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	var objs []runtime.Object
 	objs = append(objs,
@@ -677,9 +681,6 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 					Annotations: annots,
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						"kubernetes.io/os": "linux",
-					},
 					ServiceAccountName: eksLogForwarderName,
 					ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 					InitContainers: []corev1.Container{ElasticsearchContainerDecorateENVVars(corev1.Container{

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -65,6 +65,10 @@ type GuardianComponent struct {
 	tunnelSecret *corev1.Secret
 }
 
+func (c *GuardianComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *GuardianComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		createNamespace(GuardianNamespace, c.openshift),
@@ -201,9 +205,6 @@ func (c *GuardianComponent) deployment() runtime.Object {
 					},
 				},
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						"kubernetes.io/os": "linux",
-					},
 					ServiceAccountName: GuardianServiceAccountName,
 					Tolerations:        c.tolerations(),
 					ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -15,6 +15,8 @@
 package render
 
 import (
+	"time"
+
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operator "github.com/tigera/operator/pkg/apis/operator/v1"
 	"github.com/tigera/operator/pkg/components"
@@ -26,7 +28,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"time"
 )
 
 const (
@@ -63,6 +64,10 @@ type intrusionDetectionComponent struct {
 	esClusterConfig  *ElasticsearchClusterConfig
 	pullSecrets      []*corev1.Secret
 	openshift        bool
+}
+
+func (c *intrusionDetectionComponent) SupportedOSType() OSType {
+	return OSTypeLinux
 }
 
 func (c *intrusionDetectionComponent) Objects() ([]runtime.Object, []runtime.Object) {

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -58,6 +58,10 @@ type kubeControllersComponent struct {
 	authentication              interface{}
 }
 
+func (c *kubeControllersComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *kubeControllersComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	kubeControllerObjects := []runtime.Object{
 		c.controllersServiceAccount(),
@@ -318,9 +322,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 					},
 				},
 				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{
-						"kubernetes.io/os": "linux",
-					},
+					NodeSelector:       c.cr.Spec.ControlPlaneNodeSelector,
 					Tolerations:        tolerations,
 					ImagePullSecrets:   c.cr.Spec.ImagePullSecrets,
 					ServiceAccountName: "calico-kube-controllers",
@@ -349,11 +351,6 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 		},
 	}
 	setCriticalPod(&(d.Spec.Template))
-
-	// Add the ControlPlaneNodeSelector to our Deployment if one was specified.
-	for k, v := range c.cr.Spec.ControlPlaneNodeSelector {
-		d.Spec.Template.Spec.NodeSelector[k] = v
-	}
 
 	return &d
 }

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -200,6 +200,10 @@ type elasticsearchComponent struct {
 	authentication              interface{}
 }
 
+func (es *elasticsearchComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (es *elasticsearchComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	var toCreate, toDelete []runtime.Object
 

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -147,6 +147,10 @@ type managerComponent struct {
 	managementCluster          *operator.ManagementCluster
 }
 
+func (c *managerComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *managerComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		createNamespace(ManagerNamespace, c.openshift),
@@ -224,9 +228,6 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 			Annotations: annotations,
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
-			NodeSelector: map[string]string{
-				"kubernetes.io/os": "linux",
-			},
 			ServiceAccountName: ManagerServiceAccount,
 			Tolerations:        c.managerTolerations(),
 			ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -34,6 +34,10 @@ type namespaceComponent struct {
 	pullSecrets []*corev1.Secret
 }
 
+func (c *namespaceComponent) SupportedOSType() OSType {
+	return OSTypeAny
+}
+
 func (c *namespaceComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	ns := []runtime.Object{
 		createNamespace(common.CalicoNamespace, c.openshift),

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -81,6 +81,10 @@ type nodeComponent struct {
 	migrationNeeded bool
 }
 
+func (c *nodeComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *nodeComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objsToCreate := []runtime.Object{
 		c.nodeServiceAccount(),
@@ -517,9 +521,6 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *v1.ConfigMap) *apps.DaemonSet {
 					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{
-						"kubernetes.io/os": "linux",
-					},
 					Tolerations:                   c.nodeTolerations(),
 					ImagePullSecrets:              c.cr.Spec.ImagePullSecrets,
 					ServiceAccountName:            "calico-node",

--- a/pkg/render/priority_class.go
+++ b/pkg/render/priority_class.go
@@ -31,6 +31,10 @@ func PriorityClassDefinitions() Component {
 type priorityClassComponent struct {
 }
 
+func (c *priorityClassComponent) SupportedOSType() OSType {
+	return OSTypeAny
+}
+
 func (c *priorityClassComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	return []runtime.Object{c.calicoPriority()}, nil
 }

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -46,6 +46,11 @@ type Component interface {
 
 	// Ready returns true if the component is ready to be created.
 	Ready() bool
+
+	// SupportedOSTypes returns operating systems that is supported of the components returned by the Objects() function.
+	// The "componentHandler" converts the returned OSTypes to a node selectors for the "kubernetes.io/os" label on runtime.Objects
+	// that create pods. Return OSTypeAny means that no node selector should be set for the "kubernetes.io/os" label.
+	SupportedOSType() OSType
 }
 
 // A Renderer is capable of generating components to be installed on the cluster.

--- a/pkg/render/secrets.go
+++ b/pkg/render/secrets.go
@@ -27,6 +27,10 @@ type secretsComponent struct {
 	secrets []*corev1.Secret
 }
 
+func (c *secretsComponent) SupportedOSType() OSType {
+	return OSTypeAny
+}
+
 func (c *secretsComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{}
 	for _, s := range c.secrets {

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -68,6 +68,10 @@ type typhaComponent struct {
 	namespaceMigration bool
 }
 
+func (c *typhaComponent) SupportedOSType() OSType {
+	return OSTypeLinux
+}
+
 func (c *typhaComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	objs := []runtime.Object{
 		c.typhaServiceAccount(),
@@ -336,7 +340,6 @@ func (c *typhaComponent) typhaDeployment() *apps.Deployment {
 					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
-					NodeSelector:                  c.nodeSelector(),
 					Tolerations:                   c.tolerations(),
 					ImagePullSecrets:              c.installation.Spec.ImagePullSecrets,
 					ServiceAccountName:            TyphaServiceAccountName,
@@ -353,10 +356,6 @@ func (c *typhaComponent) typhaDeployment() *apps.Deployment {
 		migration.SetTyphaAntiAffinity(&d)
 	}
 	return &d
-}
-
-func (c *typhaComponent) nodeSelector() map[string]string {
-	return map[string]string{"kubernetes.io/os": "linux"}
 }
 
 // tolerations creates the typha's tolerations.


### PR DESCRIPTION
This forces every component to state what operating systems are supported for the objects being rendered. If a single OS is returned, then a node selector is used (to avoid any unnecessary disruption of the pods since node selectors were previously used), but if there are multiple OS types, then node affinity is used. The label for the selector / affinity is the "kuberentes.io/os" label.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
