### PR TITLE
check for addon manager

### DIFF
--- a/pkg/controller/migration/convert/addon_manager.go
+++ b/pkg/controller/migration/convert/addon_manager.go
@@ -1,0 +1,32 @@
+package convert
+
+import operatorv1 "github.com/tigera/operator/api/v1"
+
+func handleAddonManager(c *components, install *operatorv1.Installation) error {
+	if _, ok := c.node.Labels["addonmanager.kubernetes.io/mode"]; ok {
+		return ErrIncompatibleCluster{
+			component: ComponentCalicoNode,
+			err:       "can't modify components managed by addon-manager",
+		}
+	}
+
+	if c.typha != nil {
+		if _, ok := c.typha.Labels["addonmanager.kubernetes.io/mode"]; ok {
+			return ErrIncompatibleCluster{
+				component: ComponentTypha,
+				err:       "can't modify components managed by addon-manager",
+			}
+		}
+	}
+
+	if c.kubeControllers != nil {
+		if _, ok := c.kubeControllers.Labels["addonmanager.kubernetes.io/mode"]; ok {
+			return ErrIncompatibleCluster{
+				component: ComponentKubeControllers,
+				err:       "can't modify components managed by addon-manager",
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/migration/convert/addon_manager_test.go
+++ b/pkg/controller/migration/convert/addon_manager_test.go
@@ -1,0 +1,35 @@
+package convert
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "github.com/tigera/operator/api/v1"
+)
+
+var _ = Describe("addon manager", func() {
+	addonMgrLabel := map[string]string{"addonmanager.kubernetes.io/mode": "Reconcile"}
+
+	It("should succeed if addon manager isn't denoted", func() {
+		comps := emptyComponents()
+		i := v1.Installation{}
+		Expect(handleAddonManager(&comps, &i)).ToNot(HaveOccurred())
+	})
+	It("should fail if calico-node is managed by addon-manager", func() {
+		comps := emptyComponents()
+		comps.node.Labels = addonMgrLabel
+		i := v1.Installation{}
+		Expect(handleAddonManager(&comps, &i)).To(HaveOccurred())
+	})
+	It("should fail if kube-controllers is managed by addon-manager", func() {
+		comps := emptyComponents()
+		comps.kubeControllers.Labels = addonMgrLabel
+		i := v1.Installation{}
+		Expect(handleAddonManager(&comps, &i)).To(HaveOccurred())
+	})
+	It("should fail if typha is managed by addon-manager", func() {
+		comps := emptyComponents()
+		comps.typha.Labels = addonMgrLabel
+		i := v1.Installation{}
+		Expect(handleAddonManager(&comps, &i)).To(HaveOccurred())
+	})
+})

--- a/pkg/controller/migration/convert/handler.go
+++ b/pkg/controller/migration/convert/handler.go
@@ -12,6 +12,7 @@ import operatorv1 "github.com/tigera/operator/api/v1"
 type handler func(*components, *operatorv1.Installation) error
 
 var handlers = []handler{
+	handleAddonManager,
 	handleNetwork,
 	handleIPv6,
 	handleCore,


### PR DESCRIPTION
## Description

Addon manager will only reconcile resources with the `addonmanager.kubernetes.io/mode` label on them. As such, we can block upgrades if we detect that label on any components.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
