### PR TITLE
Validate only operator-managed certificates

### DIFF
--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -197,13 +197,15 @@ var _ = Describe("Compliance controller tests", func() {
 		assertExpectedCertDNSNames(c, expectedDNSNames...)
 	})
 
-	It("should return an error if the compliance server cert is user-supplied and has the wrong DNS names", func() {
+	It("should reconcile if the compliance server cert is user-supplied", func() {
+		// This test just validates that user-provided certs reconcile and do
+		// not overwrite the certs.
 		By("reconciling when clustertype is Standalone")
 		result, err := r.Reconcile(ctx, reconcile.Request{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Requeue).NotTo(BeTrue())
 
-		By("replacing the server certs with ones that have the wrong DNS names")
+		By("replacing the server certs with user-supplied certs")
 		Expect(c.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceServerCertSecret,
 			Namespace: rmeta.OperatorNamespace()}})).NotTo(HaveOccurred())
 		Expect(c.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceServerCertSecret,
@@ -224,13 +226,8 @@ var _ = Describe("Compliance controller tests", func() {
 		assertExpectedCertDNSNames(c, oldDNSNames...)
 
 		By("checking that an error occurred and the cert didn't change")
-		mockStatus.On(
-			"SetDegraded",
-			"Error ensuring compliance TLS certificate \"tigera-compliance-server-tls\" exists and has valid DNS names",
-			"Expected cert \"tigera-compliance-server-tls\" to have DNS names: compliance, compliance.tigera-compliance, compliance.tigera-compliance.svc, compliance.tigera-compliance.svc.cluster.local",
-		).Return()
 		result, err = r.Reconcile(ctx, reconcile.Request{})
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Requeue).NotTo(BeTrue())
 		assertExpectedCertDNSNames(c, oldDNSNames...)
 	})

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -568,15 +568,17 @@ var _ = Describe("LogStorage controller", func() {
 					mockStatus.AssertExpectations(GinkgoT())
 				})
 
-				It("test that LogStorage is degraded if the user-supplied certs have invalid DNS names", func() {
-					// Create the certs with old DNS names upfront so we can
-					// verify that the controller sets the degraded bit.
-					// These certs are not operator-managed. The user must
-					// update these certs.
+				It("test that LogStorage reconciles if the user-supplied certs have any DNS names", func() {
+					// This test currently just validates that user-provided
+					// certs will reconcile and not return an error and won't be
+					// overwritten by the operator. This test
+					// will change once we add validation for user-provided
+					// certs.
+					esDNSNames := []string{"es.example.com", "192.168.10.10"}
 					testCA := test.MakeTestCA("logstorage-test")
 					esSecret, err := secret.CreateTLSSecret(testCA,
 						render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace(), "tls.key", "tls.crt",
-						rmeta.DefaultCertificateDuration, nil, "tigera-secure-es-http.tigera-elasticsearch.svc",
+						rmeta.DefaultCertificateDuration, nil, esDNSNames...,
 					)
 					Expect(err).ShouldNot(HaveOccurred())
 
@@ -584,66 +586,9 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(cli.Create(ctx, esSecret)).ShouldNot(HaveOccurred())
 					Expect(cli.Create(ctx, esPublicSecret)).ShouldNot(HaveOccurred())
 
+					kbDNSNames = []string{"kb.example.com", "192.168.10.11"}
 					kbSecret, err := secret.CreateTLSSecret(testCA,
-						render.TigeraKibanaCertSecret, rmeta.OperatorNamespace(), "tls.key", "tls.crt",
-						rmeta.DefaultCertificateDuration, nil, "tigera-secure-kb-http.tigera-elasticsearch.svc",
-					)
-					Expect(err).ShouldNot(HaveOccurred())
-					kbPublicSecret := createPubSecret(render.KibanaPublicCertSecret, render.KibanaNamespace, kbSecret.Data["tls.crt"], "tls.crt")
-					Expect(cli.Create(ctx, kbSecret)).ShouldNot(HaveOccurred())
-					Expect(cli.Create(ctx, kbPublicSecret)).ShouldNot(HaveOccurred())
-
-					Expect(cli.Create(ctx, &storagev1.StorageClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: storageClassName,
-						},
-					})).ShouldNot(HaveOccurred())
-
-					Expect(cli.Create(ctx, &operatorv1.LogStorage{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "tigera-secure",
-						},
-						Spec: operatorv1.LogStorageSpec{
-							Nodes: &operatorv1.Nodes{
-								Count: int64(1),
-							},
-							StorageClassName: storageClassName,
-						},
-					})).ShouldNot(HaveOccurred())
-
-					Expect(cli.Create(ctx, &corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
-						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
-					})).ShouldNot(HaveOccurred())
-
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					mockStatus.On("SetDegraded", "Failed to create elasticsearch secrets", "Expected cert \"tigera-secure-elasticsearch-cert\" to have DNS names: tigera-secure-es-http, tigera-secure-es-http.tigera-elasticsearch, tigera-secure-es-http.tigera-elasticsearch.svc, tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local").Return()
-					_, err = r.Reconcile(ctx, reconcile.Request{})
-					Expect(err).Should(HaveOccurred())
-				})
-
-				It("test that LogStorage reconciles if the user-supplied certs have the expected DNS names", func() {
-					// Create the certs with correct DNS names upfront so we can
-					// verify that the controller reconciles and loads the ES
-					// and KB cert secrets.
-
-					dnsNames := append(esDNSNames, "es.example.com", "192.168.10.10")
-					testCA := test.MakeTestCA("logstorage-test")
-					esSecret, err := secret.CreateTLSSecret(testCA,
-						render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace(), "tls.key", "tls.crt",
-						rmeta.DefaultCertificateDuration, nil, dnsNames...,
-					)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					esPublicSecret := createPubSecret(relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, esSecret.Data["tls.crt"], "tls.crt")
-					Expect(cli.Create(ctx, esSecret)).ShouldNot(HaveOccurred())
-					Expect(cli.Create(ctx, esPublicSecret)).ShouldNot(HaveOccurred())
-
-					dnsNames = append(kbDNSNames, "kb.example.com", "192.168.10.11")
-					kbSecret, err := secret.CreateTLSSecret(testCA,
-						render.TigeraKibanaCertSecret, rmeta.OperatorNamespace(), "tls.key", "tls.crt", rmeta.DefaultCertificateDuration, nil, dnsNames...,
+						render.TigeraKibanaCertSecret, rmeta.OperatorNamespace(), "tls.key", "tls.crt", rmeta.DefaultCertificateDuration, nil, kbDNSNames...,
 					)
 					Expect(err).ShouldNot(HaveOccurred())
 					kbPublicSecret := createPubSecret(render.KibanaPublicCertSecret, render.KibanaNamespace, kbSecret.Data["tls.crt"], "tls.crt")
@@ -680,6 +625,12 @@ var _ = Describe("LogStorage controller", func() {
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
 					_, err = r.Reconcile(ctx, reconcile.Request{})
 					Expect(err).ShouldNot(HaveOccurred())
+
+					Expect(cli.Get(ctx, esCertSecretOperKey, esSecret)).ShouldNot(HaveOccurred())
+					test.VerifyCert(esSecret, "tls.key", "tls.crt", esDNSNames...)
+
+					Expect(cli.Get(ctx, kbCertSecretOperKey, kbSecret)).ShouldNot(HaveOccurred())
+					test.VerifyCert(kbSecret, "tls.key", "tls.crt", kbDNSNames...)
 				})
 
 				It("test that LogStorage creates new certs if operator managed certs have invalid DNS names", func() {

--- a/pkg/controller/utils/certs.go
+++ b/pkg/controller/utils/certs.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 	"time"
 
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -74,28 +73,30 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 		)
 	}
 
-	err = SecretHasExpectedDNSNames(secret, certName, svcDNSNames)
-	if err == ErrInvalidCertDNSNames {
-		// If the cert's DNS names are invalid and the cert secret is managed
-		// by the operator, then create a new secret to replace the invalid one.
-		operatorManaged, err := IsOperatorManaged(secret, certName)
-		if err != nil {
-			return nil, err
-		}
-		if operatorManaged {
-			certsLogger.Info(fmt.Sprintf("operator-managed cert %q has wrong DNS names, recreating it", secretName))
-
-			return rsecret.CreateTLSSecret(nil,
-				secretName, rmeta.OperatorNamespace(), keyName, certName,
-				rmeta.DefaultCertificateDuration, nil, svcDNSNames...,
-			)
-		}
-		// Otherwise, the secret was supplied so return an error.
-		return nil, fmt.Errorf("Expected cert %q to have DNS names: %v", secretName, strings.Join(svcDNSNames, ", "))
+	operatorManaged, err := IsOperatorManaged(secret, certName)
+	if err != nil {
+		return nil, err
 	}
 
-	// Return the original secret.
-	return secret, nil
+	// For user provided certs, skip checking whether they have the right DNS
+	// names.
+	if !operatorManaged {
+		return secret, err
+	}
+
+	err = SecretHasExpectedDNSNames(secret, certName, svcDNSNames)
+	if err == ErrInvalidCertDNSNames {
+		// If the cert's DNS names are invalid, then create a new secret to
+		// replace the invalid one since it's managed by the operator.
+		certsLogger.Info(fmt.Sprintf("operator-managed cert %q has wrong DNS names, recreating it", secretName))
+
+		return rsecret.CreateTLSSecret(nil,
+			secretName, rmeta.OperatorNamespace(), keyName, certName,
+			rmeta.DefaultCertificateDuration, nil, svcDNSNames...,
+		)
+	}
+
+	return secret, err
 }
 
 // Check if the cert secret is created and managed by the operator.


### PR DESCRIPTION
## Description

Before v1.14.0, we did not validate custom TLS cert DNS names. In v1.14.0 we changed the DNS names in certain certs, but also imposed a requirement of custom TLS certs to contain the full range of service DNS names.

This PR changes the validation of cert DNS names to only validate operator-managed certificates. Custom TLS certs are just passed through, as with versions < v1.14.0.

This is the first step; the next step is to add back in the validation of custom TLS certs. In order to do so, we'll need to add a way to detect whether we're running hybrid clusters - the logstorage controller does a simple watch on the nodes and checks if we have Windows nodes or not. We'll need something that will work in other controllers too.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
