### PR TITLE
Switch Updates after defaulting to use Patch

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1066,6 +1066,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
@@ -134,6 +134,7 @@ func (r *ReconcileAmazonCloudIntegration) Reconcile(request reconcile.Request) (
 	}
 	r.status.OnCRFound()
 	reqLogger.V(2).Info("Loaded config", "config", instance)
+	preDefaultPatchFrom := client.MergeFrom(instance.DeepCopy())
 
 	// Validate the configuration.
 	if err = validateCustomResource(instance); err != nil {
@@ -143,7 +144,7 @@ func (r *ReconcileAmazonCloudIntegration) Reconcile(request reconcile.Request) (
 
 	// Write the discovered configuration back to the API. This is essentially a poor-man's defaulting, and
 	// ensures that we don't surprise anyone by changing defaults in a future version of the operator.
-	if err = r.client.Update(ctx, instance); err != nil {
+	if err = r.client.Patch(ctx, instance, preDefaultPatchFrom); err != nil {
 		r.SetDegraded("Failed to write defaults", err, reqLogger)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -133,6 +133,7 @@ func (r *ReconcileAuthentication) Reconcile(request reconcile.Request) (reconcil
 	}
 	r.status.OnCRFound()
 	reqLogger.V(2).Info("Loaded config", "config", authentication)
+	preDefaultPatchFrom := client.MergeFrom(authentication.DeepCopy())
 
 	// Set defaults for backwards compatibility.
 	updateAuthenticationWithDefaults(authentication)
@@ -144,7 +145,7 @@ func (r *ReconcileAuthentication) Reconcile(request reconcile.Request) (reconcil
 	}
 
 	// Write the authentication back to the datastore, so the controllers depending on this can reconcile.
-	if err := r.client.Update(ctx, authentication); err != nil {
+	if err = r.client.Patch(ctx, authentication, preDefaultPatchFrom); err != nil {
 		log.Error(err, "Failed to write defaults")
 		r.status.SetDegraded("Failed to write defaults", err.Error())
 		return reconcile.Result{}, err

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -566,6 +566,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 	status := instance.Status
+	preDefaultPatchFrom := client.MergeFrom(instance.DeepCopy())
 
 	// mark CR found so we can report converter problems via tigerastatus
 	r.status.OnCRFound()
@@ -611,7 +612,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	// ensures that we don't surprise anyone by changing defaults in a future version of the operator.
 	// Note that we only write the 'base' installation back. We don't want to write the changes from 'overlay', as those should only
 	// be stored in the 'overlay' resource.
-	if err := r.client.Update(ctx, instance); err != nil {
+	if err := r.client.Patch(ctx, instance, preDefaultPatchFrom); err != nil {
 		r.SetDegraded("Failed to write defaults", err, reqLogger)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -164,6 +164,7 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 	}
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 	r.status.OnCRFound()
+	preDefaultPatchFrom := client.MergeFrom(instance.DeepCopy())
 
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
@@ -339,7 +340,7 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 
 	// Update the LogCollector instance with any changes that have occurred.
 	if isModified {
-		if err = r.client.Update(ctx, instance); err != nil {
+		if err = r.client.Patch(ctx, instance, preDefaultPatchFrom); err != nil {
 			r.status.SetDegraded(
 				fmt.Sprintf(
 					"Failed to set defaults for LogCollector fields: [%s]",

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -154,7 +154,7 @@ type ReconcileManager struct {
 
 // GetManager returns the default manager instance with defaults populated.
 func GetManager(ctx context.Context, cli client.Client) (*operatorv1.Manager, error) {
-	// Fetch the manager instance. We only support a single instance named "default".
+	// Fetch the manager instance. We only support a single instance named "tigera-secure".
 	instance := &operatorv1.Manager{}
 	err := cli.Get(ctx, utils.DefaultTSEEInstanceKey, instance)
 	if err != nil {
@@ -189,12 +189,6 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 	r.status.OnCRFound()
-
-	// Write the manager back to the datastore.
-	if err = r.client.Update(ctx, instance); err != nil {
-		r.status.SetDegraded("Failed to write defaults", err.Error())
-		return reconcile.Result{}, err
-	}
 
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")


### PR DESCRIPTION
Use Patch call to update defaults to ensure fields the operator
doesn't know about (like due to new fields during upgrade) are not
deleted by an 'old' already running operator.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
