### PR TITLE
Automated cherry pick of #1222: Fix autoscaler to look at labels, not annotations

### DIFF
--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -248,7 +248,7 @@ func (t *typhaAutoscaler) getNodeCounts() (int, int, error) {
 		if n.Spec.Unschedulable {
 			continue
 		}
-		if n.GetObjectMeta().GetAnnotations()["projectcalico.org/operator-node-migration"] == "pre-operator" {
+		if n.GetObjectMeta().GetLabels()["projectcalico.org/operator-node-migration"] == "pre-operator" {
 			// This node hasn't been migrated to the operator yet. Don't include it in the number of desired Typhas.
 			continue
 		}


### PR DESCRIPTION
Cherry pick of #1222 on release-v1.15.

#1222: Fix autoscaler to look at labels, not annotations