### PR TITLE
Disable IDS job installer within managed clusters

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -293,6 +293,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		r.provider == operatorv1.ProviderOpenShift,
 		r.clusterDomain,
 		esLicenseType,
+		managementClusterConnection != nil,
 	)
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
@@ -231,6 +231,47 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 					components.ComponentElasticTseeInstaller.Image,
 					"sha256:intrusiondetectionjobinstallerhash")))
 		})
+		It("should not register intrusion-detection-job-installer image when cluster is managed", func() {
+			Expect(c.Create(ctx, &operatorv1.ManagementClusterConnection{
+				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+				Spec: operatorv1.ManagementClusterConnectionSpec{
+					ManagementClusterAddr: "127.0.0.1:12345",
+				},
+			})).ToNot(HaveOccurred())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			j := batchv1.Job{
+				TypeMeta: metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.IntrusionDetectionInstallerJobName,
+					Namespace: render.IntrusionDetectionNamespace,
+				},
+			}
+			// Shouldn't be able to find the job in a managed cluster.
+			Expect(test.GetResource(c, &j)).NotTo(BeNil())
+		})
+		It("should register intrusion-detection-job-installer image when in a management cluster", func() {
+			Expect(c.Create(ctx, &operatorv1.ManagementCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+				Spec: operatorv1.ManagementClusterSpec{
+					Address: "127.0.0.1:12345",
+				},
+			})).ToNot(HaveOccurred())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			j := batchv1.Job{
+				TypeMeta: metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.IntrusionDetectionInstallerJobName,
+					Namespace: render.IntrusionDetectionNamespace,
+				},
+			}
+			Expect(test.GetResource(c, &j)).To(BeNil())
+		})
 	})
 
 	Context("Feature intrusion detection not active", func() {

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -59,6 +59,7 @@ func IntrusionDetection(
 	openshift bool,
 	clusterDomain string,
 	esLicenseType ElasticsearchLicenseType,
+	managedCluster bool,
 ) Component {
 	return &intrusionDetectionComponent{
 		lc:               lc,
@@ -70,6 +71,7 @@ func IntrusionDetection(
 		openshift:        openshift,
 		clusterDomain:    clusterDomain,
 		esLicenseType:    esLicenseType,
+		managedCluster:   managedCluster,
 	}
 }
 
@@ -85,13 +87,16 @@ type intrusionDetectionComponent struct {
 	esLicenseType     ElasticsearchLicenseType
 	jobInstallerImage string
 	controllerImage   string
+	managedCluster    bool
 }
 
 func (c *intrusionDetectionComponent) ResolveImages(is *operator.ImageSet) error {
 	reg := c.installation.Registry
 	path := c.installation.ImagePath
 	var err error
-	c.jobInstallerImage, err = components.GetReference(components.ComponentElasticTseeInstaller, reg, path, is)
+	if !c.managedCluster {
+		c.jobInstallerImage, err = components.GetReference(components.ComponentElasticTseeInstaller, reg, path, is)
+	}
 	errMsgs := []string{}
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
@@ -123,8 +128,11 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 		c.intrusionDetectionClusterRoleBinding(),
 		c.intrusionDetectionRole(),
 		c.intrusionDetectionRoleBinding(),
-		c.intrusionDetectionDeployment(),
-		c.intrusionDetectionElasticsearchJob())
+		c.intrusionDetectionDeployment())
+
+	if !c.managedCluster {
+		objs = append(objs, c.intrusionDetectionElasticsearchJob())
+	}
 
 	objs = append(objs, c.globalAlertTemplates()...)
 
@@ -228,10 +236,6 @@ func (c *intrusionDetectionComponent) intrusionDetectionJobContainer() v1.Contai
 			{
 				Name:  "CLUSTER_NAME",
 				Value: c.esClusterConfig.ClusterName(),
-			},
-			{
-				Name:  "ELASTIC_LICENSE_TYPE",
-				Value: string(c.esLicenseType),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{{

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -28,6 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	managedCluster    = true
+	notManagedCluster = false
+)
+
 var _ = Describe("Intrusion Detection rendering tests", func() {
 	It("should render all resources for a default configuration", func() {
 		esConfigMap := relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
@@ -37,7 +42,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			nil,
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
 			&operatorv1.InstallationSpec{Registry: "testregistry.com/"},
-			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown,
+			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, notManagedCluster,
 		)
 		resources, _ := component.Objects()
 
@@ -102,7 +107,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			nil,
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
 			&operatorv1.InstallationSpec{Registry: "testregistry.com/"},
-			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown,
+			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, notManagedCluster,
 		)
 		resources, _ := component.Objects()
 
@@ -175,13 +180,67 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		}
 	})
 
+	It("should not render intrusion-detection-es-job-installer when cluster is managed", func() {
+		esConfigMap := relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
+
+		component := render.IntrusionDetection(
+			nil,
+			nil,
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
+			&operatorv1.InstallationSpec{Registry: "testregistry.com/"},
+			esConfigMap, nil, notOpenshift, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, managedCluster,
+		)
+		resources, _ := component.Objects()
+
+		// Should render the correct resources.
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{name: "tigera-intrusion-detection", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.TigeraKibanaCertSecret, ns: "tigera-intrusion-detection", group: "", version: "", kind: ""},
+			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
+			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Deployment"},
+			{name: "policy.pod", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "policy.globalnetworkpolicy", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "policy.globalnetworkset", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "policy.serviceaccount", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.cloudapi", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.ssh", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.lateral.access", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "network.lateral.originate", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "dns.servfail", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "dns.dos", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
+			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
+			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+		}
+
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+		for i, expectedRes := range expectedResources {
+			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+			if expectedRes.kind == "GlobalAlertTemplate" {
+				rtest.ExpectGlobalAlertTemplateToBePopulated(resources[i])
+			}
+		}
+	})
+
 	It("should apply controlPlaneNodeSelector correctly", func() {
 		component := render.IntrusionDetection(nil, nil,
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret}},
 			&operatorv1.InstallationSpec{
 				ControlPlaneNodeSelector: map[string]string{"foo": "bar"},
 			},
-			&relasticsearch.ClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown,
+			&relasticsearch.ClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, notManagedCluster,
 		)
 		resources, _ := component.Objects()
 		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
@@ -200,7 +259,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			&operatorv1.InstallationSpec{
 				ControlPlaneTolerations: []corev1.Toleration{t},
 			},
-			&relasticsearch.ClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown)
+			&relasticsearch.ClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, notManagedCluster)
 		resources, _ := component.Objects()
 		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
 		job := rtest.GetResource(resources, render.IntrusionDetectionInstallerJobName, render.IntrusionDetectionNamespace, "batch", "v1", "Job").(*batchv1.Job)


### PR DESCRIPTION
## Description
This PR disables the intrusion detection job installer in managed clusters.

## Issue
https://tigera.atlassian.net/browse/SAAS-1328

## Related PRs
Intrusion Detection: https://github.com/tigera/intrusion-detection/pull/295
Kube Controllers: https://github.com/tigera/kube-controllers-private/pull/242

## Testing
Validated in Standalone, Management and Managed clusters.