### PR TITLE
[master] Dex PR follow-up

### DIFF
--- a/api/v1/manager_types.go
+++ b/api/v1/manager_types.go
@@ -22,7 +22,7 @@ import (
 
 // ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 type ManagerSpec struct {
-	// Auth defines the authentication strategy for the Calico Enterprise manager GUI.
+	// Deprecated. Please use the Authentication CR for configuring authentication.
 	// +optional
 	Auth *Auth `json:"auth,omitempty"`
 }
@@ -32,6 +32,9 @@ type ManagerStatus struct {
 	// Deprecated. Please use the Authentication CR for configuring authentication.
 	// +optional
 	Auth *Auth `json:"auth,omitempty"`
+
+	// State provides user-readable status.
+	State string `json:"state,omitempty"`
 }
 
 // Auth defines authentication configuration.

--- a/config/crd/bases/operator.tigera.io_managers.yaml
+++ b/config/crd/bases/operator.tigera.io_managers.yaml
@@ -40,8 +40,8 @@ spec:
               manager.
             properties:
               auth:
-                description: Auth defines the authentication strategy for the Calico
-                  Enterprise manager GUI.
+                description: Deprecated. Please use the Authentication CR for configuring
+                  authentication.
                 properties:
                   authority:
                     description: Authority configures the OAuth2/OIDC authority/issuer
@@ -87,6 +87,9 @@ spec:
                     - OAuth
                     type: string
                 type: object
+              state:
+                description: State provides user-readable status.
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -134,7 +134,10 @@ func (r *ReconcileAuthentication) Reconcile(request reconcile.Request) (reconcil
 	updateAuthenticationWithDefaults(authentication)
 
 	// Validate the configuration
-	err = validateAuthentication(authentication)
+	if err := validateAuthentication(authentication); err != nil {
+		r.status.SetDegraded("Invalid Authentication provided", err.Error())
+		return reconcile.Result{}, err
+	}
 
 	// Write the authentication back to the datastore, so the controllers depending on this can reconcile.
 	if err := r.client.Update(ctx, authentication); err != nil {

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -286,6 +286,10 @@ func (r *ReconcileCompliance) Reconcile(request reconcile.Request) (reconcile.Re
 		r.status.SetDegraded("Error querying Authentication", err.Error())
 		return reconcile.Result{}, err
 	}
+	if authentication != nil && authentication.Status.State != operatorv1.TigeraStatusReady {
+		r.status.SetDegraded("Authentication is not ready", fmt.Sprintf("authentication status: %s", authentication.Status.State))
+		return reconcile.Result{}, nil
+	}
 
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -718,6 +718,10 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 			r.status.SetDegraded("An error occurred retrieving the authentication configuration", err.Error())
 			return reconcile.Result{}, err
 		}
+		if authentication != nil && authentication.Status.State != operator.TigeraStatusReady {
+			r.status.SetDegraded("Authentication is not ready", fmt.Sprintf("authentication status: %s", authentication.Status.State))
+			return reconcile.Result{}, nil
+		}
 	}
 
 	typhaNodeTLS, err := r.GetTyphaFelixTLSConfig()

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -545,10 +545,14 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	// Get the installation object if it exists so that we can save the original
 	// status before we merge/fill that object with other values.
 	instance := &operator.Installation{}
-	if err := r.client.Get(ctx, utils.DefaultInstanceKey, instance); err != nil && apierrors.IsNotFound(err) {
-		reqLogger.Info("Installation config not found")
-		r.status.OnCRNotFound()
-		return reconcile.Result{}, nil
+	if err := r.client.Get(ctx, utils.DefaultInstanceKey, instance); err != nil {
+		if apierrors.IsNotFound(err) {
+			reqLogger.Info("Installation config not found")
+			r.status.OnCRNotFound()
+			return reconcile.Result{}, nil
+		}
+		reqLogger.Error(err, "An error occurred when querying the Installation resource")
+		return reconcile.Result{}, err
 	}
 	status := instance.Status
 

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -473,6 +473,10 @@ func (r *ReconcileLogStorage) Reconcile(request reconcile.Request) (reconcile.Re
 		r.status.SetDegraded("Error while fetching Authentication", err.Error())
 		return reconcile.Result{}, err
 	}
+	if authentication != nil && authentication.Status.State != operatorv1.TigeraStatusReady {
+		r.status.SetDegraded("Authentication is not ready", fmt.Sprintf("authentication status: %s", authentication.Status.State))
+		return reconcile.Result{}, nil
+	}
 
 	var dexCfg render.DexRelyingPartyConfig
 	if authentication != nil {

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -355,11 +355,12 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 			Namespace: render.OperatorNamespace(),
 		}, internalTrafficSecret)
 		if err != nil {
-			r.status.SetDegraded(fmt.Sprintf("Error validating TLS secret %s", render.ManagerInternalTLSSecretName), err.Error())
+			if errors.IsNotFound(err) {
+				r.status.SetDegraded(fmt.Sprintf("Waiting for secret %s in namespace %s to be available", render.ManagerInternalTLSSecretName, render.OperatorNamespace()), "")
+				return reconcile.Result{}, nil
+			}
+			r.status.SetDegraded(fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.ManagerInternalTLSSecretName, render.OperatorNamespace()), err.Error())
 			return reconcile.Result{}, err
