### PR TITLE
[release-v.12] Fix missing entry in enterprise.go

### DIFF
--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -105,6 +105,11 @@ var (
 		Image:   "tigera/cnx-manager",
 	}
 
+	ComponentDex = component{
+		Version: "v2.25.0",
+		Image:   "dexidp/dex",
+	}
+
 	ComponentManagerProxy = component{
 		Version: "release-calient-v3.4",
 		Image:   "tigera/voltron",


### PR DESCRIPTION
DexComponent was missing in the enterprise.go file.