### PR TITLE
Use -felix-ready for calico-node readiness on OpenShift

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1086,18 +1086,11 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 		readinessCmd = []string{"/bin/calico-node", "-felix-ready"}
 	}
 
+	// For Openshift, we need a different port since our default port is already in use.
 	if c.cr.Spec.KubernetesProvider == operator.ProviderOpenShift {
-		// For Openshift, we need special configuration since our default port is already in use.
-		// Additionally, since the node readiness probe doesn't yet support
-		// custom ports, we need to disable felix readiness for now.
 		livenessPort = intstr.FromInt(9199)
-
-		if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
-			readinessCmd = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
-		} else {
-			readinessCmd = []string{"/bin/calico-node", "-bird-ready"}
-		}
 	}
+
 	lp := &v1.Probe{
 		Handler: v1.Handler{
 			HTTPGet: &v1.HTTPGetAction{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -2387,21 +2387,11 @@ func verifyProbes(ds *apps.DaemonSet, isOpenshift, isEnterprise bool) {
 	Expect(found).To(BeTrue())
 
 	switch {
-	case !isOpenshift && !isEnterprise && !bgp:
+	case !bgp:
 		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
-	case !isOpenshift && !isEnterprise && bgp:
+	case bgp && !isEnterprise:
 		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
-	case !isOpenshift && isEnterprise && !bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
-	case !isOpenshift && isEnterprise && bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
-	case isOpenshift && !isEnterprise && !bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
-	case isOpenshift && !isEnterprise && bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
-	case isOpenshift && isEnterprise && !bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
-	case isOpenshift && isEnterprise && bgp:
+	case bgp && isEnterprise:
 		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
 	}
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -16,6 +16,7 @@ package render_test
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -646,15 +647,8 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
 
 		// Verify readiness and liveness probes.
-		expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-felix-ready"}}}}
-		expectedLiveness := &v1.Probe{Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Host: "localhost",
-				Path: "/liveness",
-				Port: intstr.FromInt(9099),
-			}}}
-		Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
-		Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+
+		verifyProbes(ds, false, false)
 	})
 
 	It("should properly render a configuration using the AmazonVPC CNI plugin", func() {
@@ -810,15 +804,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
 
 		// Verify readiness and liveness probes.
-		expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-felix-ready"}}}}
-		expectedLiveness := &v1.Probe{Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Host: "localhost",
-				Path: "/liveness",
-				Port: intstr.FromInt(9099),
-			}}}
-		Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
-		Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+		verifyProbes(ds, false, true)
 	})
 
 	DescribeTable("should properly render configuration using non-Calico CNI plugin",
@@ -865,15 +851,7 @@ var _ = Describe("Node rendering tests", func() {
 			}
 
 			// Verify readiness and liveness probes.
-			expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-felix-ready"}}}}
-			expectedLiveness := &v1.Probe{Handler: v1.Handler{
-				HTTPGet: &v1.HTTPGetAction{
-					Host: "localhost",
-					Path: "/liveness",
-					Port: intstr.FromInt(9099),
-				}}}
-			Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
-			Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+			verifyProbes(ds, false, false)
 		},
 		Entry("GKE", operator.PluginGKE, operator.IPAMPluginHostLocal, []v1.EnvVar{
 			{Name: "FELIX_INTERFACEPREFIX", Value: "gke"},
@@ -1119,15 +1097,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
 
 		// Verify readiness and liveness probes.
-		expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-felix-ready"}}}}
-		expectedLiveness := &v1.Probe{Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Host: "localhost",
-				Path: "/liveness",
-				Port: intstr.FromInt(9099),
-			}}}
-		Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
-		Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+		verifyProbes(ds, false, false)
 	})
 
 	It("should properly render a configuration using the AmazonVPC CNI plugin", func() {
@@ -1283,15 +1253,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
 
 		// Verify readiness and liveness probes.
-		expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-felix-ready"}}}}
-		expectedLiveness := &v1.Probe{Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Host: "localhost",
-				Path: "/liveness",
-				Port: intstr.FromInt(9099),
-			}}}
-		Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
-		Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+		verifyProbes(ds, false, false)
 	})
 
 	It("should render all resources when running on openshift", func() {
@@ -2321,16 +2283,40 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env).To(ConsistOf(expectedCNIEnv))
 
 		// Verify readiness and liveness probes.
-		expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-felix-ready"}}}}
-		expectedLiveness := &v1.Probe{Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Host: "localhost",
-				Path: "/liveness",
-				Port: intstr.FromInt(9099),
-			}}}
-		Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
-		Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+		verifyProbes(ds, false, false)
 	})
