### PR TITLE
use system-node-critical priority class for k8s v1.17+

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,11 +203,18 @@ func main() {
 		log.Error(err, fmt.Sprintf("Couldn't find the cluster domain from the resolv.conf, defaulting to %s", clusterDomain))
 	}
 
+	version, err := utils.GetKubernetesVersion(ctx, clientset)
+	if err != nil {
+		setupLog.Error(err, "failed to determine version of k8s-apiserver")
+		os.Exit(1)
+	}
+
 	options := options.AddOptions{
 		DetectedProvider:    provider,
 		EnterpriseCRDExists: enterpriseCRDExists,
 		AmazonCRDExists:     amazonCRDExists,
 		ClusterDomain:       clusterDomain,
+		K8sAPIServerVersion: version,
 	}
 
 	err = controllers.AddToManager(mgr, options)

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -1,6 +1,9 @@
 package options
 
-import v1 "github.com/tigera/operator/api/v1"
+import (
+	v1 "github.com/tigera/operator/api/v1"
+	"k8s.io/apimachinery/pkg/version"
+)
 
 // AddOptions are passed to controllers when added to the controller manager. They
 // detail options detected by the daemon at startup that some controllers may either
@@ -11,4 +14,5 @@ type AddOptions struct {
 	EnterpriseCRDExists bool
 	AmazonCRDExists     bool
 	ClusterDomain       string
+	K8sAPIServerVersion *version.Info
 }

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -2,7 +2,7 @@ package options
 
 import (
 	v1 "github.com/tigera/operator/api/v1"
-	"k8s.io/apimachinery/pkg/version"
+	"github.com/tigera/operator/pkg/controller/utils"
 )
 
 // AddOptions are passed to controllers when added to the controller manager. They
@@ -14,5 +14,5 @@ type AddOptions struct {
 	EnterpriseCRDExists bool
 	AmazonCRDExists     bool
 	ClusterDomain       string
-	K8sAPIServerVersion *version.Info
+	K8sAPIServerVersion *utils.VersionInfo
 }

