### PR TITLE
use independent logger for migrations

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -791,7 +791,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	// Run this after we have rendered our components so the new (operator created)
 	// Deployments and Daemonset exist with our special migration nodeSelectors.
 	if needNsMigration {
-		if err := r.namespaceMigration.Run(reqLogger); err != nil {
+		if err := r.namespaceMigration.Run(); err != nil {
 			r.SetDegraded("error migrating resources to calico-system", err, reqLogger)
 			// We should always requeue a migration problem. Don't return error
 			// to make sure we never start backing off retrying.


### PR DESCRIPTION
## Description

I'm debugging failed migration logic and found it much easier to follow if it used a separate logger from core controller. So I created a new 'controller_migration' logger. The results were very useful:

```
go run ./cmd/manager --zap-devel | grep controller_migration                                                                                                                           ()
2020-09-29T13:59:11.471-0400    DEBUG   controller_migration    Deleted previous calico-kube-controllers deployment
2020-09-29T13:59:11.506-0400    DEBUG   controller_migration    Operator Typha Deployment is ready
2020-09-29T13:59:11.998-0400    DEBUG   controller_migration    All unmigrated nodes labeled
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.