### PR TITLE
Add reading ConfigMap for extra Kibana config

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -16,6 +16,7 @@ package logstorage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	cmnv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -208,6 +209,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		if err = utils.AddConfigMapWatch(c, name, render.ElasticsearchNamespace); err != nil {
 			return fmt.Errorf("log-storage-controller failed to watch the ConfigMap resource: %w", err)
 		}
+	}
+
+	// Cloud modifications
+	if err = utils.AddConfigMapWatch(c, "cloud-kibana-config", rmeta.OperatorNamespace()); err != nil {
+		return fmt.Errorf("log-storage-controller failed to watch the ConfigMap resource: %w", err)
 	}
 
 	return nil
@@ -530,6 +536,21 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			}
 		}
 		dexCfg = render.NewDexRelyingPartyConfig(authentication, dexTLSSecret, dexSecret, r.clusterDomain)
+	}
+
+	// Cloud modifications
+	kbCm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: "cloud-kibana-config", Namespace: rmeta.OperatorNamespace()}
+	if err = r.client.Get(ctx, key, kbCm); err != nil {
+		if !errors.IsNotFound(err) {
+			return reconcile.Result{}, fmt.Errorf("Failed to read cloud-kibana-config ConfigMap: %s", err.Error())
+		}
+	} else {
+		render.CloudKibanaConfigOverrides = map[string]interface{}{}
+		if err = json.Unmarshal([]byte(kbCm.Data["config"]), &render.CloudKibanaConfigOverrides); err != nil {
+			r.status.SetDegraded("Failed to unmarshall config in cloud-kibana-config ConfigMap", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	component := render.LogStorage(

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -148,6 +148,8 @@ echo "Keystore initialization successful."
 
 var log = logf.Log.WithName("render")
 
+var CloudKibanaConfigOverrides = map[string]interface{}{}
+
 // Elasticsearch renders the
 func LogStorage(
 	logStorage *operatorv1.LogStorage,
@@ -1140,6 +1142,12 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 			"enabled":        true,
 			"licenseEdition": "enterpriseEdition",
 		},
+	}
+
+	if len(CloudKibanaConfigOverrides) != 0 {
+		for k, v := range CloudKibanaConfigOverrides {
+			config[k] = v
+		}
 	}
 
 	if es.supportsOIDC() {


### PR DESCRIPTION
To avoid changing LogStorage render the kibana config is a public
variable of render/logstorage so the controller can set the field
without passing in an additional variable.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
