### PR TITLE
Add Elasticsearch / Fluentd metrics monitoring

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -82,3 +82,6 @@ components:
   cloud-controllers:
     image: tigera/cloud-controllers
     version: master
+  elasticsearch-metrics:
+    image: tigera/elasticsearch-metrics
+    version: master

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -178,6 +178,12 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components "elasticsearch-metrics" }}
+	ComponentElasticsearchMetrics = component{
+		Version: "{{ .Version }}",
+		Image:   "{{ .Image }}",
+	}
+{{- end }}
 
 	EnterpriseComponents = []component{
 		ComponentAPIServer,
@@ -207,5 +213,6 @@ var (
 		ComponentTigeraTypha,
 		ComponentTigeraCNI,
 		ComponentCloudControllers,
+		ComponentElasticsearchMetrics,
 	}
 )

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -152,6 +152,11 @@ var (
 		Image:   "tigera/cloud-controllers",
 	}
 
+	ComponentElasticsearchMetrics = component{
+		Version: "master",
+		Image:   "tigera/elasticsearch-metrics",
+	}
+
 	EnterpriseComponents = []component{
 		ComponentAPIServer,
 		ComponentComplianceBenchmarker,
@@ -180,5 +185,6 @@ var (
 		ComponentTigeraTypha,
 		ComponentTigeraCNI,
 		ComponentCloudControllers,
+		ComponentElasticsearchMetrics,
 	}
 )

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -33,6 +33,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rsecret "github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -409,13 +410,13 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	var elasticsearchSecrets, kibanaSecrets, curatorSecrets []*corev1.Secret
+	var esCertSecret, esCertSecretESCopy, esPubCertSecret, esAdminUserSecret *corev1.Secret
+	var kibanaSecrets, curatorSecrets []*corev1.Secret
 	var clusterConfig *relasticsearch.ClusterConfig
 	var esLicenseType render.ElasticsearchLicenseType
 	applyTrial := false
 
 	if managementClusterConnection == nil {
-
 		var flowShards = calculateFlowShards(ls.Spec.Nodes, defaultElasticsearchShards)
 		clusterConfig = relasticsearch.NewClusterConfig(render.DefaultElasticsearchClusterName, ls.Replicas(), defaultElasticsearchShards, flowShards)
 
@@ -433,7 +434,13 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, nil
 		}
 
-		if elasticsearchSecrets, err = r.elasticsearchSecrets(ctx); err != nil {
+		// Get the secret - might be nil
+		esAdminUserSecret, err = utils.GetSecret(ctx, r.client, render.ElasticsearchAdminUserSecret, render.ElasticsearchNamespace)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if esCertSecretESCopy, esPubCertSecret, esAdminUserSecret, err = r.getElasticsearchCertificateSecrets(ctx); err != nil {
 			reqLogger.Error(err, err.Error())
 			r.status.SetDegraded("Failed to create elasticsearch secrets", err.Error())
 			return reconcile.Result{}, err
@@ -530,7 +537,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		elasticsearch,
 		kibana,
 		clusterConfig,
-		elasticsearchSecrets,
+		[]*corev1.Secret{esCertSecret, esCertSecretESCopy, esPubCertSecret, esAdminUserSecret},
 		kibanaSecrets,
 		pullSecrets,
 		r.provider,
@@ -595,6 +602,33 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 				return reconcile.Result{}, err
 			}
 		}
