### PR TITLE
Move managing OIDC elsticsearch user configmap and secret from operator

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -372,8 +372,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 	var elasticsearchSecrets, kibanaSecrets, curatorSecrets []*corev1.Secret
 	var clusterConfig *render.ElasticsearchClusterConfig
 	var esLicenseType render.ElasticsearchLicenseType
-	var oidcUserConfigMap *corev1.ConfigMap
-	var oidcUserSecret *corev1.Secret
 	applyTrial := false
 
 	if managementClusterConnection == nil {
@@ -429,15 +427,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			}
 		}
 
-		if oidcUserConfigMap, err = r.getOIDCUserConfigMap(ctx); err != nil {
-			r.status.SetDegraded("Failed to read oid user configmap", err.Error())
-			return reconcile.Result{}, err
-		}
-
-		if oidcUserSecret, err = r.oidcUsersEsSecret(ctx); err != nil {
-			r.status.SetDegraded("Failed to read oid user secret", err.Error())
-			return reconcile.Result{}, err
-		}
 	}
 
 	elasticsearch, err := r.getElasticsearch(ctx)
@@ -512,8 +501,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		applyTrial,
 		dexCfg,
 		esLicenseType,
-		oidcUserConfigMap,
-		oidcUserSecret,
 	)
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
@@ -551,6 +538,16 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			reqLogger.Error(err, "failed to create or update Elasticsearch lifecycle policies")
 			r.status.SetDegraded("Failed to create or update Elasticsearch lifecycle policies", err.Error())
 			return reconcile.Result{}, err
+		}
+
+		// kube-controller creates the ConfigMap and Secret needed for SSO into Kibana.
+		// If elastisearch uses basic license, degrade logstorage if the ConfigMap and Secret
+		// needed for logging user into Kibana is not available.
+		if esLicenseType == render.ElasticsearchLicenseTypeBasic {
+			if err = r.checkOIDCUsersEsResource(ctx); err != nil {
+				r.status.SetDegraded("Failed to get oidc user Secret and ConfigMap", err.Error())
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
@@ -720,38 +717,15 @@ func (r *ReconcileLogStorage) getKibanaService(ctx context.Context) (*corev1.Ser
 	return &svc, nil
 }
 
-func (r *ReconcileLogStorage) getOIDCUserConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
-	cm := &corev1.ConfigMap{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersConfigMapName, Namespace: render.ElasticsearchNamespace}, cm); err != nil {
-		if errors.IsNotFound(err) {
-			return &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.OIDCUsersConfigMapName,
-					Namespace: render.ElasticsearchNamespace,
-				},
-			}, nil
-		}
-		return nil, err
+func (r *ReconcileLogStorage) checkOIDCUsersEsResource(ctx context.Context) error {
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersConfigMapName, Namespace: render.ElasticsearchNamespace}, &corev1.ConfigMap{}); err != nil {
+		return err
 	}
-	return cm, nil
-}
 
-func (r *ReconcileLogStorage) oidcUsersEsSecret(ctx context.Context) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersEsSecreteName, Namespace: render.ElasticsearchNamespace}, secret); err != nil {
-		if errors.IsNotFound(err) {
-			return &corev1.Secret{
-				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.OIDCUsersEsSecreteName,
-					Namespace: render.ElasticsearchNamespace,
-				},
-			}, nil
-		}
-		return nil, err
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersEsSecreteName, Namespace: render.ElasticsearchNamespace}, &corev1.Secret{}); err != nil {
+		return err
 	}
-	return secret, nil
+	return nil
 }
 
 func calculateFlowShards(nodesSpecifications *operatorv1.Nodes, defaultShards int) int {


### PR DESCRIPTION
## Description

Move managing of OIDC Elsticsearch users ConfigMap and Secret from operator to kube-controller. 
ConfigMap `tigera-known-oidc-users` and Secret `tigera-oidc-users-elasticsearch-credentials`, needs to updated by few other internal components and doesn't fit well into tigera-operator design.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
