### PR TITLE
Use kind in ipv4 mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ run-uts:
 	$(CONTAINERIZED) sh -c '$(GIT_CONFIG_SSH) \
 	ginkgo -r --skipPackage ./vendor -focus="$(GINKGO_FOCUS)" $(GINKGO_ARGS) "$(WHAT)"'
 
-## Create a local kind dual stack cluster.
+## Create a local kind cluster.
 KUBECONFIG?=./kubeconfig.yaml
 cluster-create: kubectl
 	# First make sure any previous cluster is deleted

--- a/deploy/scripts/create_kind_cluster.sh
+++ b/deploy/scripts/create_kind_cluster.sh
@@ -9,8 +9,10 @@
 # Set config variables needed for ${kubectl}.
 export KUBECONFIG=~/.kube/kind-config-kind
 
-echo "Download kind executable"
-curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.10.0/kind-linux-amd64 -o ${KIND}
+echo "Download kind executable with dual stack support"
+# We need to replace kind executable and node image
+# with official release once dual stack is fully supported by upstream.
+curl -L https://github.com/song-jiang/kind/releases/download/dualstack-1.17.0/kind -o ${KIND}
 chmod +x ${KIND}
 
 echo "Create kind cluster"

--- a/deploy/scripts/create_kind_cluster.sh
+++ b/deploy/scripts/create_kind_cluster.sh
@@ -9,43 +9,18 @@
 # Set config variables needed for ${kubectl}.
 export KUBECONFIG=~/.kube/kind-config-kind
 
-function checkModule(){
-  MODULE="$1"
-  echo "Checking kernel module $MODULE ..."
-  if lsmod | grep "$MODULE" &> /dev/null ; then
-    return 0
-  else
-    return 1
-  fi
-}
-
-echo "kubernetes dualstack requires ipvs mode kube-proxy for the moment."
-MODULES=("ip_vs" "ip_vs_rr" "ip_vs_wrr" "ip_vs_sh" "nf_conntrack_ipv4")
-for m in "${MODULES[@]}"; do
-  checkModule $m || {
-      echo "Could not find kernel module $m. install it..."
-      # Modules could be built into kernel and not exist as a kernel module anymore.
-      # For instance, kernel 5.0.0 ubuntu has nf_conntrack_ipv4 built in.
-      # So try to install modules required and continue if it failed..
-      sudo modprobe $m || true
-  }
-done
-echo
-
-echo "Download kind executable with dual stack support"
-# We need to replace kind executable and node image
-# with official release once dual stack is fully supported by upstream.
-curl -L https://github.com/song-jiang/kind/releases/download/dualstack-1.17.0/kind -o ${KIND}
+echo "Download kind executable"
+curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.10.0/kind-linux-amd64 -o ${KIND}
 chmod +x ${KIND}
 
 echo "Create kind cluster"
-${KIND} create cluster --image songtjiang/kindnode-dualstack:1.17.0 --config - <<EOF
+${KIND} create cluster --config - <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
-  podSubnet: "192.168.0.0/16,fd00:10:244::/64"
-  ipFamily: DualStack
+  podSubnet: "192.168.0.0/16"
+  ipFamily: ipv4
 nodes:
 # the control plane node
 - role: control-plane
@@ -57,8 +32,6 @@ kubeadmConfigPatches:
   kind: ClusterConfiguration
   metadata:
     name: config
-  featureGates:
-    IPv6DualStack: true
 - |
   apiVersion: kubeproxy.config.k8s.io/v1alpha1
   kind: KubeProxyConfiguration
@@ -70,11 +43,5 @@ EOF
 ${kubectl} get no -o wide
 ${kubectl} get po --all-namespaces -o wide
 
-echo "Set ipv6 address on each node"
-docker exec kind-control-plane ip -6 a a 2001:20::8/64 dev eth0
-docker exec kind-worker ip -6 a a 2001:20::1/64 dev eth0
-docker exec kind-worker2 ip -6 a a 2001:20::2/64 dev eth0
-echo
-
-echo "dual stack kind cluster is ready without network plugin"
+echo "kind cluster is ready without network plugin"
 echo "export KUBECONFIG=~/.kube/kind-config-kind to access cluster."


### PR DESCRIPTION
## Description

This PR enables ipv4 mode for the kind cluster brought up for tests. We don't use the dualstack mode for tests.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
