### PR TITLE
typha and namespace adjustments for AKS

### DIFF
--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -103,6 +103,34 @@ var _ = Describe("Test typha autoscaler ", func() {
 		Expect(err).To(BeNil())
 		verifyTyphaReplicas(c, 2)
 	})
+
+	It("should ignore aks virtual nodes in its count", func() {
+		typhaMeta := metav1.ObjectMeta{
+			Name:      "calico-typha",
+			Namespace: "calico-system",
+		}
+		// Create a typha deployment
+		typha := &appsv1.Deployment{
+			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+			ObjectMeta: typhaMeta,
+		}
+		err := c.Create(ctx, typha)
+		Expect(err).To(BeNil())
+
+		// Create two nodes, one of which is a virtual-kubelet
+		createNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux", "kubernetes.azure.com/cluster": "foo", "type": "virtual-kubelet"})
+
+		// Create the autoscaler and run it
+		ta := newTyphaAutoscaler(c, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
+		ta.start()
+
+		// normally we'd expect to see three replicas for three nodes, but since one node is a virtual-kubelet,
+		// we should still only expect two
+		verifyTyphaReplicas(c, 2)
+	})
+
 	It("should be degraded if there's not enough linux nodes", func() {
 		typhaMeta := metav1.ObjectMeta{
 			Name:      "calico-typha",

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -105,7 +105,7 @@ func ConvertSecretToCredential(s *corev1.Secret) (*AmazonCredential, error) {
 
 func (c *amazonCloudIntegrationComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(AmazonCloudIntegrationNamespace, c.openshift),
+		createNamespace(AmazonCloudIntegrationNamespace, c.installation.KubernetesProvider),
 	}
 	secrets := secret.CopyToNamespace(AmazonCloudIntegrationNamespace, c.pullSecrets...)
 	objs = append(objs, secret.ToRuntimeObjects(secrets...)...)

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -164,7 +164,7 @@ func (c *apiServerComponent) SupportedOSType() rmeta.OSType {
 
 func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(APIServerNamespace, c.openshift),
+		createNamespace(APIServerNamespace, c.installation.KubernetesProvider),
 	}
 	secrets := secret.CopyToNamespace(APIServerNamespace, c.pullSecrets...)
 	objs = append(objs, secret.ToRuntimeObjects(secrets...)...)

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -152,7 +152,7 @@ func (c *complianceComponent) SupportedOSType() rmeta.OSType {
 
 func (c *complianceComponent) Objects() ([]client.Object, []client.Object) {
 	complianceObjs := append(
-		[]client.Object{createNamespace(ComplianceNamespace, c.openshift)},
+		[]client.Object{createNamespace(ComplianceNamespace, c.installation.KubernetesProvider)},
 		secret.ToRuntimeObjects(secret.CopyToNamespace(ComplianceNamespace, c.pullSecrets...)...)...,
 	)
 	complianceObjs = append(complianceObjs,

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -236,7 +236,7 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	objs = append(objs,
 		createNamespace(
 			LogCollectorNamespace,
-			c.installation.KubernetesProvider == operatorv1.ProviderOpenShift))
+			c.installation.KubernetesProvider))
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.pullSecrets...)...)...)
 	if c.s3Credential != nil {
 		objs = append(objs, c.s3CredentialSecret())

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -84,7 +84,7 @@ func (c *GuardianComponent) SupportedOSType() rmeta.OSType {
 
 func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(GuardianNamespace, c.openshift),
+		createNamespace(GuardianNamespace, c.installation.KubernetesProvider),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(GuardianNamespace, c.pullSecrets...)...)...)
 	objs = append(objs,
@@ -95,7 +95,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		c.service(),
 		secret.CopyToNamespace(GuardianNamespace, c.tunnelSecret)[0],
 		// Add tigera-manager service account for impersonation
-		createNamespace(ManagerNamespace, c.openshift),
+		createNamespace(ManagerNamespace, c.installation.KubernetesProvider),
 		managerServiceAccount(),
 		managerClusterRole(false, true, c.openshift),
 		managerClusterRoleBinding(),

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -113,7 +113,7 @@ func (c *intrusionDetectionComponent) SupportedOSType() rmeta.OSType {
 }
 
 func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Object) {
-	objs := []client.Object{createNamespace(IntrusionDetectionNamespace, c.openshift)}
+	objs := []client.Object{createNamespace(IntrusionDetectionNamespace, c.installation.KubernetesProvider)}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.pullSecrets...)...)...)
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.esSecrets...)...)...)
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.kibanaCertSecret)...)...)

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -291,7 +291,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 
 		// ECK CRs
 		toCreate = append(toCreate,
-			createNamespace(ECKOperatorNamespace, es.provider == operatorv1.ProviderOpenShift),
+			createNamespace(ECKOperatorNamespace, es.installation.KubernetesProvider),
 		)
 
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ECKOperatorNamespace, es.pullSecrets...)...)...)
@@ -322,7 +322,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.eckOperatorStatefulSet())
 
 		// Elasticsearch CRs
