### PR TITLE
Use elasticsearch secrets in kube controllers

### DIFF
--- a/pkg/render/fixtures_test.go
+++ b/pkg/render/fixtures_test.go
@@ -51,6 +51,20 @@ var elasticsearchSecret = v1.Secret{
 	},
 }
 
+var elasticsearchAdminUserSecret = v1.Secret{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Secret",
+		APIVersion: "v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      render.ElasticsearchAdminUserSecret,
+		Namespace: rmeta.OperatorNamespace(),
+	},
+	Data: map[string][]byte{
+		"elastic": []byte("password"),
+	},
+}
+
 var kibanaSecret = v1.Secret{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Secret",

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -66,6 +66,7 @@ const (
 	ElasticsearchServiceName              = "tigera-secure-es-http"
 	ElasticsearchSecureSettingsSecretName = "tigera-elasticsearch-secure-settings"
 	ElasticsearchOperatorUserSecret       = "tigera-ee-operator-elasticsearch-access"
+	ElasticsearchAdminUserSecret          = "tigera-secure-es-elastic-user"
 
 	KibanaHTTPSEndpoint    = "https://tigera-secure-kb-http.tigera-kibana.svc.%s:5601"
 	KibanaName             = "tigera-secure"

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -63,7 +63,8 @@ const (
 	tlsSecretHashAnnotation          = "hash.operator.tigera.io/tls-secret"
 	ManagerInternalTLSHashAnnotation = "hash.operator.tigera.io/internal-tls-secret"
 
-	KibanaTLSHashAnnotation = "hash.operator.tigera.io/kibana-secrets"
+	KibanaTLSHashAnnotation         = "hash.operator.tigera.io/kibana-secrets"
+	ElasticsearchUserHashAnnotation = "hash.operator.tigera.io/elasticsearch-user"
 )
 
 // ManagementClusterConnection configuration constants

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -80,6 +80,7 @@ func Calico(
 	nodeAppArmorProfile string,
 	clusterDomain string,
 	esLicenseType ElasticsearchLicenseType,
+	esAdminSecret *corev1.Secret,
 ) (Renderer, error) {
 	var tcms []*corev1.ConfigMap
 	var tss []*corev1.Secret
@@ -150,6 +151,7 @@ func Calico(
 		nodeAppArmorProfile:         nodeAppArmorProfile,
 		esLicenseType:               esLicenseType,
 		clusterDomain:               clusterDomain,
+		esAdminSecret:               esAdminSecret,
 	}, nil
 }
 
@@ -232,6 +234,7 @@ type calicoRenderer struct {
 	nodeAppArmorProfile         string
 	clusterDomain               string
 	esLicenseType               ElasticsearchLicenseType
+	esAdminSecret               *corev1.Secret
 }
 
 func (r calicoRenderer) Render() []Component {
@@ -242,7 +245,9 @@ func (r calicoRenderer) Render() []Component {
 	components = appendNotNil(components, Secrets(r.tlsSecrets))
 	components = appendNotNil(components, Typha(r.k8sServiceEp, r.installation, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade, r.clusterDomain))
 	components = appendNotNil(components, Node(r.k8sServiceEp, r.installation, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade, r.nodeAppArmorProfile, r.clusterDomain))
-	components = appendNotNil(components, KubeControllers(r.k8sServiceEp, r.installation, r.logStorageExists, r.managementCluster, r.managementClusterConnection, r.managerInternalTLSecret, r.elasticsearchSecret, r.kibanaSecret, r.authentication, r.esLicenseType))
+	components = appendNotNil(components, KubeControllers(r.k8sServiceEp, r.installation, r.logStorageExists, r.managementCluster,
+		r.managementClusterConnection, r.managerInternalTLSecret, r.elasticsearchSecret, r.kibanaSecret, r.authentication,
+		r.esLicenseType, r.clusterDomain, r.esAdminSecret))
 	return components
 }
 

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 
 	. "github.com/onsi/ginkgo"
@@ -89,7 +90,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 5 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment, PodSecurityPolicy)
 		// - 1 namespace
 		// - 1 PriorityClass
-		c, err := render.Calico(k8sServiceEp, instance, false, nil, nil, nil, nil, typhaNodeTLS, nil, nil, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown)
+		c, err := render.Calico(k8sServiceEp, instance, false, nil, nil, nil, nil, typhaNodeTLS, nil, nil, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal(6 + 4 + 2 + 7 + 5 + 1 + 1))
 	})
@@ -102,7 +103,7 @@ var _ = Describe("Rendering tests", func() {
 		var nodeMetricsPort int32 = 9081
 		instance.Variant = operator.TigeraSecureEnterprise
 		instance.NodeMetricsPort = &nodeMetricsPort
-		c, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown)
+		c, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c.Render())).To(Equal((6 + 4 + 2 + 7 + 5 + 1 + 1) + 1 + 1))
 	})
@@ -121,7 +122,7 @@ var _ = Describe("Rendering tests", func() {
 				Name: render.ManagerInternalTLSSecretName, Namespace: rmeta.OperatorNamespace(),
 			},
 		}
-		c, err := render.Calico(k8sServiceEp, instance, true, &operator.ManagementCluster{}, nil, nil, nil, typhaNodeTLS, internalManagerTLSSecret, nil, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown)
+		c, err := render.Calico(k8sServiceEp, instance, true, &operator.ManagementCluster{}, nil, nil, nil, typhaNodeTLS, internalManagerTLSSecret, nil, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 
 		expectedResources := []struct {
@@ -177,7 +178,7 @@ var _ = Describe("Rendering tests", func() {
 
 	It("should render calico with a apparmor profile if annotation is present in installation", func() {
 		apparmorProf := "foobar"
-		r, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, nil, nil, operator.ProviderNone, nil, false, apparmorProf, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown)
+		r, err := render.Calico(k8sServiceEp, instance, true, nil, nil, nil, nil, typhaNodeTLS, nil, nil, nil, nil, operator.ProviderNone, nil, false, apparmorProf, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		comps := r.Render()
 		var cn *appsv1.DaemonSet


### PR DESCRIPTION
Kube controllers has been changed to use env variables to configure the elasticsearch client instead of looking them up in k8s

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
