### PR TITLE
Use certificate/v1 instead when kubernetes version is 1.19 onward

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,8 +213,8 @@ func main() {
 
 	kubernetesVersion, err := common.GetKubernetesVersion(clientset)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("Unable to resolve Kubernetes version"))
-		os.Exit(1)
+		log.Error(err, fmt.Sprintf("Unable to resolve Kubernetes version, defaulting to v1.18"))
+		kubernetesVersion = &common.VersionInfo{Major: 1, Minor: 18}
 	}
 
 	options := options.AddOptions{

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/tigera/operator/controllers"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/awssgsetup"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -210,11 +211,18 @@ func main() {
 		log.Error(err, fmt.Sprintf("Couldn't find the cluster domain from the resolv.conf, defaulting to %s", clusterDomain))
 	}
 
+	kubernetesVersion, err := common.GetKubernetesVersion(clientset)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Unable to resolve Kubernetes version"))
+		os.Exit(1)
+	}
+
 	options := options.AddOptions{
 		DetectedProvider:    provider,
 		EnterpriseCRDExists: enterpriseCRDExists,
 		AmazonCRDExists:     amazonCRDExists,
 		ClusterDomain:       clusterDomain,
+		KubernetesVersion:   kubernetesVersion,
 	}
 
 	err = controllers.AddToManager(mgr, options)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -28,10 +28,3 @@ const (
 	// ExportLogsFeature to 3rd party systems feature name
 	ExportLogsFeature = "export-logs"
 )
-
-// VersionInfo contains information about the version of Kubernetes API the cluster is using
-// Major and Minor fields map to the v<Major>.<Minor>+ part of the version string
-type VersionInfo struct {
-	Major int
-	Minor int
-}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -29,6 +29,8 @@ const (
 	ExportLogsFeature = "export-logs"
 )
 
+// VersionInfo contains information about the version of Kubernetes API the cluster is using
+// Major and Minor fields map to the v<Major>.<Minor>+ part of the version string
 type VersionInfo struct {
 	Major int
 	Minor int

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -28,3 +28,8 @@ const (
 	// ExportLogsFeature to 3rd party systems feature name
 	ExportLogsFeature = "export-logs"
 )
+
+type VersionInfo struct {
+	Major int
+	Minor int
+}

--- a/pkg/common/kubernetes_version.go
+++ b/pkg/common/kubernetes_version.go
@@ -16,10 +16,18 @@ package common
 
 import (
 	"fmt"
-	"k8s.io/client-go/kubernetes"
 	"strconv"
 	"strings"
+
+	"k8s.io/client-go/kubernetes"
 )
+
+// VersionInfo contains information about the version of Kubernetes API the cluster is using
+// Major and Minor fields map to the v<Major>.<Minor>+ part of the version string
+type VersionInfo struct {
+	Major int
+	Minor int
+}
 
 func GetKubernetesVersion(clientset kubernetes.Interface) (*VersionInfo, error) {
 	v, err := clientset.Discovery().ServerVersion()
@@ -42,4 +50,12 @@ func GetKubernetesVersion(clientset kubernetes.Interface) (*VersionInfo, error) 
 		Major: major,
 		Minor: minor,
 	}, nil
+}
+
+// ProvidesCertV1API returns if k8s.io/api/certificates/v1 is supported given the current k8s version
+func (v *VersionInfo) ProvidesCertV1API() bool {
+	if v != nil && (v.Major > 1 || (v.Major == 1 && v.Minor >= 19)) {
+		return true
+	}
+	return false
 }

--- a/pkg/common/kubernetes_version.go
+++ b/pkg/common/kubernetes_version.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"k8s.io/client-go/kubernetes"
+	"strconv"
+	"strings"
+)
+
+func GetKubernetesVersion(clientset kubernetes.Interface) (*VersionInfo, error) {
+	v, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check k8s version: %v", err)
+	}
+
+	major, err := strconv.Atoi(v.Major)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse k8s major version: %s", v.Major)
+	}
+
+	// filter out a proceeding '+' from the minor version since openshift includes that.
+	minor, err := strconv.Atoi(strings.TrimSuffix(v.Minor, "+"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse k8s minor version: %s", v.Minor)
+	}
+
+	return &VersionInfo{
+		Major: major,
+		Minor: minor,
+	}, nil
+}

