### PR TITLE
include OS node selector in PodTemplate resource types

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -301,6 +301,8 @@ func ensureOSSchedulingRestrictions(obj client.Object, osType render.OSType) {
 
 	var podSpecs []*v1.PodSpec
 	switch obj.(type) {
+	case *v1.PodTemplate:
+		podSpecs = []*v1.PodSpec{&obj.(*v1.PodTemplate).Template.Spec}
 	case *apps.Deployment:
 		podSpecs = []*v1.PodSpec{&obj.(*apps.Deployment).Spec.Template.Spec}
 	case *apps.DaemonSet:

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -212,6 +212,8 @@ var _ = Describe("Component handler tests", func() {
 
 		var nodeSelectors map[string]string
 		switch obj.(type) {
+		case *v1.PodTemplate:
+			nodeSelectors = obj.(*v1.PodTemplate).Template.Spec.NodeSelector
 		case *apps.Deployment:
 			nodeSelectors = obj.(*apps.Deployment).Spec.Template.Spec.NodeSelector
 		case *apps.DaemonSet:
@@ -237,6 +239,44 @@ var _ = Describe("Component handler tests", func() {
 
 		Expect(nodeSelectors).Should(Equal(expectedNodeSelectors))
 	},
+		TableEntry{
+			Description: "linux - sets the required annotations for a podtemplate when they're not set",
+			Parameters: []interface{}{
+				&fakeComponent{
+					supportedOSType: render.OSTypeLinux,
+					objs: []client.Object{&v1.PodTemplate{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-podtemplate"},
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								NodeSelector: map[string]string{},
+							},
+						},
+					}},
+				}, client.ObjectKey{Name: "test-podtemplate"}, &v1.PodTemplate{},
+				map[string]string{
+					"kubernetes.io/os": "linux",
+				},
+			},
+		},
+		TableEntry{
+			Description: "windows - sets the required annotations for a podtemplate when they're not set",
+			Parameters: []interface{}{
+				&fakeComponent{
+					supportedOSType: render.OSTypeWindows,
+					objs: []client.Object{&v1.PodTemplate{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-podtemplate"},
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								NodeSelector: map[string]string{},
+							},
+						},
+					}},
+				}, client.ObjectKey{Name: "test-podtemplate"}, &v1.PodTemplate{},
+				map[string]string{
+					"kubernetes.io/os": "windows",
+				},
+			},
+		},
 		TableEntry{
 			Description: "linux - sets the required annotations for a deployment when they're not set",
 			Parameters: []interface{}{


### PR DESCRIPTION
## Description

Compliance defines a pod template - looks like the pods template is not included in the os-node-selector updates - it should be,

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
