### PR TITLE
Added a watch for the kubernetes_services_endpoint configmap.

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -92,7 +92,7 @@ func add(mgr manager.Manager, r *ReconcileAPIServer) error {
 	}
 
 	if err = utils.AddConfigMapWatch(c, render.K8sSvcEndpointConfigMapName, rmeta.OperatorNamespace()); err != nil {
-		return fmt.Errorf("tigera-installation-controller failed to watch ConfigMap %s: %w", render.K8sSvcEndpointConfigMapName, err)
+		return fmt.Errorf("apiserver-controller failed to watch ConfigMap %s: %w", render.K8sSvcEndpointConfigMapName, err)
 	}
 
 	for _, namespace := range []string{rmeta.OperatorNamespace(), render.APIServerNamespace} {

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -34,6 +34,7 @@ import (
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -262,7 +263,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		}
 	}
 
-	k8sEndpoint, err := utils.GetK8sServiceEndPoint(r.client)
+	err = utils.GetK8sServiceEndPoint(r.client)
 	if err != nil {
 		log.Error(err, "Error reading services endpoint configmap")
 		r.status.SetDegraded("Error reading services endpoint configmap", err.Error())
@@ -274,7 +275,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
-	component, err := render.APIServer(*k8sEndpoint, network, managementCluster, managementClusterConnection, amazon, tlsSecret, pullSecrets, r.provider == operatorv1.ProviderOpenShift,
+	component, err := render.APIServer(k8sapi.Endpoint, network, managementCluster, managementClusterConnection, amazon, tlsSecret, pullSecrets, r.provider == operatorv1.ProviderOpenShift,
 		tunnelCASecret, r.clusterDomain)
 	if err != nil {
 		log.Error(err, "Error rendering APIServer")

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -34,6 +34,7 @@ import (
 	operator "github.com/tigera/operator/api/v1"
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration"
 	"github.com/tigera/operator/pkg/controller/migration/convert"
 	"github.com/tigera/operator/pkg/controller/options"
@@ -918,7 +919,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	k8sEndpoint, err := utils.GetK8sServiceEndPoint(r.client)
+	err = utils.GetK8sServiceEndPoint(r.client)
 	if err != nil {
 		log.Error(err, "Error reading services endpoint configmap")
 		r.SetDegraded("Error reading services endpoint configmap", err, reqLogger)
@@ -1010,7 +1011,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	// Render the desired Calico components based on our configuration and then
 	// create or update them.
 	calico, err := render.Calico(
-		*k8sEndpoint,
+		k8sapi.Endpoint,
 		&instance.Spec,
 		logStorageExists,
 		managementCluster,

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -43,11 +43,11 @@ import (
 )
 
 const (
-	BirdTemplatesConfigMapName = "bird-templates"
-	birdTemplateHashAnnotation = "hash.operator.tigera.io/bird-templates"
-	nodeCertHashAnnotation     = "hash.operator.tigera.io/node-cert"
-	nodeCniConfigAnnotation    = "hash.operator.tigera.io/cni-config"
-	CSRLabelCalicoSystem       = "calico-system"
+	BirdTemplatesConfigMapName  = "bird-templates"
+	birdTemplateHashAnnotation  = "hash.operator.tigera.io/bird-templates"
+	nodeCertHashAnnotation      = "hash.operator.tigera.io/node-cert"
+	nodeCniConfigAnnotation     = "hash.operator.tigera.io/cni-config"
+	CSRLabelCalicoSystem        = "calico-system"
 	K8sSvcEndpointConfigMapName = "kubernetes-services-endpoint"
 )
 

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -48,6 +48,7 @@ const (
 	nodeCertHashAnnotation     = "hash.operator.tigera.io/node-cert"
 	nodeCniConfigAnnotation    = "hash.operator.tigera.io/cni-config"
 	CSRLabelCalicoSystem       = "calico-system"
+	K8sSvcEndpointConfigMapName = "kubernetes-services-endpoint"
 )
 
 var (


### PR DESCRIPTION
Added a watch for kubernetes_service_endpoints and operator reads the configmap and pushes the changes to calico-node ds, typha and apiserver deployments.


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
