### PR TITLE
Check that cert is managed by operator by checking cert issuer

### DIFF
--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -292,7 +292,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	// the user, set the component degraded.
 	svcDNSNames := dns.GetServiceDNSNames(render.ComplianceServiceName, render.ComplianceNamespace, r.clusterDomain)
 	complianceServerCertSecret, err = utils.EnsureCertificateSecret(
-		render.ComplianceServerCertSecret, complianceServerCertSecret, render.ComplianceServerKeyName, render.ComplianceServerCertName, render.DefaultCertificateDuration, instance.GetUID(), svcDNSNames...,
+		render.ComplianceServerCertSecret, complianceServerCertSecret, render.ComplianceServerKeyName, render.ComplianceServerCertName, render.DefaultCertificateDuration, svcDNSNames...,
 	)
 
 	if err != nil {

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -395,13 +395,13 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, nil
 		}
 
-		if elasticsearchSecrets, err = r.elasticsearchSecrets(ctx, ls.GetUID()); err != nil {
+		if elasticsearchSecrets, err = r.elasticsearchSecrets(ctx); err != nil {
 			reqLogger.Error(err, err.Error())
 			r.status.SetDegraded("Failed to create elasticsearch secrets", err.Error())
 			return reconcile.Result{}, err
 		}
 
-		if kibanaSecrets, err = r.kibanaSecrets(ctx, ls.GetUID()); err != nil {
+		if kibanaSecrets, err = r.kibanaSecrets(ctx); err != nil {
 			reqLogger.Error(err, err.Error())
 			r.status.SetDegraded("Failed to create kibana secrets", err.Error())
 			return reconcile.Result{}, err
@@ -574,7 +574,7 @@ func (r *ReconcileLogStorage) deleteInvalidECKManagedPublicCertSecret(ctx contex
 	return r.client.Delete(ctx, secret)
 }
 
-func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context, logstorageUID types.UID) ([]*corev1.Secret, error) {
+func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context) ([]*corev1.Secret, error) {
 	var secrets []*corev1.Secret
 	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
 
@@ -585,7 +585,7 @@ func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context, logstora
 	}
 
 	// Ensure that cert is valid.
-	secret, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, secret, "tls.key", "tls.crt", render.DefaultCertificateDuration, logstorageUID, svcDNSNames...)
+	secret, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, secret, "tls.key", "tls.crt", render.DefaultCertificateDuration, svcDNSNames...)
 	if err != nil {
 		return nil, err
 	}
@@ -630,7 +630,7 @@ func (r *ReconcileLogStorage) shouldApplyElasticTrialSecret(ctx context.Context)
 	return false, nil
 }
 
-func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context, logstorageUID types.UID) ([]*corev1.Secret, error) {
+func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context) ([]*corev1.Secret, error) {
 	var secrets []*corev1.Secret
 	svcDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
 
@@ -641,7 +641,7 @@ func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context, logstorageUID t
 	}
 
 	// Ensure that cert is valid.