+
+	DescribeTable("test node probes",
+		func(isOpenshift, isEnterprise bool, bgpOption operator.BGPOption) {
+			if isOpenshift {
+				defaultInstance.Spec.KubernetesProvider = operator.ProviderOpenShift
+			}
+
+			if isEnterprise {
+				defaultInstance.Spec.Variant = operator.TigeraSecureEnterprise
+			}
+
+			defaultInstance.Spec.CalicoNetwork.BGP = &bgpOption
+
+			component := render.Node(k8sServiceEp, defaultInstance, nil, typhaNodeTLS, nil, false)
+			resources, _ := component.Objects()
+			dsResource := GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+			Expect(dsResource).ToNot(BeNil())
+
+			ds := dsResource.(*apps.DaemonSet)
+			verifyProbes(ds, isOpenshift, isEnterprise)
+		},
+
+		Entry("k8s Calico OS no BGP", false, false, operator.BGPDisabled),
+		Entry("k8s Calico OS w/ BGP", false, false, operator.BGPEnabled),
+		Entry("k8s Enterprise no BGP", false, true, operator.BGPDisabled),
+		Entry("k8s Enterprise w/ BGP", false, true, operator.BGPEnabled),
+		Entry("OCP Calico OS no BGP", true, false, operator.BGPDisabled),
+		Entry("OCP Calico OSS w/ BGP", true, false, operator.BGPEnabled),
+		Entry("OCP Enterprise no BGP", true, true, operator.BGPDisabled),
+		Entry("OCP Enterprise w/ BGP", true, true, operator.BGPEnabled),
+	)
+
 	Context("with k8s overrides set", func() {
 		It("should override k8s endpoints", func() {
 			k8sServiceEp := render.K8sServiceEndpoint{
@@ -2383,16 +2369,42 @@ func verifyProbes(ds *apps.DaemonSet, isOpenshift, isEnterprise bool) {
 			Port: intstr.FromInt(9099),
 		}}}
 
-	switch {
-	case isOpenshift && isEnterprise:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
+	if isOpenshift {
 		expectedLiveness.HTTPGet.Port = intstr.FromInt(9199)
-	case isOpenshift && !isEnterprise:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready"}
-		expectedLiveness.HTTPGet.Port = intstr.FromInt(9199)
-	case !isOpenshift && isEnterprise:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
 	}
+
+	var found bool
+	var bgp bool
+	for _, env := range ds.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "CLUSTER_TYPE" {
+			if strings.Contains(env.Value, ",bgp") {
+				bgp = true
+			}
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue())
+
+	switch {
+	case !isOpenshift && !isEnterprise && !bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
+	case !isOpenshift && !isEnterprise && bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
+	case !isOpenshift && isEnterprise && !bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
+	case !isOpenshift && isEnterprise && bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
+	case isOpenshift && !isEnterprise && !bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready"}
+	case isOpenshift && !isEnterprise && bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready"}
+	case isOpenshift && isEnterprise && !bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
+	case isOpenshift && isEnterprise && bgp:
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
+	}
+
 	Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
 	Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
 }

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -2396,13 +2396,13 @@ func verifyProbes(ds *apps.DaemonSet, isOpenshift, isEnterprise bool) {
 	case !isOpenshift && isEnterprise && bgp:
 		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
 	case isOpenshift && !isEnterprise && !bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready"}
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
 	case isOpenshift && !isEnterprise && bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready"}
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
 	case isOpenshift && isEnterprise && !bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-felix-ready"}
 	case isOpenshift && isEnterprise && bgp:
-		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
+		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
 	}
 
 	Expect(ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))


### PR DESCRIPTION
## Description

We previously had to use `-bird-ready` for the calico-node readiness probe command because Felix did not support configurable health ports at the time. This PR fixes the readiness probe (since calico-node supports[ configurable Felix health ports](https://github.com/projectcalico/node/pull/241) already).

This also fixes OCP with VXLAN and no BGP clusters not able to come up healthy since that would use `-bird-ready` in the readiness command.

I'm not sure of the milestone but this would need to go into the operator slated for Calico v3.17.0

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
