### PR TITLE
Nodeselectors tolerations

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -79,10 +79,15 @@ type InstallationSpec struct {
 	// +optional
 	TyphaAffinity *TyphaAffinity `json:"typhaAffinity,omitempty"`
 
-	// ControlPlaneNodeSelector is used to select control plane nodes on which to run specific Calico
-	// components. This currently only applies to kube-controllers and the apiserver.
+	// ControlPlaneNodeSelector is used to select control plane nodes on which to run Calico
+	// components. This is globally applied to all resources created by the operator excluding daemonsets.
 	// +optional
 	ControlPlaneNodeSelector map[string]string `json:"controlPlaneNodeSelector,omitempty"`
+
+	// ControlPlaneTolerations specify tolerations which are then globally applied to all resources
+	// created by the operator.
+	// +optional
+	ControlPlaneTolerations []v1.Toleration `json:"controlPlaneTolerations,omitempty"`
 
 	// NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not enabled.
 	// If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -762,6 +762,13 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ControlPlaneTolerations != nil {
+		in, out := &in.ControlPlaneTolerations, &out.ControlPlaneTolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.NodeMetricsPort != nil {
 		in, out := &in.NodeMetricsPort, &out.NodeMetricsPort
 		*out = new(int32)

--- a/config/crd/bases/operator.tigera.io_installations.yaml
+++ b/config/crd/bases/operator.tigera.io_installations.yaml
@@ -285,9 +285,50 @@ spec:
                 additionalProperties:
                   type: string
                 description: ControlPlaneNodeSelector is used to select control plane
-                  nodes on which to run specific Calico components. This currently
-                  only applies to kube-controllers and the apiserver.
+                  nodes on which to run Calico components. This is globally applied
+                  to all resources created by the operator excluding daemonsets.
                 type: object
+              controlPlaneTolerations:
+                description: ControlPlaneTolerations specify tolerations which are
+                  then globally applied to all resources created by the operator.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               flexVolumePath:
                 description: FlexVolumePath optionally specifies a custom path for
                   FlexVolume. If not specified, FlexVolume will be enabled by default.
@@ -751,9 +792,51 @@ spec:
                     additionalProperties:
                       type: string
                     description: ControlPlaneNodeSelector is used to select control
-                      plane nodes on which to run specific Calico components. This
-                      currently only applies to kube-controllers and the apiserver.
+                      plane nodes on which to run Calico components. This is globally
+                      applied to all resources created by the operator excluding daemonsets.
                     type: object
+                  controlPlaneTolerations:
+                    description: ControlPlaneTolerations specify tolerations which
+                      are then globally applied to all resources created by the operator.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   flexVolumePath:
                     description: FlexVolumePath optionally specifies a custom path
                       for FlexVolume. If not specified, FlexVolume will be enabled

--- a/pkg/controller/installation/merge.go
+++ b/pkg/controller/installation/merge.go
@@ -82,6 +82,12 @@ func overrideInstallationSpec(cfg, override operatorv1.InstallationSpec) operato
 		}
 	}
 
