### PR TITLE
Revert "Revert "[cherry-pick v1.14] remove OIDC elsticsearch user configmap and secret""

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -372,8 +372,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 	var elasticsearchSecrets, kibanaSecrets, curatorSecrets []*corev1.Secret
 	var clusterConfig *render.ElasticsearchClusterConfig
 	var esLicenseType render.ElasticsearchLicenseType
-	var oidcUserConfigMap *corev1.ConfigMap
-	var oidcUserSecret *corev1.Secret
 	applyTrial := false
 
 	if managementClusterConnection == nil {
@@ -429,15 +427,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			}
 		}
 
-		if oidcUserConfigMap, err = r.getOIDCUserConfigMap(ctx); err != nil {
-			r.status.SetDegraded("Failed to read oid user configmap", err.Error())
-			return reconcile.Result{}, err
-		}
-
-		if oidcUserSecret, err = r.oidcUsersEsSecret(ctx); err != nil {
-			r.status.SetDegraded("Failed to read oid user secret", err.Error())
-			return reconcile.Result{}, err
-		}
 	}
 
 	elasticsearch, err := r.getElasticsearch(ctx)
@@ -512,8 +501,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		applyTrial,
 		dexCfg,
 		esLicenseType,
-		oidcUserConfigMap,
-		oidcUserSecret,
 	)
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
@@ -550,6 +537,16 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			reqLogger.Error(err, "failed to create or update Elasticsearch lifecycle policies")
 			r.status.SetDegraded("Failed to create or update Elasticsearch lifecycle policies", err.Error())
 			return reconcile.Result{}, err
+		}
+
+		// kube-controller creates the ConfigMap and Secret needed for SSO into Kibana.
+		// If elastisearch uses basic license, degrade logstorage if the ConfigMap and Secret
+		// needed for logging user into Kibana is not available.
+		if esLicenseType == render.ElasticsearchLicenseTypeBasic {
+			if err = r.checkOIDCUsersEsResource(ctx); err != nil {
+				r.status.SetDegraded("Failed to get oidc user Secret and ConfigMap", err.Error())
+				return reconcile.Result{}, err
+			}
 		}
 	}
 
@@ -719,38 +716,15 @@ func (r *ReconcileLogStorage) getKibanaService(ctx context.Context) (*corev1.Ser
 	return &svc, nil
 }
 
-func (r *ReconcileLogStorage) getOIDCUserConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
-	cm := &corev1.ConfigMap{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersConfigMapName, Namespace: render.ElasticsearchNamespace}, cm); err != nil {
-		if errors.IsNotFound(err) {
-			return &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.OIDCUsersConfigMapName,
-					Namespace: render.ElasticsearchNamespace,
-				},
-			}, nil
-		}
-		return nil, err
+func (r *ReconcileLogStorage) checkOIDCUsersEsResource(ctx context.Context) error {
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersConfigMapName, Namespace: render.ElasticsearchNamespace}, &corev1.ConfigMap{}); err != nil {
+		return err
 	}
-	return cm, nil
-}
 
-func (r *ReconcileLogStorage) oidcUsersEsSecret(ctx context.Context) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersEsSecreteName, Namespace: render.ElasticsearchNamespace}, secret); err != nil {
-		if errors.IsNotFound(err) {
-			return &corev1.Secret{
-				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.OIDCUsersEsSecreteName,
-					Namespace: render.ElasticsearchNamespace,
-				},
-			}, nil
-		}
-		return nil, err
+	if err := r.client.Get(ctx, types.NamespacedName{Name: render.OIDCUsersEsSecreteName, Namespace: render.ElasticsearchNamespace}, &corev1.Secret{}); err != nil {
+		return err
 	}
-	return secret, nil
+	return nil
 }
 
 func calculateFlowShards(nodesSpecifications *operatorv1.Nodes, defaultShards int) int {

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -159,9 +159,7 @@ func LogStorage(
 	clusterDomain string,
 	applyTrial bool,
 	dexCfg DexRelyingPartyConfig,
-	elasticLicenseType ElasticsearchLicenseType,
-	oidcUserConfigMap *corev1.ConfigMap,
-	oidcUserSecret *corev1.Secret) Component {
+	elasticLicenseType ElasticsearchLicenseType) Component {
 
 	return &elasticsearchComponent{
 		logStorage:                  logStorage,
@@ -182,8 +180,6 @@ func LogStorage(
 		applyTrial:                  applyTrial,
 		dexCfg:                      dexCfg,
 		elasticLicenseType:          elasticLicenseType,
-		oidcUserConfigMap:           oidcUserConfigMap,
-		oidcUserSecret:              oidcUserSecret,
 	}
 }
 
@@ -206,8 +202,6 @@ type elasticsearchComponent struct {
 	applyTrial                  bool
 	dexCfg                      DexRelyingPartyConfig
 	elasticLicenseType          ElasticsearchLicenseType
-	oidcUserConfigMap           *corev1.ConfigMap
-	oidcUserSecret              *corev1.Secret
 	esImage                     string
 	esOperatorImage             string
 	kibanaImage                 string
@@ -378,17 +372,6 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 
 		toCreate = append(toCreate, es.oidcUserRole()...)
 		toCreate = append(toCreate, es.oidcUserRoleBinding()...)
-
-		// OIDCUsersConfigMapName and OIDCUsersEsSecreteName should be created only once
-		// when the external IdP is set and Elasticsearch uses basic license.
-		// If external IdP is not configured or if Elasticsearch is not using Basic license, delete these objects if available.
-		if es.elasticLicenseType == ElasticsearchLicenseTypeBasic && es.dexCfg != nil {
-			toCreate = append(toCreate, es.oidcUserConfigMap)
-			toCreate = append(toCreate, es.oidcUserSecret)
-		} else {
-			toDelete = append(toDelete, es.oidcUserConfigMap)
-			toDelete = append(toDelete, es.oidcUserSecret)
-		}
 
 		// If we converted from a ManagedCluster to a Standalone or Management then we need to delete the elasticsearch
 		// service as it differs between these cluster types
@@ -1480,13 +1463,13 @@ func (es elasticsearchComponent) oidcUserRole() []client.Object {
 					APIGroups:     []string{""},
 					Resources:     []string{"configmaps"},
 					ResourceNames: []string{OIDCUsersConfigMapName},
-					Verbs:         []string{"get", "list", "watch"},
+					Verbs:         []string{"get", "list", "watch", "create", "delete"},
 				},
 				{
 					APIGroups:     []string{""},
 					Resources:     []string{"secrets"},
 					ResourceNames: []string{OIDCUsersEsSecreteName},
-					Verbs:         []string{"update", "get"},
+					Verbs:         []string{"get", "list", "watch", "create", "update", "delete"},
 				},
 			},
 		},


### PR DESCRIPTION
This PR reverts tigera/operator#1173 and restores https://github.com/tigera/operator/pull/1147

The initial revert was to allow for an operator patch release without a corresponding v3.5.x patch release.