### PR TITLE
Support Elasticsearch native users

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -245,7 +245,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	var elasticLicenseType render.ElasticLicenseType
+	var esLicenseType render.ElasticsearchLicenseType
 	managementClusterConnection, err := utils.GetManagementClusterConnection(ctx, r.client)
 	if err != nil {
 		log.Error(err, "Failed to read ManagementClusterConnection")
@@ -253,7 +253,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 	if managementClusterConnection == nil {
-		if elasticLicenseType, err = utils.GetElasticLicenseType(ctx, r.client, reqLogger); err != nil {
+		if esLicenseType, err = utils.GetElasticLicenseType(ctx, r.client, reqLogger); err != nil {
 			r.status.SetDegraded("Failed to get Elasticsearch license", err.Error())
 			return reconcile.Result{}, err
 		}
@@ -273,7 +273,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(request reconcile.Request) (reco
 		pullSecrets,
 		r.provider == operatorv1.ProviderOpenShift,
 		r.clusterDomain,
-		elasticLicenseType,
+		esLicenseType,
 	)
 	if err := handler.CreateOrUpdate(context.Background(), component, r.status); err != nil {
 		r.status.SetDegraded("Error creating / updating resource", err.Error())

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -316,7 +316,7 @@ var _ = Describe("LogStorage controller", func() {
 
 					Expect(cli.Create(ctx, &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
-						Data:       map[string]string{"eck_license_level": string(render.ElasticLicenseTypeEnterprise)},
+						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
 					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
@@ -365,6 +365,109 @@ var _ = Describe("LogStorage controller", func() {
 
 					By("confirming curator job is created")
 					Expect(cli.Get(ctx, curatorObjKey, &batchv1beta.CronJob{})).ShouldNot(HaveOccurred())
+
+					By("confirming elastic user ConfigMap is not available")
+					Expect(cli.Get(ctx,
+						types.NamespacedName{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersConfigMapName},
+						&corev1.ConfigMap{})).Should(HaveOccurred())
+
+					mockStatus.AssertExpectations(GinkgoT())
+				})
+				It("test LogStorage reconciles successfully for elasticsearch basic license", func() {
+
+					Expect(cli.Create(ctx, &operatorv1.Authentication{
+						ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+						Spec: operatorv1.AuthenticationSpec{
+							ManagerDomain: "https://example.com",
+							OIDC: &operatorv1.AuthenticationOIDC{
+								IssuerURL:     "https://example.com",
+								UsernameClaim: "email",
+								GroupsClaim:   "group",
+							},
+						},
+						Status: operatorv1.AuthenticationStatus{State: operatorv1.TigeraStatusReady},
+					})).ToNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, render.CreateDexClientSecret())).ToNot(HaveOccurred())
+					Expect(cli.Create(ctx, render.CreateDexTLSSecret("tigera-dex.tigera-dex.svc.cluster.local"))).ToNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &operatorv1.LogStorage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "tigera-secure",
+						},
+						Spec: operatorv1.LogStorageSpec{
+							Nodes: &operatorv1.Nodes{
+								Count: int64(1),
+							},
+							StorageClassName: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
+						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeBasic)},
+					})).ShouldNot(HaveOccurred())
+
+					r, err := logstorage.NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
+					result, err := r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					// Expect to be waiting for Elasticsearch and Kibana to be functional
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					By("asserting the finalizers have been set on the LogStorage CR")
+					ls := &operatorv1.LogStorage{}
+					Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, ls)).ShouldNot(HaveOccurred())
+					Expect(ls.Finalizers).Should(ContainElement("tigera.io/eck-cleanup"))
+					Expect(ls.Spec.StorageClassName).To(Equal(storageClassName))
+
+					Expect(cli.Get(ctx, eckOperatorObjKey, &appsv1.StatefulSet{})).ShouldNot(HaveOccurred())
+
+					es := &esv1.Elasticsearch{}
+					Expect(cli.Get(ctx, esObjKey, es)).ShouldNot(HaveOccurred())
+
+					es.Status.Phase = esv1.ElasticsearchReadyPhase
+					Expect(cli.Update(ctx, es)).ShouldNot(HaveOccurred())
+
+					kb := &kbv1.Kibana{}
+					Expect(cli.Get(ctx, kbObjKey, kb)).ShouldNot(HaveOccurred())
+
+					kb.Status.AssociationStatus = cmnv1.AssociationEstablished
+					Expect(cli.Update(ctx, kb)).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: esPublicCertObjMeta})).ShouldNot(HaveOccurred())
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: kbPublicCertObjMeta})).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Waiting for curator secrets to become available", "").Return()
+					result, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					// Expect to be waiting for curator secret
+					Expect(result).Should(Equal(reconcile.Result{}))
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: curatorUsrSecretObjMeta})).ShouldNot(HaveOccurred())
+
+					mockStatus.On("ClearDegraded")
+					result, err = r.Reconcile(reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					By("confirming curator job is created")
+					Expect(cli.Get(ctx, curatorObjKey, &batchv1beta.CronJob{})).ShouldNot(HaveOccurred())
+
+					By("confirming elastic user ConfigMap is created")
+					Expect(cli.Get(ctx,
+						types.NamespacedName{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersConfigMapName},
+						&corev1.ConfigMap{})).ShouldNot(HaveOccurred())
+					Expect(cli.Get(ctx,
+						types.NamespacedName{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersSecreteName},
+						&corev1.Secret{})).ShouldNot(HaveOccurred())
 
 					mockStatus.AssertExpectations(GinkgoT())
 				})
