### PR TITLE
Custom certs only need to contain the expected svc DNS names as a subset

### DIFF
--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Compliance controller tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Requeue).NotTo(BeTrue())
 
-		By("replacing the server certs with ones that have the wrong DNS names")
+		By("replacing the server certs with ones that include the expected DNS names")
 		Expect(c.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceServerCertSecret,
 			Namespace: render.OperatorNamespace()}})).NotTo(HaveOccurred())
 		Expect(c.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceServerCertSecret,

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -603,11 +603,7 @@ func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context, logstora
 		return secrets, nil
 	}
 
-	var isExactMatch bool
-	if utils.IsOwnedByUID(secret, logstorageUID) {
-		isExactMatch = true
-	}
-	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames, isExactMatch)
+	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames)
 	if err == utils.ErrInvalidCertDNSNames {
 		if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
 			return nil, err
@@ -663,11 +659,7 @@ func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context, logstorageUID t
 		return secrets, nil
 	}
 
-	var isExactMatch bool
-	if utils.IsOwnedByUID(secret, logstorageUID) {
-		isExactMatch = true
-	}
-	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames, isExactMatch)
+	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames)
 	if err == utils.ErrInvalidCertDNSNames {
 		if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
 			return nil, err

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -603,7 +603,11 @@ func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context, logstora
 		return secrets, nil
 	}
 
-	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames)
+	var isExactMatch bool
+	if utils.IsOwnedByUID(secret, logstorageUID) {
+		isExactMatch = true
+	}
+	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames, isExactMatch)
 	if err == utils.ErrInvalidCertDNSNames {
 		if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
 			return nil, err
@@ -659,7 +663,11 @@ func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context, logstorageUID t
 		return secrets, nil
 	}
 
-	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames)
+	var isExactMatch bool
+	if utils.IsOwnedByUID(secret, logstorageUID) {
+		isExactMatch = true
+	}
+	err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames, isExactMatch)
 	if err == utils.ErrInvalidCertDNSNames {
 		if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
 			return nil, err

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -230,7 +230,8 @@ var _ = Describe("Manager controller tests", func() {
 		})
 
 		It("should reconcile if existing user-supplied cert has the expected DNS names", func() {
-			// Create a manager cert secret with invalid DNS name
+			// Create a manager cert secret with DNS names that include the
+			// expected DNS names.
 			dnsNames := append(expectedDNSNames, "manager.example.com", "192.168.10.22")
 			secret, err := render.CreateOperatorTLSSecret(
 				nil, render.ManagerTLSSecretName, render.ManagerSecretKeyName, render.ManagerSecretCertName, render.DefaultCertificateDuration, nil, dnsNames...)

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On(
 				"SetDegraded",
 				"Error ensuring manager TLS certificate \"manager-tls\" exists and has valid DNS names",
-				"Expected cert \"manager-tls\" to have DNS names: localhost, tigera-manager, tigera-manager.tigera-manager, tigera-manager.tigera-manager.svc, tigera-manager.tigera-manager.svc.some.domain",
+				"Expected cert \"manager-tls\" to have DNS names: tigera-manager, tigera-manager.tigera-manager, tigera-manager.tigera-manager.svc, tigera-manager.tigera-manager.svc.some.domain, localhost",
 			).Return()
 
 			// Create a manager cert secret with invalid DNS name

--- a/pkg/controller/utils/certs.go
+++ b/pkg/controller/utils/certs.go
@@ -72,7 +72,7 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 	if err == ErrInvalidCertDNSNames {
 		// If the cert's DNS names are invalid and the secret is owned by the
 		// component, then create a new secret to replace the invalid one.
-		if IsOwnedByUID(secret, componentUID) {
+		if isOwnedByUID(secret, componentUID) {
 			certsLogger.Info(fmt.Sprintf("cert %q has wrong DNS names, recreating it", secretName))
 			return render.CreateOperatorTLSSecret(nil,
 				secretName, keyName, certName,
@@ -88,7 +88,7 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 }
 
 // Check if object is owned by the resource with given UID.
-func IsOwnedByUID(obj client.Object, uid types.UID) bool {
+func isOwnedByUID(obj client.Object, uid types.UID) bool {
 	ownerRefs := obj.GetOwnerReferences()
 	for _, ref := range ownerRefs {
 		if ref.UID == uid {


### PR DESCRIPTION
## Description

Custom certs might include other SANs aside from the required internal k8s service DNS names.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
