### PR TITLE
Follow-up fixes to cert SANs

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,17 +197,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	localDNS, err := dns.GetLocalDNSName(dns.DefaultResolveConfPath)
+	clusterDomain, err := dns.GetClusterDomain(dns.DefaultResolveConfPath)
 	if err != nil {
-		localDNS = dns.DefaultLocalDNS
-		log.Error(err, fmt.Sprintf("Couldn't find the local dns name from the resolv.conf, defaulting to %s", localDNS))
+		clusterDomain = dns.DefaultClusterDomain
+		log.Error(err, fmt.Sprintf("Couldn't find the cluster domain from the resolv.conf, defaulting to %s", clusterDomain))
 	}
 
 	options := options.AddOptions{
 		DetectedProvider:    provider,
 		EnterpriseCRDExists: enterpriseCRDExists,
 		AmazonCRDExists:     amazonCRDExists,
-		LocalDNS:            localDNS,
+		ClusterDomain:       clusterDomain,
 	}
 
 	err = controllers.AddToManager(mgr, options)

--- a/pkg/controller/authentication/authentication_suite_test.go
+++ b/pkg/controller/authentication/authentication_suite_test.go
@@ -39,12 +39,12 @@ func NewReconciler(
 	scheme *runtime.Scheme,
 	provider oprv1.Provider,
 	status status.StatusManager,
-	localDNS string) *ReconcileAuthentication {
+	clusterDomain string) *ReconcileAuthentication {
 	return &ReconcileAuthentication{
-		client:   client,
-		scheme:   scheme,
-		provider: provider,
-		status:   status,
-		localDNS: localDNS,
+		client:        client,
+		scheme:        scheme,
+		provider:      provider,
+		status:        status,
+		clusterDomain: clusterDomain,
 	}
 }

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -97,7 +97,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions) (*ReconcileInst
 		namespaceMigration:   nm,
 		amazonCRDExists:      opts.AmazonCRDExists,
 		enterpriseCRDsExist:  opts.EnterpriseCRDExists,
-		localDNS:             opts.LocalDNS,
+		clusterDomain:        opts.ClusterDomain,
 	}
 	r.status.Run()
 	r.typhaAutoscaler.start()
@@ -232,7 +232,7 @@ type ReconcileInstallation struct {
 	enterpriseCRDsExist  bool
 	amazonCRDExists      bool
 	migrationChecked     bool
-	localDNS             string
+	clusterDomain        string
 }
 
 // GetInstallation returns the current installation, for use by other controllers. It accounts for overlays and
@@ -828,7 +828,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		aci,
 		needNsMigration,
 		nodeAppArmorProfile,
-		r.localDNS,
+		r.clusterDomain,
 	)
 	if err != nil {
 		log.Error(err, "Error with rendering Calico")

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -50,17 +50,17 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, opts.DetectedProvider, opts.LocalDNS))
+	return add(mgr, newReconciler(mgr, opts.DetectedProvider, opts.ClusterDomain))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider, localDNS string) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, provider operatorv1.Provider, clusterDomain string) reconcile.Reconciler {
 	c := &ReconcileLogCollector{
-		client:   mgr.GetClient(),
-		scheme:   mgr.GetScheme(),
-		provider: provider,
-		status:   status.New(mgr.GetClient(), "log-collector"),
-		localDNS: localDNS,
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		provider:      provider,
+		status:        status.New(mgr.GetClient(), "log-collector"),
+		clusterDomain: clusterDomain,
 	}
 	c.status.Run()
 	return c
@@ -110,11 +110,11 @@ var _ reconcile.Reconciler = &ReconcileLogCollector{}
 type ReconcileLogCollector struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client   client.Client
-	scheme   *runtime.Scheme
-	provider operatorv1.Provider
-	status   status.StatusManager
-	localDNS string
+	client        client.Client
+	scheme        *runtime.Scheme
+	provider      operatorv1.Provider
+	status        status.StatusManager
+	clusterDomain string
 }
 
 // GetLogCollector returns the default LogCollector instance with defaults populated.
