### PR TITLE
Fix circular dependency between core controller and logstorage

### DIFF
--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -320,7 +320,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 	if c.cr.Variant == operator.TigeraSecureEnterprise {
 		enabledControllers = append(enabledControllers, "service", "federatedservices")
 
-		if c.logStorageExists {
+		if c.logStorageExists && c.elasticsearchUserSecret != nil && c.elasticsearchSecret != nil {
 			// These controllers require that Elasticsearch exists within the cluster Kube Controllers is running in, i.e.
 			// Full Standalone and Management clusters, not Minimal Standalone and Managed clusters.
 			enabledControllers = append(enabledControllers, "authorization", "elasticsearchconfiguration")
@@ -368,7 +368,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 		VolumeMounts: kubeControllersVolumeMounts(c.managerInternalSecret),
 	}
 
-	if !c.isManagedCluster() && c.logStorageExists {
+	if c.logStorageExists && c.elasticsearchUserSecret != nil && c.elasticsearchSecret != nil {
 		container = relasticsearch.ContainerDecorate(container, DefaultElasticsearchClusterName,
 			ElasticsearchKubeControllersUserSecret, c.clusterDomain, rmeta.OSTypeLinux)
 	}
@@ -382,7 +382,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 		Volumes:            kubeControllersVolumes(defaultMode, c.managerInternalSecret),
 	}
 
-	if !c.isManagedCluster() && c.logStorageExists {
+	if c.logStorageExists && c.elasticsearchUserSecret != nil && c.elasticsearchSecret != nil {
 		podSpec = relasticsearch.PodSpecDecorate(podSpec)
 	}
 

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -367,7 +367,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			Openshift:      &operator.AuthenticationOpenshift{IssuerURL: "https://api.example.com"},
 		}}
 
-		component := render.KubeControllers(k8sServiceEp, instance, true, nil, nil, nil, nil, nil, authentication, render.ElasticsearchLicenseTypeUnknown, dns.DefaultClusterDomain, nil)
+		component := render.KubeControllers(k8sServiceEp, instance, true, nil, nil, nil, &elasticsearchSecret, nil, authentication,
+			render.ElasticsearchLicenseTypeUnknown, dns.DefaultClusterDomain, &elasticsearchAdminUserSecret)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
@@ -395,7 +396,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 	It("should add the Elasticsearch license type env variables", func() {
 		instance.Variant = operator.TigeraSecureEnterprise
 
-		component := render.KubeControllers(k8sServiceEp, instance, true, nil, nil, nil, nil, nil, nil, render.ElasticsearchLicenseTypeBasic, dns.DefaultClusterDomain, nil)
+		component := render.KubeControllers(k8sServiceEp, instance, true, nil, nil, nil, &elasticsearchSecret, nil, nil,
+			render.ElasticsearchLicenseTypeBasic, dns.DefaultClusterDomain, &elasticsearchAdminUserSecret)
 		resources, _ := component.Objects()
 
 		depResource := rtest.GetResource(resources, "calico-kube-controllers", "calico-system", "apps", "v1", "Deployment")


### PR DESCRIPTION
Right now kube controllers fails to come up correctly because it requires logstorage, which we thought would be fine because it would just be temporarily unavailable, but the core controller doesn't write the installation status until all the core calico components are working, so logstorage doesn't create elasticsearch since the vairant isn't avaiable in the installation status.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
