### PR TITLE
Use existing logger for Elasticsearch client

### DIFF
--- a/pkg/controller/utils/elasticsearch.go
+++ b/pkg/controller/utils/elasticsearch.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-logr/logr"
-
 	"github.com/olivere/elastic/v7"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/render"
@@ -66,12 +64,10 @@ type policyDetail struct {
 	policy       map[string]interface{}
 }
 
-type logrWrappedESLogger struct {
-	l logr.Logger
-}
+type logrWrappedESLogger struct{}
 
 func (l logrWrappedESLogger) Printf(format string, v ...interface{}) {
-	l.l.Error(nil, fmt.Sprintf(format, v...))
+	log.Error(nil, fmt.Sprintf(format, v...))
 }
 
 // ElasticsearchSecrets gets the secrets needed for a component to be able to access Elasticsearch


### PR DESCRIPTION
## Description

re-use `sigs.k8s.io/controller-runtime/pkg/log` for Elasticsearch client.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
