### PR TITLE
raise error if podSubnet not set

### DIFF
--- a/pkg/controller/installation/pod_cidr_detection.go
+++ b/pkg/controller/installation/pod_cidr_detection.go
@@ -1,6 +1,7 @@
 package installation
 
 import (
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -25,6 +26,10 @@ func extractKubeadmCIDRs(kubeadmConfig *v1.ConfigMap) ([]string, error) {
 		if line = re.FindStringSubmatch(l); line != nil {
 			break
 		}
+	}
+
+	if len(line) == 0 {
+		return foundCIDRs, fmt.Errorf("kubeadm configuration is missing required podSubnet field")
 	}
 
 	if len(line) != 0 {

--- a/pkg/controller/installation/pod_cidr_detection_test.go
+++ b/pkg/controller/installation/pod_cidr_detection_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("kubeadm pod-network-cidr detection", func() {
+	It("should parse podSubnet if it exists", func() {
+		var data = `
+networking:
+  dnsDomain: cluster.local
+  podSubnet: 192.168.0.0/16
+  serviceSubnet: 10.96.0.0/12`
+		cidr, err := extractKubeadmCIDRs(&corev1.ConfigMap{
+			Data: map[string]string{
+				"ClusterConfiguration": data,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cidr).To(Equal([]string{"192.168.0.0/16"}))
+	})
+
+	It("should error if podSubnet is missing", func() {
+		var data = `
+networking:
+  dnsDomain: cluster.local
+  serviceSubnet: 10.96.0.0/12`
+		_, err := extractKubeadmCIDRs(&corev1.ConfigMap{
+			Data: map[string]string{
+				"ClusterConfiguration": data,
+			},
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## Description

When running on kubeadm, calico requires that podNetwork be set in kubeadm. Our current code raises a nondescript error for this: 
```
Could not resolve CalicoNetwork IPPool and kubeadm configuration: IPPool 172.16.0.0/16 is not within the platform's configured pod network CIDR(s)
```

This PR modifies logic to detect if no podNetwork cidr is set, and raise an explicit error for that:
```
Could not resolve CalicoNetwork IPPool and kubeadm configuration: kubeadm configuration is missing required podSubnet field
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