@@ -368,7 +368,7 @@ func (r *ReconcileLogCollector) Reconcile(request reconcile.Request) (reconcile.
 		eksConfig,
 		pullSecrets,
 		installation,
-		r.localDNS,
+		r.clusterDomain,
 	)
 
 	if err := handler.CreateOrUpdate(ctx, component, r.status); err != nil {

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 
 	apps "k8s.io/api/apps/v1"
@@ -533,9 +534,13 @@ func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context) ([]*core
 	secret := &corev1.Secret{}
 	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraElasticsearchCertSecret, Namespace: render.OperatorNamespace()}, secret); err != nil {
 		if errors.IsNotFound(err) {
+			svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf(render.ElasticsearchHTTPURL, r.clusterDomain), r.clusterDomain)
+			if err != nil {
+				return nil, err
+			}
 			secret, err = render.CreateOperatorTLSSecret(nil,
 				render.TigeraElasticsearchCertSecret, "tls.key", "tls.crt",
-				render.DefaultCertificateDuration, nil, fmt.Sprintf(render.ElasticsearchHTTPURL, r.clusterDomain),
+				render.DefaultCertificateDuration, nil, svcDNSNames...,
 			)
 		} else {
 			return nil, err
@@ -575,9 +580,13 @@ func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context) ([]*corev1.Secr
 	secret := &corev1.Secret{}
 	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraKibanaCertSecret, Namespace: render.OperatorNamespace()}, secret); err != nil {
 		if errors.IsNotFound(err) {
+			svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf(render.KibanaHTTPURL, r.clusterDomain), r.clusterDomain)
+			if err != nil {
+				return nil, err
+			}
 			secret, err = render.CreateOperatorTLSSecret(nil,
 				render.TigeraKibanaCertSecret, "tls.key", "tls.crt",
-				render.DefaultCertificateDuration, nil, fmt.Sprintf(render.KibanaHTTPURL, r.clusterDomain),
+				render.DefaultCertificateDuration, nil, svcDNSNames...,
 			)
 		} else {
 			return nil, err

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -534,10 +534,7 @@ func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context) ([]*core
 	secret := &corev1.Secret{}
 	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraElasticsearchCertSecret, Namespace: render.OperatorNamespace()}, secret); err != nil {
 		if errors.IsNotFound(err) {
-			svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf(render.ElasticsearchHTTPURL, r.clusterDomain), r.clusterDomain)
-			if err != nil {
-				return nil, err
-			}
+			svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
 			secret, err = render.CreateOperatorTLSSecret(nil,
 				render.TigeraElasticsearchCertSecret, "tls.key", "tls.crt",
 				render.DefaultCertificateDuration, nil, svcDNSNames...,
@@ -580,10 +577,7 @@ func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context) ([]*corev1.Secr
 	secret := &corev1.Secret{}
 	if err := r.client.Get(ctx, types.NamespacedName{Name: render.TigeraKibanaCertSecret, Namespace: render.OperatorNamespace()}, secret); err != nil {
 		if errors.IsNotFound(err) {
-			svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf(render.KibanaHTTPURL, r.clusterDomain), r.clusterDomain)
-			if err != nil {
-				return nil, err
-			}
+			svcDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
 			secret, err = render.CreateOperatorTLSSecret(nil,
 				render.TigeraKibanaCertSecret, "tls.key", "tls.crt",
 				render.DefaultCertificateDuration, nil, svcDNSNames...,

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -180,8 +180,8 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("ClearDegraded")
 					})
 
-					DescribeTable("tests that the ExternalService is setup with the default service name", func(localDNS, expectedSvcName string) {
-						r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, localDNS)
+					DescribeTable("tests that the ExternalService is setup with the default service name", func(clusterDomain, expectedSvcName string) {
+						r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, clusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 						_, err = r.Reconcile(reconcile.Request{})
 						Expect(err).ShouldNot(HaveOccurred())
@@ -193,8 +193,8 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(svc.Spec.ExternalName).Should(Equal(expectedSvcName))
 						Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
 					},
-						Entry("default local DNS", dns.DefaultLocalDNS, "tigera-guardian.tigera-guardian.svc.cluster.local"),
-						Entry("custom local DNS", "svc.custom-domain.internal", "tigera-guardian.tigera-guardian.svc.custom-domain.internal"),
+						Entry("default cluster domain", dns.DefaultClusterDomain, "tigera-guardian.tigera-guardian.svc.cluster.local"),
+						Entry("custom cluster domain", "custom-domain.internal", "tigera-guardian.tigera-guardian.svc.custom-domain.internal"),
 					)
 				})
 
@@ -205,7 +205,7 @@ var _ = Describe("LogStorage controller", func() {
 					})
 
 					It("returns an error if the LogStorage resource exists and is not marked for deletion", func() {
-						r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultLocalDNS)
+						r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", "LogStorage validation failed", "cluster type is managed but LogStorage CR still exists").Return()
 						result, err := r.Reconcile(reconcile.Request{})
@@ -222,7 +222,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("AddCronJobs", mock.Anything)
 						mockStatus.On("ClearDegraded", mock.Anything).Return()
 
-						r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultLocalDNS)
+						r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						ls := &operatorv1.LogStorage{}
@@ -314,7 +314,7 @@ var _ = Describe("LogStorage controller", func() {
 						},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultLocalDNS)
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -402,7 +402,7 @@ var _ = Describe("LogStorage controller", func() {
 				})
 
 				It("deletes Elasticsearch and Kibana then removes the finalizers on the LogStorage CR", func() {
-					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultLocalDNS)
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("making sure LogStorage has successfully reconciled")

--- a/pkg/controller/logstorage/shim_test.go
+++ b/pkg/controller/logstorage/shim_test.go
@@ -30,7 +30,7 @@ func NewReconcilerWithShims(
 	status status.StatusManager,
 	provider operatorv1.Provider,
 	esClient utils.ElasticClient,
-	localDNS string) (*ReconcileLogStorage, error) {
+	clusterDomain string) (*ReconcileLogStorage, error) {
 
-	return newReconciler(cli, schema, status, provider, esClient, localDNS)
+	return newReconciler(cli, schema, status, provider, esClient, clusterDomain)
 }

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -10,5 +10,5 @@ type AddOptions struct {
 	DetectedProvider    v1.Provider
 	EnterpriseCRDExists bool
 	AmazonCRDExists     bool
-	LocalDNS            string
+	ClusterDomain       string
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 )
 
 const (
@@ -61,26 +60,17 @@ func GetClusterDomain(resolvConfPath string) (string, error) {
 }
 
 // GetServiceDNSNames parses the fully-qualified domain service name and
-// returns a list of its qualified service names.
-func GetServiceDNSNames(fqdnServiceName string, clusterDomain string) ([]string, error) {
-	all := strings.Split(fqdnServiceName, ".")
-
-	// The FQDN service name will be: <svc_name>.<ns>.svc.<cluster-domain>
-	// There is no guarantee the cluster-domain will be dotted (kubelet does not
-	// validate the cluster domain).
-	if len(all) < 4 {
-		return nil, fmt.Errorf("failed to split FQDN service name %q", fqdnServiceName)
+// returns a list of its service names.
+// We return:
+// - <svc_name>
+// - <svc_name>.<ns>
+// - <svc_name>.<ns>.svc
+// - <svc_name>.<ns>.svc.<cluster-domain>
+func GetServiceDNSNames(name, namespace, clusterDomain string) []string {
+	return []string{
+		name,
+		fmt.Sprintf("%s.%s", name, namespace),
+		fmt.Sprintf("%s.%s.svc", name, namespace),
+		fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain),
 	}
-
-	// We return:
-	// - <svc_name>
-	// - <svc_name>.<ns>
-	// - <svc_name>.<ns>.svc
-	// - <svc_name>.<ns>.svc.<cluster-domain>
-	name := all[0]
-	nameWithNs := fmt.Sprintf("%s.%s", name, all[1])
-	svcNameWithNs := fmt.Sprintf("%s.svc", nameWithNs)
-	fqdnSvcName := fmt.Sprintf("%s.%s", svcNameWithNs, clusterDomain)
-
-	return []string{name, nameWithNs, svcNameWithNs, fqdnSvcName}, nil
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -73,12 +73,14 @@ func GetServiceDNSNames(fqdnServiceName string, clusterDomain string) ([]string,
 	}
 
 	// We return:
+	// - <svc_name>
 	// - <svc_name>.<ns>
 	// - <svc_name>.<ns>.svc
 	// - <svc_name>.<ns>.svc.<cluster-domain>
-	nameWithNs := fmt.Sprintf("%s.%s", all[0], all[1])
+	name := all[0]
+	nameWithNs := fmt.Sprintf("%s.%s", name, all[1])
 	svcNameWithNs := fmt.Sprintf("%s.svc", nameWithNs)
 	fqdnSvcName := fmt.Sprintf("%s.%s", svcNameWithNs, clusterDomain)
 
-	return []string{nameWithNs, svcNameWithNs, fqdnSvcName}, nil
+	return []string{name, nameWithNs, svcNameWithNs, fqdnSvcName}, nil
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -26,25 +26,25 @@ const (
 	DefaultResolveConfPath = "/etc/resolv.conf"
 
 	// Default cluster domain value for k8s clusters.
-	DefaultLocalDNS = "svc.cluster.local"
+	DefaultClusterDomain = "cluster.local"
 )
 
-// GetLocalDNSName parses the path to resolv.conf to find the local DNS name.
-func GetLocalDNSName(resolvConfPath string) (string, error) {
-	var localDNSName string
+// GetClusterDomain parses the path to resolv.conf to find the cluster domain.
+func GetClusterDomain(resolvConfPath string) (string, error) {
+	var clusterDomain string
 	file, err := os.Open(resolvConfPath)
 	if err != nil {
 		return "", err
 	}
 	defer file.Close()
 
-	reg := regexp.MustCompile(`^search.*?\s(svc\.[^\s]*)`)
+	reg := regexp.MustCompile(`^search.*?\ssvc\.([^\s]*)`)
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		match := reg.FindStringSubmatch(scanner.Text())
 		if len(match) > 0 {
-			localDNSName = match[1]
+			clusterDomain = match[1]
 		}
 	}
 
@@ -52,9 +52,9 @@ func GetLocalDNSName(resolvConfPath string) (string, error) {
 		return "", err
 	}
 
-	if localDNSName == "" {
-		return "", fmt.Errorf("failed to find local DNS name in resolv.conf")
+	if clusterDomain == "" {
+		return "", fmt.Errorf("failed to find cluster domain in resolv.conf")
 	}
 
-	return localDNSName, nil
+	return clusterDomain, nil
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -60,7 +60,7 @@ func GetClusterDomain(resolvConfPath string) (string, error) {
 	return clusterDomain, nil
 }
 
-// GetServiceDNSNames parses the fully-qualified domain service name nd
+// GetServiceDNSNames parses the fully-qualified domain service name and
 // returns a list of its qualified service names.
 func GetServiceDNSNames(fqdnServiceName string, clusterDomain string) ([]string, error) {
 	all := strings.Split(fqdnServiceName, ".")

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -44,18 +44,13 @@ var _ = Describe("Common Tests", func() {
 		})
 	})
 
-	Context("Get qualified names for a service", func() {
-		DescribeTable("Should return the correct qualified names from the service's FQDN", func(fqdn, clusterDomain string, expectError bool, expectedPQDNs []string) {
-			pqdns, err := dns.GetServiceDNSNames(fqdn, clusterDomain)
-			if !expectError {
-				Expect(err).To(BeNil())
-			}
-			Expect(pqdns).To(ConsistOf(expectedPQDNs))
+	Context("Get all DNS names for a service", func() {
+		DescribeTable("Should return the correct services names", func(service, namespace, clusterDomain string, expectedDNSNames []string) {
+			names := dns.GetServiceDNSNames(service, namespace, clusterDomain)
+			Expect(names).To(ConsistOf(expectedDNSNames))
 		},
-			Entry("default", "a.b.svc.cluster.local", "cluster.local", false, []string{"a", "a.b", "a.b.svc", "a.b.svc.cluster.local"}),
-			Entry("default", "a.b.svc.somedomain", "somedomain", false, []string{"a", "a.b", "a.b.svc", "a.b.svc.somedomain"}),
-			Entry("default", "a.b.svc", "cluster.local", true, []string{}),
-			Entry("default", "a.b", "cluster.local", true, []string{}),
+			Entry("default", "a", "b", dns.DefaultClusterDomain, []string{"a", "a.b", "a.b.svc", "a.b.svc.cluster.local"}),
+			Entry("default", "a", "b", "somedomain", []string{"a", "a.b", "a.b.svc", "a.b.svc.somedomain"}),
 		)
 	})
 })

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/tigera/operator/pkg/dns"
@@ -41,5 +42,20 @@ var _ = Describe("Common Tests", func() {
 			_, err := dns.GetClusterDomain("does-not.exist")
 			Expect(err).To(HaveOccurred())
 		})
+	})
+
+	Context("Get qualified names for a service", func() {
+		DescribeTable("Should return the correct qualified names from the service's FQDN", func(fqdn, clusterDomain string, expectError bool, expectedPQDNs []string) {
+			pqdns, err := dns.GetServiceDNSNames(fqdn, clusterDomain)
+			if !expectError {
+				Expect(err).To(BeNil())
+			}
+			Expect(pqdns).To(ConsistOf(expectedPQDNs))
+		},
+			Entry("default", "a.b.svc.cluster.local", "cluster.local", false, []string{"a.b", "a.b.svc", "a.b.svc.cluster.local"}),
+			Entry("default", "a.b.svc.somedomain", "somedomain", false, []string{"a.b", "a.b.svc", "a.b.svc.somedomain"}),
+			Entry("default", "a.b.svc", "cluster.local", true, []string{}),
+			Entry("default", "a.b", "cluster.local", true, []string{}),
+		)
 	})
 })

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var _ = Describe("Common Tests", func() {
-	Context("DNS Resolution", func() {
+	Context("Get cluster domain", func() {
 
 		It("Should have the right value for the alternative resolv.conf", func() {
 			dir, err := os.Getwd()
@@ -32,13 +32,13 @@ var _ = Describe("Common Tests", func() {
 				panic(err)
 			}
 			resolvConfPath := dir + "/testdata/resolv.conf"
-			localDNS, err := dns.GetLocalDNSName(resolvConfPath)
-			Expect(localDNS).To(Equal("svc.othername.local"))
+			clusterDomain, err := dns.GetClusterDomain(resolvConfPath)
+			Expect(clusterDomain).To(Equal("othername.local"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Should throw an error for a nonexisting file", func() {
-			_, err := dns.GetLocalDNSName("does-not.exist")
+			_, err := dns.GetClusterDomain("does-not.exist")
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Common Tests", func() {
 			}
 			Expect(pqdns).To(ConsistOf(expectedPQDNs))
 		},
-			Entry("default", "a.b.svc.cluster.local", "cluster.local", false, []string{"a.b", "a.b.svc", "a.b.svc.cluster.local"}),
-			Entry("default", "a.b.svc.somedomain", "somedomain", false, []string{"a.b", "a.b.svc", "a.b.svc.somedomain"}),
+			Entry("default", "a.b.svc.cluster.local", "cluster.local", false, []string{"a", "a.b", "a.b.svc", "a.b.svc.cluster.local"}),
+			Entry("default", "a.b.svc.somedomain", "somedomain", false, []string{"a", "a.b", "a.b.svc", "a.b.svc.somedomain"}),
 			Entry("default", "a.b.svc", "cluster.local", true, []string{}),
 			Entry("default", "a.b", "cluster.local", true, []string{}),
 		)

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -42,11 +42,11 @@ const (
 	apiServiceName          = "tigera-api"
 )
 
-func APIServer(k8sServiceEndpoint k8sapi.ServiceEndpoint, installation *operator.InstallationSpec, managementCluster *operator.ManagementCluster, managementClusterConnection *operator.ManagementClusterConnection, aci *operator.AmazonCloudIntegration, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool, tunnelCASecret *corev1.Secret, localDNS string) (Component, error) {
+func APIServer(k8sServiceEndpoint k8sapi.ServiceEndpoint, installation *operator.InstallationSpec, managementCluster *operator.ManagementCluster, managementClusterConnection *operator.ManagementClusterConnection, aci *operator.AmazonCloudIntegration, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool, tunnelCASecret *corev1.Secret, clusterDomain string) (Component, error) {
 	tlsSecrets := []*corev1.Secret{}
 	tlsHashAnnotations := make(map[string]string)
 
-	apiServiceHostname := strings.Join([]string{apiServiceName, APIServerNamespace, localDNS}, ".")
+	apiServiceHostname := strings.Join([]string{apiServiceName, APIServerNamespace, "svc", clusterDomain}, ".")
 
 	if tlsKeyPair == nil {
 		var err error

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -45,11 +45,7 @@ const (
 func APIServer(k8sServiceEndpoint k8sapi.ServiceEndpoint, installation *operator.InstallationSpec, managementCluster *operator.ManagementCluster, managementClusterConnection *operator.ManagementClusterConnection, aci *operator.AmazonCloudIntegration, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool, tunnelCASecret *corev1.Secret, clusterDomain string) (Component, error) {
 	tlsSecrets := []*corev1.Secret{}
 	tlsHashAnnotations := make(map[string]string)
-
-	svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf("%s.%s.svc.%s", apiServiceName, APIServerNamespace, clusterDomain), clusterDomain)
-	if err != nil {
-		return nil, err
-	}
+	svcDNSNames := dns.GetServiceDNSNames(apiServiceName, APIServerNamespace, clusterDomain)
 
 	if tlsKeyPair == nil {
 		var err error

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -16,7 +16,6 @@ package render
 
 import (
 	"fmt"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
+	"github.com/tigera/operator/pkg/dns"
 )
 
 const (
@@ -46,7 +46,10 @@ func APIServer(k8sServiceEndpoint k8sapi.ServiceEndpoint, installation *operator
 	tlsSecrets := []*corev1.Secret{}
 	tlsHashAnnotations := make(map[string]string)
 
-	apiServiceHostname := strings.Join([]string{apiServiceName, APIServerNamespace, "svc", clusterDomain}, ".")
+	svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf("%s.%s.svc.%s", apiServiceName, APIServerNamespace, clusterDomain), clusterDomain)
+	if err != nil {
+		return nil, err
+	}
 
 	if tlsKeyPair == nil {
 		var err error
@@ -56,7 +59,7 @@ func APIServer(k8sServiceEndpoint k8sapi.ServiceEndpoint, installation *operator
 			APIServerSecretCertName,
 			DefaultCertificateDuration,
 			nil,
-			apiServiceHostname,
+			svcDNSNames...,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -660,6 +660,7 @@ func verifyCertSANs(certBytes []byte, clusterDomain string) {
 	cert, err := x509.ParseCertificate(pemBlock.Bytes)
 	Expect(err).To(BeNil(), "Error parsing bytes from secret into certificate")
 	expectedDNSNames := []string{
+		"tigera-api",
 		"tigera-api.tigera-system",
 		"tigera-api.tigera-system.svc",
 		"tigera-api.tigera-system.svc." + clusterDomain,

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -659,7 +659,11 @@ func verifyCertSANs(certBytes []byte, clusterDomain string) {
 	pemBlock, _ := pem.Decode(certBytes)
 	cert, err := x509.ParseCertificate(pemBlock.Bytes)
 	Expect(err).To(BeNil(), "Error parsing bytes from secret into certificate")
-	expectedDNSNames := []string{fmt.Sprintf("tigera-api.tigera-system.svc.%s", clusterDomain)}
+	expectedDNSNames := []string{
+		"tigera-api.tigera-system",
+		"tigera-api.tigera-system.svc",
+		"tigera-api.tigera-system.svc." + clusterDomain,
+	}
 	Expect(cert.DNSNames).To(ConsistOf(expectedDNSNames), "Expect cert SAN's to match extension API server service DNS names")
 }
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -52,7 +52,7 @@ var _ = Describe("API server rendering tests", func() {
 		k8sServiceEp = k8sapi.ServiceEndpoint{}
 	})
 
-	DescribeTable("should render an API server with default configuration", func(localDNS string) {
+	DescribeTable("should render an API server with default configuration", func(clusterDomain string) {
 		expectedResources := []struct {
 			name    string
 			ns      string
@@ -85,7 +85,7 @@ var _ = Describe("API server rendering tests", func() {
 		}
 
 		// APIServer(registry string, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool
-		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, localDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, clusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 
 		resources, _ := component.Objects()
@@ -121,15 +121,15 @@ var _ = Describe("API server rendering tests", func() {
 
 		operatorCert, ok := GetResource(resources, "tigera-apiserver-certs", "tigera-operator", "", "v1", "Secret").(*corev1.Secret)
 		Expect(ok).To(BeTrue(), "Expected v1.Secret")
-		verifyCert(operatorCert, localDNS)
+		verifyCert(operatorCert, clusterDomain)
 
 		tigeraCert, ok := GetResource(resources, "tigera-apiserver-certs", "tigera-system", "", "v1", "Secret").(*corev1.Secret)
 		Expect(ok).To(BeTrue(), "Expected v1.Secret")
-		verifyCert(tigeraCert, localDNS)
+		verifyCert(tigeraCert, clusterDomain)
 
 		apiService, ok := GetResource(resources, "v3.projectcalico.org", "", "apiregistration.k8s.io", "v1beta1", "APIService").(*v1beta1.APIService)
 		Expect(ok).To(BeTrue(), "Expected v1beta1.APIService")
-		verifyAPIService(apiService, localDNS)
+		verifyAPIService(apiService, clusterDomain)
 
 		d := GetResource(resources, "tigera-apiserver", "tigera-system", "", "v1", "Deployment").(*v1.Deployment)
 
@@ -229,8 +229,8 @@ var _ = Describe("API server rendering tests", func() {
 		clusterRole = GetResource(resources, "tigera-ui-user", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(clusterRole.Rules).To(ConsistOf(uiUserPolicyRules))
 	},
-		Entry("default local DNS", dns.DefaultLocalDNS),
-		Entry("custom local DNS", ".svc.custom-domain.internal"),
+		Entry("default cluster domain", dns.DefaultClusterDomain),
+		Entry("custom cluster domain", "custom-domain.internal"),
 	)
 
 	It("should render an API server with custom configuration", func() {
@@ -265,7 +265,7 @@ var _ = Describe("API server rendering tests", func() {
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 		}
 
-		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -312,7 +312,7 @@ var _ = Describe("API server rendering tests", func() {
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 		}
 
-		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -367,7 +367,7 @@ var _ = Describe("API server rendering tests", func() {
 		}
 
 		instance.ControlPlaneNodeSelector = map[string]string{"nodeName": "control01"}
-		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -409,7 +409,7 @@ var _ = Describe("API server rendering tests", func() {
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 		}
 
-		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -442,7 +442,7 @@ var _ = Describe("API server rendering tests", func() {
 				PodSecurityGroupID:   "sg-podsgid",
 			},
 		}
-		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, aci, nil, nil, openshift, nil, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, aci, nil, nil, openshift, nil, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -468,7 +468,7 @@ var _ = Describe("API server rendering tests", func() {
 		k8sServiceEp.Host = "k8shost"
 		k8sServiceEp.Port = "1234"
 
-		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
@@ -480,7 +480,7 @@ var _ = Describe("API server rendering tests", func() {
 	})
 
 	It("should render an API server with custom configuration with MCM enabled at startup", func() {
-		component, err := render.APIServer(k8sServiceEp, instance, managementCluster, nil, nil, nil, nil, openshift, nil, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, managementCluster, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 
 		resources, _ := component.Objects()
@@ -562,7 +562,7 @@ var _ = Describe("API server rendering tests", func() {
 	})
 
 	It("should render an API server with custom configuration with MCM enabled at restart", func() {
-		component, err := render.APIServer(k8sServiceEp, instance, managementCluster, nil, nil, nil, nil, openshift, &voltronTunnelSecret, dns.DefaultLocalDNS)
+		component, err := render.APIServer(k8sServiceEp, instance, managementCluster, nil, nil, nil, nil, openshift, &voltronTunnelSecret, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 
 		resources, _ := component.Objects()
@@ -636,7 +636,7 @@ var _ = Describe("API server rendering tests", func() {
 	})
 })
 
-func verifyAPIService(service *v1beta1.APIService, localDNS string) {
+func verifyAPIService(service *v1beta1.APIService, clusterDomain string) {
 	Expect(service.Name).To(Equal("v3.projectcalico.org"))
 	Expect(service.Spec.Group).To(Equal("projectcalico.org"))
 	Expect(service.Spec.Version).To(Equal("v3"))
@@ -645,21 +645,22 @@ func verifyAPIService(service *v1beta1.APIService, localDNS string) {
 	Expect(service.Spec.InsecureSkipTLSVerify).To(BeFalse())
 
 	ca := service.Spec.CABundle
-	verifyCertSANs(ca, localDNS)
+	verifyCertSANs(ca, clusterDomain)
 }
 
-func verifyCert(secret *corev1.Secret, localDNS string) {
+func verifyCert(secret *corev1.Secret, clusterDomain string) {
 	Expect(secret.Data).To(HaveKey("apiserver.crt"))
 	Expect(secret.Data).To(HaveKey("apiserver.key"))
 
-	verifyCertSANs(secret.Data["apiserver.crt"], localDNS)
+	verifyCertSANs(secret.Data["apiserver.crt"], clusterDomain)
 }
 
-func verifyCertSANs(certBytes []byte, localDNS string) {
+func verifyCertSANs(certBytes []byte, clusterDomain string) {
 	pemBlock, _ := pem.Decode(certBytes)
 	cert, err := x509.ParseCertificate(pemBlock.Bytes)
 	Expect(err).To(BeNil(), "Error parsing bytes from secret into certificate")
-	Expect(cert.DNSNames).To(ConsistOf([]string{"tigera-api.tigera-system." + localDNS}), "Expect cert SAN's to match extension API server service DNS name")
+	expectedDNSNames := []string{fmt.Sprintf("tigera-api.tigera-system.svc.%s", clusterDomain)}
+	Expect(cert.DNSNames).To(ConsistOf(expectedDNSNames), "Expect cert SAN's to match extension API server service DNS names")
 }
 
 func validateTunnelSecret(voltronSecret *corev1.Secret) {

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -21,6 +21,7 @@ import (
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/dns"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -68,12 +69,17 @@ func Compliance(
 	var complianceServerCertSecrets []*corev1.Secret
 	if complianceServerCertSecret == nil {
 		var err error
+		svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf("compliance.tigera-compliance.svc.%s", clusterDomain), clusterDomain)
+		if err != nil {
+			return nil, err
+		}
+
 		complianceServerCertSecret, err = CreateOperatorTLSSecret(nil,
 			ComplianceServerCertSecret,
 			"tls.key",
 			"tls.crt",
 			DefaultCertificateDuration,
-			nil, fmt.Sprintf("compliance.tigera-compliance.svc.%s", clusterDomain),
+			nil, svcDNSNames...,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -63,7 +63,7 @@ func Compliance(
 	managementCluster *operatorv1.ManagementCluster,
 	managementClusterConnection *operatorv1.ManagementClusterConnection,
 	dexCfg DexKeyValidatorConfig,
-	localDNS string,
+	clusterDomain string,
 ) (Component, error) {
 	var complianceServerCertSecrets []*corev1.Secret
 	if complianceServerCertSecret == nil {
@@ -73,7 +73,7 @@ func Compliance(
 			"tls.key",
 			"tls.crt",
 			DefaultCertificateDuration,
-			nil, fmt.Sprintf("compliance.tigera-compliance.%s", localDNS),
+			nil, fmt.Sprintf("compliance.tigera-compliance.svc.%s", clusterDomain),
 		)
 		if err != nil {
 			return nil, err
@@ -91,7 +91,7 @@ func Compliance(
 		pullSecrets:                 pullSecrets,
 		complianceServerCertSecrets: complianceServerCertSecrets,
 		openshift:                   openshift,
-		localDNS:                    localDNS,
+		clusterDomain:               clusterDomain,
 		managementCluster:           managementCluster,
 		managementClusterConnection: managementClusterConnection,
 		dexCfg:                      dexCfg,
@@ -106,7 +106,7 @@ type complianceComponent struct {
 	pullSecrets                 []*corev1.Secret
 	complianceServerCertSecrets []*corev1.Secret
 	openshift                   bool
-	localDNS                    string
+	clusterDomain               string
 	managementCluster           *operatorv1.ManagementCluster
 	managementClusterConnection *operatorv1.ManagementClusterConnection
 	dexCfg                      DexKeyValidatorConfig
@@ -371,7 +371,7 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 					Image:         components.GetReference(components.ComponentComplianceController, c.installation.Registry, c.installation.ImagePath),
 					Env:           envVars,
 					LivenessProbe: complianceLivenessProbe,
-				}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceControllerUserSecret, c.localDNS),
+				}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceControllerUserSecret, c.clusterDomain),
 			},
 		}),
 	}, c.esClusterConfig, c.esSecrets).(*corev1.PodTemplateSpec)
@@ -504,7 +504,7 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 							VolumeMounts: []corev1.VolumeMount{
 								{MountPath: "/var/log/calico", Name: "var-log-calico"},
 							},
-						}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceReporterUserSecret, c.localDNS), c.esClusterConfig.Replicas(), c.esClusterConfig.Shards(),
+						}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceReporterUserSecret, c.clusterDomain), c.esClusterConfig.Replicas(), c.esClusterConfig.Shards(),
 					),
 				},
 				Volumes: []corev1.Volume{
@@ -692,7 +692,7 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 						FailureThreshold:    5,
 					},
 					VolumeMounts: c.complianceVolumeMounts(),
-				}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceServerUserSecret, c.localDNS),
+				}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceServerUserSecret, c.clusterDomain),
 			},
 			Volumes: c.complianceVolumes(),
 		}),
@@ -899,7 +899,7 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 						Image:         components.GetReference(components.ComponentComplianceSnapshotter, c.installation.Registry, c.installation.ImagePath),
 						Env:           envVars,
 						LivenessProbe: complianceLivenessProbe,
-					}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceSnapshotterUserSecret, c.localDNS), c.esClusterConfig.Replicas(), c.esClusterConfig.Shards(),
+					}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceSnapshotterUserSecret, c.clusterDomain), c.esClusterConfig.Replicas(), c.esClusterConfig.Shards(),
 				),
 			},
 		}),
@@ -1057,7 +1057,7 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 						Env:           envVars,
 						VolumeMounts:  volMounts,
 						LivenessProbe: complianceLivenessProbe,
-					}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceBenchmarkerUserSecret, c.localDNS), c.esClusterConfig.Replicas(), c.esClusterConfig.Shards(),
+					}, c.esClusterConfig.ClusterName(), ElasticsearchComplianceBenchmarkerUserSecret, c.clusterDomain), c.esClusterConfig.Replicas(), c.esClusterConfig.Shards(),
 				),
 			},
 			Volumes: vols,

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	ComplianceNamespace       = "tigera-compliance"
+	ComplianceServiceName     = "compliance"
 	ComplianceServerName      = "compliance-server"
 	ComplianceControllerName  = "compliance-controller"
 	ComplianceSnapshotterName = "compliance-snapshotter"
@@ -69,11 +70,7 @@ func Compliance(
 	var complianceServerCertSecrets []*corev1.Secret
 	if complianceServerCertSecret == nil {
 		var err error
-		svcDNSNames, err := dns.GetServiceDNSNames(fmt.Sprintf("compliance.tigera-compliance.svc.%s", clusterDomain), clusterDomain)
-		if err != nil {
-			return nil, err
-		}
-
+		svcDNSNames := dns.GetServiceDNSNames(ComplianceServiceName, ComplianceNamespace, clusterDomain)
 		complianceServerCertSecret, err = CreateOperatorTLSSecret(nil,
 			ComplianceServerCertSecret,
 			"tls.key",

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -31,7 +31,7 @@ var _ = Describe("compliance rendering tests", func() {
 			component, err := render.Compliance(nil, nil, &operatorv1.InstallationSpec{
 				KubernetesProvider: operatorv1.ProviderNone,
 				Registry:           "testregistry.com/",
-			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift, nil, nil, nil, dns.DefaultLocalDNS)
+			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift, nil, nil, nil, dns.DefaultClusterDomain)
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
 
@@ -132,7 +132,7 @@ var _ = Describe("compliance rendering tests", func() {
 				&operatorv1.InstallationSpec{
 					KubernetesProvider: operatorv1.ProviderNone,
 					Registry:           "testregistry.com/",
-				}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift, &operatorv1.ManagementCluster{}, nil, nil, dns.DefaultLocalDNS)
+				}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift, &operatorv1.ManagementCluster{}, nil, nil, dns.DefaultClusterDomain)
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
 
@@ -245,7 +245,7 @@ var _ = Describe("compliance rendering tests", func() {
 			component, err := render.Compliance(nil, nil, &operatorv1.InstallationSpec{
 				KubernetesProvider: operatorv1.ProviderNone,
 				Registry:           "testregistry.com/",
-			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift, nil, &operatorv1.ManagementClusterConnection{}, nil, dns.DefaultLocalDNS)
+			}, nil, render.NewElasticsearchClusterConfig("cluster", 1, 1, 1), nil, notOpenshift, nil, &operatorv1.ManagementClusterConnection{}, nil, dns.DefaultClusterDomain)
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
 

--- a/pkg/render/dex_config_test.go
+++ b/pkg/render/dex_config_test.go
@@ -72,7 +72,7 @@ var _ = Describe("dex config tests", func() {
 
 	Context("OIDC connector config options", func() {
 		It("should configure insecureSkipEmailVerified ", func() {
-			connector := render.NewDexConfig(authentication, tlsSecret, dexSecret, idpSecret, dns.DefaultLocalDNS).Connector()
+			connector := render.NewDexConfig(authentication, tlsSecret, dexSecret, idpSecret, dns.DefaultClusterDomain).Connector()
 			cfg := connector["config"].(map[string]interface{})
 			Expect(cfg["insecureSkipEmailVerified"]).To(Equal(true))
 		})
@@ -80,9 +80,9 @@ var _ = Describe("dex config tests", func() {
 
 	Context("Hashes should be consistent and not be affected by fields with pointers", func() {
 		It("should produce consistent hashes for dex config", func() {
-			hashes1 := render.NewDexConfig(authentication, tlsSecret, dexSecret, idpSecret, dns.DefaultLocalDNS).RequiredAnnotations()
-			hashes2 := render.NewDexConfig(authentication.DeepCopy(), tlsSecret, dexSecret, idpSecret, dns.DefaultLocalDNS).RequiredAnnotations()
-			hashes3 := render.NewDexConfig(authenticationDiff, tlsSecret, dexSecret, idpSecret, dns.DefaultLocalDNS).RequiredAnnotations()
+			hashes1 := render.NewDexConfig(authentication, tlsSecret, dexSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes2 := render.NewDexConfig(authentication.DeepCopy(), tlsSecret, dexSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes3 := render.NewDexConfig(authenticationDiff, tlsSecret, dexSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
 			Expect(hashes1).To(HaveLen(4))
 			Expect(hashes2).To(HaveLen(4))
 			Expect(hashes3).To(HaveLen(4))
@@ -91,9 +91,9 @@ var _ = Describe("dex config tests", func() {
 		})
 
 		It("should produce consistent hashes for rp's", func() {
-			hashes1 := render.NewDexRelyingPartyConfig(authentication, tlsSecret, idpSecret, dns.DefaultLocalDNS).RequiredAnnotations()
-			hashes2 := render.NewDexRelyingPartyConfig(authentication.DeepCopy(), tlsSecret, idpSecret, dns.DefaultLocalDNS).RequiredAnnotations()
-			hashes3 := render.NewDexRelyingPartyConfig(authenticationDiff, tlsSecret, idpSecret, dns.DefaultLocalDNS).RequiredAnnotations()
+			hashes1 := render.NewDexRelyingPartyConfig(authentication, tlsSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes2 := render.NewDexRelyingPartyConfig(authentication.DeepCopy(), tlsSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes3 := render.NewDexRelyingPartyConfig(authenticationDiff, tlsSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
 			Expect(hashes1).To(HaveLen(3))
 			Expect(hashes2).To(HaveLen(3))
 			Expect(hashes3).To(HaveLen(3))
@@ -102,9 +102,9 @@ var _ = Describe("dex config tests", func() {
 		})
 
 		It("should produce consistent hashes for verifiers", func() {
-			hashes1 := render.NewDexKeyValidatorConfig(authentication, tlsSecret, dns.DefaultLocalDNS).RequiredAnnotations()
-			hashes2 := render.NewDexKeyValidatorConfig(authentication.DeepCopy(), tlsSecret, dns.DefaultLocalDNS).RequiredAnnotations()
-			hashes3 := render.NewDexKeyValidatorConfig(authenticationDiff, tlsSecret, dns.DefaultLocalDNS).RequiredAnnotations()
+			hashes1 := render.NewDexKeyValidatorConfig(authentication, tlsSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes2 := render.NewDexKeyValidatorConfig(authentication.DeepCopy(), tlsSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes3 := render.NewDexKeyValidatorConfig(authenticationDiff, tlsSecret, dns.DefaultClusterDomain).RequiredAnnotations()
 			Expect(hashes1).To(HaveLen(2))
 			Expect(hashes2).To(HaveLen(2))
 			Expect(hashes3).To(HaveLen(2))

--- a/pkg/render/elasticsearch_decorator.go
+++ b/pkg/render/elasticsearch_decorator.go
@@ -47,8 +47,8 @@ func ElasticsearchDecorateAnnotations(obj Annotatable, config *ElasticsearchClus
 	return obj
 }
 
-func ElasticsearchContainerDecorate(c corev1.Container, cluster, secret, localDNS string) corev1.Container {
-	return ElasticsearchContainerDecorateVolumeMounts(ElasticsearchContainerDecorateENVVars(c, cluster, secret, localDNS))
+func ElasticsearchContainerDecorate(c corev1.Container, cluster, secret, clusterDomain string) corev1.Container {
+	return ElasticsearchContainerDecorateVolumeMounts(ElasticsearchContainerDecorateENVVars(c, cluster, secret, clusterDomain))
 }
 
 func ElasticsearchContainerDecorateIndexCreator(c corev1.Container, replicas, shards int) corev1.Container {
@@ -61,8 +61,8 @@ func ElasticsearchContainerDecorateIndexCreator(c corev1.Container, replicas, sh
 	return c
 }
 
-func ElasticsearchContainerDecorateENVVars(c corev1.Container, cluster, esUserSecretName, localDNS string) corev1.Container {
-	esScheme, esHost, esPort, _ := ParseEndpoint(fmt.Sprintf(ElasticsearchHTTPSEndpoint, localDNS))
+func ElasticsearchContainerDecorateENVVars(c corev1.Container, cluster, esUserSecretName, clusterDomain string) corev1.Container {
+	esScheme, esHost, esPort, _ := ParseEndpoint(fmt.Sprintf(ElasticsearchHTTPSEndpoint, clusterDomain))
 	envVars := []corev1.EnvVar{
 		{Name: "ELASTIC_INDEX_SUFFIX", Value: cluster},
 		{Name: "ELASTIC_SCHEME", Value: esScheme},

--- a/pkg/render/elasticsearch_decorator_test.go
+++ b/pkg/render/elasticsearch_decorator_test.go
@@ -53,8 +53,8 @@ var _ = Describe("Elasticsearch decorator tests", func() {
 				Expect(c.Env).To(ContainElement(expected))
 			}
 		},
-			Entry("default cluster DNS", "svc.cluster.local", "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"),
-			Entry("custom cluster DNS", "svc.acme.internal", "tigera-secure-es-http.tigera-elasticsearch.svc.acme.internal"),
+			Entry("default cluster domain", "cluster.local", "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"),
+			Entry("custom cluster domain", "acme.internal", "tigera-secure-es-http.tigera-elasticsearch.svc.acme.internal"),
 		)
 	})
 })

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -85,7 +85,7 @@ func Fluentd(
 	eksConfig *EksCloudwatchLogConfig,
 	pullSecrets []*corev1.Secret,
 	installation *operatorv1.InstallationSpec,
-	localDNS string,
+	clusterDomain string,
 ) Component {
 	return &fluentdComponent{
 		lc:              lc,
@@ -97,7 +97,7 @@ func Fluentd(
 		eksConfig:       eksConfig,
 		pullSecrets:     pullSecrets,
 		installation:    installation,
-		localDNS:        localDNS,
+		clusterDomain:   clusterDomain,
 	}
 }
 
@@ -120,7 +120,7 @@ type fluentdComponent struct {
 	eksConfig       *EksCloudwatchLogConfig
 	pullSecrets     []*corev1.Secret
 	installation    *operatorv1.InstallationSpec
-	localDNS        string
+	clusterDomain   string
 }
 
 func (c *fluentdComponent) SupportedOSType() OSType {
@@ -362,7 +362,7 @@ func (c *fluentdComponent) container() corev1.Container {
 		VolumeMounts:    volumeMounts,
 		LivenessProbe:   c.liveness(),
 		ReadinessProbe:  c.readiness(),
-	}, c.esClusterConfig.ClusterName(), ElasticsearchLogCollectorUserSecret, c.localDNS)
+	}, c.esClusterConfig.ClusterName(), ElasticsearchLogCollectorUserSecret, c.clusterDomain)
 }
 
 func (c *fluentdComponent) envvars() []corev1.EnvVar {
@@ -717,13 +717,13 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 						Command:      []string{"/bin/eks-log-forwarder-startup"},
 						Env:          envVars,
 						VolumeMounts: c.eksLogForwarderVolumeMounts(),
-					}, c.esClusterConfig.ClusterName(), ElasticsearchEksLogForwarderUserSecret, c.localDNS)},
+					}, c.esClusterConfig.ClusterName(), ElasticsearchEksLogForwarderUserSecret, c.clusterDomain)},
 					Containers: []corev1.Container{ElasticsearchContainerDecorateENVVars(corev1.Container{
 						Name:         eksLogForwarderName,
 						Image:        components.GetReference(components.ComponentFluentd, c.installation.Registry, c.installation.ImagePath),
 						Env:          envVars,
 						VolumeMounts: c.eksLogForwarderVolumeMounts(),
-					}, c.esClusterConfig.ClusterName(), ElasticsearchEksLogForwarderUserSecret, c.localDNS)},
+					}, c.esClusterConfig.ClusterName(), ElasticsearchEksLogForwarderUserSecret, c.clusterDomain)},
 					Volumes: c.eksLogForwarderVolumes(),
 				},
 			},

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		esConfigMap = render.NewElasticsearchClusterConfig("clusterTestName", 1, 1, 1)
 	})
 
-	DescribeTable("should render with a default configuration", func(localDNS, expectedElasticHost string) {
+	DescribeTable("should render with a default configuration", func(clusterDomain, expectedElasticHost string) {
 		expectedResources := []struct {
 			name    string
 			ns      string
@@ -67,7 +67,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		// Should render the correct resources.
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, localDNS)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, clusterDomain)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -98,8 +98,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			Expect(envs).To(ContainElement(expected))
 		}
 	},
-		Entry("default cluster DNS", dns.DefaultLocalDNS, "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"),
-		Entry("custom cluster DNS", "svc.acme.internal", "tigera-secure-es-http.tigera-elasticsearch.svc.acme.internal"),
+		Entry("default cluster DNS", dns.DefaultClusterDomain, "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"),
+		Entry("custom cluster DNS", "acme.internal", "tigera-secure-es-http.tigera-elasticsearch.svc.acme.internal"),
 	)
 
 	It("should render with S3 configuration", func() {
@@ -132,7 +132,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		// Should render the correct resources.
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultLocalDNS)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -205,7 +205,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 				},
 			},
 		}
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultLocalDNS)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -288,7 +288,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		// Should render the correct resources.
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultLocalDNS)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -369,7 +369,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		// Should render the correct resources.
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultLocalDNS)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -438,7 +438,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		// Should render the correct resources.
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultLocalDNS)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -490,7 +490,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		installation = &operatorv1.InstallationSpec{
 			KubernetesProvider: operatorv1.ProviderEKS,
 		}
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultLocalDNS)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +34,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			nil,
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
 			&operatorv1.InstallationSpec{Registry: "testregistry.com/"},
-			esConfigMap, nil, notOpenshift, "svc.cluster.local",
+			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain,
 		)
 		resources, _ := component.Objects()
 
@@ -98,7 +99,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			nil,
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
 			&operatorv1.InstallationSpec{Registry: "testregistry.com/"},
-			esConfigMap, nil, notOpenshift, "svc.cluster.local",
+			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain,
 		)
 		resources, _ := component.Objects()
 

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -343,7 +344,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: render.OperatorNamespace()}},
 						{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchPublicCertSecret, Namespace: render.OperatorNamespace()}},
 					},
-					nil, nil, "svc.cluster.local", true, nil)
+					nil, nil, dns.DefaultClusterDomain, true, nil)
 
 				createResources, deleteResources := component.Objects()
 
@@ -511,7 +512,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						RequestedScopes: []string{"scope"},
 					},
 				},
-			}, render.CreateDexTLSSecret("cn"), render.CreateDexClientSecret(), "svc.cluster.local")
+			}, render.CreateDexTLSSecret("cn"), render.CreateDexClientSecret(), "cluster.local")
 
 			component := render.LogStorage(
 				logStorage,
@@ -585,13 +586,13 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						svc := resource.(*corev1.Service)
 
 						Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
-						Expect(svc.Spec.ExternalName).Should(Equal(fmt.Sprintf("%s.%s.cluster.local", render.GuardianServiceName, render.GuardianNamespace)))
+						Expect(svc.Spec.ExternalName).Should(Equal(fmt.Sprintf("%s.%s.svc.%s", render.GuardianServiceName, render.GuardianNamespace, dns.DefaultClusterDomain)))
 					}},
 					{render.KibanaServiceName, render.KibanaNamespace, &corev1.Service{}, func(resource runtime.Object) {
 						svc := resource.(*corev1.Service)
 
 						Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
-						Expect(svc.Spec.ExternalName).Should(Equal(fmt.Sprintf("%s.%s.cluster.local", render.GuardianServiceName, render.GuardianNamespace)))
+						Expect(svc.Spec.ExternalName).Should(Equal(fmt.Sprintf("%s.%s.svc.%s", render.GuardianServiceName, render.GuardianNamespace, dns.DefaultClusterDomain)))
 					}},
 				}
 

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -16,6 +16,7 @@ package render_test
 
 import (
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/dns"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -345,7 +346,7 @@ func renderObjects(oidc bool, managementCluster *operator.ManagementCluster,
 				ManagerDomain: "https://127.0.0.1",
 				OIDC:          &operator.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
 
-		dexCfg = render.NewDexKeyValidatorConfig(authentication, render.CreateDexTLSSecret("cn"), "svc.cluster.local")
+		dexCfg = render.NewDexKeyValidatorConfig(authentication, render.CreateDexTLSSecret("cn"), dns.DefaultClusterDomain)
 	}
 
 	var tunnelSecret *corev1.Secret
@@ -376,7 +377,7 @@ func renderObjects(oidc bool, managementCluster *operator.ManagementCluster,
 		managementCluster,
 		tunnelSecret,
 		internalTraffic,
-		"svc.cluster.local")
+		dns.DefaultClusterDomain)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 	resources, _ := component.Objects()
 	return resources

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -80,7 +80,7 @@ func Calico(
 	aci *operator.AmazonCloudIntegration,
 	up bool,
 	nodeAppArmorProfile string,
-	localDNS string,
+	clusterDomain string,
 ) (Renderer, error) {
 	tcms := []*corev1.ConfigMap{}
 	tss := []*corev1.Secret{}
@@ -133,7 +133,7 @@ func Calico(
 			825*24*time.Hour, // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
 			nil,
 			ManagerServiceIP,
-			fmt.Sprintf(ManagerServiceDNS, localDNS),
+			fmt.Sprintf(ManagerServiceDNS, clusterDomain),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("generating certificates for manager was not finalized due to %v", err)

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
+	"github.com/tigera/operator/pkg/dns"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -87,7 +88,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 5 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment, PodSecurityPolicy)
 		// - 1 namespace
 		// - 1 PriorityClass
-		c, err := render.Calico(k8sServiceEp, instance, false, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, "", "svc.cluster.local")
+		c, err := render.Calico(k8sServiceEp, instance, false, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(6 + 4 + 2 + 7 + 5 + 1 + 1))
 	})
@@ -100,7 +101,7 @@ var _ = Describe("Rendering tests", func() {
 		var nodeMetricsPort int32 = 9081
 		instance.Variant = operator.TigeraSecureEnterprise
 		instance.NodeMetricsPort = &nodeMetricsPort
-		c, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, "", "svc.cluster.local")
+		c, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal((6 + 4 + 2 + 7 + 5 + 1 + 1) + 1 + 1))
 	})
@@ -113,7 +114,7 @@ var _ = Describe("Rendering tests", func() {
 		instance.Variant = operator.TigeraSecureEnterprise
 		instance.NodeMetricsPort = &nodeMetricsPort
 
-		c, err := render.Calico(k8sServiceEp, instance, true, &operator.ManagementCluster{}, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, "", "svc.cluster.local")
+		c, err := render.Calico(k8sServiceEp, instance, true, &operator.ManagementCluster{}, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 
 		expectedResources := []struct {
@@ -169,7 +170,7 @@ var _ = Describe("Rendering tests", func() {
 
 	It("should render calico with a apparmor profile if annotation is present in installation", func() {
 		apparmorProf := "foobar"
-		r, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, apparmorProf, "svc.cluster.local")
+		r, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, operator.ProviderNone, nil, false, apparmorProf, dns.DefaultClusterDomain)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		comps := r.Render()
 		var cn *appsv1.DaemonSet


### PR DESCRIPTION
## Description

This PR follows up on https://github.com/tigera/operator/pull/1029
Using only FQDN service names for cert SANs breaks things in a few places. Notably, kube-apiserver proxies to API services using the `.svc` name.

- Refactor dns.GetLocalDNSName to return the cluster domain instead of `svc.<cluster_domain>` 
- Update certs to contain the service's qualified names in its SANs

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
