### PR TITLE
[PICK] Create Elasticsearch client on the fly instead of caching it

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -64,7 +64,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return nil
 	}
 
-	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage"), opts.DetectedProvider, utils.NewElasticClient(), opts.ClusterDomain)
+	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage"), opts.DetectedProvider, utils.NewElasticClient, opts.ClusterDomain)
 	if err != nil {
 		return err
 	}
@@ -73,13 +73,13 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(cli client.Client, schema *runtime.Scheme, statusMgr status.StatusManager, provider operatorv1.Provider, esClient utils.ElasticClient, clusterDomain string) (*ReconcileLogStorage, error) {
+func newReconciler(cli client.Client, schema *runtime.Scheme, statusMgr status.StatusManager, provider operatorv1.Provider, esCliCreator utils.ElasticsearchClientCreator, clusterDomain string) (*ReconcileLogStorage, error) {
 	c := &ReconcileLogStorage{
 		client:        cli,
 		scheme:        schema,
 		status:        statusMgr,
 		provider:      provider,
-		esClient:      esClient,
+		esCliCreator:  esCliCreator,
 		clusterDomain: clusterDomain,
 	}
 
@@ -219,7 +219,7 @@ type ReconcileLogStorage struct {
 	scheme        *runtime.Scheme
 	status        status.StatusManager
 	provider      operatorv1.Provider
-	esClient      utils.ElasticClient
+	esCliCreator  utils.ElasticsearchClientCreator
 	clusterDomain string
 }
 
@@ -533,7 +533,14 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		}
 
 		// ES should be in ready phase when execution reaches here, apply ILM polices
-		if err = r.esClient.SetILMPolicies(r.client, ctx, ls, render.ElasticsearchHTTPSEndpoint(component.SupportedOSType(), r.clusterDomain)); err != nil {
+		esClient, err := r.esCliCreator(r.client, ctx, render.ElasticsearchHTTPSEndpoint(component.SupportedOSType(), r.clusterDomain))
+		if err != nil {
+			reqLogger.Error(err, "failed to create the Elasticsearch client")
+			r.status.SetDegraded("Failed to connect to Elasticsearch", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		if err = esClient.SetILMPolicies(ctx, ls); err != nil {
 			reqLogger.Error(err, "failed to create or update Elasticsearch lifecycle policies")
 			r.status.SetDegraded("Failed to create or update Elasticsearch lifecycle policies", err.Error())
 			return reconcile.Result{}, err

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -78,6 +78,10 @@ var (
 	kbDNSNames = dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, dns.DefaultClusterDomain)
 )
 
+func mockEsCliCreator(client client.Client, ctx context.Context, elasticHTTPSEndpoint string) (utils.ElasticClient, error) {
+	return &mockESClient{}, nil
+}
+
 type mockESClient struct {
 }
 
@@ -195,7 +199,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("ClearDegraded")
 					})
 					DescribeTable("tests that the ExternalService is setup with the default service name", func(clusterDomain, expectedSvcName string) {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, clusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 						_, err = r.Reconcile(ctx, reconcile.Request{})
 						Expect(err).ShouldNot(HaveOccurred())
@@ -219,7 +223,7 @@ var _ = Describe("LogStorage controller", func() {
 					})
 
 					It("returns an error if the LogStorage resource exists and is not marked for deletion", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", "LogStorage validation failed", "cluster type is managed but LogStorage CR still exists").Return()
 						result, err := r.Reconcile(ctx, reconcile.Request{})
@@ -236,7 +240,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("AddCronJobs", mock.Anything)
 						mockStatus.On("ClearDegraded", mock.Anything).Return()
 
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						ls := &operatorv1.LogStorage{}
@@ -335,7 +339,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -470,7 +474,7 @@ var _ = Describe("LogStorage controller", func() {
 						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersEsSecreteName},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -589,7 +593,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -627,7 +631,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -787,7 +791,7 @@ var _ = Describe("LogStorage controller", func() {
 						}
 					})
 					It("should use default images", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						By("running reconcile")
@@ -874,7 +878,7 @@ var _ = Describe("LogStorage controller", func() {
 								},
 							},
 						})).ToNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						By("running reconcile")
@@ -989,7 +993,7 @@ var _ = Describe("LogStorage controller", func() {
 				})
 
 				It("deletes Elasticsearch and Kibana then removes the finalizers on the LogStorage CR", func() {
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("making sure LogStorage has successfully reconciled")
@@ -1219,7 +1223,7 @@ var _ = Describe("LogStorage w/ Certificate management", func() {
 			install.Spec.CertificateManagement = &operatorv1.CertificateManagement{CACert: []byte("ca"), SignerName: "a.b/c"}
 			Expect(cli.Create(ctx, install)).ShouldNot(HaveOccurred())
 			Expect(cli.Create(ctx, logstorageCR)).To(BeNil())
-			r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, &mockESClient{}, dns.DefaultClusterDomain)
+			r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 			Expect(err).ShouldNot(HaveOccurred())
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).Should(HaveOccurred())
@@ -1227,6 +1231,6 @@ var _ = Describe("LogStorage w/ Certificate management", func() {
 	})
 })
 
-func (*mockESClient) SetILMPolicies(client client.Client, ctx context.Context, ls *operatorv1.LogStorage, elasticHTTPSEndpoint string) error {
+func (*mockESClient) SetILMPolicies(ctx context.Context, ls *operatorv1.LogStorage) error {
 	return nil
 }

--- a/pkg/controller/logstorage/shim_test.go
+++ b/pkg/controller/logstorage/shim_test.go
@@ -29,8 +29,8 @@ func NewReconcilerWithShims(
 	schema *runtime.Scheme,
 	status status.StatusManager,
 	provider operatorv1.Provider,
-	esClient utils.ElasticClient,
+	esCliCreator utils.ElasticsearchClientCreator,
 	clusterDomain string) (*ReconcileLogStorage, error) {
 
-	return newReconciler(cli, schema, status, provider, esClient, clusterDomain)
+	return newReconciler(cli, schema, status, provider, esCliCreator, clusterDomain)
 }

--- a/pkg/controller/utils/elasticsearch.go
+++ b/pkg/controller/utils/elasticsearch.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/olivere/elastic/v7"
@@ -109,69 +108,55 @@ func GetElasticsearchClusterConfig(ctx context.Context, cli client.Client) (*ren
 	return render.NewElasticsearchClusterConfigFromConfigMap(configMap)
 }
 
+type ElasticsearchClientCreator func(client client.Client, ctx context.Context, elasticHTTPSEndpoint string) (ElasticClient, error)
+
 type ElasticClient interface {
-	SetILMPolicies(client.Client, context.Context, *operatorv1.LogStorage, string) error
+	SetILMPolicies(context.Context, *operatorv1.LogStorage) error
 }
 
 type esClient struct {
 	client *elastic.Client
-	lock   sync.Mutex
 }
 
-func NewElasticClient() ElasticClient {
-	return &esClient{}
+func NewElasticClient(client client.Client, ctx context.Context, elasticHTTPSEndpoint string) (ElasticClient, error) {
+	user, password, root, err := getClientCredentials(client, ctx)
+	if err != nil {
+		return nil, err
+	}
+	h := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: root}},
+	}
+
+	options := []elastic.ClientOptionFunc{
+		elastic.SetURL(elasticHTTPSEndpoint),
+		elastic.SetHttpClient(h),
+		elastic.SetErrorLog(logrWrappedESLogger{}),
+		elastic.SetSniff(false),
+		elastic.SetHealthcheck(false),
+		elastic.SetBasicAuth(user, password),
+	}
+	retryInterval, err := time.ParseDuration(ElasticConnRetryInterval)
+	if err != nil {
+		return nil, err
+	}
+
+	var esCli *elastic.Client
+	for i := 0; i < ElasticConnRetries; i++ {
+		esCli, err = elastic.NewClient(options...)
+		if err == nil {
+			break
+		}
+		log.Error(err, "Elastic connect failed, retrying")
+		time.Sleep(retryInterval)
+	}
+
+	return &esClient{client: esCli}, err
 }
 
 // SetILMPolicies creates ILM policies for each timeseries based index using the retention period and storage size in LogStorage
-func (es *esClient) SetILMPolicies(client client.Client, ctx context.Context, ls *operatorv1.LogStorage, elasticHTTPSEndpoint string) error {
-	es.lock.Lock()
-	if err := es.createElasticClient(client, ctx, elasticHTTPSEndpoint); err != nil {
-		es.lock.Unlock()
-		return err
-	}
-	es.lock.Unlock()
+func (es *esClient) SetILMPolicies(ctx context.Context, ls *operatorv1.LogStorage) error {
 	policyList := es.listILMPolicies(ls)
 	return es.createOrUpdatePolicies(ctx, policyList)
-}
-
-func (es *esClient) createElasticClient(client client.Client, ctx context.Context, elasticHTTPSEndpoint string) error {
-	if es.client == nil {
-		user, password, root, err := getClientCredentials(client, ctx)
-		if err != nil {
-			return err
-		}
-		h := &http.Client{
-			Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: root}},
-		}
-
-		options := []elastic.ClientOptionFunc{
-			elastic.SetURL(elasticHTTPSEndpoint),
-			elastic.SetHttpClient(h),
-			elastic.SetErrorLog(logrWrappedESLogger{}),
-			elastic.SetSniff(false),
-			elastic.SetHealthcheck(false),
-			elastic.SetBasicAuth(user, password),
-		}
-		retryInterval, err := time.ParseDuration(ElasticConnRetryInterval)
-		if err != nil {
-			return err
-		}
-
-		var eserr error
-		var esClient *elastic.Client
-		for i := 0; i < ElasticConnRetries; i++ {
-
-			esClient, eserr = elastic.NewClient(options...)
-			if eserr == nil {
-				es.client = esClient
-				return nil
-			}
-			log.Error(eserr, "Elastic connect failed, retrying")
-			time.Sleep(retryInterval)
-		}
-		return eserr
-	}
-	return nil
 }
 
 // listILMPolicies generates ILM policies based on disk space and retention in LogStorage
@@ -211,12 +196,7 @@ func (es *esClient) createOrUpdatePolicies(ctx context.Context, listPolicy map[s
 
 		res, err := es.client.XPackIlmGetLifecycle().Policy(policyName).Do(ctx)
 		if err != nil {
-			if elastic.IsConnErr(err) {
-				// If connection error, reset elasticsearch client
-				es.lock.Lock()
-				es.client = nil
-				es.lock.Unlock()
-			} else if elastic.IsNotFound(err) {
+			if elastic.IsNotFound(err) {
 				// If policy doesn't exist, create one
 				return applyILMPolicy(ctx, es.client, indexName, pd.policy)
 			}


### PR DESCRIPTION
Pick of https://github.com/tigera/operator/pull/1192

This commit changes logstorage to create the Elasticsearch client for every reconcile. This has been changed because we could be reconciling Elasticsearch credentials being recreated, in which case the cached client wouldn't work.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
