### PR TITLE
Picking changes from release-v1.11 since v1.11.0 into tech-preview-migrate-install

### DIFF
--- a/config/calico_versions.yml
+++ b/config/calico_versions.yml
@@ -1,11 +1,11 @@
 components:
   typha:
-    version: master
+    version: v3.16.4
   calico/node:
-    version: master
+    version: v3.16.4
   calico/cni:
-    version: master
+    version: v3.16.4
   calico/kube-controllers:
-    version: master
+    version: v3.16.4
   flexvol:
-    version: master
+    version: v3.16.4

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -1,36 +1,36 @@
 components:
   cnx-manager:
     image: tigera/cnx-manager
-    version: v3.3.1
+    version: v3.3.2
   voltron:
     image: tigera/voltron
-    version: v3.3.1
+    version: v3.3.2
   cnx-apiserver:
     image: tigera/cnx-apiserver
-    version: v3.3.1
+    version: v3.3.2
   cnx-queryserver:
     image: tigera/cnx-queryserver
-    version: v3.3.1
+    version: v3.3.2
   cnx-kube-controllers:
     image: tigera/kube-controllers
-    version: v3.3.1
+    version: v3.3.2
   typha:
     image: tigera/typha
-    version: v3.3.1
+    version: v3.3.2
   cnx-node:
     image: tigera/cnx-node
-    version: v3.3.1
+    version: v3.3.2
   fluentd:
     image: tigera/fluentd
-    version: v3.3.1
+    version: v3.3.2
   es-proxy:
     image: tigera/es-proxy
-    version: v3.3.1
+    version: v3.3.2
   eck-kibana:
     version: 7.6.2
   kibana:
     image: tigera/kibana
-    version: v3.3.1
+    version: v3.3.2
   elasticsearch-operator:
     registry: docker.elastic.co
     image: eck/eck-operator
@@ -39,39 +39,39 @@ components:
     version: 7.6.2
   elasticsearch:
     image: tigera/elasticsearch
-    version: v3.3.1
+    version: v3.3.2
   elastic-tsee-installer:
     image: tigera/intrusion-detection-job-installer
-    version: v3.3.1
+    version: v3.3.2
   es-curator:
     image: tigera/es-curator
-    version: v3.3.1
+    version: v3.3.2
   intrusion-detection-controller:
     image: tigera/intrusion-detection-controller
-    version: v3.3.1
+    version: v3.3.2
   compliance-controller:
     image: tigera/compliance-controller
-    version: v3.3.1
+    version: v3.3.2
   compliance-reporter:
     image: tigera/compliance-reporter
-    version: v3.3.1
+    version: v3.3.2
   compliance-snapshotter:
     image: tigera/compliance-snapshotter
-    version: v3.3.1
+    version: v3.3.2
   compliance-server:
     image: tigera/compliance-server
-    version: v3.3.1
+    version: v3.3.2
   compliance-benchmarker:
     image: tigera/compliance-benchmarker
-    version: v3.3.1
+    version: v3.3.2
   # Below components are all maintained by 3rd parties and thus specify a 'registry' to indicate
   # to the docs & manifest tooling not to default to the tigera registry.
   guardian:
     image: tigera/guardian
-    version: v3.3.1
+    version: v3.3.2
   tigera-cni:
     image: tigera/cni
-    version: v3.3.1
+    version: v3.3.2
   cloud-controllers:
     image: tigera/cloud-controllers
-    version: v3.3.1
+    version: v3.3.2

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -1,36 +1,36 @@
 components:
   cnx-manager:
     image: tigera/cnx-manager
-    version: v3.3.0
+    version: v3.3.1
   voltron:
     image: tigera/voltron
-    version: v3.3.0
+    version: v3.3.1
   cnx-apiserver:
     image: tigera/cnx-apiserver
-    version: v3.3.0
+    version: v3.3.1
   cnx-queryserver:
     image: tigera/cnx-queryserver