-	secret, err = utils.EnsureCertificateSecret(render.TigeraKibanaCertSecret, secret, "tls.key", "tls.crt", render.DefaultCertificateDuration, logstorageUID, svcDNSNames...)
+	secret, err = utils.EnsureCertificateSecret(render.TigeraKibanaCertSecret, secret, "tls.key", "tls.crt", render.DefaultCertificateDuration, svcDNSNames...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -533,9 +533,10 @@ var _ = Describe("LogStorage controller", func() {
 				It("test that LogStorage is degraded if the user-supplied certs have invalid DNS names", func() {
 					// Create the certs with old DNS names upfront so we can
 					// verify that the controller sets the degraded bit.
-					// These certs are not owned by LogStorage. The user must
+					// These certs are not operator-managed. The user must
 					// update these certs.
-					esSecret, err := render.CreateOperatorTLSSecret(nil,
+					testCA := test.MakeTestCA("logstorage-test")
+					esSecret, err := render.CreateOperatorTLSSecret(testCA,
 						render.TigeraElasticsearchCertSecret, "tls.key", "tls.crt", render.DefaultCertificateDuration, nil, "tigera-secure-es-http.tigera-elasticsearch.svc",
 					)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -544,7 +545,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(cli.Create(ctx, esSecret)).ShouldNot(HaveOccurred())
 					Expect(cli.Create(ctx, esPublicSecret)).ShouldNot(HaveOccurred())
 
-					kbSecret, err := render.CreateOperatorTLSSecret(nil,
+					kbSecret, err := render.CreateOperatorTLSSecret(testCA,
 						render.TigeraKibanaCertSecret, "tls.key", "tls.crt", render.DefaultCertificateDuration, nil, "tigera-secure-kb-http.tigera-elasticsearch.svc",
 					)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -589,7 +590,8 @@ var _ = Describe("LogStorage controller", func() {
 					// and KB cert secrets.
 
 					dnsNames := append(esDNSNames, "es.example.com", "192.168.10.10")
-					esSecret, err := render.CreateOperatorTLSSecret(nil,
+					testCA := test.MakeTestCA("logstorage-test")
+					esSecret, err := render.CreateOperatorTLSSecret(testCA,
 						render.TigeraElasticsearchCertSecret, "tls.key", "tls.crt", render.DefaultCertificateDuration, nil, dnsNames...,
 					)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -599,7 +601,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(cli.Create(ctx, esPublicSecret)).ShouldNot(HaveOccurred())
 
 					dnsNames = append(kbDNSNames, "kb.example.com", "192.168.10.11")
-					kbSecret, err := render.CreateOperatorTLSSecret(nil,
+					kbSecret, err := render.CreateOperatorTLSSecret(testCA,
 						render.TigeraKibanaCertSecret, "tls.key", "tls.crt", render.DefaultCertificateDuration, nil, dnsNames...,
 					)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -639,7 +641,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 				})
 
-				It("test that LogStorage creates new certs if the LogStorage owned certs have invalid DNS names", func() {
+				It("test that LogStorage creates new certs if operator managed certs have invalid DNS names", func() {
 					Expect(cli.Create(ctx, &storagev1.StorageClass{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: storageClassName,

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -240,21 +240,29 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
-	// If the manager TLS secret exists but is not managed by the operator,
-	// then skip checking its DNS names. Validation of DNS names is not required
-	// for a user-provided manager TLS secret.
-	//
-	// If the secret does not exist or if the secret is owned by the Manager cr,
-	// then we ensure that the secret exists and that the cert has the correct DNS
-	// names.
-	if tlsSecret == nil || utils.IsOwnedByUID(tlsSecret, instance.GetUID()) {
+	// If the manager TLS secret exists, check whether it is managed by the
+	// operator.
+	var certOperatorManaged bool
+	if tlsSecret != nil {
+		certOperatorManaged, err = utils.IsOperatorManaged(tlsSecret, render.ManagerInternalSecretCertName)
+		if err != nil {
+			r.status.SetDegraded(fmt.Sprintf("Error checking if manager TLS certificate is operator managed"), err.Error())
+			return reconcile.Result{}, err
+		}
+	}
+
+	// If the secret does not exist, then create one.
+	// If the secret exists but is operator managed, then check that it has the
+	// right DNS names and update it if necessary.
+	if tlsSecret == nil || certOperatorManaged {
 		// Create the cert if doesn't exist. If the cert exists, check that the cert
 		// has the expected DNS names. If the cert doesn't exist, the cert is recreated and returned.
+		// Note that validation of DNS names is not required for a user-provided manager TLS secret.
 		svcDNSNames := dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain)
 		svcDNSNames = append(svcDNSNames, "localhost")
 		certDur := 825 * 24 * time.Hour // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
 		tlsSecret, err = utils.EnsureCertificateSecret(
-			render.ManagerTLSSecretName, tlsSecret, render.ManagerSecretKeyName, render.ManagerSecretCertName, certDur, instance.GetUID(), svcDNSNames...,
+			render.ManagerTLSSecretName, tlsSecret, render.ManagerSecretKeyName, render.ManagerSecretCertName, certDur, svcDNSNames...,
 		)
 
 		if err != nil {

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -181,10 +181,6 @@ var _ = Describe("Manager controller tests", func() {
 			oldCert, err := render.CreateOperatorTLSSecret(
 				nil, render.ManagerTLSSecretName, render.ManagerSecretKeyName, render.ManagerSecretCertName, render.DefaultCertificateDuration, nil, "tigera-manager.tigera-manager.svc")
 			Expect(err).ShouldNot(HaveOccurred())
-
-			oldCert.SetOwnerReferences([]metav1.OwnerReference{
-				{UID: cr.GetUID()},
-			})
 			Expect(c.Create(ctx, oldCert)).NotTo(HaveOccurred())
 
 			_, err = r.Reconcile(ctx, reconcile.Request{})
@@ -200,17 +196,13 @@ var _ = Describe("Manager controller tests", func() {
 		})
 
 		It("should reconcile if user supplied a manager TLS cert", func() {
-			// Create a manager cert secret with invalid DNS name
+			// Create a manager cert secret.
 			dnsNames := []string{"manager.example.com", "192.168.10.22"}
+			testCA := test.MakeTestCA("manager-test")
 			secret, err := render.CreateOperatorTLSSecret(
-				nil, render.ManagerTLSSecretName, render.ManagerSecretKeyName, render.ManagerSecretCertName, render.DefaultCertificateDuration, nil, dnsNames...)
+				testCA, render.ManagerTLSSecretName, render.ManagerSecretKeyName, render.ManagerSecretCertName, render.DefaultCertificateDuration, nil, dnsNames...)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(c.Create(ctx, secret)).NotTo(HaveOccurred())
-
-			// Copy the cert secret to the manager namespace as would have
-			// already been done by the controller.
-			secretOperNs := render.CopySecrets(render.ManagerNamespace, secret)[0]
-			Expect(c.Create(ctx, secretOperNs)).NotTo(HaveOccurred())
 
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -223,19 +215,33 @@ var _ = Describe("Manager controller tests", func() {
 			test.VerifyCert(secret, render.ManagerSecretKeyName, render.ManagerSecretCertName, dnsNames...)
 		})
 
-		It("should reconcile if existing user-supplied cert has the expected DNS names", func() {
-			// Create a manager cert secret with DNS names that include the
-			// expected DNS names.
-			dnsNames := append(expectedDNSNames, "manager.example.com", "192.168.10.22")
-			secret, err := render.CreateOperatorTLSSecret(
-				nil, render.ManagerTLSSecretName, render.ManagerSecretKeyName, render.ManagerSecretCertName, render.DefaultCertificateDuration, nil, dnsNames...)
+		It("should reconcile if operator-managed cert exists and user supplied a custom cert", func() {
+			// Reconcile and check that the operator managed cert was created
+			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(c.Create(ctx, secret)).NotTo(HaveOccurred())
 
-			// Copy the cert secret to the manager namespace as would have
-			// already been done by the controller.
-			secretOperNs := render.CopySecrets(render.ManagerNamespace, secret)[0]
-			Expect(c.Create(ctx, secretOperNs)).NotTo(HaveOccurred())
+			secret := &corev1.Secret{}
+			// Verify that the operator managed cert secrets exist. These cert
+			// secrets should have the manager service DNS names plus localhost only.
+			Expect(c.Get(ctx, types.NamespacedName{Name: render.ManagerTLSSecretName, Namespace: render.OperatorNamespace()}, secret)).ShouldNot(HaveOccurred())
+			test.VerifyCert(secret, render.ManagerSecretKeyName, render.ManagerSecretCertName, expectedDNSNames...)
+
+			Expect(c.Get(ctx, types.NamespacedName{Name: render.ManagerTLSSecretName, Namespace: render.ManagerNamespace}, secret)).ShouldNot(HaveOccurred())
+			test.VerifyCert(secret, render.ManagerSecretKeyName, render.ManagerSecretCertName, expectedDNSNames...)
+
+			// Create a custom manager cert secret.
+			dnsNames := []string{"manager.example.com", "192.168.10.22"}
+			testCA := test.MakeTestCA("manager-test")
+			customSecret, err := render.CreateOperatorTLSSecret(
+				testCA, render.ManagerTLSSecretName, render.ManagerSecretKeyName, render.ManagerSecretCertName, render.DefaultCertificateDuration, nil, dnsNames...)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Update the existing operator managed cert secret with bytes from
+			// the custom manager cert secret.
+			Expect(c.Get(ctx, types.NamespacedName{Name: render.ManagerTLSSecretName, Namespace: render.OperatorNamespace()}, secret)).ShouldNot(HaveOccurred())
+			secret.Data[render.ManagerSecretCertName] = customSecret.Data[render.ManagerSecretCertName]
+			secret.Data[render.ManagerSecretKeyName] = customSecret.Data[render.ManagerSecretKeyName]
+			Expect(c.Update(ctx, secret)).NotTo(HaveOccurred())
 
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -176,8 +176,8 @@ var _ = Describe("Manager controller tests", func() {
 			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 		})
 
-		It("should render a new manager cert if existing cert has invalid DNS names and the cert is owned by the Manager CR", func() {
-			// Create a manager cert that is owned by the CR.
+		It("should render a new manager cert if existing cert has invalid DNS names and the cert is operator managed", func() {
+			// Create a manager cert managed by the operator.
 			oldCert, err := render.CreateOperatorTLSSecret(
 				nil, render.ManagerTLSSecretName, render.ManagerSecretKeyName, render.ManagerSecretCertName, render.DefaultCertificateDuration, nil, "tigera-manager.tigera-manager.svc")
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/controller/utils/certs.go
+++ b/pkg/controller/utils/certs.go
@@ -20,6 +20,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -36,6 +37,8 @@ var (
 	certsLogger             = logf.Log.WithName("certs")
 	ErrInvalidCertDNSNames  = errors.New("cert has the wrong DNS names")
 	ErrInvalidCertNoPEMData = errors.New("cert has no PEM data")
+
+	operatorIssuedCertRegexp = regexp.MustCompile(fmt.Sprintf(`%s@\d+`, render.TigeraOperatorCAIssuerPrefix))
 )
 
 func GetSecret(ctx context.Context, client client.Client, name string, ns string) (*corev1.Secret, error) {
@@ -56,7 +59,7 @@ func GetSecret(ctx context.Context, client client.Client, name string, ns string
 // If the cert in the secret has invalid DNS names and the secret is owned by
 // the provided component, then a new secret is created and returned. Otherwise,
 // if the secret is user-supplied, an error is returned.
-func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName string, certName string, certDuration time.Duration, componentUID types.UID, svcDNSNames ...string) (*corev1.Secret, error) {
+func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName string, certName string, certDuration time.Duration, svcDNSNames ...string) (*corev1.Secret, error) {
 	var err error
 
 	// Create the secret if it doesn't exist.
@@ -70,10 +73,14 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 
 	err = SecretHasExpectedDNSNames(secret, certName, svcDNSNames)
 	if err == ErrInvalidCertDNSNames {
-		// If the cert's DNS names are invalid and the secret is owned by the
-		// component, then create a new secret to replace the invalid one.
-		if IsOwnedByUID(secret, componentUID) {
-			certsLogger.Info(fmt.Sprintf("cert %q has wrong DNS names, recreating it", secretName))
+		// If the cert's DNS names are invalid and the cert secret is managed
+		// by the operator, then create a new secret to replace the invalid one.
+		operatorManaged, err := IsOperatorManaged(secret, certName)
+		if err != nil {
+			return nil, err
+		}
+		if operatorManaged {
+			certsLogger.Info(fmt.Sprintf("operator-managed cert %q has wrong DNS names, recreating it", secretName))
 			return render.CreateOperatorTLSSecret(nil,
 				secretName, keyName, certName,
 				render.DefaultCertificateDuration, nil, svcDNSNames...,
@@ -87,25 +94,33 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 	return secret, nil
 }
 
-// Check if object is owned by the resource with given UID.
-func IsOwnedByUID(obj client.Object, uid types.UID) bool {
-	ownerRefs := obj.GetOwnerReferences()
-	for _, ref := range ownerRefs {
-		if ref.UID == uid {
-			return true
-		}
+// Check if the cert secret is created and managed by the operator.
+func IsOperatorManaged(certSecret *corev1.Secret, certKeyName string) (bool, error) {
+	cert, err := parseCertificate(certSecret, certKeyName)
+	if err != nil {
+		certsLogger.Info(fmt.Sprintf("Parsing certificate error: %v", err))
+		return false, err
 	}
-	return false
+
+	return operatorIssuedCertRegexp.MatchString(cert.Issuer.CommonName), nil
+}
+
+func parseCertificate(secret *corev1.Secret, certKeyName string) (*x509.Certificate, error) {
+	certBytes := secret.Data[certKeyName]
+	pemBlock, _ := pem.Decode(certBytes)
+	if pemBlock == nil {
+		return nil, ErrInvalidCertNoPEMData
+	}
+	cert, err := x509.ParseCertificate(pemBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
 }
 
 // Check that the cert in the secret has the expected DNS names.
-func SecretHasExpectedDNSNames(secret *corev1.Secret, certName string, expectedDNSNames []string) error {
-	certBytes := secret.Data[certName]
-	pemBlock, _ := pem.Decode(certBytes)
-	if pemBlock == nil {
-		return ErrInvalidCertNoPEMData
-	}
-	cert, err := x509.ParseCertificate(pemBlock.Bytes)
+func SecretHasExpectedDNSNames(secret *corev1.Secret, certKeyName string, expectedDNSNames []string) error {
+	cert, err := parseCertificate(secret, certKeyName)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/utils/certs.go
+++ b/pkg/controller/utils/certs.go
@@ -55,9 +55,9 @@ func GetSecret(ctx context.Context, client client.Client, name string, ns string
 // EnsureCertificateSecret ensures that the certificate in the
 // secret has the expected DNS names. If no secret is provided, a new
 // secret is created and returned. If the secret does have the
-// right DNS name then the secret is returned.
-// If the cert in the secret has invalid DNS names and the secret is owned by
-// the provided component, then a new secret is created and returned. Otherwise,
+// right DNS names then the secret is returned.
+// If the cert in the secret has invalid DNS names and the secret is operator
+// managed, then a new secret is created and returned. Otherwise,
 // if the secret is user-supplied, an error is returned.
 func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName string, certName string, certDuration time.Duration, svcDNSNames ...string) (*corev1.Secret, error) {
 	var err error

--- a/pkg/render/common.go
+++ b/pkg/render/common.go
@@ -44,6 +44,12 @@ const (
 	OSTypeAny     OSType = "any"
 	OSTypeLinux   OSType = "linux"
 	OSTypeWindows OSType = "windows"
+
+	// The name prefix used for the CA issuer, which is used for self-signed
+	// certificates issued for operator-managed certificates.
+	// NOTE: Do not change this field since we use this value to identify
+	// certificates managed by this operator.
+	TigeraOperatorCAIssuerPrefix = "tigera-operator-signer"
 )
 
 // This type helps ensure that we only use defined os types
@@ -90,7 +96,7 @@ func envVarSourceFromSecret(secretName, key string, optional bool) *v1.EnvVarSou
 }
 
 func makeCA() (*crypto.CA, error) {
-	signerName := fmt.Sprintf("%s-signer@%d", "tigera-operator", time.Now().Unix())
+	signerName := fmt.Sprintf("%s@%d", TigeraOperatorCAIssuerPrefix, time.Now().Unix())
 
 	caConfig, err := crypto.MakeSelfSignedCAConfigForDuration(
 		signerName,

--- a/test/utils.go
+++ b/test/utils.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/library-go/pkg/crypto"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,4 +114,16 @@ func VerifyCertSANs(certBytes []byte, expectedSANs ...string) {
 	cert, err := x509.ParseCertificate(pemBlock.Bytes)
 	Expect(err).To(BeNil(), "Error parsing bytes from secret into certificate")
 	Expect(cert.DNSNames).To(ConsistOf(expectedSANs), "Expect cert SAN's to match expected service DNS names")
+}
+
+func MakeTestCA(signer string) *crypto.CA {
+	caConfig, err := crypto.MakeSelfSignedCAConfigForDuration(
+		signer,
+		100*365*24*time.Hour, //100years*365days*24hours
+	)
+	Expect(err).To(BeNil(), "Error creating CA config")
+	return &crypto.CA{
+		SerialGenerator: &crypto.RandomSerialGenerator{},
+		Config:          caConfig,
+	}
 }


### PR DESCRIPTION
## Description
Previous PRs added logic to check whether a cert is operator managed or supplied by the user by checking the certificate secret's ownerreference which is incorrect.

Instead this PR uses the fact that the self-signed certs issued by the operator have used the same CA signer name prefix.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