--- a/pkg/common/kubernetes_version_test.go
+++ b/pkg/common/kubernetes_version_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/version"
+	discoveryFake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test get Kubernetes version", func() {
+	var clientset kubernetes.Interface
+
+	BeforeEach(func() {
+		clientset = fake.NewSimpleClientset()
+	})
+
+	It("should return expected major and minor version when both version numbers are valid integers", func() {
+		expectedMajor := 3
+		expectedMinor := 22
+		clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
+			Major: strconv.Itoa(expectedMajor),
+			Minor: strconv.Itoa(expectedMinor),
+		}
+
+		version, err := GetKubernetesVersion(clientset)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version.Major).To(Equal(expectedMajor))
+		Expect(version.Minor).To(Equal(expectedMinor))
+	})
+
+	It("should return error when major version is invalid", func() {
+		invalidMajor := "invalid_major_version"
+		clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
+			Major: invalidMajor,
+			Minor: "19",
+		}
+
+		v, err := GetKubernetesVersion(clientset)
+		Expect(v).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(fmt.Errorf("failed to parse k8s major version: %s", invalidMajor)))
+	})
+
+	It("should return error when minor version is invalid", func() {
+		invalidMinor := "invalid_minor_version"
+		clientset.Discovery().(*discoveryFake.FakeDiscovery).FakedServerVersion = &version.Info{
+			Major: "1",
+			Minor: invalidMinor,
+		}
+
+		v, err := GetKubernetesVersion(clientset)
+		Expect(v).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(fmt.Errorf("failed to parse k8s minor version: %s", invalidMinor)))
+	})
+})

--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
@@ -52,16 +52,16 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, opts.DetectedProvider))
+	return add(mgr, newReconciler(mgr, opts))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions) reconcile.Reconciler {
 	r := &ReconcileAmazonCloudIntegration{
 		client:   mgr.GetClient(),
 		scheme:   mgr.GetScheme(),
-		provider: provider,
-		status:   status.New(mgr.GetClient(), "amazon-cloud-integration"),
+		provider: opts.DetectedProvider,
+		status:   status.New(mgr.GetClient(), "amazon-cloud-integration", opts.KubernetesVersion),
 	}
 	r.status.Run()
 	return r

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -51,18 +51,18 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, opts.DetectedProvider, opts.AmazonCRDExists, opts.ClusterDomain))
+	return add(mgr, newReconciler(mgr, opts))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider, amazonCRDExists bool, clusterDomain string) *ReconcileAPIServer {
+func newReconciler(mgr manager.Manager, opts options.AddOptions) *ReconcileAPIServer {
 	r := &ReconcileAPIServer{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
-		provider:        provider,
-		amazonCRDExists: amazonCRDExists,
-		status:          status.New(mgr.GetClient(), "apiserver"),
-		clusterDomain:   clusterDomain,
+		provider:        opts.DetectedProvider,
+		amazonCRDExists: opts.AmazonCRDExists,
+		status:          status.New(mgr.GetClient(), "apiserver", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
 	}
 	r.status.Run()
 	return r

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -62,17 +62,17 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		// No need to start this controller.
 		return nil
 	}
-	return add(mgr, newReconciler(mgr, opts.DetectedProvider, opts.ClusterDomain))
+	return add(mgr, newReconciler(mgr, opts))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider oprv1.Provider, clusterDomain string) *ReconcileAuthentication {
+func newReconciler(mgr manager.Manager, opts options.AddOptions) *ReconcileAuthentication {
 	r := &ReconcileAuthentication{
 		client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
-		provider:      provider,
-		status:        status.New(mgr.GetClient(), "authentication"),
-		clusterDomain: clusterDomain,
+		provider:      opts.DetectedProvider,
+		status:        status.New(mgr.GetClient(), "authentication", opts.KubernetesVersion),
+		clusterDomain: opts.ClusterDomain,
 	}
 	r.status.Run()
 	return r

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -51,7 +51,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		// No need to start this controller.
 		return nil
 	}
-	statusManager := status.New(mgr.GetClient(), "management-cluster-connection")
+	statusManager := status.New(mgr.GetClient(), "management-cluster-connection", opts.KubernetesVersion)
 	return add(mgr, newReconciler(mgr.GetClient(), mgr.GetScheme(), statusManager, opts.DetectedProvider))
 }
 

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -57,7 +57,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 	var licenseAPIReady = &utils.ReadyFlag{}
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts.DetectedProvider, opts.ClusterDomain, licenseAPIReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("compliance-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -77,13 +77,13 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new *reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider, clusterDomain string, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	r := &ReconcileCompliance{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
-		provider:        provider,
-		status:          status.New(mgr.GetClient(), "compliance"),
-		clusterDomain:   clusterDomain,
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "compliance", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
 		licenseAPIReady: licenseAPIReady,
 	}
 	r.status.Run()

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -99,7 +99,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions) (*ReconcileInst
 		return nil, fmt.Errorf("Failed to initialize Namespace migration: %w", err)
 	}
 