@@ -521,7 +624,19 @@ func setUpLogStorageComponents(cli client.Client, ctx context.Context, storageCl
 			{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: render.OperatorNamespace()}},
 			{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchPublicCertSecret, Namespace: render.OperatorNamespace()}},
 		},
-		nil, nil, "cluster.local", false, nil, render.ElasticLicenseTypeBasic)
+		nil, nil, "cluster.local", false, nil, render.ElasticsearchLicenseTypeBasic,
+		&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.OIDCUsersConfigMapName,
+				Namespace: render.ElasticsearchNamespace,
+			}},
+		&corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.OIDCUsersSecreteName,
+				Namespace: render.ElasticsearchNamespace,
+			}})
 
 	createObj, _ := component.Objects()
 	for _, obj := range createObj {

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -138,6 +138,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return fmt.Errorf("manager-controller failed to watch resource: %w", err)
 	}
 
+	if err = utils.AddConfigMapWatch(c, render.ECKLicenseConfigMapName, render.ECKOperatorNamespace); err != nil {
+		return fmt.Errorf("manager-controller failed to watch the ConfigMap resource: %v", err)
+	}
 	return nil
 }
 
@@ -381,6 +384,14 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		dexCfg = render.NewDexKeyValidatorConfig(authentication, dexTLSSecret, r.clusterDomain)
 	}
 
