### PR TITLE
cherry-pick: fix maybe-build-release to work on earlier versions of git

### DIFF
--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -6,7 +6,7 @@ if ! tag=$(git describe --exact-match --tags HEAD); then
 	exit 0
 fi
 
-if [[ ! "$(git branch --show-current)" =~ (release-v*.*|master) ]]; then
+if [[ ! "$(git rev-parse --abbrev-ref HEAD)" =~ (release-v*.*|master) ]]; then
 	echo "not on 'master' or 'release-vX.Y'"
 	exit 0
 fi


### PR DESCRIPTION
## Description

git branch --show-current was introduced for git 2.22, which semaphoreci
does not meet.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