-    version: v3.3.0
+    version: v3.3.1
   cnx-kube-controllers:
     image: tigera/kube-controllers
-    version: v3.3.0
+    version: v3.3.1
   typha:
     image: tigera/typha
-    version: v3.3.0
+    version: v3.3.1
   cnx-node:
     image: tigera/cnx-node
-    version: v3.3.0
+    version: v3.3.1
   fluentd:
     image: tigera/fluentd
-    version: v3.3.0
+    version: v3.3.1
   es-proxy:
     image: tigera/es-proxy
-    version: v3.3.0
+    version: v3.3.1
   eck-kibana:
     version: 7.6.2
   kibana:
     image: tigera/kibana
-    version: v3.3.0
+    version: v3.3.1
   elasticsearch-operator:
     registry: docker.elastic.co
     image: eck/eck-operator
@@ -39,39 +39,39 @@ components:
     version: 7.6.2
   elasticsearch:
     image: tigera/elasticsearch
-    version: v3.3.0
+    version: v3.3.1
   elastic-tsee-installer:
     image: tigera/intrusion-detection-job-installer
-    version: v3.3.0
+    version: v3.3.1
   es-curator:
     image: tigera/es-curator
-    version: v3.3.0
+    version: v3.3.1
   intrusion-detection-controller:
     image: tigera/intrusion-detection-controller
-    version: v3.3.0
+    version: v3.3.1
   compliance-controller:
     image: tigera/compliance-controller
-    version: v3.3.0
+    version: v3.3.1
   compliance-reporter:
     image: tigera/compliance-reporter
-    version: v3.3.0
+    version: v3.3.1
   compliance-snapshotter:
     image: tigera/compliance-snapshotter
-    version: v3.3.0
+    version: v3.3.1
   compliance-server:
     image: tigera/compliance-server
-    version: v3.3.0
+    version: v3.3.1
   compliance-benchmarker:
     image: tigera/compliance-benchmarker
-    version: v3.3.0
+    version: v3.3.1
   # Below components are all maintained by 3rd parties and thus specify a 'registry' to indicate
   # to the docs & manifest tooling not to default to the tigera registry.
   guardian:
     image: tigera/guardian
-    version: v3.3.0
+    version: v3.3.1
   tigera-cni:
     image: tigera/cni
-    version: v3.3.0
+    version: v3.3.1
   cloud-controllers:
     image: tigera/cloud-controllers
-    version: v3.3.0
+    version: v3.3.1

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -18,27 +18,27 @@ import "github.com/tigera/operator/version"
 
 var (
 	ComponentCalicoCNI = component{
-		Version: "master",
+		Version: "v3.16.4",
 		Image:   "calico/cni",
 	}
 
 	ComponentCalicoKubeControllers = component{
-		Version: "master",
+		Version: "v3.16.4",
 		Image:   "calico/kube-controllers",
 	}
 
 	ComponentCalicoNode = component{
-		Version: "master",
+		Version: "v3.16.4",
 		Image:   "calico/node",
 	}
 
 	ComponentCalicoTypha = component{
-		Version: "master",
+		Version: "v3.16.4",
 		Image:   "calico/typha",
 	}
 
 	ComponentFlexVolume = component{
-		Version: "master",
+		Version: "v3.16.4",
 		Image:   "calico/pod2daemon-flexvol",
 	}
 

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -16,32 +16,32 @@ package components
 
 var (
 	ComponentAPIServer = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/cnx-apiserver",
 	}
 
 	ComponentComplianceBenchmarker = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/compliance-benchmarker",
 	}
 
 	ComponentComplianceController = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/compliance-controller",
 	}
 
 	ComponentComplianceReporter = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/compliance-reporter",
 	}
 
 	ComponentComplianceServer = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/compliance-server",
 	}
 
 	ComponentComplianceSnapshotter = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/compliance-snapshotter",
 	}
 
