### PR TITLE
[v1.14] Only enable groups params if secrets are present (google oidc)

### DIFF
--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -458,7 +458,7 @@ func (d *dexConfig) Connector() map[string]interface{} {
 	}
 
 	//Google specific.
-	if d.idpSecret.Data[serviceAccountSecretField] != nil || d.idpSecret.Data[adminEmailSecretField] == nil {
+	if d.idpSecret.Data[serviceAccountSecretField] != nil && d.idpSecret.Data[adminEmailSecretField] != nil {
 		config["serviceAccountFilePath"] = serviceAccountSecretLocation
 		config[adminEmailSecretField] = fmt.Sprintf("$%s", googleAdminEmailEnv)
 	}

--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -40,6 +40,7 @@ const (
 	serviceAccountSecretField    = "serviceAccountSecret"
 	ClientSecretSecretField      = "clientSecret"
 	adminEmailSecretField        = "adminEmail"
+	serviceAccountFilePathField  = "serviceAccountFilePath"
 	RootCASecretField            = "rootCA"
 	OIDCSecretName               = "tigera-oidc-credentials"
 	OpenshiftSecretName          = "tigera-openshift-credentials"
@@ -459,7 +460,7 @@ func (d *dexConfig) Connector() map[string]interface{} {
 
 	//Google specific.
 	if d.idpSecret.Data[serviceAccountSecretField] != nil && d.idpSecret.Data[adminEmailSecretField] != nil {
-		config["serviceAccountFilePath"] = serviceAccountSecretLocation
+		config[serviceAccountFilePathField] = serviceAccountSecretLocation
 		config[adminEmailSecretField] = fmt.Sprintf("$%s", googleAdminEmailEnv)
 	}
 

--- a/pkg/render/dex_config_test.go
+++ b/pkg/render/dex_config_test.go
@@ -114,7 +114,7 @@ var _ = Describe("dex config tests", func() {
 			Expect(reflect.DeepEqual(hashes1, hashes3)).To(BeFalse())
 		})
 	})
-	google      := &operatorv1.Authentication{Spec: operatorv1.AuthenticationSpec{ManagerDomain: domain, OIDC: &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
+	google := &operatorv1.Authentication{Spec: operatorv1.AuthenticationSpec{ManagerDomain: "https://127.0.0.1:9443", OIDC: &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
 	DescribeTable("Test dex connector for Google ", func(secretData map[string][]byte, expectPresent bool) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/dex_config_test.go
+++ b/pkg/render/dex_config_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -30,6 +31,7 @@ import (
 
 var _ = Describe("dex config tests", func() {
 	verify := operatorv1.EmailVerificationTypeSkip
+	email := "a@b.com"
 
 	// Create two different authentication objects
 	authentication := &operatorv1.Authentication{
@@ -61,7 +63,7 @@ var _ = Describe("dex config tests", func() {
 		},
 		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 		Data: map[string][]byte{
-			"adminEmail":           []byte("a@b.com"),
+			"adminEmail":           []byte(email),
 			"clientID":             []byte("a.b.com"),
 			"clientSecret":         []byte("my-secret"),
 			"serviceAccountSecret": []byte("my-secret2"),
@@ -112,4 +114,49 @@ var _ = Describe("dex config tests", func() {
 			Expect(reflect.DeepEqual(hashes1, hashes3)).To(BeFalse())
 		})
 	})
+	google      := &operatorv1.Authentication{Spec: operatorv1.AuthenticationSpec{ManagerDomain: domain, OIDC: &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
+	DescribeTable("Test dex connector for Google ", func(secretData map[string][]byte, expectPresent bool) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.OIDCSecretName,
+				Namespace: render.OperatorNamespace(),
+			},
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			Data:     secretData,
+		}
+		dexConfig := render.NewDexConfig(google, tlsSecret, dexSecret, secret, dns.DefaultClusterDomain)
+		connector := dexConfig.Connector()["config"].(map[string]interface{})
+
+		email, emailFound := connector["adminEmail"]
+		saPath, saFound := connector["serviceAccountFilePath"]
+		if expectPresent {
+			Expect(email).To(Equal(email))
+			Expect(emailFound).To(BeTrue())
+			Expect(saPath).To(Equal("/etc/dex/secrets/google-groups.json"))
+			Expect(saFound).To(BeTrue())
+		} else {
+			Expect(emailFound).To(BeFalse())
+			Expect(saFound).To(BeFalse())
+		}
+	},
+		Entry("Compare actual and expected OIDC config", map[string][]byte{
+			"adminEmail":           []byte(email),
+			"clientID":             []byte("a.b.com"),
+			"clientSecret":         []byte("my-secret"),
+			"serviceAccountSecret": []byte("my-secret2"),
+		}, true),
+		Entry("Compare actual and expected OIDC config", map[string][]byte{
+			"clientID":     []byte("a.b.com"),
+			"clientSecret": []byte("my-secret"),
+		}, false),
+		Entry("Compare actual and expected OIDC config", map[string][]byte{
+			"clientID":             []byte("a.b.com"),
+			"clientSecret":         []byte("my-secret"),
+			"serviceAccountSecret": []byte("my-secret2"),
+		}, false),
+		Entry("Compare actual and expected OIDC config", map[string][]byte{
+			"adminEmail":   []byte(email),
+			"clientID":     []byte("a.b.com"),
+			"clientSecret": []byte("my-secret"),
+		}, false))
 })


### PR DESCRIPTION
Cannot be picked.

Only enable groups params if secrets are present (google oidc)