### PR TITLE
[cherry-pick for release-v1.12] Custom Dex component

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -28,6 +28,9 @@ components:
     version: release-calient-v3.4
   eck-kibana:
     version: 7.6.2
+  dex:
+    image: tigera/dex
+    version: release-calient-v3.4
   kibana:
     image: tigera/kibana
     version: release-calient-v3.4
@@ -75,6 +78,3 @@ components:
   cloud-controllers:
     image: tigera/cloud-controllers
     version: release-calient-v3.4
-  dex:
-    image: dexidp/dex
-    version: v2.25.0

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -106,8 +106,8 @@ var (
 	}
 
 	ComponentDex = component{
-		Version: "v2.25.0",
-		Image:   "dexidp/dex",
+		Version: "release-calient-v3.4",
+		Image:   "tigera/dex",
 	}
 
 	ComponentManagerProxy = component{

--- a/pkg/components/images.go
+++ b/pkg/components/images.go
@@ -25,5 +25,4 @@ const (
 	InitRegistry   = "quay.io/"
 	K8sGcrRegistry = "gcr.io/"
 	ECKRegistry    = "docker.elastic.co/"
-	DexRegistry    = "quay.io/"
 )

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -39,8 +39,6 @@ func GetReference(c component, registry, imagepath string) string {
 			registry = CalicoRegistry
 		case ComponentElasticsearchOperator:
 			registry = ECKRegistry
-		case ComponentDex:
-			registry = DexRegistry
 		default:
 			registry = TigeraRegistry
 		}


### PR DESCRIPTION
## Description
- Switching dex component from using external image to internal custom image.

This is a cherry-pick of https://github.com/tigera/operator/pull/980.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
