### PR TITLE
Bugfix for checking SyslogLogIDSEvents in syslog.LogTypes field

### DIFF
--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -258,8 +258,8 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 
 			// Try to grab the ManagementClusterConnection CR because we need it for some
 			// validation with respect to Syslog.logTypes.
-			managementClusterConnection, mccErr := utils.GetManagementClusterConnection(ctx, r.client)
-			if mccErr != nil {
+			managementClusterConnection, err := utils.GetManagementClusterConnection(ctx, r.client)
+			if err != nil {
 				// Not finding a ManagementClusterConnection CR is not an error, as only a managed cluster will
 				// have this CR available, but we should communicate any other kind of error that we encounter.
 				if !errors.IsNotFound(err) {
@@ -276,13 +276,13 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 			// ManagementClusterConnection CR is present). This is because IDS events
 			// are only forwarded within a non-managed cluster (where LogStorage is present).
 			if syslog.LogTypes != nil {
-				if mccErr == nil && managementClusterConnection != nil {
+				if err == nil && managementClusterConnection != nil {
 					for _, l := range syslog.LogTypes {
 						// Set status to degraded to warn user and let them fix the issue themselves.
 						if l == v1.SyslogLogIDSEvents {
 							r.status.SetDegraded(
 								"IDSEvents option is not supported for Syslog config in a managed cluster",
-								err.Error(),
+								"",
 							)
 							return reconcile.Result{}, err
 						}


### PR DESCRIPTION
## Description
- Fixes bug in check for SyslogLogIDSEvents value in syslog.LogTypes field for managed cluster scenario.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
