### PR TITLE
Use FQDN elasticsearch and kibana endpoints only for Windows

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -186,6 +186,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		// Check that if the apiserver cert pair secret exists that it is valid (has key and cert fields)
 		// If it does not exist then this function still returns true
 		tlsSecret, err = utils.ValidateCertPair(r.client,
+			rmeta.OperatorNamespace(),
 			render.APIServerTLSSecretName,
 			render.APIServerSecretKeyName,
 			render.APIServerSecretCertName,
@@ -227,6 +228,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	var tunnelCASecret *v1.Secret
 	if managementCluster != nil {
 		tunnelCASecret, err = utils.ValidateCertPair(r.client,
+			rmeta.OperatorNamespace(),
 			render.VoltronTunnelSecretName,
 			render.VoltronTunnelSecretKeyName,
 			render.VoltronTunnelSecretCertName,

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -278,6 +278,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	var managerInternalTLSSecret *corev1.Secret
 	if managementCluster != nil {
 		managerInternalTLSSecret, err = utils.ValidateCertPair(r.client,
+			rmeta.OperatorNamespace(),
 			render.ManagerInternalTLSSecretName,
 			render.ManagerInternalSecretCertName,
 			render.ManagerInternalSecretKeyName,
@@ -290,6 +291,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	complianceServerCertSecret, err := utils.ValidateCertPair(r.client,
+		rmeta.OperatorNamespace(),
 		render.ComplianceServerCertSecret,
 		render.ComplianceServerCertName,
 		render.ComplianceServerKeyName,

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -805,7 +805,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	}
 
 	var managerInternalTLSSecret *corev1.Secret
-	managerInternalTLSSecret, err = utils.ValidateCertPairInNamespace(r.client,
+	managerInternalTLSSecret, err = utils.ValidateCertPair(r.client,
 		common.CalicoNamespace,
 		render.ManagerInternalTLSSecretName,
 		render.ManagerInternalSecretCertName,
@@ -1101,6 +1101,7 @@ func (r *ReconcileInstallation) GetTyphaFelixTLSConfig() (*render.TyphaNodeTLS, 
 
 	node, err := utils.ValidateCertPair(
 		r.client,
+		rmeta.OperatorNamespace(),
 		render.NodeTLSSecretName,
 		render.TLSSecretKeyName,
 		render.TLSSecretCertName,
@@ -1120,6 +1121,7 @@ func (r *ReconcileInstallation) GetTyphaFelixTLSConfig() (*render.TyphaNodeTLS, 
 
 	typha, err := utils.ValidateCertPair(
 		r.client,
+		rmeta.OperatorNamespace(),
 		render.TyphaTLSSecretName,
 		render.TLSSecretKeyName,
 		render.TLSSecretCertName,

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -574,8 +574,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		}
 
 		// ES should be in ready phase when execution reaches here, apply ILM polices
-		esEndpoint := fmt.Sprintf(relasticsearch.HTTPSEndpoint, r.clusterDomain)
-		if err = r.esClient.SetILMPolicies(r.client, ctx, ls, esEndpoint); err != nil {
+		if err = r.esClient.SetILMPolicies(r.client, ctx, ls, relasticsearch.HTTPSEndpoint(component.SupportedOSType(), r.clusterDomain)); err != nil {
 			reqLogger.Error(err, "failed to create or update Elasticsearch lifecycle policies")
 			r.status.SetDegraded("Failed to create or update Elasticsearch lifecycle policies", err.Error())
 			return reconcile.Result{}, err

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -234,6 +234,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	// If it does not exist then this function returns a nil secret but no error and a self-signed
 	// certificate will be generated when rendering below.
 	tlsSecret, err := utils.ValidateCertPair(r.client,
+		rmeta.OperatorNamespace(),
 		render.ManagerTLSSecretName,
 		render.ManagerSecretKeyName,
 		render.ManagerSecretCertName,
@@ -298,6 +299,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 
 		complianceServerCertSecret, err := utils.ValidateCertPair(r.client,
+			rmeta.OperatorNamespace(),
 			render.ComplianceServerCertSecret,
 			render.ComplianceServerCertName,
 			render.ComplianceServerKeyName,

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -197,18 +197,12 @@ func IsFeatureActive(license v3.LicenseKey, featureName string) bool {
 	return false
 }
 
-// ValidateCertPair validates the cert pair secret in the tigera-operator namespace.
-func ValidateCertPair(client client.Client, certPairSecretName, keyName, certName string) (*corev1.Secret, error) {
-	return ValidateCertPairInNamespace(client, rmeta.OperatorNamespace(), certPairSecretName, keyName, certName)
-}
-
-// ValidateCertPairInNamespace checks if the given secret exists in the given
+// ValidateCertPair checks if the given secret exists in the given
 // namespace and if so that it contains key and cert fields. If a secret exists then it is returned.
 // If there is an error accessing the secret (except NotFound) or the cert
 // does not have both a key and cert field then an appropriate error is returned.
 // If no secret exists then nil, nil is returned to represent that no cert is valid.
-// TODO: Replace this with version of ValidateCertPair taking in a ns.
-func ValidateCertPairInNamespace(client client.Client, namespace, certPairSecretName, keyName, certName string) (*corev1.Secret, error) {
+func ValidateCertPair(client client.Client, namespace, certPairSecretName, keyName, certName string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secretNamespacedName := types.NamespacedName{
 		Name:      certPairSecretName,

--- a/pkg/render/common/elasticsearch/decorator.go
+++ b/pkg/render/common/elasticsearch/decorator.go
@@ -15,7 +15,6 @@
 package elasticsearch
 
 import (
-	"fmt"
 	"strconv"
 
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -86,7 +85,7 @@ func ContainerDecorateENVVars(
 	cluster, esUserSecretName, clusterDomain string,
 	osType rmeta.OSType) corev1.Container {
 	certPath := elasticCertPath(osType)
-	esScheme, esHost, esPort, _ := url.ParseEndpoint(fmt.Sprintf(HTTPSEndpoint, clusterDomain))
+	esScheme, esHost, esPort, _ := url.ParseEndpoint(HTTPSEndpoint(osType, clusterDomain))
 	envVars := []corev1.EnvVar{
 		{Name: "ELASTIC_INDEX_SUFFIX", Value: cluster},
 		{Name: "ELASTIC_SCHEME", Value: esScheme},

--- a/pkg/render/common/kibana/service.go
+++ b/pkg/render/common/kibana/service.go
@@ -1,4 +1,4 @@
-package elasticsearch
+package kibana
 
 import (
 	"fmt"
@@ -6,11 +6,11 @@ import (
 )
 
 const (
-	httpsEndpoint     = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
-	httpsFQDNEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc.%s:9200"
+	httpsEndpoint     = "https://tigera-secure-kb-http.tigera-kibana.svc:5601"
+	httpsFQDNEndpoint = "https://tigera-secure-kb-http.tigera-kibana.svc.%s:5601"
 )
 
-// HTTPSEndpoint returns the endpoint for the Elasticsearch service. For
+// HTTPSEndpoint returns the full endpoint for the Kibana service. For
 // Windows, the FQDN endpoint is returned.
 func HTTPSEndpoint(osType rmeta.OSType, clusterDomain string) string {
 	if osType == rmeta.OSTypeWindows {

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -122,7 +122,7 @@ var _ = Describe("compliance rendering tests", func() {
 			envs := d.Spec.Template.Spec.Containers[0].Env
 
 			expectedEnvs := []corev1.EnvVar{
-				{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"},
+				{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
 				{Name: "ELASTIC_PORT", Value: "9200"},
 			}
 			for _, expected := range expectedEnvs {

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -16,7 +16,6 @@ package render_test
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -53,7 +52,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		esConfigMap = relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
 	})
 
-	DescribeTable("should render with a default configuration", func(clusterDomain, expectedElasticHost string) {
+	It("should render with a default configuration", func() {
 		expectedResources := []struct {
 			name    string
 			ns      string
@@ -70,7 +69,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		// Should render the correct resources.
-		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, clusterDomain, rmeta.OSTypeLinux)
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain, rmeta.OSTypeLinux)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -89,7 +88,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{Name: "FLOW_LOG_FILE", Value: "/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "/var/log/calico/dnslogs/dns.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
-			{Name: "ELASTIC_HOST", Value: expectedElasticHost},
+			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
 			{Name: "ELASTIC_PORT", Value: "9200"},
 			{
 				Name: "NODENAME",
@@ -101,10 +100,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		for _, expected := range expectedEnvs {
 			Expect(envs).To(ContainElement(expected))
 		}
-	},
-		Entry("default cluster DNS", dns.DefaultClusterDomain, "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"),
-		Entry("custom cluster DNS", "acme.internal", "tigera-secure-es-http.tigera-elasticsearch.svc.acme.internal"),
-	)
+	})
 
 	It("should render for Windows nodes", func() {
 		expectedResources := []struct {
@@ -588,7 +584,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		envs := deploy.Spec.Template.Spec.Containers[0].Env
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "K8S_PLATFORM", Value: "eks"}))
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "AWS_REGION", Value: eksConfig.AwsRegion}))
-		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"}))
+		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"}))
 
 		fetchIntervalVal := "900"
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "EKS_CLOUDWATCH_LOG_FETCH_INTERVAL", Value: fetchIntervalVal}))

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -32,6 +32,7 @@ import (
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rkibana "github.com/tigera/operator/pkg/render/common/kibana"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
@@ -188,7 +189,7 @@ func (c *intrusionDetectionComponent) intrusionDetectionElasticsearchJob() *batc
 }
 
 func (c *intrusionDetectionComponent) intrusionDetectionJobContainer() v1.Container {
-	kScheme, kHost, kPort, _ := url.ParseEndpoint(fmt.Sprintf(KibanaHTTPSEndpoint, c.clusterDomain))
+	kScheme, kHost, kPort, _ := url.ParseEndpoint(rkibana.HTTPSEndpoint(c.SupportedOSType(), c.clusterDomain))
 	secretName := ElasticsearchIntrusionDetectionJobUserSecret
 	return corev1.Container{
 		Name:  "elasticsearch-job-installer",

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rkibana "github.com/tigera/operator/pkg/render/common/kibana"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podsecuritycontext"
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
@@ -468,7 +469,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		{Name: "VOLTRON_PORT", Value: defaultVoltronPort},
 		{Name: "VOLTRON_COMPLIANCE_ENDPOINT", Value: fmt.Sprintf("https://compliance.%s.svc.%s", ComplianceNamespace, c.clusterDomain)},
 		{Name: "VOLTRON_LOGLEVEL", Value: "info"},
-		{Name: "VOLTRON_KIBANA_ENDPOINT", Value: fmt.Sprintf(KibanaHTTPSEndpoint, c.clusterDomain)},
+		{Name: "VOLTRON_KIBANA_ENDPOINT", Value: rkibana.HTTPSEndpoint(c.SupportedOSType(), c.clusterDomain)},
 		{Name: "VOLTRON_KIBANA_BASE_PATH", Value: fmt.Sprintf("/%s/", KibanaBasePath)},
 		{Name: "VOLTRON_KIBANA_CA_BUNDLE_PATH", Value: "/certs/kibana/tls.crt"},
 		{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.managementCluster != nil)},
@@ -525,7 +526,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 	env := []v1.EnvVar{
 		{Name: "ELASTIC_LICENSE_TYPE", Value: string(c.esLicenseType)},
 		{Name: "ELASTIC_VERSION", Value: components.ComponentEckElasticsearch.Version},
-		{Name: "ELASTIC_KIBANA_ENDPOINT", Value: fmt.Sprintf(KibanaHTTPSEndpoint, c.clusterDomain)},
+		{Name: "ELASTIC_KIBANA_ENDPOINT", Value: rkibana.HTTPSEndpoint(c.SupportedOSType(), c.clusterDomain)},
 	}
 
 	if c.dexCfg != nil {


### PR DESCRIPTION
## Description

For components running on Linux, FQDN endpoints for ES and Kibana aren't required so revert that change. This smooths out the upgrade for users of custom TLS certs.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
