### PR TITLE
Disable healthcheck on es client

### DIFF
--- a/pkg/controller/utils/elasticsearch.go
+++ b/pkg/controller/utils/elasticsearch.go
@@ -149,6 +149,7 @@ func (es *esClient) createElasticClient(client client.Client, ctx context.Contex
 			elastic.SetHttpClient(h),
 			elastic.SetErrorLog(logrWrappedESLogger{}),
 			elastic.SetSniff(false),
+			elastic.SetHealthcheck(false),
 			elastic.SetBasicAuth(user, password),
 		}
 		retryInterval, err := time.ParseDuration(ElasticConnRetryInterval)


### PR DESCRIPTION
## Description

Elasticsearch client hits context deadline if health check is enabled,

> "msg":"Elastic connect failed, retrying","error":"Head \"https://tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local:9200\": context deadline exceeded"

https://github.com/olivere/elastic/issues/484
https://github.com/olivere/elastic/issues/880

Disabling the Healthcheck, as we are already handling the case where we check for dead connection and re-create it.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