-		toCreate = append(toCreate, createNamespace(ElasticsearchNamespace, es.provider == operatorv1.ProviderOpenShift))
+		toCreate = append(toCreate, createNamespace(ElasticsearchNamespace, es.installation.KubernetesProvider))
 
 		if len(es.pullSecrets) > 0 {
 			toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ElasticsearchNamespace, es.pullSecrets...)...)...)
@@ -343,7 +343,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.elasticsearchCluster(len(secureSettings.Data) > 0))
 
 		// Kibana CRs
-		toCreate = append(toCreate, createNamespace(KibanaNamespace, false))
+		toCreate = append(toCreate, createNamespace(KibanaNamespace, es.installation.KubernetesProvider))
 		toCreate = append(toCreate, es.kibanaServiceAccount())
 
 		if len(es.pullSecrets) > 0 {
@@ -391,8 +391,8 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		}
 	} else {
 		toCreate = append(toCreate,
-			createNamespace(ElasticsearchNamespace, es.provider == operatorv1.ProviderOpenShift),
-			createNamespace(KibanaNamespace, es.provider == operatorv1.ProviderOpenShift),
+			createNamespace(ElasticsearchNamespace, es.installation.KubernetesProvider),
+			createNamespace(KibanaNamespace, es.installation.KubernetesProvider),
 			es.elasticsearchExternalService(),
 			es.kibanaExternalService(),
 		)

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -181,7 +181,7 @@ func (c *managerComponent) SupportedOSType() rmeta.OSType {
 
 func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(ManagerNamespace, c.openshift),
+		createNamespace(ManagerNamespace, c.installation.KubernetesProvider),
 	}
 	pullSecrets := secret.CopyToNamespace(ManagerNamespace, c.pullSecrets...)
 	pullSecrets = append(pullSecrets, secret.CopyToNamespace(common.TigeraPrometheusNamespace, c.pullSecrets...)...)

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -48,11 +48,11 @@ func (c *namespaceComponent) SupportedOSType() rmeta.OSType {
 
 func (c *namespaceComponent) Objects() ([]client.Object, []client.Object) {
 	ns := []client.Object{
-		createNamespace(common.CalicoNamespace, c.installation.KubernetesProvider == operatorv1.ProviderOpenShift),
+		createNamespace(common.CalicoNamespace, c.installation.KubernetesProvider),
 	}
 	if c.installation.Variant == operatorv1.TigeraSecureEnterprise {
 		// We need to always have ns tigera-dex even when the Authentication CR is not present, so policies can be added to this namespace.
-		ns = append(ns, createNamespace(DexObjectName, c.installation.KubernetesProvider == operatorv1.ProviderOpenShift))
+		ns = append(ns, createNamespace(DexObjectName, c.installation.KubernetesProvider))
 	}
 	if len(c.pullSecrets) > 0 {
 		ns = append(ns, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.pullSecrets...)...)...)
@@ -65,7 +65,7 @@ func (c *namespaceComponent) Ready() bool {
 	return true
 }
 
-func createNamespace(name string, openshift bool) *corev1.Namespace {
+func createNamespace(name string, provider operatorv1.Provider) *corev1.Namespace {
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -75,10 +75,12 @@ func createNamespace(name string, openshift bool) *corev1.Namespace {
 		},
 	}
 
-	// OpenShift requires special labels and annotations.
-	if openshift {
+	switch provider {
+	case operatorv1.ProviderOpenShift:
 		ns.Labels["openshift.io/run-level"] = "0"
 		ns.Annotations["openshift.io/node-selector"] = ""
+	case operatorv1.ProviderAKS:
+		ns.Labels["control-plane"] = "true"
 	}
 	return ns
 }

--- a/pkg/render/namespaces_test.go
+++ b/pkg/render/namespaces_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Namespace rendering tests", func() {
 		meta := resources[0].(metav1.ObjectMetaAccessor).GetObjectMeta()
 		Expect(meta.GetLabels()["name"]).To(Equal("calico-system"))
 		Expect(meta.GetLabels()).NotTo(ContainElement("openshift.io/run-level"))
+		Expect(meta.GetLabels()).NotTo(ContainElement("control-plane"))
 		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
 	})
 
@@ -49,7 +50,19 @@ var _ = Describe("Namespace rendering tests", func() {
 		rtest.ExpectResource(resources[0], "calico-system", "", "", "v1", "Namespace")
 		meta := resources[0].(metav1.ObjectMetaAccessor).GetObjectMeta()
 		Expect(meta.GetLabels()["openshift.io/run-level"]).To(Equal("0"))
+		Expect(meta.GetLabels()).NotTo(ContainElement("control-plane"))
 		Expect(meta.GetAnnotations()["openshift.io/node-selector"]).To(Equal(""))
+	})
+
+	It("should render a namespace for aks", func() {
+		installation.KubernetesProvider = v1.ProviderAKS
+		component := render.Namespaces(installation, nil)
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(1))
+		rtest.ExpectResource(resources[0], "calico-system", "", "", "v1", "Namespace")
+		meta := resources[0].(metav1.ObjectMetaAccessor).GetObjectMeta()
+		Expect(meta.GetLabels()).NotTo(ContainElement("openshift.io/run-level"))
+		Expect(meta.GetLabels()["control-plane"]).To(Equal("true"))
 	})
 
 	It("should render a namespace for tigera-dex on EE", func() {

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -398,7 +398,7 @@ func (c *typhaComponent) typhaDeployment() *apps.Deployment {
 				},
 				Spec: v1.PodSpec{
 					Tolerations:                   rmeta.TolerateAll,
-					Affinity:                      toAffinity(c.installation.TyphaAffinity),
+					Affinity:                      c.affinity(),
 					ImagePullSecrets:              c.installation.ImagePullSecrets,
 					ServiceAccountName:            TyphaServiceAccountName,
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
@@ -607,17 +607,43 @@ func (c *typhaComponent) typhaPodSecurityPolicy() *policyv1beta1.PodSecurityPoli
 	return psp
 }
 
-// toAffinity converts a typha affinity to a k8s affinity.
-func toAffinity(t *operator.TyphaAffinity) *v1.Affinity {
-	if t == nil {
-		return nil
+// affinity sets the affinity on typha, accounting for the kubernetes-provider and user-specified values.
+func (c *typhaComponent) affinity() (aff *v1.Affinity) {
+	// in AKS, there is a feature called 'virtual-nodes' which represent azure's container service as a node in the kubernetes cluster.
+	// virtual-nodes have many limitations, namely it's unable to run hostNetworked pods. virtual-kubelets are tainted to prevent pods from running on them,
+	// but typha tolerates all taints and will run there.
+	// as such, we add a required anti-affinity for virtual-nodes if running on azure
+	if c.installation.KubernetesProvider == operator.ProviderAKS {
+		aff = &v1.Affinity{
+			NodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "type",
+								Operator: corev1.NodeSelectorOpNotIn,
+								Values:   []string{"virtual-node"},
+							},
+							{
+								Key:      "kubernetes.azure.com/cluster",
+								Operator: v1.NodeSelectorOpExists,
+							},
+						},
+					}},
+				},
+			},
+		}
 	}
