### PR TITLE
avoid virtual nodes in aks

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -517,6 +517,23 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *v1.ConfigMap) *apps.DaemonSet {
 		initContainers = append(initContainers, c.flexVolumeContainer())
 	}
 
+	var affinity *v1.Affinity
+	if c.cr.KubernetesProvider == operator.ProviderAKS {
+		affinity = &v1.Affinity{
+			NodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchExpressions: []v1.NodeSelectorRequirement{{
+							Key:      "type",
+							Operator: v1.NodeSelectorOpNotIn,
+							Values:   []string{"virtual-kubelet"},
+						}},
+					}},
+				},
+			},
+		}
+	}
+
 	ds := apps.DaemonSet{
 		TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -534,6 +551,7 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *v1.ConfigMap) *apps.DaemonSet {
 				},
 				Spec: v1.PodSpec{
 					Tolerations:                   c.nodeTolerations(),
+					Affinity:                      affinity,
 					ImagePullSecrets:              c.cr.ImagePullSecrets,
 					ServiceAccountName:            "calico-node",
 					TerminationGracePeriodSeconds: &terminationGracePeriod,


### PR DESCRIPTION
## Description

AKS has a feature called [virtual node](https://docs.microsoft.com/en-us/azure/aks/virtual-nodes) which is an adapter that allows use of Azure Container Service (ACS) in a Kubernetes cluster. Pods running there have many limitations, most notably cannot volume mount to the host, resulting in this error:

>Pod calico-node requires volume which is unsupported type.

The node is tainted to prevent pods like typha and kube-controllers from running there, but Calico-node tolerates all taints. As such, they prevent calico-node from running on it using an Affinity.

```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.azure.com/cluster
          operator: Exists
        - key: type
          operator: NotIn
          values:
          - virtual-kubelet
```

This PR prevents calico-node from running on these nodes by setting an affinity to block type=virtual-kubelet if kubernetesProvider=AKS.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