+	switch compareFields(inst.ControlPlaneTolerations, override.ControlPlaneTolerations) {
+	case BOnlySet, Different:
+		inst.ControlPlaneTolerations = make([]v1.Toleration, len(override.ControlPlaneTolerations))
+		copy(inst.ControlPlaneTolerations, override.ControlPlaneTolerations)
+	}
+
 	switch compareFields(inst.NodeMetricsPort, override.NodeMetricsPort) {
 	case BOnlySet, Different:
 		inst.NodeMetricsPort = override.NodeMetricsPort

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -236,8 +236,9 @@ func (c *amazonCloudIntegrationComponent) deployment() *appsv1.Deployment {
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
+					NodeSelector:       c.installation.ControlPlaneNodeSelector,
 					ServiceAccountName: AmazonCloudIntegrationComponentName,
-					Tolerations:        c.tolerations(),
+					Tolerations:        tolerateAll,
 					ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 					Containers: []corev1.Container{
 						c.container(),
@@ -307,17 +308,6 @@ func (c *amazonCloudIntegrationComponent) container() corev1.Container {
 			FailureThreshold:    3,
 		},
 	}
-}
-
-// tolerations creates the tolerations used by the API server deployment.
-func (c *amazonCloudIntegrationComponent) tolerations() []corev1.Toleration {
-	tolerations := []corev1.Toleration{
-		{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-		{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-		{Operator: corev1.TolerationOpExists, Key: "CriticalAddonsOnly"},
-	}
-
-	return tolerations
 }
 
 func GetTigeraSecurityGroupEnvVariables(aci *operator.AmazonCloudIntegration) []corev1.EnvVar {

--- a/pkg/render/amazoncloudintegration_test.go
+++ b/pkg/render/amazoncloudintegration_test.go
@@ -59,6 +59,17 @@ var _ = Describe("AmazonCloudIntegration rendering tests", func() {
 		installation = &operator.InstallationSpec{}
 	})
 
+	It("should render controlPlaneNodeSelector", func() {
+		component, err := render.AmazonCloudIntegration(instance, &operator.InstallationSpec{
+			ControlPlaneNodeSelector: map[string]string{"foo": "bar"},
+		}, credential, nil, false)
+		Expect(err).ToNot(HaveOccurred())
+		resources, _ := component.Objects()
+		resource := GetResource(resources, AwsCIName, AwsCINs, "", "v1", "Deployment")
+		d := resource.(*v1.Deployment)
+		Expect(d.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+	})
+
 	It("should render an AmazonCloudConfiguration with specified configuration", func() {
 		// AmazonCloudIntegration(aci *operatorv1.AmazonCloudIntegration, installation *operator.Installation, cred *AmazonCredential, ps []*corev1.Secret, openshift bool) (Component, error) {
 		component, err := render.AmazonCloudIntegration(instance, installation, credential, nil, openshift)
@@ -115,12 +126,7 @@ var _ = Describe("AmazonCloudIntegration rendering tests", func() {
 
 		Expect(d.Spec.Template.Spec.ServiceAccountName).To(Equal(AwsCIName))
 
-		expectedTolerations := []corev1.Toleration{
-			{Operator: "Exists", Effect: "NoSchedule"},
-			{Operator: "Exists", Effect: "NoExecute"},
-			{Operator: "Exists", Key: "CriticalAddonsOnly"},
-		}
-		Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
+		Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(tolerateAll))
 
 		Expect(d.Spec.Template.Spec.ImagePullSecrets).To(BeEmpty())
 		Expect(d.Spec.Template.ObjectMeta.Annotations).To(HaveKey("hash.operator.tigera.io/credential-secret"))

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -803,10 +803,7 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 
 // tolerations creates the tolerations used by the API server deployment.
 func (c *apiServerComponent) tolerations() []corev1.Toleration {
-	tolerations := []corev1.Toleration{
-		{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
-	}
-	return tolerations
+	return append(c.installation.ControlPlaneTolerations, tolerateMaster)
 }
 
 func (c *apiServerComponent) getTLSObjects() []runtime.Object {

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -151,10 +151,7 @@ var _ = Describe("API server rendering tests", func() {
 
 		Expect(d.Spec.Template.Spec.ServiceAccountName).To(Equal("tigera-apiserver"))
 
-		expectedTolerations := []corev1.Toleration{
-			{Key: "node-role.kubernetes.io/master", Effect: "NoSchedule"},
-		}
-		Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
+		Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(tolerateMaster))
 
 		Expect(d.Spec.Template.Spec.ImagePullSecrets).To(BeEmpty())
 		Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(2))
@@ -375,6 +372,21 @@ var _ = Describe("API server rendering tests", func() {
 
 		d := GetResource(resources, "tigera-apiserver", "tigera-system", "", "v1", "Deployment").(*v1.Deployment)
 		Expect(d.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("nodeName", "control01"))
+	})
+
+	It("should include a ControlPlaneToleration when specified", func() {
+		tol := corev1.Toleration{
+			Key:      "foo",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "bar",
+			Effect:   corev1.TaintEffectNoExecute,
+		}
+		instance.ControlPlaneTolerations = []corev1.Toleration{tol}
+		component, err := render.APIServer(k8sServiceEp, instance, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		resources, _ := component.Objects()
+		d := GetResource(resources, "tigera-apiserver", "tigera-system", "", "v1", "Deployment").(*v1.Deployment)
+		Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(tol, tolerateMaster))
 	})
 
 	It("should include a ClusterRole and ClusterRoleBindings for reading webhook configuration", func() {

--- a/pkg/render/aws-securitygroup-setup.go
+++ b/pkg/render/aws-securitygroup-setup.go
@@ -73,11 +73,7 @@ func (c *awsSGSetupComponent) setupJob() *batchv1.Job {
 					ImagePullSecrets:   c.pullSecrets,
 					ServiceAccountName: TigeraAWSSGSetupName,
 					HostNetwork:        true,
-					Tolerations: []corev1.Toleration{
-						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-						{Operator: corev1.TolerationOpExists, Key: "CriticalAddonsOnly"},
-					},
+					Tolerations:        tolerateAll,
 					Containers: []corev1.Container{{
 						Name:  "aws-security-group-setup",
 						Image: components.GetOperatorInitReference(c.installcr.Registry, c.installcr.ImagePath),

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -376,3 +376,31 @@ func basePodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
 		},
 	}
 }
+
+var (
+	// tolerateMaster allows pod to be scheduled on master nodes
+	tolerateMaster = corev1.Toleration{
+		Key:    "node-role.kubernetes.io/master",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	// tolerateCriticalAddonsOnly allows pods to be rescheduled while the node is in "critical add-ons only" mode.
+	tolerateCriticalAddonsOnly = corev1.Toleration{
+		Key:      "CriticalAddonsOnly",
+		Operator: corev1.TolerationOpExists,
+	}
+)
+
+// tolerateAll returns tolerations to tolerate all taints. When used, it is not necessary
+// to include the user's custom tolerations because we already tolerate everything.
+var tolerateAll = []corev1.Toleration{
+	tolerateCriticalAddonsOnly,
+	{
+		Effect:   corev1.TaintEffectNoSchedule,
+		Operator: corev1.TolerationOpExists,
+	},
+	{
+		Effect:   corev1.TaintEffectNoExecute,
+		Operator: corev1.TolerationOpExists,
+	},
+}

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -361,13 +361,9 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
 			ServiceAccountName: "tigera-compliance-controller",
-			Tolerations: []corev1.Toleration{
-				{
-					Key:    "node-role.kubernetes.io/master",
-					Effect: corev1.TaintEffectNoSchedule,
-				},
-			},
-			ImagePullSecrets: getImagePullSecretReferenceList(c.pullSecrets),
+			Tolerations:        append(c.installation.ControlPlaneTolerations, tolerateMaster),
+			NodeSelector:       c.installation.ControlPlaneNodeSelector,
+			ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 			Containers: []corev1.Container{
 				ElasticsearchContainerDecorate(corev1.Container{
 					Name:          ComplianceControllerName,
@@ -487,13 +483,9 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 			},
 			Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
 				ServiceAccountName: "tigera-compliance-reporter",
-				Tolerations: []corev1.Toleration{
-					{
-						Key:    "node-role.kubernetes.io/master",
-						Effect: corev1.TaintEffectNoSchedule,
-					},
-				},
-				ImagePullSecrets: getImagePullSecretReferenceList(c.pullSecrets),
+				Tolerations:        append(c.installation.ControlPlaneTolerations, tolerateMaster),
+				NodeSelector:       c.installation.ControlPlaneNodeSelector,
+				ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 				Containers: []corev1.Container{
 					ElasticsearchContainerDecorateIndexCreator(
 						ElasticsearchContainerDecorate(corev1.Container{
@@ -658,13 +650,9 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
 			ServiceAccountName: "tigera-compliance-server",
-			Tolerations: []corev1.Toleration{
-				{
-					Key:    "node-role.kubernetes.io/master",
-					Effect: corev1.TaintEffectNoSchedule,
-				},
-			},
-			ImagePullSecrets: getImagePullSecretReferenceList(c.pullSecrets),
+			Tolerations:        append(c.installation.ControlPlaneTolerations, tolerateMaster),
+			NodeSelector:       c.installation.ControlPlaneNodeSelector,
+			ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 			Containers: []corev1.Container{
 				ElasticsearchContainerDecorate(corev1.Container{
 					Name:  ComplianceServerName,
@@ -888,13 +876,9 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
 			ServiceAccountName: "tigera-compliance-snapshotter",
-			Tolerations: []corev1.Toleration{
-				{
-					Key:    "node-role.kubernetes.io/master",
-					Effect: corev1.TaintEffectNoSchedule,
-				},
-			},
-			ImagePullSecrets: getImagePullSecretReferenceList(c.pullSecrets),
+			Tolerations:        append(c.installation.ControlPlaneTolerations, tolerateMaster),
+			NodeSelector:       c.installation.ControlPlaneNodeSelector,
+			ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 			Containers: []corev1.Container{
 				ElasticsearchContainerDecorateIndexCreator(
 					ElasticsearchContainerDecorate(corev1.Container{
@@ -1037,21 +1021,8 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
 			ServiceAccountName: "tigera-compliance-benchmarker",
 			HostPID:            true,
-			Tolerations: []corev1.Toleration{
-				{
-					Effect:   corev1.TaintEffectNoSchedule,
-					Operator: corev1.TolerationOpExists,
-				},
-				{
-					Key:      "CriticalAddonsOnly",
-					Operator: corev1.TolerationOpExists,
-				},
-				{
-					Effect:   corev1.TaintEffectNoExecute,
-					Operator: corev1.TolerationOpExists,
-				},
-			},
-			ImagePullSecrets: getImagePullSecretReferenceList(c.pullSecrets),
+			Tolerations:        tolerateAll,
+			ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 			Containers: []corev1.Container{
 				ElasticsearchContainerDecorateIndexCreator(
 					ElasticsearchContainerDecorate(corev1.Container{

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -171,16 +171,8 @@ func (c *dexComponent) deployment() runtime.Object {
 				Spec: corev1.PodSpec{
 					NodeSelector:       c.installation.ControlPlaneNodeSelector,
 					ServiceAccountName: DexObjectName,
-					Tolerations: []corev1.Toleration{
-						{
-							Key:               "node-role.kubernetes.io/master",
-							Operator:          "",
-							Value:             "",
-							Effect:            corev1.TaintEffectNoSchedule,
-							TolerationSeconds: nil,
-						},
-					},
-					ImagePullSecrets: getImagePullSecretReferenceList(c.pullSecrets),
+					Tolerations:        append(c.installation.ControlPlaneTolerations, tolerateMaster),
+					ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 					Containers: []corev1.Container{
 						{
 							Name:            DexObjectName,

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -125,5 +126,22 @@ var _ = Describe("dex rendering tests", func() {
 			Entry("default cluster domain", dns.DefaultClusterDomain),
 			Entry("custom cluster domain", "custom.internal"),
 		)
+
+		It("should apply tolerations", func() {
+			t := corev1.Toleration{
+				Key:      "foo",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "bar",
+				Effect:   corev1.TaintEffectNoExecute,
+			}
+
+			dexCfg := render.NewDexConfig(authentication, tlsSecret, dexSecret, idpSecret, "svc.cluster.local")
+			component := render.Dex(pullSecrets, false, &operatorv1.InstallationSpec{
+				ControlPlaneTolerations: []corev1.Toleration{t},
+			}, dexCfg)
+			resources, _ := component.Objects()
+			d := GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(t, tolerateMaster))
+		})
 	})
 })

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -709,6 +709,7 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 					Annotations: annots,
 				},
 				Spec: corev1.PodSpec{
+					Tolerations:        c.installation.ControlPlaneTolerations,
 					ServiceAccountName: eksLogForwarderName,
 					ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 					InitContainers: []corev1.Container{ElasticsearchContainerDecorateENVVars(corev1.Container{

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -487,8 +487,14 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			GroupName:     "dummy-eks-cluster-cloudwatch-log-group",
 			FetchInterval: fetchInterval,
 		}
+		t := corev1.Toleration{
+			Key:      "foo",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "bar",
+		}
 		installation = &operatorv1.InstallationSpec{
-			KubernetesProvider: operatorv1.ProviderEKS,
+			KubernetesProvider:      operatorv1.ProviderEKS,
+			ControlPlaneTolerations: []corev1.Toleration{t},
 		}
 		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain)
 		resources, _ := component.Objects()
@@ -505,6 +511,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 		Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(deploy.Spec.Template.Annotations).To(HaveKey("hash.operator.tigera.io/eks-cloudwatch-log-credentials"))
+		Expect(deploy.Spec.Template.Spec.Tolerations).To(ContainElement(t))
 		envs := deploy.Spec.Template.Spec.Containers[0].Env
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "K8S_PLATFORM", Value: "eks"}))
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "AWS_REGION", Value: eksConfig.AwsRegion}))

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -200,33 +200,16 @@ func (c *GuardianComponent) deployment() runtime.Object {
 					Labels: map[string]string{
 						"k8s-app": GuardianName,
 					},
-					Annotations: map[string]string{
-						"scheduler.alpha.kubernetes.io/critical-pod": "",
-					},
 				},
 				Spec: corev1.PodSpec{
+					NodeSelector:       c.installation.ControlPlaneNodeSelector,
 					ServiceAccountName: GuardianServiceAccountName,
-					Tolerations:        c.tolerations(),
+					Tolerations:        append(c.installation.ControlPlaneTolerations, tolerateMaster, tolerateCriticalAddonsOnly),
 					ImagePullSecrets:   getImagePullSecretReferenceList(c.pullSecrets),
 					Containers:         c.container(),
 					Volumes:            c.volumes(),
 				},
 			},
-		},
-	}
-}
-
-func (c *GuardianComponent) tolerations() []v1.Toleration {
-	return []v1.Toleration{
-		{
-			Key:    "node-role.kubernetes.io/master",
-			Effect: v1.TaintEffectNoSchedule,
-		},
-		// Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-		// This, along with the annotation above marks this pod as a critical add-on.
-		{
-			Key:      "CriticalAddonsOnly",
-			Operator: v1.TolerationOpExists,
 		},
 	}
 }

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -117,6 +117,8 @@ func (c *intrusionDetectionComponent) intrusionDetectionElasticsearchJob() *batc
 			Labels: map[string]string{"job-name": IntrusionDetectionInstallerJobName},
 		},
 		Spec: ElasticsearchPodSpecDecorate(v1.PodSpec{
+			Tolerations:      c.installation.ControlPlaneTolerations,
+			NodeSelector:     c.installation.ControlPlaneNodeSelector,
 			RestartPolicy:    v1.RestartPolicyOnFailure,
 			ImagePullSecrets: getImagePullSecretReferenceList(c.pullSecrets),
 			Containers: []v1.Container{
@@ -386,6 +388,8 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 			},
 		},
 		Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
+			Tolerations:        c.installation.ControlPlaneTolerations,
+			NodeSelector:       c.installation.ControlPlaneNodeSelector,
 			ServiceAccountName: "intrusion-detection-controller",
 			ImagePullSecrets:   ps,
 			Containers: []corev1.Container{

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -249,11 +249,6 @@ func (c *kubeControllersComponent) controllersRoleBinding() *rbacv1.ClusterRoleB
 }
 
 func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
-	tolerations := []v1.Toleration{
-		{Key: "CriticalAddonsOnly", Operator: v1.TolerationOpExists},
-		{Key: "node-role.kubernetes.io/master", Effect: v1.TaintEffectNoSchedule},
-	}
-
 	env := []v1.EnvVar{
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 	}
@@ -328,7 +323,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 				},
 				Spec: v1.PodSpec{
 					NodeSelector:       c.cr.ControlPlaneNodeSelector,
-					Tolerations:        tolerations,
+					Tolerations:        append(c.cr.ControlPlaneTolerations, tolerateMaster, tolerateCriticalAddonsOnly),
 					ImagePullSecrets:   c.cr.ImagePullSecrets,
 					ServiceAccountName: "calico-kube-controllers",
 					Containers: []v1.Container{

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -511,6 +511,13 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	if es.supportsOIDC() {
 		volumes = es.dexCfg.RequiredVolumes()
 	}
+
+	// default to controlPlaneNodeSelector unless DataNodeSelector is set
+	nodeSels := es.installation.ControlPlaneNodeSelector
+	if es.logStorage.Spec.DataNodeSelector != nil {
+		nodeSels = es.logStorage.Spec.DataNodeSelector
+	}
+
 	podTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: annotations,
@@ -519,7 +526,8 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			InitContainers:     initContainers,
 			Containers:         []corev1.Container{esContainer},
 			ImagePullSecrets:   getImagePullSecretReferenceList(es.pullSecrets),
-			NodeSelector:       es.logStorage.Spec.DataNodeSelector,
+			NodeSelector:       nodeSels,
+			Tolerations:        es.installation.ControlPlaneTolerations,
 			ServiceAccountName: "tigera-elasticsearch",
 			Volumes:            volumes,
 		},
@@ -976,6 +984,8 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *appsv1.StatefulSet {
 					ServiceAccountName: "elastic-operator",
 					ImagePullSecrets:   getImagePullSecretReferenceList(es.pullSecrets),
 					HostNetwork:        false,
+					NodeSelector:       es.installation.ControlPlaneNodeSelector,
+					Tolerations:        es.installation.ControlPlaneTolerations,
 					Containers: []corev1.Container{{
 						Image: components.GetReference(components.ComponentElasticsearchOperator, es.installation.Registry, es.installation.ImagePath),
 						Name:  "manager",
@@ -1092,6 +1102,8 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 				Spec: corev1.PodSpec{
 					ImagePullSecrets:   getImagePullSecretReferenceList(es.pullSecrets),
 					ServiceAccountName: "tigera-kibana",
+					NodeSelector:       es.installation.ControlPlaneNodeSelector,
+					Tolerations:        es.installation.ControlPlaneTolerations,
 					Containers: []corev1.Container{{
 						Name: "kibana",
 						ReadinessProbe: &corev1.Probe{
@@ -1153,6 +1165,8 @@ func (es elasticsearchComponent) curatorCronJob() *batchv1beta.CronJob {
 							},
 						},
 						Spec: ElasticsearchPodSpecDecorate(corev1.PodSpec{
+							NodeSelector: es.installation.ControlPlaneNodeSelector,
+							Tolerations:  es.installation.ControlPlaneTolerations,
 							Containers: []corev1.Container{
 								ElasticsearchContainerDecorate(corev1.Container{
 									Name:          EsCuratorName,

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -333,6 +334,49 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				Verbs:     []string{"impersonate"},
 			},
 		}))
+	})
+
+	// renderManager passes in as few parameters as possible to render.Manager without it
+	// panicing. It accepts variations on the installspec for testing purposes.
+	renderManager := func(i *operator.InstallationSpec) *v1.Deployment {
+		component, err := render.Manager(nil, nil, nil,
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.ComplianceServerCertSecret,
+					Namespace: render.OperatorNamespace(),
+				},
+				Data: map[string][]byte{
+					"tls.crt": []byte("crt"),
+					"tls.key": []byte("crt"),
+				},
+			},
+			&render.ElasticsearchClusterConfig{},
+			nil, nil, false,
+			i,
+			nil, nil, nil, "")
+		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
+		resources, _ := component.Objects()
+		return GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
+	}
+
+	It("should apply controlPlaneNodeSelectors", func() {
+		deployment := renderManager(&operator.InstallationSpec{
+			ControlPlaneNodeSelector: map[string]string{
+				"foo": "bar",
+			},
+		})
+		Expect(deployment.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+	})
+	It("should apply controlPlaneTolerations", func() {
+		t := corev1.Toleration{
+			Key:      "foo",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "bar",
+		}
+		deployment := renderManager(&operator.InstallationSpec{
+			ControlPlaneTolerations: []corev1.Toleration{t},
+		})
+		Expect(deployment.Spec.Template.Spec.Tolerations).To(ContainElements(t, tolerateMaster, tolerateCriticalAddonsOnly))
 	})
 })
 

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -550,7 +550,7 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *v1.ConfigMap) *apps.DaemonSet {
 					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
-					Tolerations:                   c.nodeTolerations(),
+					Tolerations:                   tolerateAll,
 					Affinity:                      affinity,
 					ImagePullSecrets:              c.cr.ImagePullSecrets,
 					ServiceAccountName:            "calico-node",
@@ -574,15 +574,6 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *v1.ConfigMap) *apps.DaemonSet {
 		migration.LimitDaemonSetToMigratedNodes(&ds)
 	}
 	return &ds
-}
-
-// nodeTolerations creates the node's tolerations.
-func (c *nodeComponent) nodeTolerations() []v1.Toleration {
-	return []v1.Toleration{
-		{Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule},
-		{Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoExecute},
-		{Operator: v1.TolerationOpExists, Key: "CriticalAddonsOnly"},
-	}
 }
 
 // cniDirectories returns the binary and network config directories for the configured platform.

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -296,12 +296,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 
 		// Verify tolerations.
-		expectedTolerations := []v1.Toleration{
-			{Operator: "Exists", Effect: "NoSchedule"},
-			{Operator: "Exists", Effect: "NoExecute"},
-			{Operator: "Exists", Key: "CriticalAddonsOnly"},
-		}
-		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
+		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(tolerateAll))
 
 		verifyProbes(ds, false, false)
 	})
@@ -690,12 +685,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 
 		// Verify tolerations.
-		expectedTolerations := []v1.Toleration{
-			{Operator: "Exists", Effect: "NoSchedule"},
-			{Operator: "Exists", Effect: "NoExecute"},
-			{Operator: "Exists", Key: "CriticalAddonsOnly"},
-		}
-		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
+		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(tolerateAll))
 
 		// Verify readiness and liveness probes.
 
@@ -842,12 +832,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
 		// Verify tolerations.
-		expectedTolerations := []v1.Toleration{
-			{Operator: "Exists", Effect: "NoSchedule"},
-			{Operator: "Exists", Effect: "NoExecute"},
-			{Operator: "Exists", Key: "CriticalAddonsOnly"},
-		}
-		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
+		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(tolerateAll))
 
 		// Verify readiness and liveness probes.
 		verifyProbes(ds, false, true)
@@ -1131,12 +1116,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 
 		// Verify tolerations.
-		expectedTolerations := []v1.Toleration{
-			{Operator: "Exists", Effect: "NoSchedule"},
-			{Operator: "Exists", Effect: "NoExecute"},
-			{Operator: "Exists", Key: "CriticalAddonsOnly"},
-		}
-		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
+		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(tolerateAll))
 
 		// Verify readiness and liveness probes.
 		verifyProbes(ds, false, false)
@@ -1282,12 +1262,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
 		// Verify tolerations.
-		expectedTolerations := []v1.Toleration{
-			{Operator: "Exists", Effect: "NoSchedule"},
-			{Operator: "Exists", Effect: "NoExecute"},
-			{Operator: "Exists", Key: "CriticalAddonsOnly"},
-		}
-		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(expectedTolerations))
+		Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(tolerateAll))
 
 		// Verify readiness and liveness probes.
 		verifyProbes(ds, false, false)

--- a/pkg/render/render_utils_test.go
+++ b/pkg/render/render_utils_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -91,3 +92,30 @@ func ExpectEnv(env []v1.EnvVar, key, value string) {
 	}
 	Expect(false).To(BeTrue(), fmt.Sprintf("Missing expected environment variable %s", key))
 }
+
+var (
+	tolerateMaster = corev1.Toleration{
+		Key:    "node-role.kubernetes.io/master",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	tolerateCriticalAddonsOnly = corev1.Toleration{
+		Key:      "CriticalAddonsOnly",
+		Operator: v1.TolerationOpExists,
+	}
+
+	tolerateAll = []corev1.Toleration{
+		{
+			Key:      "CriticalAddonsOnly",
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
+		},
+		{
+			Effect:   corev1.TaintEffectNoExecute,
+			Operator: corev1.TolerationOpExists,
+		},
+	}
+)

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -341,7 +341,7 @@ func (c *typhaComponent) typhaDeployment() *apps.Deployment {
 					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
-					Tolerations:                   c.tolerations(),
+					Tolerations:                   tolerateAll,
 					Affinity:                      toAffinity(c.installation.TyphaAffinity),
 					ImagePullSecrets:              c.installation.ImagePullSecrets,
 					ServiceAccountName:            TyphaServiceAccountName,
@@ -358,17 +358,6 @@ func (c *typhaComponent) typhaDeployment() *apps.Deployment {
 		migration.SetTyphaAntiAffinity(&d)
 	}
 	return &d
-}
-
-// tolerations creates the typha's tolerations.
-func (c *typhaComponent) tolerations() []v1.Toleration {
-	tolerations := []v1.Toleration{
-		{Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule},
-		{Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoExecute},
-		{Operator: v1.TolerationOpExists, Key: "CriticalAddonsOnly"},
-	}
-
-	return tolerations
 }
 
 // volumes creates the typha's volumes.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

**Background / Use Case**

A lot of users have been asking for the ability to set custom nodeSelectors and tolerations on resources launched by the Operator. The initial request was to be able to set it individually for each individual component. But when we asked about their use case, it became clear that users are mainly using nodeSelectors and tolerations to place infrastructure components (like calico) on separate, more persistent infrastructure nodes, while running their business logic workloads on worker nodes.

This use case closely matches what the (arguably poorly named) controlPlaneNodeSelector field was designed for. However, controlPlaneNodeSelector only is applied to the OS product.

**Changes**

This PR does the following:
- Extends `controlPlaneNodeSelector` to all other components, with a few exceptions:
  - It still does not apply to Typha, as it's use case is different.
  - It still does not apply to daemonsets like fluentd, calico-node, or compliance-benchmarker.
- Introduce a new `controlPlaneToleration` which applies to all components (unless they already tolerate all taints).

Note that the LogStorage CR already has a `DataNodeSelector` field. As part of this PR, that field will now override the value set in `controlPlaneNodeSelector`.

To accomplish this, I've added some helper methods to be able to more easily group our tolerations together. 
I also removed the 'critical-pod' annotation since it has been deprecated in favor of the toleration since v1.16.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
