### PR TITLE
Add startup probe to fluentd pods to make them more resilient to slow startup

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -62,11 +62,8 @@ const (
 	SplunkFluentdDefaultCertDir              = "/etc/ssl/splunk/"
 	SplunkFluentdDefaultCertPath             = SplunkFluentdDefaultCertDir + SplunkFluentdSecretCertificateKey
 
-	// fluentd startup is slower on Windows.
-	ProbeTimeoutSeconds        = 5
-	ProbeTimeoutSecondsWindows = 10
-	ProbePeriodSeconds         = 10
-	ProbePeriodSecondsWindows  = 20
+	ProbeTimeoutSeconds = 5
+	ProbePeriodSeconds  = 10
 
 	fluentdName        = "tigera-fluentd"
 	fluentdWindowsName = "tigera-fluentd-windows"
@@ -199,20 +196,6 @@ func (c *fluentdComponent) livenessCmd() []string {
 		return []string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}
 	}
 	return []string{"sh", "-c", "/bin/liveness.sh"}
-}
-
-func (c *fluentdComponent) probeTimeout() int32 {
-	if c.osType == rmeta.OSTypeWindows {
-		return ProbeTimeoutSecondsWindows
-	}
-	return ProbeTimeoutSeconds
-}
-
-func (c *fluentdComponent) probePeriod() int32 {
-	if c.osType == rmeta.OSTypeWindows {
-		return ProbePeriodSecondsWindows
-	}
-	return ProbePeriodSeconds
 }
 
 func (c *fluentdComponent) volumeHostPath() string {
@@ -625,8 +608,8 @@ func (c *fluentdComponent) liveness() *corev1.Probe {
 				Command: c.livenessCmd(),
 			},
 		},
-		TimeoutSeconds: c.probeTimeout(),
-		PeriodSeconds:  c.probePeriod(),
+		TimeoutSeconds: ProbeTimeoutSeconds,
+		PeriodSeconds:  ProbePeriodSeconds,
 	}
 }
 


### PR DESCRIPTION
## Description

On some platforms/scenarios, the fluentd pod gets into a CrashLoopBackoff cycle due to slow DNS resolution of ES. Pod startup can also be slow on Windows.

This PR reverts some changes to probe timeouts and periods previously added specifically for Windows. Instead, a startupProbe is added, using the same checks as the liveness probe, with a larger failure threshold and larger timeout.

I still need to do some testing on k8s 1.18 (where we're seeing slow DNS queries on some platforms), k8s 1.20 (where probe timeouts are respected), and hybrid clusters.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