+
+		esMetricsSecret, err := utils.GetSecret(context.Background(), r.client, esmetrics.ElasticsearchMetricsSecret, rmeta.OperatorNamespace())
+		if err != nil {
+			r.status.SetDegraded("Failed to retrieve Elasticsearch metrics user secret.", err.Error())
+			return reconcile.Result{}, err
+		} else if esMetricsSecret == nil {
+			r.status.SetDegraded("Waiting for elasticsearch metrics secrets to become available", "")
+			return reconcile.Result{}, nil
+		}
+
+		if esPubCertSecret == nil {
+			r.status.SetDegraded("Waiting for elasticsearch public cert secret to become available", "")
+			return reconcile.Result{}, nil
+		}
+
+		esMetricsComponent := esmetrics.ElasticsearchMetrics(install, clusterConfig, esMetricsSecret, esPubCertSecret, r.clusterDomain)
+		if err = imageset.ApplyImageSet(ctx, r.client, variant, esMetricsComponent); err != nil {
+			reqLogger.Error(err, "Error with images from ImageSet")
+			r.status.SetDegraded("Error with images from ImageSet", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		if err := hdler.CreateOrUpdate(ctx, esMetricsComponent, r.status); err != nil {
+			reqLogger.Error(err, err.Error())
+			r.status.SetDegraded("Error creating / updating resource", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	r.status.ClearDegraded()
@@ -617,63 +651,57 @@ func (r *ReconcileLogStorage) deleteInvalidECKManagedPublicCertSecret(ctx contex
 	return r.client.Delete(ctx, secret)
 }
 
-func (r *ReconcileLogStorage) elasticsearchSecrets(ctx context.Context) ([]*corev1.Secret, error) {
-	var secrets []*corev1.Secret
+// getElasticsearchCertificateSecrets retrieves Elasticsearch certificate secrets needed for Elasticsearch to run or for
+// components to communicate with Elasticsearch. The order of the secrets returned are:
+// 1) The certificate secret needed for Elasticsearch (in the operator namespace). If the user didn't create this it is
+//    created.
+// 2) The certificate secret needed for Elasticsearch (in the Elasticsearch namespace).
+// 3) The certificate secret created by the ECK operator using the secret in 2).
+func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Context) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
 	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
 
 	// Get the secret - might be nil
-	secret, err := utils.GetSecret(ctx, r.client, render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace())
+	certSecret, err := utils.GetSecret(ctx, r.client, render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace())
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
 	// Ensure that cert is valid.
-	secret, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, secret, "tls.key", "tls.crt", rmeta.DefaultCertificateDuration, svcDNSNames...)
+	certSecret, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, certSecret, "tls.key", "tls.crt", rmeta.DefaultCertificateDuration, svcDNSNames...)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
-	secrets = append(secrets, secret, rsecret.CopyToNamespace(render.ElasticsearchNamespace, secret)[0])
+	certSecretESCopy := rsecret.CopyToNamespace(render.ElasticsearchNamespace, certSecret)[0]
 
 	// Get the pub secret - might be nil
 	pubSecret, err := utils.GetSecret(ctx, r.client, relasticsearch.PublicCertSecret, render.ElasticsearchNamespace)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 
-	if pubSecret == nil {
-		log.Info(fmt.Sprintf("Public cert secret %q not found yet", relasticsearch.PublicCertSecret))
-		return secrets, nil
-	}
+	// If the provided certificate secret (secret) is managed by the operator we need to check if the secret that
+	// Elasticsearch creates from that given secret (pubSecret) has the expected DNS name. If it doesn't, delete the
+	// public secret so it can get recreated.
+	if pubSecret != nil {
+		operatorManaged, err := utils.IsOperatorManaged(certSecret, "tls.crt")
+		if err != nil {
+			return nil, nil, nil, err
+		}
 
-	operatorManaged, err := utils.IsOperatorManaged(secret, "tls.crt")
-	if err != nil {
-		return nil, err
-	}
-
-	if operatorManaged {
-		err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames)
-		if err == utils.ErrInvalidCertDNSNames {
-			if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
-				return nil, err
+		if operatorManaged {
+			err = utils.SecretHasExpectedDNSNames(pubSecret, "tls.crt", svcDNSNames)
+			if err == utils.ErrInvalidCertDNSNames {
+				if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
+					return nil, nil, nil, err
+				}
 			}
 		}
+
+		pubSecret = rsecret.CopyToNamespace(rmeta.OperatorNamespace(), pubSecret)[0]
 	}
 
-	// If the cert was not deleted, copy the valid cert to operator namespace.
-	secrets = append(secrets, rsecret.CopyToNamespace(rmeta.OperatorNamespace(), pubSecret)...)
-
-	// Get the secret - might be nil
-	secret, err = utils.GetSecret(ctx, r.client, render.ElasticsearchAdminUserSecret, render.ElasticsearchNamespace)
-	if err != nil {
-		return nil, err
-	}
-
-	if secret != nil {
-		secrets = append(secrets, rsecret.CopyToNamespace(rmeta.OperatorNamespace(), secret)...)
-	}
-
-	return secrets, nil
+	return certSecret, certSecretESCopy, pubSecret, nil
 }
 
 // Returns true if we want to apply a new trial license. Returns false if there already is a trial license in the cluster.

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -32,6 +32,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 	"github.com/tigera/operator/test"
 
 	"github.com/stretchr/testify/mock"
@@ -74,11 +75,12 @@ var (
 	kbCertPubSecretKey     = client.ObjectKey{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}
 	kbCertPubSecretOperKey = client.ObjectKey{Name: render.KibanaPublicCertSecret, Namespace: rmeta.OperatorNamespace()}
 
-	esPublicCertObjMeta      = metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: render.ElasticsearchNamespace}
-	kbPublicCertObjMeta      = metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}
-	curatorUsrSecretObjMeta  = metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: rmeta.OperatorNamespace()}
-	operatorUsrSecretObjMeta = metav1.ObjectMeta{Name: render.ElasticsearchOperatorUserSecret, Namespace: rmeta.OperatorNamespace()}
-	storageClassName         = "test-storage-class"
+	esPublicCertObjMeta       = metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: render.ElasticsearchNamespace}
+	kbPublicCertObjMeta       = metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}
+	curatorUsrSecretObjMeta   = metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: rmeta.OperatorNamespace()}
+	esMetricsUsrSecretObjMeta = metav1.ObjectMeta{Name: esmetrics.ElasticsearchMetricsSecret, Namespace: rmeta.OperatorNamespace()}
+	operatorUsrSecretObjMeta  = metav1.ObjectMeta{Name: render.ElasticsearchOperatorUserSecret, Namespace: rmeta.OperatorNamespace()}
+	storageClassName          = "test-storage-class"
 
 	esDNSNames = dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
 	kbDNSNames = dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, dns.DefaultClusterDomain)