-	statusManager := status.New(mgr.GetClient(), "calico")
+	statusManager := status.New(mgr.GetClient(), "calico", opts.KubernetesVersion)
 
 	// The typhaAutoscaler needs a clientset.
 	cs, err := kubernetes.NewForConfig(mgr.GetConfig())

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -61,7 +61,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	var licenseAPIReady = &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts.DetectedProvider, opts.ClusterDomain, licenseAPIReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("intrusiondetection-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -81,13 +81,13 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, p operatorv1.Provider, clusterDomain string, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	r := &ReconcileIntrusionDetection{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
-		provider:        p,
-		status:          status.New(mgr.GetClient(), "intrusion-detection"),
-		clusterDomain:   clusterDomain,
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "intrusion-detection", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
 		licenseAPIReady: licenseAPIReady,
 	}
 	r.status.Run()

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -60,7 +60,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	var licenseAPIReady = &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts.DetectedProvider, opts.ClusterDomain, licenseAPIReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("logcollector-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -80,13 +80,13 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider, clusterDomain string, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	c := &ReconcileLogCollector{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
-		provider:        provider,
-		status:          status.New(mgr.GetClient(), "log-collector"),
-		clusterDomain:   clusterDomain,
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "log-collector", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
 		licenseAPIReady: licenseAPIReady,
 	}
 	c.status.Run()

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -70,7 +70,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return nil
 	}
 
-	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage"), opts.DetectedProvider, utils.NewElasticClient, opts.ClusterDomain)
+	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage", opts.KubernetesVersion), opts.DetectedProvider, utils.NewElasticClient, opts.ClusterDomain)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -59,7 +59,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	var licenseAPIReady = &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts.DetectedProvider, opts.ClusterDomain, licenseAPIReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("cmanager-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -79,13 +79,13 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, provider operatorv1.Provider, clusterDomain string, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	c := &ReconcileManager{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
-		provider:        provider,
-		status:          status.New(mgr.GetClient(), "manager"),
-		clusterDomain:   clusterDomain,
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "manager", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
 		licenseAPIReady: licenseAPIReady,
 	}
 	c.status.Run()

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -1,6 +1,9 @@
 package options
 
-import v1 "github.com/tigera/operator/api/v1"
+import (
+	v1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+)
 
 // AddOptions are passed to controllers when added to the controller manager. They
 // detail options detected by the daemon at startup that some controllers may either
