### PR TITLE
sort bird mounts alphabetically to prevent reconcile loop

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -17,6 +17,7 @@ package render
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -788,7 +789,16 @@ func (c *nodeComponent) nodeVolumeMounts() []v1.VolumeMount {
 	}
 
 	if c.birdTemplates != nil {
+		// create a volume mount for each bird template, but sort them alphabetically first,
+		// otherwise, since map iteration is random, they'll be added to the list of volumes in a random order,
+		// which will cause another reconciliation event when calico-node is updated.
+		sortedKeys := []string{}
 		for k := range c.birdTemplates {
+			sortedKeys = append(sortedKeys, k)
+		}
+		sort.Strings(sortedKeys)
+
+		for _, k := range sortedKeys {
 			nodeVolumeMounts = append(nodeVolumeMounts,
 				v1.VolumeMount{
 					Name:      "bird-templates",


### PR DESCRIPTION
## Description

A customer recently reported that their calico-node daemonsets were constantly being updated, and were on their ~50 thousandth generation, when using custom bird configs.

Turns out the bird configs were being added as volume mounts to calico-node in a random order (since map iteration in golang is random). Each calico-node daemonset render was different, which causes new reconcile events to happen.

This PR fixes the problem by sorting the bird volumes alphabetically by key before creating them, ensuring their order is consistent.

Custom BGP templates are unusable with operator until this is merged!

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.