--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -21,6 +21,7 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -97,6 +98,10 @@ func AutoDiscoverProvider(ctx context.Context, clientset kubernetes.Interface) (
 
 	// Couldn't detect any specific platform.
 	return operatorv1.ProviderNone, nil
+}
+
+func GetKubernetesVersion(ctx context.Context, clientset kubernetes.Interface) (*version.Info, error) {
+	return clientset.Discovery().ServerVersion()
 }
 
 // autodetectFromGroup auto detects the platform based on the API groups that are present.

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -33,10 +32,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/version"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/utils"
 )
 
 const (
@@ -56,13 +55,10 @@ func SetTestLogger(l logr.Logger) {
 	log = l
 }
 
-func setCriticalPod(t *v1.PodTemplateSpec, v version.Info) {
+func setCriticalPod(t *v1.PodTemplateSpec, v *utils.VersionInfo) {
 	// skip creation of the priorityClass if this is k8s >= v1.17 as we can
 	// use system-node-critical outside of the kube-system namespace.
-	// also, filter out a proceeding '+' from the minor version since openshift
-	// includes that.
-	minor, err := strconv.Atoi(strings.TrimSuffix(v.Minor, "+"))
-	if err == nil && v.Major == "1" && minor >= 17 {
+	if v != nil && v.Minor >= 17 {
 		t.Spec.PriorityClassName = "system-node-critical"
 		return
 	}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration"
+	"github.com/tigera/operator/pkg/controller/utils"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -35,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/version"
 )
 
 const (
@@ -63,7 +63,7 @@ func Node(
 	aci *operator.AmazonCloudIntegration,
 	migrate bool,
 	nodeAppArmorProfile string,
-	k8sVersion version.Info,
+	k8sVersion *utils.VersionInfo,
 ) Component {
 	return &nodeComponent{
 		k8sServiceEp:        k8sServiceEp,
@@ -85,7 +85,7 @@ type nodeComponent struct {
 	amazonCloudInt      *operator.AmazonCloudIntegration
 	migrationNeeded     bool
 	nodeAppArmorProfile string
-	k8sVersion          version.Info
+	k8sVersion          *utils.VersionInfo
 }
 
 func (c *nodeComponent) SupportedOSType() OSType {

--- a/pkg/render/priority_class.go
+++ b/pkg/render/priority_class.go
@@ -15,26 +15,20 @@
 package render
 
 import (
-	"strconv"
-	"strings"
-
+	"github.com/tigera/operator/pkg/controller/utils"
 	schedv1beta "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/version"
 )
 
 const (
 	PriorityClassName = "calico-priority"
 )
 
-func PriorityClassDefinitions(v version.Info) Component {
+func PriorityClassDefinitions(v *utils.VersionInfo) Component {
 	// skip creation of the priorityClass if this is k8s >= v1.17 as we can
 	// use system-node-critical outside of the kube-system namespace.
-	// also, filter out a proceeding '+' from the minor version since openshift
-	// includes that.
-	minor, err := strconv.Atoi(strings.TrimSuffix(v.Minor, "+"))
-	if err == nil && v.Major == "1" && minor >= 17 {
+	if v != nil && v.Minor >= 17 {
 		return nil
 	}
 	return &priorityClassComponent{}

--- a/pkg/render/priority_class.go
+++ b/pkg/render/priority_class.go
@@ -15,16 +15,28 @@
 package render
 
 import (
+	"strconv"
+	"strings"
+
 	schedv1beta "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
 )
 
 const (
 	PriorityClassName = "calico-priority"
 )
 
-func PriorityClassDefinitions() Component {
+func PriorityClassDefinitions(v version.Info) Component {
+	// skip creation of the priorityClass if this is k8s >= v1.17 as we can
+	// use system-node-critical outside of the kube-system namespace.
+	// also, filter out a proceeding '+' from the minor version since openshift
+	// includes that.
+	minor, err := strconv.Atoi(strings.TrimSuffix(v.Minor, "+"))
+	if err == nil && v.Major == "1" && minor >= 17 {
+		return nil
+	}
 	return &priorityClassComponent{}
 }
 

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
 
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
@@ -234,16 +235,17 @@ type calicoRenderer struct {
 	upgrade                     bool
 	authentication              *operator.Authentication
 	nodeAppArmorProfile         string
+	k8sVersion                  version.Info
 }
 
 func (r calicoRenderer) Render() []Component {
 	var components []Component
-	components = appendNotNil(components, PriorityClassDefinitions())
+	components = appendNotNil(components, PriorityClassDefinitions(r.k8sVersion))
 	components = appendNotNil(components, Namespaces(r.installation, r.pullSecrets))
 	components = appendNotNil(components, ConfigMaps(r.tlsConfigMaps))
 	components = appendNotNil(components, Secrets(r.tlsSecrets))
 	components = appendNotNil(components, Typha(r.k8sServiceEp, r.installation, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade))
-	components = appendNotNil(components, Node(r.k8sServiceEp, r.installation, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade, r.nodeAppArmorProfile))
+	components = appendNotNil(components, Node(r.k8sServiceEp, r.installation, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade, r.nodeAppArmorProfile, r.k8sVersion))
 	components = appendNotNil(components, KubeControllers(r.k8sServiceEp, r.installation, r.logStorageExists, r.managementCluster, r.managementClusterConnection, r.managerInternalTLSecret, r.authentication))
 	return components
 }


### PR DESCRIPTION
## Description

### Background

In a manifest-based install, calico-node is typically run in the kube-system namespace with the builtin 'system-node-critical` priority class.

With the advent of Operator, calico-node was moved to the `calico-system` namespace. Unfortunately, at the time, the system-node-critical priorityClass was not usable by components outside of kube-system.

Until now! Since k8s v1.17, you can use system-node-critical outside of kube-system.

### Changes

This PR switches calico-node back onto system-node-critical priorityclass. It does this conditionally if the k8s version >= v1.17.

This kind of conditional rendering based on k8s version is the first of it's kind in our Operator. To implement it, this PR adds code to the discovery utils to use the Discovery clientset's ServerVersion endpoint. This data is then piped into the controllers, and through to the render package. A value of `nil` is used to represent "unknown", and in those scenarios, the code assumes it's the lowest supported version.

### :warning:  **Note:** This PR only modifies the core controller. I will update other controllers once this overall design is approved 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
