### PR TITLE
Add NonZeroValueDefaulter for setting non zero defaults on types

### DIFF
--- a/test/struct_defaulter.go
+++ b/test/struct_defaulter.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const (
+	DefaultNonZeroInt64   int64   = 1
+	DefaultNonZeroUint64  uint64  = 1
+	DefaultNonZeroFloat64 float64 = 1
+	DefaultNonZeroString  string  = "not-zero"
+	DefaultNonZeroBool    bool    = true
+)
+
+type NonZeroDefaultOption func(defaulter *nonZeroValueDefaulter)
+
+func WithInterfaceImplementations(ifaceImpls map[string]interface{}) NonZeroDefaultOption {
+	return func(defaulter *nonZeroValueDefaulter) {
+		defaulter.ifaceImpls = ifaceImpls
+	}
+}
+
+type ValueDefaulter interface {
+	SetDefault(interface{}) error
+}
+
+type nonZeroValueDefaulter struct {
+	ifaceImpls map[string]interface{}
+}
+
+// NewNonZeroStructDefaulter creates an implementation of the ValueDefaulter that
+func NewNonZeroStructDefaulter(options ...NonZeroDefaultOption) ValueDefaulter {
+	defaulter := &nonZeroValueDefaulter{}
+	for _, option := range options {
+		option(defaulter)
+	}
+	return defaulter
+}
+
+func (defaulter *nonZeroValueDefaulter) SetDefault(strct interface{}) error {
+	return defaulter.setDefaultValue(reflect.ValueOf(strct).Elem())
+}
+
+func (defaulter *nonZeroValueDefaulter) setDefaultValue(value reflect.Value) error {
+	if !value.CanSet() {
+		return nil
+	}
+
+	switch value.Kind() {
+	case reflect.Ptr:
+		p := reflect.New(value.Type().Elem())
+		if err := defaulter.setDefaultValue(p.Elem()); err != nil {
+			return err
+		}
+
+		value.Set(p)
+	case reflect.Struct:
+		for i := 0; i < value.NumField(); i++ {
+			f := value.Field(i)
+			if err := defaulter.setDefaultValue(f); err != nil {
+				return err
+			}
+		}
+	case reflect.Interface:
+		ifaceName := value.Type().Name()
+		if impl, exists := defaulter.ifaceImpls[ifaceName]; exists {
+			implValue := reflect.New(reflect.TypeOf(impl))
+			if err := defaulter.setDefaultValue(implValue.Elem()); err != nil {
+				return err
+			}
+			value.Set(implValue)
+		} else {
+			return fmt.Errorf("no implementation for interface '%s'", value.Type().Name())
+		}
+	case reflect.Slice:
+		v2 := reflect.New(value.Type().Elem())
+		if err := defaulter.setDefaultValue(v2.Elem()); err != nil {
+			return err
+		}
+
+		value.Set(reflect.Append(value, v2.Elem()))
+	case reflect.Map:
+		mapKey := reflect.New(value.Type().Key())
+		mapValue := reflect.New(value.Type().Elem())
+		if err := defaulter.setDefaultValue(mapKey.Elem()); err != nil {
+			return err
+		}
+
+		if err := defaulter.setDefaultValue(mapValue.Elem()); err != nil {
+			return err
+		}
+
+		m := reflect.MakeMap(value.Type())
+		m.SetMapIndex(mapKey.Elem(), mapValue.Elem())
+
+		value.Set(m)
+	case reflect.Chan:
+		value.Set(reflect.MakeChan(value.Type(), 1))
+	default:
+		if err := setPrimitive(value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setPrimitive(v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Int:
+		fallthrough
+	case reflect.Int8:
+		fallthrough
+	case reflect.Int16:
+		fallthrough
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int64:
+		v.SetInt(DefaultNonZeroInt64)
+	case reflect.Uint:
+		fallthrough
+	case reflect.Uint8:
+		fallthrough
+	case reflect.Uint16:
+		fallthrough
+	case reflect.Uint32:
+		fallthrough
+	case reflect.Uint64:
+		v.SetUint(DefaultNonZeroUint64)
+	case reflect.Float32:
+		fallthrough
+	case reflect.Float64:
+		v.SetFloat(DefaultNonZeroFloat64)
+	case reflect.String:
+		v.SetString(DefaultNonZeroString)
+	case reflect.Bool:
+		v.SetBool(DefaultNonZeroBool)
+	default:
+		return fmt.Errorf("unknown type %s", v.Kind())
+	}
+
+	return nil
+}

--- a/test/struct_defaulter_test.go
+++ b/test/struct_defaulter_test.go
@@ -1,0 +1,171 @@
+package test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type testStruct1 struct {
+	PrimitivesStruct
+	Struct    testInterfaceImpl
+	StructPtr *testInterfaceImpl
+	Interface testInterface
+}
+
+type testInterface interface {
+	TestFunc()
+}
+
+type testInterfaceImpl struct {
+	PrimitivesStruct
+}
+
+func (t *testInterfaceImpl) TestFunc() {}
+
+type PrimitivesStruct struct {
+	Int        int
+	IntPtr     *int
+	Int32      int32
+	Int32Ptr   *int32
+	Int64      int64
+	Int64Ptr   *int64
+	Uint       uint
+	UintPtr    *uint
+	Uint32     uint32
+	Uint32Ptr  *uint32
+	Uint64     uint64
+	Uint64Ptr  *uint64
+	Float32    float32
+	Float32Ptr *float32
+	Float64    float64
+	Float64Ptr *float64
+	String     string
+	StringPtr  *string
+	Bool       bool
+	BoolPtr    *bool
+}
+
+var _ = FDescribe("StructDefaulter", func() {
+	It("returns an error if it doesn't have an implementation for an interface", func() {
+		defaulter := NewNonZeroStructDefaulter()
+		strct := struct {
+			Interface testInterface
+		}{}
+		Expect(defaulter.SetDefault(&strct)).Should(Equal(fmt.Errorf("no implementation for interface 'testInterface'")))
+	})
+
+	It("defaults all primitive types", func() {
+		defaulter := NewNonZeroStructDefaulter()
+		primitives := PrimitivesStruct{}
+		Expect(defaulter.SetDefault(&primitives)).ShouldNot(HaveOccurred())
+		Expect(primitives).Should(Equal(getPrimitivesStruct()))
+	})
+
+	It("defaults structs all primitive types", func() {
+		defaulter := NewNonZeroStructDefaulter()
+		strct := struct {
+			Primitives PrimitivesStruct
+		}{}
+		Expect(defaulter.SetDefault(&strct)).ShouldNot(HaveOccurred())
+		Expect(strct).Should(Equal(struct {
+			Primitives PrimitivesStruct
+		}{
+			Primitives: getPrimitivesStruct(),
+		}))
+	})
+
+	It("defaults struct pointers all primitive types", func() {
+		defaulter := NewNonZeroStructDefaulter()
+		strct := struct {
+			Primitives *PrimitivesStruct
+		}{}
+
+		primitives := getPrimitivesStruct()
+		Expect(defaulter.SetDefault(&strct)).ShouldNot(HaveOccurred())
+		Expect(strct).Should(Equal(struct {
+			Primitives *PrimitivesStruct
+		}{
+			Primitives: &primitives,
+		}))
+	})
+
+	It("uses the given implementation for an interface with default values", func() {
+		defaulter := NewNonZeroStructDefaulter(WithInterfaceImplementations(map[string]interface{}{
+			"testInterface": testInterfaceImpl{},
+		}))
+		strct := struct {
+			Interface testInterface
+		}{}
+		Expect(defaulter.SetDefault(&strct)).ShouldNot(HaveOccurred())
+		Expect(strct.Interface).Should(Equal(&testInterfaceImpl{
+			PrimitivesStruct: getPrimitivesStruct(),
+		}))
+	})
+
+	It("defaults array types", func() {
+		strct := struct {
+			Array []string
+		}{}
+		defaulter := NewNonZeroStructDefaulter()
+		Expect(defaulter.SetDefault(&strct)).ShouldNot(HaveOccurred())
+		Expect(strct.Array).Should(Equal([]string{DefaultNonZeroString}))
+	})
+
+	It("defaults map types", func() {
+		strct := struct {
+			Map map[string]string
+		}{}
+		defaulter := NewNonZeroStructDefaulter()
+		Expect(defaulter.SetDefault(&strct)).ShouldNot(HaveOccurred())
+		Expect(strct.Map).Should(Equal(map[string]string{
+			DefaultNonZeroString: DefaultNonZeroString,
+		}))
+	})
+
+	It("defaults chan types", func() {
+		strct := struct {
+			Chan chan string
+		}{}
+		defaulter := NewNonZeroStructDefaulter()
+		Expect(defaulter.SetDefault(&strct)).ShouldNot(HaveOccurred())
+		Expect(strct.Chan).ShouldNot(BeNil())
+	})
+})
+
+func getPrimitivesStruct() PrimitivesStruct {
+	defaultInt := int(DefaultNonZeroInt64)
+	defaultInt32 := int32(DefaultNonZeroInt64)
+	defaultInt64 := DefaultNonZeroInt64
+	defaultUint := uint(DefaultNonZeroUint64)
+	defaultUint32 := uint32(DefaultNonZeroUint64)
+	defaultUint64 := DefaultNonZeroUint64
+	defaultFloat32 := float32(DefaultNonZeroFloat64)
+	defaultFloat64 := DefaultNonZeroFloat64
+	defaultString := DefaultNonZeroString
+	defaultBool := DefaultNonZeroBool
+
+	return PrimitivesStruct{
+		Int:        defaultInt,
+		IntPtr:     &defaultInt,
+		Int32:      defaultInt32,
+		Int32Ptr:   &defaultInt32,
+		Int64:      defaultInt64,
+		Int64Ptr:   &defaultInt64,
+		Uint:       defaultUint,
+		UintPtr:    &defaultUint,
+		Uint32:     defaultUint32,
+		Uint32Ptr:  &defaultUint32,
+		Uint64:     defaultUint64,
+		Uint64Ptr:  &defaultUint64,
+		Float32:    defaultFloat32,
+		Float32Ptr: &defaultFloat32,
+		Float64:    defaultFloat64,
+		Float64Ptr: &defaultFloat64,
+		String:     defaultString,
+		StringPtr:  &defaultString,
+		Bool:       defaultBool,
+		BoolPtr:    &defaultBool,
+	}
+}


### PR DESCRIPTION
This commit creates the ValueDefaulter interface with the NonZeroValueDefaulter implementation. The ValueDefaulter is use to set defaults for a given value type, and the NonZeroValueDefaulter impl makes sure the default
value is not a nil or zero value.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
