### PR TITLE
Revert "[cherry-pick v1.14] remove OIDC elsticsearch user configmap and secret"

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -372,6 +372,8 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 	var elasticsearchSecrets, kibanaSecrets, curatorSecrets []*corev1.Secret
 	var clusterConfig *render.ElasticsearchClusterConfig
 	var esLicenseType render.ElasticsearchLicenseType
+	var oidcUserConfigMap *corev1.ConfigMap
+	var oidcUserSecret *corev1.Secret
 	applyTrial := false
 
 	if managementClusterConnection == nil {
@@ -427,6 +429,15 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			}
 		}
 
+		if oidcUserConfigMap, err = r.getOIDCUserConfigMap(ctx); err != nil {
+			r.status.SetDegraded("Failed to read oid user configmap", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		if oidcUserSecret, err = r.oidcUsersEsSecret(ctx); err != nil {
+			r.status.SetDegraded("Failed to read oid user secret", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	elasticsearch, err := r.getElasticsearch(ctx)
@@ -501,6 +512,8 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		applyTrial,
 		dexCfg,
 		esLicenseType,
+		oidcUserConfigMap,
+		oidcUserSecret,
 	)
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
@@ -537,16 +550,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			reqLogger.Error(err, "failed to create or update Elasticsearch lifecycle policies")
 			r.status.SetDegraded("Failed to create or update Elasticsearch lifecycle policies", err.Error())
 			return reconcile.Result{}, err
-		}
-
-		// kube-controller creates the ConfigMap and Secret needed for SSO into Kibana.
-		// If elastisearch uses basic license, degrade logstorage if the ConfigMap and Secret
-		// needed for logging user into Kibana is not available.
-		if esLicenseType == render.ElasticsearchLicenseTypeBasic {
-			if err = r.checkOIDCUsersEsResource(ctx); err != nil {
-				r.status.SetDegraded("Failed to get oidc user Secret and ConfigMap", err.Error())
-				return reconcile.Result{}, err
-			}
 		}
 	}
 
@@ -716,15 +719,38 @@ func (r *ReconcileLogStorage) getKibanaService(ctx context.Context) (*corev1.Ser
 	return &svc, nil
 }
 
-func (r *ReconcileLogStorage) checkOIDCUsersEsResource(ctx context.Context) error {
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersConfigMapName, Namespace: render.ElasticsearchNamespace}, &corev1.ConfigMap{}); err != nil {
-		return err
+func (r *ReconcileLogStorage) getOIDCUserConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersConfigMapName, Namespace: render.ElasticsearchNamespace}, cm); err != nil {
+		if errors.IsNotFound(err) {
+			return &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.OIDCUsersConfigMapName,
+					Namespace: render.ElasticsearchNamespace,
+				},
+			}, nil
+		}
+		return nil, err
 	}
+	return cm, nil
+}
 
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersEsSecreteName, Namespace: render.ElasticsearchNamespace}, &corev1.Secret{}); err != nil {
-		return err
+func (r *ReconcileLogStorage) oidcUsersEsSecret(ctx context.Context) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersEsSecreteName, Namespace: render.ElasticsearchNamespace}, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.OIDCUsersEsSecreteName,
+					Namespace: render.ElasticsearchNamespace,
+				},
+			}, nil
+		}
+		return nil, err
 	}
-	return nil
+	return secret, nil
 }
 
 func calculateFlowShards(nodesSpecifications *operatorv1.Nodes, defaultShards int) int {

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -418,9 +418,12 @@ var _ = Describe("LogStorage controller", func() {
 					By("confirming curator job is created")
 					Expect(cli.Get(ctx, curatorObjKey, &batchv1beta.CronJob{})).ShouldNot(HaveOccurred())
 
+					By("confirming elastic user ConfigMap is not available")
+					Expect(cli.Get(ctx,
+						types.NamespacedName{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersConfigMapName},
+						&corev1.ConfigMap{})).Should(HaveOccurred())
 					mockStatus.AssertExpectations(GinkgoT())
 				})
-
 				It("test LogStorage reconciles successfully for elasticsearch basic license", func() {
 
 					Expect(cli.Create(ctx, &operatorv1.Authentication{
@@ -460,14 +463,6 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(cli.Create(ctx, &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeBasic)},
-					})).ShouldNot(HaveOccurred())
-
-					Expect(cli.Create(ctx, &corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersConfigMapName},
-					})).ShouldNot(HaveOccurred())
-
-					Expect(cli.Create(ctx, &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersEsSecreteName},
 					})).ShouldNot(HaveOccurred())
 
 					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
@@ -524,18 +519,13 @@ var _ = Describe("LogStorage controller", func() {
 					By("confirming curator job is created")
 					Expect(cli.Get(ctx, curatorObjKey, &batchv1beta.CronJob{})).ShouldNot(HaveOccurred())
 
-					By("confirming logstorage is degraded if ConfigMap is not available")
-					mockStatus.On("SetDegraded", "Failed to get oidc user Secret and ConfigMap", "configmaps \"tigera-known-oidc-users\" not found").Return()
-					Expect(cli.Delete(ctx, &corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersConfigMapName},
-					})).ShouldNot(HaveOccurred())
-
-					Expect(cli.Delete(ctx, &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersEsSecreteName},
-					})).ShouldNot(HaveOccurred())
-					result, err = r.Reconcile(ctx, reconcile.Request{})
-					Expect(err).Should(HaveOccurred())
-					Expect(result).Should(Equal(reconcile.Result{}))
+					By("confirming elastic user ConfigMap is created")
+					Expect(cli.Get(ctx,
+						types.NamespacedName{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersConfigMapName},
+						&corev1.ConfigMap{})).ShouldNot(HaveOccurred())
+					Expect(cli.Get(ctx,
+						types.NamespacedName{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersEsSecreteName},
+						&corev1.Secret{})).ShouldNot(HaveOccurred())
 
 					mockStatus.AssertExpectations(GinkgoT())
 				})
@@ -1142,7 +1132,19 @@ func setUpLogStorageComponents(cli client.Client, ctx context.Context, storageCl
 		[]*corev1.Secret{
 			{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: render.OperatorNamespace()}},
 		},
-		nil, nil, "cluster.local", false, nil, render.ElasticsearchLicenseTypeBasic)
+		nil, nil, "cluster.local", false, nil, render.ElasticsearchLicenseTypeBasic,
+		&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.OIDCUsersConfigMapName,
+				Namespace: render.ElasticsearchNamespace,
+			}},
+		&corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.OIDCUsersEsSecreteName,
+				Namespace: render.ElasticsearchNamespace,
+			}})
 
 	createObj, _ := component.Objects()
 	for _, obj := range createObj {


### PR DESCRIPTION
Reverts tigera/operator#1147

This is a temporary revert so that we can cut a patch release of the operator that doesn't depend on component changes (kube-controllers, for instance).