### PR TITLE
Fix a permission error that occurs for elasticsearch on OCP 4.6

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -434,6 +434,14 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 		VolumeMounts: volumeMounts,
 	}
 
+	// For OpenShift, set the user to run as non-root specifically. This prevents issues with the elasticsearch
+	// image which requires that root users have permissions to run CHROOT which is not given in OpenShift.
+	if es.provider == operatorv1.ProviderOpenShift {
+		esContainer.SecurityContext = &corev1.SecurityContext{
+			RunAsUser: Int64(1000),
+		}
+	}
+
 	// If the user has provided resource requirements, then use the user overrides instead
 	if es.logStorage.Spec.Nodes != nil && es.logStorage.Spec.Nodes.ResourceRequirements != nil {
 		userOverrides := *es.logStorage.Spec.Nodes.ResourceRequirements


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
In OpenShift, this runs elasticsearch as a non root user so that chroot permissions will not be required when running the elasticsearch image. This is caused because the random UID assignment that we depend upon in OpenShift becomes disabled if ANY container (init or regular) specifies a user to run as. In our case, we specify an init container to be run as root so random UID assignment is disabled for the entire pod.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
