### PR TITLE
don't migrate if the daemonset and deployments are deleting

### DIFF
--- a/pkg/controller/migration/namespace_migration.go
+++ b/pkg/controller/migration/namespace_migration.go
@@ -89,24 +89,24 @@ func (m *CoreNamespaceMigration) NeedsCoreNamespaceMigration(ctx context.Context
 		return false, nil
 	}
 
-	_, err := m.client.AppsV1().DaemonSets(kubeSystem).Get(ctx, nodeDaemonSetName, metav1.GetOptions{})
-	if err == nil {
+	nds, err := m.client.AppsV1().DaemonSets(kubeSystem).Get(ctx, nodeDaemonSetName, metav1.GetOptions{})
+	if err == nil && nds.DeletionTimestamp != nil {
 		return true, nil
 	}
 	if !apierrs.IsNotFound(err) {
 		return false, fmt.Errorf("failed to get daemonset %s in kube-system: %s", nodeDaemonSetName, err)
 	}
 
-	_, err = m.client.AppsV1().Deployments(kubeSystem).Get(ctx, kubeControllerDeploymentName, metav1.GetOptions{})
-	if err == nil {
+	kcdeploy, err := m.client.AppsV1().Deployments(kubeSystem).Get(ctx, kubeControllerDeploymentName, metav1.GetOptions{})
+	if err == nil && kcdeploy.DeletionTimestamp != nil {
 		return true, nil
 	}
 	if !apierrs.IsNotFound(err) {
 		return false, fmt.Errorf("failed to get deployment %s in kube-system: %s", kubeControllerDeploymentName, err)
 	}
 
-	_, err = m.client.AppsV1().Deployments(kubeSystem).Get(ctx, typhaDeploymentName, metav1.GetOptions{})
-	if err == nil {
+	tdeploy, err := m.client.AppsV1().Deployments(kubeSystem).Get(ctx, typhaDeploymentName, metav1.GetOptions{})
+	if err == nil && tdeploy.DeletionTimestamp != nil {
 		return true, nil
 	}
 	if !apierrs.IsNotFound(err) {


### PR DESCRIPTION
## Description
If calico is deployed with addonmanager there is actuall a race where addon manager will purge before operator comes up. Most of the time this seems okay. Howver if a pod is slow to terminate then the operator will migrate the deleting daemonset and nodes can get stuck pretty easily.  

https://github.com/projectcalico/calico/issues/4525#issuecomment-830115368

Even if it's not the whole solution having operator ignore deleting daemonsets might be better than current behavior. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
