### PR TITLE
Fix the service account assignments for kibana and elasticsearch

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -503,10 +503,11 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 
 	podTemplate := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
-			InitContainers:   initContainers,
-			Containers:       []corev1.Container{esContainer},
-			ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
-			NodeSelector:     es.logStorage.Spec.DataNodeSelector,
+			InitContainers:     initContainers,
+			Containers:         []corev1.Container{esContainer},
+			ImagePullSecrets:   getImagePullSecretReferenceList(es.pullSecrets),
+			NodeSelector:       es.logStorage.Spec.DataNodeSelector,
+			ServiceAccountName: "tigera-elasticsearch",
 		},
 	}
 
@@ -606,8 +607,7 @@ func (es elasticsearchComponent) elasticsearchCluster(secureSettings bool) *esv1
 					},
 				},
 			},
-			NodeSets:           es.nodeSets(),
-			ServiceAccountName: "tigera-elasticsearch",
+			NodeSets: es.nodeSets(),
 		},
 	}
 
@@ -1065,9 +1065,8 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 			},
 		},
 		Spec: kbv1.KibanaSpec{
-			Version:            components.ComponentEckKibana.Version,
-			Image:              components.GetReference(components.ComponentKibana, es.installation.Spec.Registry, es.installation.Spec.ImagePath),
-			ServiceAccountName: "tigera-kibana",
+			Version: components.ComponentEckKibana.Version,
+			Image:   components.GetReference(components.ComponentKibana, es.installation.Spec.Registry, es.installation.Spec.ImagePath),
 			Config: &cmnv1.Config{
 				Data: config,
 			},
@@ -1092,7 +1091,8 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 					},
 				},
 				Spec: corev1.PodSpec{
-					ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
+					ImagePullSecrets:   getImagePullSecretReferenceList(es.pullSecrets),
+					ServiceAccountName: "tigera-kibana",
 					Containers: []corev1.Container{{
 						Name: "kibana",
 						ReadinessProbe: &corev1.Probe{


### PR DESCRIPTION
## Description

Fixes an issue where pod security policies will not be properly applied since the service accounts are not specified correctly.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