@@ -56,12 +56,12 @@ var (
 	}
 
 	ComponentElasticTseeInstaller = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/intrusion-detection-job-installer",
 	}
 
 	ComponentElasticsearch = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/elasticsearch",
 	}
 
@@ -71,72 +71,72 @@ var (
 	}
 
 	ComponentEsCurator = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/es-curator",
 	}
 
 	ComponentEsProxy = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/es-proxy",
 	}
 
 	ComponentFluentd = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/fluentd",
 	}
 
 	ComponentGuardian = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/guardian",
 	}
 
 	ComponentIntrusionDetectionController = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/intrusion-detection-controller",
 	}
 
 	ComponentKibana = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/kibana",
 	}
 
 	ComponentManager = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/cnx-manager",
 	}
 
 	ComponentManagerProxy = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/voltron",
 	}
 
 	ComponentQueryServer = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/cnx-queryserver",
 	}
 
 	ComponentTigeraKubeControllers = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/kube-controllers",
 	}
 
 	ComponentTigeraNode = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/cnx-node",
 	}
 
 	ComponentTigeraTypha = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/typha",
 	}
 
 	ComponentTigeraCNI = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/cni",
 	}
 
 	ComponentCloudControllers = component{
-		Version: "v3.3.1",
+		Version: "v3.3.2",
 		Image:   "tigera/cloud-controllers",
 	}
 )

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -16,32 +16,32 @@ package components
 
 var (
 	ComponentAPIServer = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/cnx-apiserver",
 	}
 
 	ComponentComplianceBenchmarker = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/compliance-benchmarker",
 	}
 
 	ComponentComplianceController = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/compliance-controller",
 	}
 
 	ComponentComplianceReporter = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/compliance-reporter",
 	}
 
 	ComponentComplianceServer = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/compliance-server",
 	}
 
 	ComponentComplianceSnapshotter = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/compliance-snapshotter",
 	}
 
@@ -56,12 +56,12 @@ var (
 	}
 
 	ComponentElasticTseeInstaller = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/intrusion-detection-job-installer",
 	}
 
 	ComponentElasticsearch = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/elasticsearch",
 	}
 
@@ -71,72 +71,72 @@ var (
 	}
 
 	ComponentEsCurator = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/es-curator",
 	}
 
 	ComponentEsProxy = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/es-proxy",
 	}
 
 	ComponentFluentd = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/fluentd",
 	}
 
 	ComponentGuardian = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/guardian",
 	}
 
 	ComponentIntrusionDetectionController = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/intrusion-detection-controller",
 	}
 
 	ComponentKibana = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/kibana",
 	}
 
 	ComponentManager = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/cnx-manager",
 	}
 
 	ComponentManagerProxy = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/voltron",
 	}
 
 	ComponentQueryServer = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/cnx-queryserver",
 	}
 
 	ComponentTigeraKubeControllers = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/kube-controllers",
 	}
 
 	ComponentTigeraNode = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/cnx-node",
 	}
 
 	ComponentTigeraTypha = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/typha",
 	}
 
 	ComponentTigeraCNI = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/cni",
 	}
 
 	ComponentCloudControllers = component{
-		Version: "v3.3.0",
+		Version: "v3.3.1",
 		Image:   "tigera/cloud-controllers",
 	}
 )

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -988,11 +988,11 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *appsv1.StatefulSet {
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
 								"cpu":    resource.MustParse("1"),
-								"memory": resource.MustParse("150Mi"),
+								"memory": resource.MustParse("512Mi"),
 							},
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),
-								"memory": resource.MustParse("50Mi"),
+								"memory": resource.MustParse("512Mi"),
 							},
 						},
 						Ports: []corev1.ContainerPort{{

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -503,10 +503,11 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 
 	podTemplate := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
-			InitContainers:   initContainers,
-			Containers:       []corev1.Container{esContainer},
-			ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
-			NodeSelector:     es.logStorage.Spec.DataNodeSelector,
+			InitContainers:     initContainers,
+			Containers:         []corev1.Container{esContainer},
+			ImagePullSecrets:   getImagePullSecretReferenceList(es.pullSecrets),
+			NodeSelector:       es.logStorage.Spec.DataNodeSelector,
+			ServiceAccountName: "tigera-elasticsearch",
 		},
 	}
 
