### PR TITLE
Move RootCA to alpine trusted cert location

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/r3labs/diff/v2 v2.8.0
 	github.com/robfig/cron v1.2.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
-	k8s.io/klog/v2 v2.3.0 // indirect
 	sigs.k8s.io/kube-storage-version-migrator v0.0.3 // indirect
 )
 

--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -45,7 +45,7 @@ const (
 	OIDCSecretName               = "tigera-oidc-credentials"
 	OpenshiftSecretName          = "tigera-openshift-credentials"
 	serviceAccountSecretLocation = "/etc/dex/secrets/google-groups.json"
-	rootCASecretLocation         = "/etc/ssl/openshift.pem"
+	rootCASecretLocation         = "/etc/ssl/certs/idp.pem"
 	ClientIDSecretField          = "clientID"
 
 	// OIDC well-known-config related constants.
@@ -327,7 +327,7 @@ func (d *dexConfig) RequiredVolumes() []corev1.Volume {
 		volumes = append(volumes,
 			corev1.Volume{
 				Name:         "secrets",
-				VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{DefaultMode: &defaultMode, SecretName: d.idpSecret.Name, Items: []corev1.KeyToPath{{Key: RootCASecretField, Path: "openshift.pem"}}}},
+				VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{DefaultMode: &defaultMode, SecretName: d.idpSecret.Name, Items: []corev1.KeyToPath{{Key: RootCASecretField, Path: "idp.pem"}}}},
 			},
 		)
 	}
@@ -397,7 +397,7 @@ func (d *dexConfig) RequiredVolumeMounts() []corev1.VolumeMount {
 	if d.idpSecret.Data[RootCASecretField] != nil {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "secrets",
-			MountPath: "/etc/ssl/",
+			MountPath: "/etc/ssl/certs/",
 			ReadOnly:  true,
 		})
 	}


### PR DESCRIPTION
This PR comes with a few advantages:
- By moving the location of the cert, it now enables the rootCA not only for tigera-openshift-credentials, but also for OIDC.
- This allows privately hosted OIDC connectors with certs that are not issued by public authorities. We need this for our own e2e, but we know that there are users who will need this.