@@ -438,6 +440,12 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(cli.Get(ctx, kbCertPubSecretOperKey, secret)).ShouldNot(HaveOccurred())
 					test.VerifyPublicCert(secret, "tls.crt", kbDNSNames...)
 
+					mockStatus.On("SetDegraded", "Waiting for elasticsearch metrics secrets to become available", "").Return()
+					result, err = r.Reconcile(ctx, reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: esMetricsUsrSecretObjMeta})).ShouldNot(HaveOccurred())
+
 					mockStatus.On("ClearDegraded")
 					result, err = r.Reconcile(ctx, reconcile.Request{})
 					Expect(err).ShouldNot(HaveOccurred())
@@ -543,6 +551,7 @@ var _ = Describe("LogStorage controller", func() {
 					// Expect to be waiting for curator secret
 					Expect(result).Should(Equal(reconcile.Result{}))
 					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: curatorUsrSecretObjMeta})).ShouldNot(HaveOccurred())
+					Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: esMetricsUsrSecretObjMeta})).ShouldNot(HaveOccurred())
 
 					mockStatus.On("ClearDegraded")
 					result, err = r.Reconcile(ctx, reconcile.Request{})
@@ -808,6 +817,7 @@ var _ = Describe("LogStorage controller", func() {
 								Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 							},
 							&corev1.Secret{ObjectMeta: curatorUsrSecretObjMeta},
+							&corev1.Secret{ObjectMeta: esMetricsUsrSecretObjMeta},
 							&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 								Name: render.ElasticsearchCuratorUserSecret, Namespace: render.ElasticsearchNamespace}},
 						}
