### PR TITLE
Only merge metadata if it's not set on the desired state

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -195,10 +195,16 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 	currentMeta := current.(metav1.ObjectMetaAccessor).GetObjectMeta()
 	desiredMeta := desired.(metav1.ObjectMetaAccessor).GetObjectMeta()
 
-	// Merge common metadata fields.
-	desiredMeta.SetResourceVersion(currentMeta.GetResourceVersion())
-	desiredMeta.SetUID(currentMeta.GetUID())
-	desiredMeta.SetCreationTimestamp(currentMeta.GetCreationTimestamp())
+	// Merge common metadata fields if not present on the desired state.
+	if desiredMeta.GetResourceVersion() == "" {
+		desiredMeta.SetResourceVersion(currentMeta.GetResourceVersion())
+	}
+	if desiredMeta.GetUID() == "" {
+		desiredMeta.SetUID(currentMeta.GetUID())
+	}
+	if reflect.DeepEqual(desiredMeta.GetCreationTimestamp(), metav1.Time{}) {
+		desiredMeta.SetCreationTimestamp(currentMeta.GetCreationTimestamp())
+	}
 
 	// Merge annotations by reconciling the ones that components expect, but leaving everything else
 	// as-is.

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -128,6 +128,20 @@ var _ = Describe("Component handler tests", func() {
 		c.Get(ctx, nsKey, ns)
 		Expect(ns.GetAnnotations()).To(Equal(expectedAnnotations))
 
+		// Re-initialize the fake component. Object metadata gets modified as part of CreateOrUpdate, leading
+		// to resource update conflicts.
+		fc = &fakeComponent{
+			supportedOSType: render.OSTypeLinux,
+			objs: []client.Object{&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+					Annotations: map[string]string{
+						fakeComponentAnnotationKey: fakeComponentAnnotationValue,
+					},
+				},
+			}},
+		}
+
 		By("initiating a merge with Openshift SCC annotations")
 		err = handler.CreateOrUpdate(ctx, fc, sm)
 		Expect(err).To(BeNil())
@@ -162,6 +176,20 @@ var _ = Describe("Component handler tests", func() {
 		ns = &v1.Namespace{}
 		c.Get(ctx, nsKey, ns)
 		Expect(ns.GetAnnotations()).To(Equal(expectedAnnotations))
+
+		// Re-initialize the fake component. Object metadata gets modified as part of CreateOrUpdate, leading
+		// to resource update conflicts.
+		fc = &fakeComponent{
+			supportedOSType: render.OSTypeLinux,
+			objs: []client.Object{&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+					Annotations: map[string]string{
+						fakeComponentAnnotationKey: fakeComponentAnnotationValue,
+					},
+				},
+			}},
+		}
 
 		By("initiating a merge with namespace containing modified desired annotation")
 		err = handler.CreateOrUpdate(ctx, fc, sm)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

If the controller, for whatever reason, wants to assert a certain
revision or UID for an object, then the merge logic should respect that.

Most objects will come through without revision information, in which
case it will be copied from the live state on the cluster.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.