### PR TITLE
Automated cherry pick of #1155: Add watch permissions to kube-controllers on IPAM blocks

### DIFF
--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -149,7 +149,7 @@ func (c *kubeControllersComponent) controllersRole() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"crd.projectcalico.org"},
 				Resources: []string{"blockaffinities", "ipamblocks", "ipamhandles", "networksets"},
-				Verbs:     []string{"get", "list", "create", "update", "delete"},
+				Verbs:     []string{"get", "list", "create", "update", "delete", "watch"},
 			},
 			{
 				// Needs access to update clusterinformations.


### PR DESCRIPTION
Cherry pick of #1155 on release-v1.15.

#1155: Add watch permissions to kube-controllers on IPAM blocks