-	if t.NodeAffinity == nil {
-		return nil
+
+	// add the user-specified typha preferred affinity if specified.
+	if c.installation.TyphaAffinity != nil && c.installation.TyphaAffinity.NodeAffinity != nil {
+		// check if above code initialized affintiy or not.
+		// this ensures we still return nil if neither condition is hit.
+		if aff == nil {
+			aff = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{}}
+		}
+		aff.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = c.installation.TyphaAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 	}
-	return &v1.Affinity{
-		NodeAffinity: &v1.NodeAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: t.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
-		},
-	}
+
+	return aff
 }

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onsi/gomega/gstruct"
 
 	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -234,6 +235,68 @@ var _ = Describe("Typha rendering tests", func() {
 		d := dResource.(*apps.Deployment)
 		na := d.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 		Expect(na).To(Equal(pfts))
+	})
+
+	It("should include virtual kubelet affinity for aks", func() {
+		installation.KubernetesProvider = operator.ProviderAKS
+		component := render.Typha(k8sServiceEp, installation, typhaNodeTLS, nil, true, defaultClusterDomain)
+		resources, _ := component.Objects()
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		Expect(dResource).ToNot(BeNil())
+		d := dResource.(*apps.Deployment)
+		na := d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		Expect(na).To(Equal(&v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{{
+			MatchExpressions: []v1.NodeSelectorRequirement{
+				{
+					Key:      "type",
+					Operator: corev1.NodeSelectorOpNotIn,
+					Values:   []string{"virtual-node"},
+				},
+				{
+					Key:      "kubernetes.azure.com/cluster",
+					Operator: "Exists",
+				},
+			},
+		}}}))
+	})
+
+	It("should combine virtual kubelet with user-specified affinity for aks", func() {
+		pfts := []v1.PreferredSchedulingTerm{{
+			Weight: 100,
+			Preference: v1.NodeSelectorTerm{
+				MatchFields: []v1.NodeSelectorRequirement{{
+					Key:      "foo",
+					Operator: "in",
+					Values:   []string{"foo", "bar"},
+				}},
+			},
+		}}
+		installation.KubernetesProvider = operator.ProviderAKS
+		installation.TyphaAffinity = &operator.TyphaAffinity{
+			NodeAffinity: &operator.PreferredNodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: pfts,
+			},
+		}
+		component := render.Typha(k8sServiceEp, installation, typhaNodeTLS, nil, true, defaultClusterDomain)
+		resources, _ := component.Objects()
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		Expect(dResource).ToNot(BeNil())
+		d := dResource.(*apps.Deployment)
+		na := d.Spec.Template.Spec.Affinity.NodeAffinity
+		Expect(na.PreferredDuringSchedulingIgnoredDuringExecution).To(Equal(pfts))
+		Expect(na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(Equal([]v1.NodeSelectorTerm{{
+			MatchExpressions: []v1.NodeSelectorRequirement{
+				{
+					Key:      "type",
+					Operator: corev1.NodeSelectorOpNotIn,
+					Values:   []string{"virtual-node"},
+				},
+				{
+					Key:      "kubernetes.azure.com/cluster",
+					Operator: "Exists",
+				},
+			},
+		}}))
 	})
 
 	It("should render all resources when certificate management is enabled", func() {


### PR DESCRIPTION
## Description

Three changes included in this PR, broken down by commit:

1. adjust typha horizontal autoscaler logic to not count aks 'virtual-nodes' towards the count because:
   1. typha cannot run on them due to hostNetworking
   2. calico-node isn't run on them due to hostNetworking and as such we won't see increased load on k8s-apiserver due to calico-node because of the virtual-node.

2. configure typha to have anti-affinity to virtual-node because it will fail to run there since it uses hostNetwork which isn't supported on virtual nodes.
3. add the label `control-plane=true` to all namespaces as AKS uses this to prevent mutating webhooks from adjusting pods running there.

A couple bits of collateral included in this PR to be aware of:
1. this updates kibana namespace creation to correctly apply openshift labels if on openshift. previously, `isOpenshift` was accidentally hardcoded to false (https://github.com/tigera/operator/pull/1166/files#diff-60a1f183b7b6ca2f0ed047c33c6f80c1ed20dd7b20b5b908d736b237a01ca811L346).
2. To support going from a boolean to enum, we no longer pass the `openshift` boolean which originates as the provider auto-detected during startup, and instead uses the provider stored in the installation resource. This was done because startup doesn't include detection for AKS, which is needed for this PR. However, the difference between the two is that the auto-detected values ignore / take precedence over what a user has specified. So though the core controller will notice a difference between the user-specified provider and the detected one, the other controllers will not.

Leaving as a draft while I write up some tests.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