@@ -903,6 +913,7 @@ var _ = Describe("LogStorage controller", func() {
 									{Image: "tigera/kibana", Digest: "sha256:kibanahash"},
 									{Image: "eck/eck-operator", Digest: "sha256:eckoperatorhash"},
 									{Image: "tigera/es-curator", Digest: "sha256:escuratorhash"},
+									{Image: "tigera/elasticsearch-metrics", Digest: "sha256:esmetricshash"},
 								},
 							},
 						})).ToNot(HaveOccurred())
@@ -1224,6 +1235,7 @@ func setUpLogStorageComponents(cli client.Client, ctx context.Context, storageCl
 			ObjectMeta: curatorUsrSecretObjMeta,
 		}),
 	).ShouldNot(HaveOccurred())
+	Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: esMetricsUsrSecretObjMeta})).ShouldNot(HaveOccurred())
 }
 
 func toSecrets(objs []client.Object) []*corev1.Secret {

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -74,6 +74,9 @@ func AnnotationHash(i interface{}) string {
 func SecretsAnnotationHash(secrets ...*corev1.Secret) string {
 	var annoteArr []map[string][]byte
 	for _, secret := range secrets {
+		if secret == nil {
+			continue
+		}
 		annoteArr = append(annoteArr, secret.Data)
 	}
 

--- a/pkg/render/common/secret/secrets.go
+++ b/pkg/render/common/secret/secrets.go
@@ -92,9 +92,12 @@ func CopyToNamespace(ns string, oSecrets ...*corev1.Secret) []*corev1.Secret {
 
 // ToRuntimeObjects converts the given list of secrets to a list of client.Objects
 func ToRuntimeObjects(secrets ...*corev1.Secret) []client.Object {
-	objs := make([]client.Object, len(secrets))
-	for i, secret := range secrets {
-		objs[i] = secret
+	var objs []client.Object
+	for _, secret := range secrets {
+		if secret == nil {
+			continue
+		}
+		objs = append(objs, secret)
 	}
 	return objs
 }

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -455,6 +455,10 @@ func (c *fluentdComponent) container() corev1.Container {
 		StartupProbe:    c.startup(),
 		LivenessProbe:   c.liveness(),
 		ReadinessProbe:  c.readiness(),
+		Ports: []corev1.ContainerPort{{
+			Name:          "metrics-port",
+			ContainerPort: 9081,
+		}},
 	}, c.esClusterConfig.ClusterName(), ElasticsearchLogCollectorUserSecret, c.clusterDomain, c.osType)
 }
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -167,7 +167,8 @@ func LogStorage(
 	clusterDomain string,
 	applyTrial bool,
 	dexCfg DexRelyingPartyConfig,
-	elasticLicenseType ElasticsearchLicenseType) Component {
+	elasticLicenseType ElasticsearchLicenseType,
+) Component {
 
 	return &elasticsearchComponent{
 		logStorage:                  logStorage,

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esmetrics
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/ptr"
+	"github.com/tigera/operator/pkg/render"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/secret"
+)
+
+const (
+	ElasticsearchMetricsSecret = "tigera-ee-elasticsearch-metrics-elasticsearch-access"
+)
+
+func ElasticsearchMetrics(
+	installation *operatorv1.InstallationSpec,
+	esConfig *relasticsearch.ClusterConfig,
+	esMetricsCredsSecret *corev1.Secret,
+	esCertSecret *corev1.Secret,
+	clusterDomain string,
+) render.Component {
+	return &elasticsearchMetrics{
+		installation:         installation,
+		esConfig:             esConfig,
+		esMetricsCredsSecret: esMetricsCredsSecret,
+		esCertSecret:         esCertSecret,
+		clusterDomain:        clusterDomain,
+	}
+}
+
+type elasticsearchMetrics struct {
+	installation         *operatorv1.InstallationSpec
+	esMetricsImage       string
+	esMetricsCredsSecret *corev1.Secret
+	esCertSecret         *corev1.Secret
+	esConfig             *relasticsearch.ClusterConfig
+	clusterDomain        string
+}
+
+func (e *elasticsearchMetrics) ResolveImages(is *operatorv1.ImageSet) error {
+	var err error
+
+	reg := e.installation.Registry
+	path := e.installation.ImagePath
+
+	e.esMetricsImage, err = components.GetReference(components.ComponentElasticsearchMetrics, reg, path, is)
+
+	return err
+}
+
+func (e *elasticsearchMetrics) Objects() (objsToCreate, objsToDelete []client.Object) {
+	toCreate := secret.ToRuntimeObjects(
+		secret.CopyToNamespace(render.ElasticsearchNamespace, e.esMetricsCredsSecret)...,
+	)
+	toCreate = append(toCreate, e.metricsService(), e.metricsDeployment())
+
+	return toCreate, nil
+}
+
+func (e *elasticsearchMetrics) Ready() bool {
+	return true
+}
+
+func (e *elasticsearchMetrics) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeLinux
+}
+
+func (e *elasticsearchMetrics) metricsService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tigera-elasticsearch-metrics",
+			Namespace: render.ElasticsearchNamespace,
+			Labels: map[string]string{
+				"k8s-app": "tigera-elasticsearch-metrics",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"k8s-app": "tigera-elasticsearch-metrics",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "metrics-port",
+					Port:       9081,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(9081),
+				},
+			},
+		},
+	}
+}
+
+func (e elasticsearchMetrics) metricsDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tigera-elasticsearch-metrics",
+			Namespace: render.ElasticsearchNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.Int32ToPtr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k8s-app": "tigera-elasticsearch-metrics",
+				},
+			},
+			Template: *relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"k8s-app": "tigera-elasticsearch-metrics",
+					},
+				},
+				Spec: relasticsearch.PodSpecDecorate(corev1.PodSpec{
+					Containers: []corev1.Container{
+						relasticsearch.ContainerDecorate(
+							corev1.Container{
+								Name:    "tigera-elasticsearch-metrics",
+								Image:   e.esMetricsImage,
+								Command: []string{"/bin/elasticsearch_exporter"},
+								Args: []string{"--es.uri=https://$(ELASTIC_USERNAME):$(ELASTIC_PASSWORD)@$(ELASTIC_HOST):$(ELASTIC_PORT)",
+									"--es.all", "--es.indices", "--es.indices_settings", "--es.shards", "--es.cluster_settings",
+									"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
+									"--web.telemetry-path=/metrics"},
+							}, render.DefaultElasticsearchClusterName, ElasticsearchMetricsSecret,
+							e.clusterDomain, e.SupportedOSType(),
+						),
+					},
+				}),
+			}, e.esConfig, []*corev1.Secret{e.esMetricsCredsSecret, e.esCertSecret}).(*corev1.PodTemplateSpec),
+		},
+	}
+}

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_suite_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_suite_test.go
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ptr
+package esmetrics
 