-		} else {
-			r.status.SetDegraded(fmt.Sprintf("Waiting for secret %s to be available", render.ManagerInternalTLSSecretName), "")
-			return reconcile.Result{}, nil
 		}
 	}
 

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -411,6 +411,7 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	// Clear the degraded bit if we've reached this far.
 	r.status.ClearDegraded()
+	instance.Status.State = operatorv1.TigeraStatusReady
 	if r.status.IsAvailable() {
 		if err = r.client.Status().Update(ctx, instance); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -370,6 +370,10 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		r.status.SetDegraded("Error while fetching Authentication", err.Error())
 		return reconcile.Result{}, err
 	}
+	if authentication != nil && authentication.Status.State != operatorv1.TigeraStatusReady {
+		r.status.SetDegraded("Authentication is not ready", fmt.Sprintf("authentication status: %s", authentication.Status.State))
+		return reconcile.Result{}, nil
+	}
 
 	var dexCfg render.DexKeyValidatorConfig
 	if authentication != nil {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -278,21 +278,6 @@ func GetAuthentication(ctx context.Context, cli client.Client) (*operatorv1.Auth
 	if err != nil {
 		return nil, err
 	}
-	if authentication.Spec.OIDC != nil && authentication.Spec.Openshift != nil {
-		return nil, fmt.Errorf("multiple IdP connectors were specified, but only 1 is allowed in the Authentication spec")
-	} else if authentication.Spec.OIDC == nil && authentication.Spec.Openshift == nil {
-		return nil, fmt.Errorf("no IdP connector was specified, please add a connector to the Authentication spec")
-	}
-
-	// Backwards compatibility settings.
-	if authentication.Spec.OIDC != nil {
-		if authentication.Spec.OIDC.UsernamePrefix != "" && authentication.Spec.UsernamePrefix == "" {
-			authentication.Spec.UsernamePrefix = authentication.Spec.OIDC.UsernamePrefix
-		}
-		if authentication.Spec.OIDC.GroupsPrefix != "" && authentication.Spec.GroupsPrefix == "" {
-			authentication.Spec.GroupsPrefix = authentication.Spec.OIDC.GroupsPrefix
-		}
-	}
 
 	return authentication, nil
 }

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -82,6 +82,7 @@ func (c *dexComponent) Objects() ([]runtime.Object, []runtime.Object) {
 	}
 	objs = append(objs, secretsToRuntimeObjects(c.dexConfig.RequiredSecrets(OperatorNamespace())...)...)
 	objs = append(objs, secretsToRuntimeObjects(c.dexConfig.RequiredSecrets(DexNamespace)...)...)
+	objs = append(objs, copyImagePullSecrets(c.pullSecrets, DexNamespace)...)
 	return objs, nil
 }
 

--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -73,13 +73,20 @@ type DexConfig interface {
 type DexKeyValidatorConfig interface {
 	// ManagerURI returns the address where the Manager UI can be found. Ex: https://example.org
 	ManagerURI() string
-	K8sAttributes
+	// RequiredEnv returns env that is used to configure pods with dex options.
+	RequiredEnv(prefix string) []corev1.EnvVar
+	// RequiredAnnotations returns annotations that make your the pods get refreshed if any of the config/secrets change.
+	RequiredAnnotations() map[string]string
+	// RequiredSecrets returns secrets that you need to render for dex.
+	RequiredSecrets(namespace string) []*corev1.Secret
+	// RequiredVolumeMounts returns volume mounts that are related to dex.
+	RequiredVolumeMounts() []corev1.VolumeMount
+	// RequiredVolumes returns volumes that are related to dex.
+	RequiredVolumes() []corev1.Volume
 }
 
 // DexRelyingPartyConfig is a config for relying parties / applications that use Dex as their IdP.
 type DexRelyingPartyConfig interface {
-	// ManagerURI returns the address where the Manager UI can be found. Ex: https://example.org
-	ManagerURI() string
 	// JWKSURI returns the endpoint for public keys
 	JWKSURI() string
 	// TokenURI returns the endpoint for exchanging tokens
@@ -94,7 +101,7 @@ type DexRelyingPartyConfig interface {
 	UsernameClaim() string
 	// GroupsClaim returns the part of the JWT that represents the list of user groups.
 	GroupsClaim() string
-	K8sAttributes
+	DexKeyValidatorConfig
 }
 
 func NewDexRelyingPartyConfig(

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -250,16 +250,3 @@ func appendNotNil(components []Component, c Component) []Component {
 	}
 	return components
 }
-
-type K8sAttributes interface {
-	// RequiredEnv returns env that is used to configure pods with dex options.
-	RequiredEnv(prefix string) []corev1.EnvVar
-	// RequiredAnnotations returns annotations that make your the pods get refreshed if any of the config/secrets change.
-	RequiredAnnotations() map[string]string
-	// RequiredSecrets returns secrets that you need to render for dex.
-	RequiredSecrets(namespace string) []*corev1.Secret
-	// RequiredVolumeMounts returns volume mounts that are related to dex.
-	RequiredVolumeMounts() []corev1.VolumeMount
-	// RequiredVolumes returns volumes that are related to dex.
-	RequiredVolumes() []corev1.Volume
-}


### PR DESCRIPTION
A few items were called out in the dex PR after it was merged. This PR is an attempt to address the most urgent ones:
- Use core controller pattern of fetching->filling->updating->...-> rather than abusing the GetAuthentication for this
- Fix issue where MCM was blocked by secret
- Deprecate Manager.Auth, but add Status.State
- Log error when fetching installation leads to an error (core controller)
- Pull secrets were not copied over to dex namespace