### PR TITLE
Automated cherry pick of #1019: Use a constant length for git abbreviations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,9 @@ sub-tag-images-%:
 
 # Get version from git.
 ifeq ($(LOCAL_BUILD),true)
-  GIT_VERSION?=$(shell git describe --tags --dirty --always)-dev-build
+  GIT_VERSION?=$(shell git describe --tags --dirty --always --abbrev=12)-dev-build
 else
-  GIT_VERSION?=$(shell git describe --tags --dirty --always)
+  GIT_VERSION?=$(shell git describe --tags --dirty --always --abbrev=12)
 endif
 
 build: fmt vet $(BINDIR)/operator-$(ARCH)
@@ -331,7 +331,7 @@ ifndef BRANCH_NAME
 	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
 endif
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=${BRANCH_NAME} EXCLUDEARCH="$(EXCLUDEARCH)"
-	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(shell git describe --tags --dirty --always --long) EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(shell git describe --tags --dirty --always --long --abbrev=12) EXCLUDEARCH="$(EXCLUDEARCH)"
 
 ###############################################################################
 # Release


### PR DESCRIPTION
Cherry pick of #1019 on release-v1.12.

#1019: Use a constant length for git abbreviations