-func BoolToPtr(b bool) *bool {
-	return &b
-}
+import (
+	"testing"
 
-func Int64ToPtr(i int64) *int64 {
-	return &i
-}
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
-func Int32ToPtr(i int32) *int32 {
-	return &i
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestRender(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../../report/esmetrics_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/logstorage/esmetrics Suite", []Reporter{junitReporter})
 }

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esmetrics
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/ptr"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/render"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+)
+
+var _ = Describe("Elasticsearch metrics", func() {
+	Context("Rendering resources", func() {
+		var installation *operatorv1.InstallationSpec
+		var esConfig *relasticsearch.ClusterConfig
+
+		BeforeEach(func() {
+			installation = &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderNone,
+				Registry:           "testregistry.com/",
+			}
+
+			esConfig = relasticsearch.NewClusterConfig("cluster", 1, 1, 1)
+		})
+
+		It("Successfully renders the Elasticsearch metrics resources", func() {
+			expectedResources := []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      render.TigeraElasticsearchCertSecret,
+						Namespace: render.ElasticsearchNamespace,
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-elasticsearch-metrics",
+						Namespace: render.ElasticsearchNamespace,
+						Labels:    map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "metrics-port",
+								Port:       9081,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(9081),
+							},
+						},
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-elasticsearch-metrics",
+						Namespace: render.ElasticsearchNamespace,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ptr.Int32ToPtr(1),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
+								Annotations: map[string]string{
+									"hash.operator.tigera.io/elasticsearch-configmap": "ae0242f242af19c4916434cb08e8f68f8c15f61d",
+									"hash.operator.tigera.io/elasticsearch-secrets":   "9718549725e37ca6a5f12ba2405392a04d7b5521",
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:    "tigera-elasticsearch-metrics",
+									Image:   "testregistry.com/tigera/elasticsearch-metrics@testdigest",
+									Command: []string{"/bin/elasticsearch_exporter"},
+									Args: []string{"--es.uri=https://$(ELASTIC_USERNAME):$(ELASTIC_PASSWORD)@$(ELASTIC_HOST):$(ELASTIC_PORT)",
+										"--es.all", "--es.indices", "--es.indices_settings", "--es.shards", "--es.cluster_settings",
+										"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
+										"--web.telemetry-path=/metrics"},
+									Env: []corev1.EnvVar{
+										{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
+										{Name: "ELASTIC_SCHEME", Value: "https"},
+										{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
+										{Name: "ELASTIC_PORT", Value: "9200"},
+										{Name: "ELASTIC_ACCESS_MODE", Value: "serviceuser"},
+										{Name: "ELASTIC_SSL_VERIFY", Value: "true"},
+										{
+											Name: "ELASTIC_USER",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
+													},
+													Key: "username",
+												},
+											},
+										},
+										{
+											Name: "ELASTIC_USERNAME",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
+													},
+													Key: "username",
+												},
+											},
+										},
+										{
+											Name: "ELASTIC_PASSWORD",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
+													},
+													Key: "password",
+												},
+											},
+										},
+										{Name: "ELASTIC_CA", Value: "/etc/ssl/elastic/ca.pem"},
+										{Name: "ES_CA_CERT", Value: "/etc/ssl/elastic/ca.pem"},
+										{Name: "ES_CURATOR_BACKEND_CERT", Value: "/etc/ssl/elastic/ca.pem"},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{Name: "elastic-ca-cert-volume", MountPath: "/etc/ssl/elastic/"},
+									},
+								}},
+
+								Volumes: []corev1.Volume{{
+									Name: "elastic-ca-cert-volume",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "tigera-secure-es-http-certs-public",
+											Items:      []corev1.KeyToPath{{Key: "tls.crt", Path: "ca.pem"}},
+										},
+									},
+								}},
+							},
+						},
+					},
+				},
+			}
+
+			component := ElasticsearchMetrics(installation, esConfig,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: rmeta.OperatorNamespace()}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: rmeta.OperatorNamespace()}},
+				"cluster.local")
+
+			Expect(component.ResolveImages(&operatorv1.ImageSet{
+				Spec: operatorv1.ImageSetSpec{
+					Images: []operatorv1.Image{{
+						Image:  "tigera/elasticsearch-metrics",
+						Digest: "testdigest",
+					}},
+				},
+			})).ShouldNot(HaveOccurred())
+
+			createdResources, _ := component.Objects()
+			Expect(createdResources).Should(Equal(expectedResources))
+		})
+	})
+})


### PR DESCRIPTION
This commit does two things:
1) Adds the metrics port for fluentd so we can set up a Prometheus Pod Monitor to scrape metrics from fluentd
2) Adds the elasticsearch-metrics deployment / service to pull metrics from Elasticsearch and present them to Prometheus for scraping

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