@@ -11,4 +14,5 @@ type AddOptions struct {
 	EnterpriseCRDExists bool
 	AmazonCRDExists     bool
 	ClusterDomain       string
+	KubernetesVersion   *common.VersionInfo
 }

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -17,13 +17,13 @@ package status
 import (
 	"context"
 	"fmt"
-	"github.com/tigera/operator/pkg/common"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
 
 	operator "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batch "k8s.io/api/batch/v1beta1"

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -675,9 +675,11 @@ func (m *statusManager) degradedReason() string {
 }
 
 func hasPendingCSR(ctx context.Context, m *statusManager, labelMap map[string]string) (bool, error) {
-	if m.kubernetesVersion.Major > 1 || (m.kubernetesVersion.Major == 1 && m.kubernetesVersion.Minor >= 19) {
+	if m.kubernetesVersion.ProvidesCertV1API() {
 		return hasPendingCSRUsingCertV1(ctx, m.client, labelMap)
 	}
+	// For k8s v1.19 onwards, certificate/v1beta1 will be deprecated and is planning to be removed on 1.22
+	// Once in the future we stop support v1.18, we need to change the code to only use certificate/v1
 	return hasPendingCSRUsingCertV1beta1(ctx, m.client, labelMap)
 }
 

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -17,6 +17,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"github.com/tigera/operator/pkg/common"
 	"reflect"
 	"strings"
 	"sync"
@@ -26,7 +27,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batch "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/certificates/v1beta1"
+	certV1 "k8s.io/api/certificates/v1"
+	certV1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -84,6 +86,7 @@ type statusManager struct {
 	certificatestatusrequests map[string]map[string]string
 	lock                      sync.Mutex
 	enabled                   *bool
+	kubernetesVersion         *common.VersionInfo
 
 	// Track degraded state as set by external controllers.
 	degraded               bool
@@ -95,7 +98,7 @@ type statusManager struct {
 	failing     []string
 }
 
-func New(client client.Client, component string) StatusManager {
+func New(client client.Client, component string, kubernetesVersion *common.VersionInfo) StatusManager {
 	return &statusManager{
 		client:                    client,
 		component:                 component,
@@ -104,6 +107,7 @@ func New(client client.Client, component string) StatusManager {
 		statefulsets:              make(map[string]types.NamespacedName),
 		cronjobs:                  make(map[string]types.NamespacedName),
 		certificatestatusrequests: make(map[string]map[string]string),
+		kubernetesVersion:         kubernetesVersion,
 	}
 }
 
@@ -431,7 +435,7 @@ func (m *statusManager) syncState() bool {
 	}
 
 	for _, labels := range m.certificatestatusrequests {
-		pending, err := hasPendingCSR(context.TODO(), m.client, labels)
+		pending, err := hasPendingCSR(context.TODO(), m, labels)
 		if err != nil {
 			log.WithValues("error", err).Error(err, fmt.Sprintf("Unable to poll for CertificateSigningRequest(s) with labels value %v", labels))
 		} else if pending {
@@ -670,8 +674,15 @@ func (m *statusManager) degradedReason() string {
 	return strings.Join(reasons, "; ")
 }
 
-func hasPendingCSR(ctx context.Context, cli client.Client, labelMap map[string]string) (bool, error) {
-	csrs := &v1beta1.CertificateSigningRequestList{}
+func hasPendingCSR(ctx context.Context, m *statusManager, labelMap map[string]string) (bool, error) {
+	if m.kubernetesVersion.Major > 1 || (m.kubernetesVersion.Major == 1 && m.kubernetesVersion.Minor >= 19) {
+		return hasPendingCSRUsingCertV1(ctx, m.client, labelMap)
+	}
+	return hasPendingCSRUsingCertV1beta1(ctx, m.client, labelMap)
+}
+
+func hasPendingCSRUsingCertV1(ctx context.Context, cli client.Client, labelMap map[string]string) (bool, error) {
+	csrs := &certV1.CertificateSigningRequestList{}
 	selector := labels.SelectorFromSet(labelMap)
 	err := cli.List(ctx, csrs, &client.ListOptions{LabelSelector: selector})
 	if err != nil {
@@ -691,7 +702,36 @@ func hasPendingCSR(ctx context.Context, cli client.Client, labelMap map[string]s
 		for _, condition := range csr.Status.Conditions {
 			if condition.Status == v1.ConditionUnknown {
 				return true, nil
-			} else if condition.Type == v1beta1.CertificateApproved && csr.Status.Certificate == nil {
+			} else if condition.Type == certV1.CertificateApproved && csr.Status.Certificate == nil {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func hasPendingCSRUsingCertV1beta1(ctx context.Context, cli client.Client, labelMap map[string]string) (bool, error) {
+	csrs := &certV1beta1.CertificateSigningRequestList{}
+	selector := labels.SelectorFromSet(labelMap)
+	err := cli.List(ctx, csrs, &client.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return false, err
+	}
+
+	if len(csrs.Items) == 0 {
+		return false, nil
+	}
+
+	for _, csr := range csrs.Items {
+		if len(csr.Status.Conditions) == 0 {
+			// No conditions means status is pending
+			return true, nil
+		}
+		// no condition approved, means it is pending.
+		for _, condition := range csr.Status.Conditions {
+			if condition.Status == v1.ConditionUnknown {
+				return true, nil
+			} else if condition.Type == certV1beta1.CertificateApproved && csr.Status.Certificate == nil {
 				return true, nil
 			}
 		}

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -16,27 +16,31 @@ package status
 
 import (
 	"context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/certificates/v1beta1"
+
+	certV1 "k8s.io/api/certificates/v1"
+	certV1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerRuntimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
 )
 
 var _ = Describe("Status reporting tests", func() {
 	var sm *statusManager
-	var client client.Client
+	var oldVersionSm *statusManager
+	var client controllerRuntimeClient.Client
+	var oldVersionClient controllerRuntimeClient.Client
 	var (
 		ctx    = context.Background()
 		label  = "label"
@@ -45,14 +49,22 @@ var _ = Describe("Status reporting tests", func() {
 	BeforeEach(func() {
 		// Setup Scheme for all resources
 		scheme := runtime.NewScheme()
-		Expect(v1beta1.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(certV1.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		err := apis.AddToScheme(scheme)
 		Expect(err).NotTo(HaveOccurred())
 		client = fake.NewFakeClientWithScheme(scheme)
 
-		sm = New(client, "test-component").(*statusManager)
-
+		sm = New(client, "test-component", &common.VersionInfo{Major: 1, Minor: 19}).(*statusManager)
 		Expect(sm.IsAvailable()).To(BeFalse())
+
+		oldScheme := runtime.NewScheme()
+		Expect(certV1beta1.AddToScheme(oldScheme)).ShouldNot(HaveOccurred())
+		err = apis.AddToScheme(oldScheme)
+		Expect(err).NotTo(HaveOccurred())
+		oldVersionClient = fake.NewFakeClientWithScheme(oldScheme)
+
+		oldVersionSm = New(oldVersionClient, "test-component", &common.VersionInfo{Major: 1, Minor: 18}).(*statusManager)
+		Expect(oldVersionSm.IsAvailable()).To(BeFalse())
 	})
 
 	Describe("without CR found", func() {
@@ -233,55 +245,110 @@ var _ = Describe("Status reporting tests", func() {
 			}))
 		})
 
-		DescribeTable("Monitor CSRs", func(csrs []*v1beta1.CertificateSigningRequest, expectErr bool, expectPending bool) {
-			for _, csr := range csrs {
-				Expect(client.Create(ctx, csr)).NotTo(HaveOccurred())
-			}
-			pending, err := hasPendingCSR(ctx, client, map[string]string{"k8s-app": label})
-			Expect(err != nil).To(Equal(expectErr))
-			Expect(pending).To(Equal(expectPending))
-		},
-			Entry("no CSR is present", nil, false, false),
-			Entry("1 pending CSR is present",
-				[]*v1beta1.CertificateSigningRequest{
+		DescribeTable("Monitor CSRs - k8s v1.18",
+			func(csrs []*certV1beta1.CertificateSigningRequest, expectErr bool, expectPending bool) {
+				for _, csr := range csrs {
+					Expect(oldVersionClient.Create(ctx, csr)).NotTo(HaveOccurred())
+				}
+				pending, err := hasPendingCSR(ctx, oldVersionSm, map[string]string{"k8s-app": label})
+				Expect(err != nil).To(Equal(expectErr))
+				Expect(pending).To(Equal(expectPending))
+			},
+			Entry("no CSR is present - k8s v1.18", nil, false, false),
+			Entry("1 pending CSR is present - k8s v1.18",
+				[]*certV1beta1.CertificateSigningRequest{
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels}}},
 				false, true),
-			Entry("1 pending CSR is present, but no labels",
-				[]*v1beta1.CertificateSigningRequest{
+			Entry("1 pending CSR is present, but no labels - k8s v1.18",
+				[]*certV1beta1.CertificateSigningRequest{
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr1"}}},
 				false, false),
-			Entry("1 approved CSR is present",
-				[]*v1beta1.CertificateSigningRequest{
+			Entry("1 approved CSR is present - k8s v1.18",
+				[]*certV1beta1.CertificateSigningRequest{
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
-						Status: v1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
-							Conditions: []v1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: v1beta1.CertificateApproved}}}},
+						Status: certV1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1beta1.CertificateApproved}}}},
 				}, false, false),
-			Entry("2 approved CSR are present",
-				[]*v1beta1.CertificateSigningRequest{
+			Entry("2 approved CSR are present - k8s v1.18",
+				[]*certV1beta1.CertificateSigningRequest{
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
-						Status: v1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
-							Conditions: []v1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: v1beta1.CertificateApproved}}}},
+						Status: certV1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1beta1.CertificateApproved}}}},
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr2", Labels: labels},
-						Status: v1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
-							Conditions: []v1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: v1beta1.CertificateApproved}}}},
+						Status: certV1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1beta1.CertificateApproved}}}},
 				}, false, false),
-			Entry("1 approved, 1 pending CSR are present",
-				[]*v1beta1.CertificateSigningRequest{
+			Entry("1 approved, 1 pending CSR are present - k8s v1.18",
+				[]*certV1beta1.CertificateSigningRequest{
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
-						Status: v1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
-							Conditions: []v1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: v1beta1.CertificateApproved}}}},
+						Status: certV1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1beta1.CertificateApproved}}}},
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr2", Labels: labels}},
 				}, false, true),
