### PR TITLE
Automated cherry pick of #1180: Disable IDS job installer within managed clusters

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -279,6 +279,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		r.provider == operatorv1.ProviderOpenShift,
 		r.clusterDomain,
 		esLicenseType,
+		managementClusterConnection != nil,
 	)
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {


### PR DESCRIPTION
Cherry pick of #1180 on release-v1.14.

#1180: Disable IDS job installer within managed clusters