+	var elasticLicenseType render.ElasticsearchLicenseType
+	if managementClusterConnection == nil {
+		if elasticLicenseType, err = utils.GetElasticLicenseType(ctx, r.client, reqLogger); err != nil {
+			r.status.SetDegraded("Failed to get Elasticsearch license", err.Error())
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
@@ -399,6 +410,7 @@ func (r *ReconcileManager) Reconcile(request reconcile.Request) (reconcile.Resul
 		tunnelSecret,
 		internalTrafficSecret,
 		r.clusterDomain,
+		elasticLicenseType,
 	)
 	if err != nil {
 		log.Error(err, "Error rendering Manager")

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -301,27 +301,27 @@ func GetExpectedTyphaScale(nodes int) int {
 }
 
 // GetElasticLicenseType returns the license type from elastic-licensing ConfigMap that ECK operator keeps updated.
-func GetElasticLicenseType(ctx context.Context, cli client.Client, logger logr.Logger) (render.ElasticLicenseType, error) {
+func GetElasticLicenseType(ctx context.Context, cli client.Client, logger logr.Logger) (render.ElasticsearchLicenseType, error) {
 	cm := &corev1.ConfigMap{}
 	err := cli.Get(ctx, client.ObjectKey{Name: render.ECKLicenseConfigMapName, Namespace: render.ECKOperatorNamespace}, cm)
 	if err != nil {
-		return render.ElasticLicenseTypeUnknown, err
+		return render.ElasticsearchLicenseTypeUnknown, err
 	}
 	license, ok := cm.Data["eck_license_level"]
 	if !ok {
-		return render.ElasticLicenseTypeUnknown, fmt.Errorf("eck_license_level not available.")
+		return render.ElasticsearchLicenseTypeUnknown, fmt.Errorf("eck_license_level not available.")
 	}
 
 	return StrToElasticLicenseType(license, logger), nil
 }
 
 // StrToElasticLicenseType maps Elasticsearch license to one of the known and expected value.
-func StrToElasticLicenseType(license string, logger logr.Logger) render.ElasticLicenseType {
-	if license == string(render.ElasticLicenseTypeEnterprise) ||
-		license == string(render.ElasticLicenseTypeBasic) ||
-		license == string(render.ElasticLicenseTypeEnterpriseTrial) {
-		return render.ElasticLicenseType(license)
+func StrToElasticLicenseType(license string, logger logr.Logger) render.ElasticsearchLicenseType {
+	if license == string(render.ElasticsearchLicenseTypeEnterprise) ||
+		license == string(render.ElasticsearchLicenseTypeBasic) ||
+		license == string(render.ElasticsearchLicenseTypeEnterpriseTrial) {
+		return render.ElasticsearchLicenseType(license)
 	}
 	logger.V(3).Info("Elasticsearch license %s is unexpected", license)
-	return render.ElasticLicenseTypeUnknown
+	return render.ElasticsearchLicenseTypeUnknown
 }

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,13 +67,13 @@ var _ = Describe("Utils elasticsearch license type tests", func() {
 		})).ShouldNot(HaveOccurred())
 		license, err := GetElasticLicenseType(ctx, c, log)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(license).Should(Equal(render.ElasticLicenseTypeEnterprise))
+		Expect(license).Should(Equal(render.ElasticsearchLicenseTypeEnterprise))
 	})
 
 	It("Return error if elastic-licensing not found", func() {
 		license, err := GetElasticLicenseType(ctx, c, log)
 		Expect(err).Should(HaveOccurred())
-		Expect(license).Should(Equal(render.ElasticLicenseTypeUnknown))
+		Expect(license).Should(Equal(render.ElasticsearchLicenseTypeUnknown))
 	})
 
 	It("Return error if license type if missing", func() {

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -50,31 +50,31 @@ func IntrusionDetection(
 	pullSecrets []*corev1.Secret,
 	openshift bool,
 	clusterDomain string,
-	elasticLicenseType ElasticLicenseType,
+	esLicenseType ElasticsearchLicenseType,
 ) Component {
 	return &intrusionDetectionComponent{
-		lc:                 lc,
-		esSecrets:          esSecrets,
-		kibanaCertSecret:   kibanaCertSecret,
-		installation:       installation,
-		esClusterConfig:    esClusterConfig,
-		pullSecrets:        pullSecrets,
-		openshift:          openshift,
-		clusterDomain:      clusterDomain,
-		elasticLicenseType: elasticLicenseType,
+		lc:               lc,
+		esSecrets:        esSecrets,
+		kibanaCertSecret: kibanaCertSecret,
+		installation:     installation,
+		esClusterConfig:  esClusterConfig,
+		pullSecrets:      pullSecrets,
+		openshift:        openshift,
+		clusterDomain:    clusterDomain,
+		esLicenseType:    esLicenseType,
 	}
 }
 
 type intrusionDetectionComponent struct {
-	lc                 *operatorv1.LogCollector
-	esSecrets          []*corev1.Secret
-	kibanaCertSecret   *corev1.Secret
-	installation       *operator.InstallationSpec
-	esClusterConfig    *ElasticsearchClusterConfig
-	pullSecrets        []*corev1.Secret
-	openshift          bool
-	clusterDomain      string
-	elasticLicenseType ElasticLicenseType
+	lc               *operatorv1.LogCollector
+	esSecrets        []*corev1.Secret
+	kibanaCertSecret *corev1.Secret
+	installation     *operator.InstallationSpec
+	esClusterConfig  *ElasticsearchClusterConfig
+	pullSecrets      []*corev1.Secret
+	openshift        bool
+	clusterDomain    string
+	esLicenseType    ElasticsearchLicenseType
 }
 
 func (c *intrusionDetectionComponent) SupportedOSType() OSType {
@@ -199,7 +199,7 @@ func (c *intrusionDetectionComponent) intrusionDetectionJobContainer() v1.Contai
 			},
 			{
 				Name:  "ELASTIC_LICENSE_TYPE",
-				Value: string(c.elasticLicenseType),
+				Value: string(c.esLicenseType),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{{
@@ -371,7 +371,7 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 		ElasticsearchContainerDecorate(c.intrusionDetectionControllerContainer(), c.esClusterConfig.ClusterName(), ElasticsearchIntrusionDetectionUserSecret, c.clusterDomain, OSTypeLinux),
 		c.esClusterConfig.Replicas(), c.esClusterConfig.Shards())
 
-	if c.elasticLicenseType == ElasticLicenseTypeBasic {
+	if c.esLicenseType == ElasticsearchLicenseTypeBasic {
 		envVars := []corev1.EnvVar{
 			{Name: "DISABLE_ANOMALY", Value: "yes"},
 			{Name: "DISABLE_ALERTS", Value: "yes"},

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			nil,
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
 			&operatorv1.InstallationSpec{Registry: "testregistry.com/"},
-			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticLicenseTypeUnknown,
+			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown,
 		)
 		resources, _ := component.Objects()
 
@@ -100,7 +100,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			nil,
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
 			&operatorv1.InstallationSpec{Registry: "testregistry.com/"},
-			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticLicenseTypeUnknown,
+			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown,
 		)
 		resources, _ := component.Objects()
 
@@ -179,7 +179,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			&operatorv1.InstallationSpec{
 				ControlPlaneNodeSelector: map[string]string{"foo": "bar"},
 			},
-			&render.ElasticsearchClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticLicenseTypeUnknown,
+			&render.ElasticsearchClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown,
 		)
 		resources, _ := component.Objects()
 		idc := GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
@@ -198,7 +198,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			&operatorv1.InstallationSpec{
 				ControlPlaneTolerations: []corev1.Toleration{t},
 			},
-			&render.ElasticsearchClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticLicenseTypeUnknown)
+			&render.ElasticsearchClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown)
 		resources, _ := component.Objects()
 		idc := GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
 		job := GetResource(resources, render.IntrusionDetectionInstallerJobName, render.IntrusionDetectionNamespace, "batch", "v1", "Job").(*batchv1.Job)

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -82,6 +82,7 @@ func Manager(
 	tunnelSecret *corev1.Secret,
 	internalTrafficSecret *corev1.Secret,
 	clusterDomain string,
+	esLicenseType ElasticsearchLicenseType,
 ) (Component, error) {
 	tlsSecrets := []*corev1.Secret{}
 
@@ -131,6 +132,7 @@ func Manager(
 		clusterDomain:              clusterDomain,
 		installation:               installation,
 		managementCluster:          managementCluster,
+		esLicenseType:              esLicenseType,
 	}, nil
 }
 
@@ -147,6 +149,7 @@ type managerComponent struct {
 	clusterDomain              string
 	installation               *operator.InstallationSpec
 	managementCluster          *operator.ManagementCluster
+	esLicenseType              ElasticsearchLicenseType
 }
 
 func (c *managerComponent) SupportedOSType() OSType {
@@ -480,7 +483,9 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: ManagerInternalTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true})
 	}
 
-	var env []v1.EnvVar
+	env := []v1.EnvVar{
+		{Name: "ELASTIC_LICENSE_TYPE", Value: string(c.esLicenseType)},
+	}
 	if c.dexCfg != nil {
 		env = append(env, c.dexCfg.RequiredEnv("")...)
 		volumeMounts = append(volumeMounts, c.dexCfg.RequiredVolumeMounts()...)

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -353,7 +353,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			&render.ElasticsearchClusterConfig{},
 			nil, nil, false,
 			i,
-			nil, nil, nil, "")
+			nil, nil, nil, "", render.ElasticsearchLicenseTypeUnknown)
 		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 		resources, _ := component.Objects()
 		return GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
@@ -421,7 +421,8 @@ func renderObjects(oidc bool, managementCluster *operator.ManagementCluster,
 		managementCluster,
 		tunnelSecret,
 		internalTraffic,
-		dns.DefaultClusterDomain)
+		dns.DefaultClusterDomain,
+		render.ElasticsearchLicenseTypeEnterpriseTrial)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 	resources, _ := component.Objects()
 	return resources


### PR DESCRIPTION
## Description

- Create a new ConfigMap `tigera-known-oidc-users` and a Secrete `tigera-known-oidc-users-credentials`, if external idP is configured and elasticsearch uses basic license. This ConfigMap will be used by tigera-manager to add end-user information needed to create elasticsearch native users.
- Delete ConfigMap `tigera-known-oidc-users` and the Secrete `tigera-known-oidc-users-credentials`, if external idP is not configured or elasticsearch is not in basic license
- Add permissions to manager and kube-controller to access the new ConfigMap and Secret

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