@@ -606,8 +607,7 @@ func (es elasticsearchComponent) elasticsearchCluster(secureSettings bool) *esv1
 					},
 				},
 			},
-			NodeSets:           es.nodeSets(),
-			ServiceAccountName: "tigera-elasticsearch",
+			NodeSets: es.nodeSets(),
 		},
 	}
 
@@ -1065,9 +1065,8 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 			},
 		},
 		Spec: kbv1.KibanaSpec{
-			Version:            components.ComponentEckKibana.Version,
-			Image:              components.GetReference(components.ComponentKibana, es.installation.Spec.Registry, es.installation.Spec.ImagePath),
-			ServiceAccountName: "tigera-kibana",
+			Version: components.ComponentEckKibana.Version,
+			Image:   components.GetReference(components.ComponentKibana, es.installation.Spec.Registry, es.installation.Spec.ImagePath),
 			Config: &cmnv1.Config{
 				Data: config,
 			},
@@ -1092,7 +1091,8 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 					},
 				},
 				Spec: corev1.PodSpec{
-					ImagePullSecrets: getImagePullSecretReferenceList(es.pullSecrets),
+					ImagePullSecrets:   getImagePullSecretReferenceList(es.pullSecrets),
+					ServiceAccountName: "tigera-kibana",
 					Containers: []corev1.Container{{
 						Name: "kibana",
 						ReadinessProbe: &corev1.Probe{

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -186,12 +186,6 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"watch", "list", "get"},
 			},
 			{
-				// Used when configuring bgp password in bgppeer
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"watch", "list", "get"},
-			},
-			{
 				// Some information is stored on the node status.
 				APIGroups: []string{""},
 				Resources: []string{"nodes/status"},
@@ -1086,18 +1080,11 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 		readinessCmd = []string{"/bin/calico-node", "-felix-ready"}
 	}
 
+	// For Openshift, we need a different port since our default port is already in use.
 	if c.cr.Spec.KubernetesProvider == operator.ProviderOpenShift {
-		// For Openshift, we need special configuration since our default port is already in use.
-		// Additionally, since the node readiness probe doesn't yet support
-		// custom ports, we need to disable felix readiness for now.
 		livenessPort = intstr.FromInt(9199)
-
-		if c.cr.Spec.Variant == operator.TigeraSecureEnterprise {
-			readinessCmd = []string{"/bin/calico-node", "-bird-ready", "-bgp-metrics-ready"}
-		} else {
-			readinessCmd = []string{"/bin/calico-node", "-bird-ready"}
-		}
 	}
+
 	lp := &v1.Probe{
 		Handler: v1.Handler{
 			HTTPGet: &v1.HTTPGetAction{

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -17,6 +17,7 @@ package render
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -782,7 +783,16 @@ func (c *nodeComponent) nodeVolumeMounts() []v1.VolumeMount {
 	}
 
 	if c.birdTemplates != nil {
+		// create a volume mount for each bird template, but sort them alphabetically first,
+		// otherwise, since map iteration is random, they'll be added to the list of volumes in a random order,
+		// which will cause another reconciliation event when calico-node is updated.
+		sortedKeys := []string{}
 		for k := range c.birdTemplates {
+			sortedKeys = append(sortedKeys, k)
+		}
+		sort.Strings(sortedKeys)
+
+		for _, k := range sortedKeys {
 			nodeVolumeMounts = append(nodeVolumeMounts,
 				v1.VolumeMount{
 					Name:      "bird-templates",


### PR DESCRIPTION
## Description

These changes get the branch updated to match the Enterprise changes for v3.3.2.

Cherry-picking:
- #929 
- #948 
- #955 
- #965 
- #985 
- #991

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