-			Entry("1 pending CSR are present (approved: no, cert: yes)",
-				[]*v1beta1.CertificateSigningRequest{
+			Entry("1 pending CSR are present (approved: no, cert: yes) - k8s v1.18",
+				[]*certV1beta1.CertificateSigningRequest{
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
-						Status: v1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert")}},
+						Status: certV1beta1.CertificateSigningRequestStatus{Certificate: []byte("cert")}},
 				}, false, true),
-			Entry("1 pending CSR are present (approved: yes, cert: no)",
-				[]*v1beta1.CertificateSigningRequest{
+			Entry("1 pending CSR are present (approved: yes, cert: no) - k8s v1.18",
+				[]*certV1beta1.CertificateSigningRequest{
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
-						Status: v1beta1.CertificateSigningRequestStatus{
-							Conditions: []v1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: v1beta1.CertificateApproved}}}},
+						Status: certV1beta1.CertificateSigningRequestStatus{
+							Conditions: []certV1beta1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1beta1.CertificateApproved}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr2", Labels: labels}},
+				}, false, true),
+		)
+
+		DescribeTable("Monitor CSRs - k8s v1.19",
+			func(csrs []*certV1.CertificateSigningRequest, expectErr bool, expectPending bool) {
+				for _, csr := range csrs {
+					Expect(client.Create(ctx, csr)).NotTo(HaveOccurred())
+				}
+				pending, err := hasPendingCSR(ctx, sm, map[string]string{"k8s-app": label})
+				Expect(err != nil).To(Equal(expectErr))
+				Expect(pending).To(Equal(expectPending))
+			},
+			Entry("no CSR is present - k8s v1.19", nil, false, false),
+			Entry("1 pending CSR is present - k8s v1.19",
+				[]*certV1.CertificateSigningRequest{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels}}},
+				false, true),
+			Entry("1 pending CSR is present, but no labels - k8s v1.19",
+				[]*certV1.CertificateSigningRequest{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr1"}}},
+				false, false),
+			Entry("1 approved CSR is present - k8s v1.19",
+				[]*certV1.CertificateSigningRequest{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
+						Status: certV1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1.CertificateApproved}}}},
+				}, false, false),
+			Entry("2 approved CSR are present - k8s v1.19",
+				[]*certV1.CertificateSigningRequest{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
+						Status: certV1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1.CertificateApproved}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr2", Labels: labels},
+						Status: certV1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1.CertificateApproved}}}},
+				}, false, false),
+			Entry("1 approved, 1 pending CSR are present - k8s v1.19",
+				[]*certV1.CertificateSigningRequest{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
+						Status: certV1.CertificateSigningRequestStatus{Certificate: []byte("cert"),
+							Conditions: []certV1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1.CertificateApproved}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr2", Labels: labels}},
+				}, false, true),
+			Entry("1 pending CSR are present (approved: no, cert: yes) - k8s v1.19",
+				[]*certV1.CertificateSigningRequest{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
+						Status: certV1.CertificateSigningRequestStatus{Certificate: []byte("cert")}},
+				}, false, true),
+			Entry("1 pending CSR are present (approved: yes, cert: no) - k8s v1.19",
+				[]*certV1.CertificateSigningRequest{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csr1", Labels: labels},
+						Status: certV1.CertificateSigningRequestStatus{
+							Conditions: []certV1.CertificateSigningRequestCondition{{Status: corev1.ConditionTrue, Type: certV1.CertificateApproved}}}},
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr2", Labels: labels}},
 				}, false, true),
 		)

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -17,6 +17,7 @@ package utils_test
 import (
 	"context"
 	"fmt"
+
 	"github.com/tigera/operator/pkg/common"
 
 	apps "k8s.io/api/apps/v1"

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -17,6 +17,7 @@ package utils_test
 import (
 	"context"
 	"fmt"
+	"github.com/tigera/operator/pkg/common"
 
 	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -74,7 +75,7 @@ var _ = Describe("Component handler tests", func() {
 
 		c = fake.NewFakeClientWithScheme(scheme)
 		ctx = context.Background()
-		sm = status.New(c, "fake-component")
+		sm = status.New(c, "fake-component", &common.VersionInfo{Major: 1, Minor: 19})
 
 		// We need to provide something to handler even though it seems to be unused..
 		instance = &operatorv1.Manager{


### PR DESCRIPTION
In Operator, we are watching CSRs using package certificates.k8s.io/v1beta1 which has been deprecated since v1.19 and will be unavailable since v1.22. For any cluster running K8S v1.19+, we need to use package certificates.k8s.io/v1 instead.