### PR TITLE
Fix IPv6 pool natOutgoing not working

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -907,7 +907,7 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 				nodeEnv = append(nodeEnv, v1.EnvVar{Name: "CALICO_IPV4POOL_BLOCK_SIZE", Value: fmt.Sprintf("%d", *v4pool.BlockSize)})
 			}
 			if v4pool.NATOutgoing == operator.NATOutgoingDisabled {
-				// Default for NAT Outgoing is enabled so it is only necessary to
+				// Default for IPv4 NAT Outgoing is enabled so it is only necessary to
 				// set when it is being disabled.
 				nodeEnv = append(nodeEnv, v1.EnvVar{Name: "CALICO_IPV4POOL_NAT_OUTGOING", Value: "false"})
 			}
@@ -923,8 +923,10 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 			if v6pool.BlockSize != nil {
 				nodeEnv = append(nodeEnv, v1.EnvVar{Name: "CALICO_IPV6POOL_BLOCK_SIZE", Value: fmt.Sprintf("%d", *v6pool.BlockSize)})
 			}
-			if v6pool.NATOutgoing == operator.NATOutgoingDisabled {
-				nodeEnv = append(nodeEnv, v1.EnvVar{Name: "CALICO_IPV6POOL_NAT_OUTGOING", Value: "false"})
+			if v6pool.NATOutgoing == operator.NATOutgoingEnabled {
+				// Default for IPv6 NAT Outgoing is disabled so it is only necessary to
+				// set when it is being enabled.
+				nodeEnv = append(nodeEnv, v1.EnvVar{Name: "CALICO_IPV6POOL_NAT_OUTGOING", Value: "true"})
 			}
 			if v6pool.NodeSelector != "" {
 				nodeEnv = append(nodeEnv, v1.EnvVar{Name: "CALICO_IPV6POOL_NODE_SELECTOR", Value: v6pool.NodeSelector})

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1756,6 +1756,25 @@ var _ = Describe("Node rendering tests", func() {
 				// Enabled is the default so we don't set
 				// NAT_OUTGOING if it is enabled.
 			}),
+		Entry("Pool with nat outgoing disabled (IPv6)",
+			operator.IPPool{
+				CIDR:        "fc00::/48",
+				NATOutgoing: "Disabled",
+			},
+			map[string]string{
+				"CALICO_IPV6POOL_CIDR": "fc00::/48",
+				// Disabled is the default so we don't set
+				// NAT_OUTGOING if it is disabled.
+			}),
+		Entry("Pool with nat outgoing enabled (IPv6)",
+			operator.IPPool{
+				CIDR:        "fc00::/48",
+				NATOutgoing: "Enabled",
+			},
+			map[string]string{
+				"CALICO_IPV6POOL_CIDR":         "fc00::/48",
+				"CALICO_IPV6POOL_NAT_OUTGOING": "true",
+			}),
 		Entry("Pool with CrossSubnet",
 			operator.IPPool{
 				CIDR:          "172.16.0.0/24",


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

By default, the NAT Outgoing setting for the IPv6 Pool created at startup is `false` (see [the manual](https://docs.projectcalico.org/archive/v3.17/reference/node/configuration#configuring-the-default-ip-pools)).

However, the operator only sets `CALICO_IPV6POOL_NAT_OUTGOING` to `false` when `NATOutgoing` in an IPv6 pool is disabled. Thus `CALICO_IPV6POOL_NAT_OUTGOING` is either absent or `false`, causing NAT for IPv6 pools never to be enabled.

This PR fixes this bug.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
