### PR TITLE
add linux nodeselector to elastic, kibana, and ids job

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -301,6 +301,21 @@ func ensureOSSchedulingRestrictions(obj runtime.Object, osType render.OSType) {
 		podSpec = &obj.(*apps.StatefulSet).Spec.Template.Spec
 	case *batchv1beta.CronJob:
 		podSpec = &obj.(*batchv1beta.CronJob).Spec.JobTemplate.Spec.Template.Spec
+	case *batchv1.Job:
+		podSpec = &obj.(*batchv1.Job).Spec.Template.Spec
+	case *kbv1.Kibana:
+		podSpec = &obj.(*kbv1.Kibana).Spec.PodTemplate.Spec
+	case *esv1.Elasticsearch:
+		// elasticsearch resource describes multiple nodeSets which each have a nodeSelector.
+		nodeSets := obj.(*esv1.Elasticsearch).Spec.NodeSets
+		for i, ns := range nodeSets {
+			if ns.PodTemplate.Spec.NodeSelector == nil {
+				nodeSets[i].PodTemplate.Spec.NodeSelector = make(map[string]string)
+			}
+			nodeSets[i].PodTemplate.Spec.NodeSelector["kubernetes.io/os"] = string(osType)
+		}
+		return
+
 	default:
 		return
 	}


### PR DESCRIPTION
## Description

The 1000th PR! 🎉 🎆 what an honor!

This PR adds the linux OS nodeselector to elastic, kibana, and ids jobs which were missing them, causing them to sometimes be scheduled on windows nodes in multi-os clusters.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.