### PR TITLE
Handle no resources to monitor in the status manager

### DIFF
--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller_test.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller_test.go
@@ -70,6 +70,7 @@ var _ = Describe("amazoncloudintegration controller tests", func() {
 		mockStatus.On("IsAvailable").Return(true)
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ClearDegraded")
+		mockStatus.On("ReadyToMonitor")
 
 		Expect(cli.Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -69,6 +69,7 @@ var _ = Describe("apiserver controller tests", func() {
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("AddCertificateSigningRequests", mock.Anything)
 		mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
+		mockStatus.On("ReadyToMonitor")
 
 		Expect(cli.Create(ctx, &operatorv1.Installation{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/authentication/authentication_controller_test.go
+++ b/pkg/controller/authentication/authentication_controller_test.go
@@ -74,6 +74,7 @@ var _ = Describe("authentication controller tests", func() {
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("SetDegraded", mock.Anything, mock.Anything).Return()
+		mockStatus.On("ReadyToMonitor")
 
 		idpSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -70,6 +70,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		mockStatus.On("AddCronJobs", mock.Anything)
 		mockStatus.On("ClearDegraded", mock.Anything)
 		mockStatus.On("OnCRFound").Return()
+		mockStatus.On("ReadyToMonitor")
 
 		r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone)
 		dpl = &appsv1.Deployment{

--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Compliance controller tests", func() {
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+		mockStatus.On("ReadyToMonitor")
 
 		// Create an object we can use throughout the test to do the compliance reconcile loops.
 		// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1165,6 +1165,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
+	// Tell the status manager that we're ready to monitor the resources we've told it about and receive statuses.
+	r.status.ReadyToMonitor()
+
 	// We can clear the degraded state now since as far as we know everything is in order.
 	r.status.ClearDegraded()
 

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -348,6 +348,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("ClearDegraded")
 			mockStatus.On("AddCertificateSigningRequests", mock.Anything)
 			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
+			mockStatus.On("ReadyToMonitor")
 
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
@@ -635,6 +636,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("ClearDegraded")
 			mockStatus.On("AddCertificateSigningRequests", mock.Anything)
 			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
+			mockStatus.On("ReadyToMonitor")
 
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
@@ -77,6 +77,7 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+		mockStatus.On("ReadyToMonitor")
 
 		// Create an object we can use throughout the test to do the compliance reconcile loops.
 		// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -75,6 +75,7 @@ var _ = Describe("LogCollector controller tests", func() {
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+		mockStatus.On("ReadyToMonitor")
 
 		// Create an object we can use throughout the test to do the compliance reconcile loops.
 		// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -223,6 +223,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("AddCronJobs", mock.Anything)
 						mockStatus.On("OnCRNotFound").Return()
 						mockStatus.On("ClearDegraded")
+						mockStatus.On("ReadyToMonitor")
 					})
 					DescribeTable("tests that the ExternalService is setup with the default service name", func(clusterDomain, expectedSvcName string) {
 						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain)
@@ -265,6 +266,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("AddStatefulSets", mock.Anything).Return()
 						mockStatus.On("AddCronJobs", mock.Anything)
 						mockStatus.On("ClearDegraded", mock.Anything).Return()
+						mockStatus.On("ReadyToMonitor")
 
 						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
@@ -340,6 +342,7 @@ var _ = Describe("LogStorage controller", func() {
 					mockStatus.On("AddStatefulSets", mock.Anything)
 					mockStatus.On("AddCronJobs", mock.Anything)
 					mockStatus.On("OnCRFound").Return()
+					mockStatus.On("ReadyToMonitor")
 				})
 				It("test LogStorage reconciles successfully", func() {
 					Expect(cli.Create(ctx, &storagev1.StorageClass{
@@ -1029,6 +1032,7 @@ var _ = Describe("LogStorage controller", func() {
 					mockStatus.On("AddCronJobs", mock.Anything)
 					mockStatus.On("ClearDegraded", mock.Anything)
 					mockStatus.On("OnCRFound").Return()
+					mockStatus.On("ReadyToMonitor")
 				})
 
 				It("deletes Elasticsearch and Kibana then removes the finalizers on the LogStorage CR", func() {

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -99,6 +99,7 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("OnCRFound").Return()
 			mockStatus.On("ClearDegraded")
 			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
 				client:          c,
@@ -329,6 +330,7 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("OnCRFound").Return()
 			mockStatus.On("ClearDegraded")
 			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
 				client:          c,

--- a/pkg/controller/status/mock.go
+++ b/pkg/controller/status/mock.go
@@ -5,11 +5,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// TODO use mockery to generate mock
 type MockStatus struct {
 	mock.Mock
 }
 
 func (m *MockStatus) Run() {
+	m.Called()
+}
+
+func (m *MockStatus) ReadyToMonitor() {
 	m.Called()
 }
 

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -74,6 +74,7 @@ type StatusManager interface {
 	IsAvailable() bool
 	IsProgressing() bool
 	IsDegraded() bool
+	ReadyToMonitor()
 }
 
 type statusManager struct {
@@ -96,6 +97,11 @@ type statusManager struct {
 	// Keep track of currently calculated status.
 	progressing []string
 	failing     []string
+
+	// readyToMonitor tells the status manager that it's ready to monitor the resources that it's been told to monitor,
+	// if there are any, and report statuses based on the state of those resources.
+	readyToMonitor bool
+	hasSynced      bool
 }
 
 func New(client client.Client, component string, kubernetesVersion *common.VersionInfo) StatusManager {
@@ -121,29 +127,49 @@ func (m *statusManager) updateStatus() {
 		return
 	}
 
-	if !m.syncState() {
-		return
+	// Unless we've been given an explicit degraded reason we are not ready to start reporting statuses until
+	// ReadyToMonitor has been called by the owner of the status manager. This means there's no point in syncing
+	// the state.
+	if m.readyToMonitor {
+		m.syncState()
+
+		// We've collected knowledge about the current state of the objects we're monitoring.
+		// Now, use that to update the TigeraStatus object for this manager.
+		if m.IsAvailable() {
+			m.setAvailable("All objects available", "")
+		} else {
+			m.clearAvailable()
+		}
+
+		if m.IsProgressing() {
+			m.setProgressing("Not all pods are ready", m.progressingMessage())
+		} else {
+			m.clearProgressing()
+		}
+
+		if m.IsDegraded() {
+			m.setDegraded(m.degradedReason(), m.degradedMessage())
+		} else {
+			m.clearDegraded()
+		}
+	} else {
+		log.V(2).WithName(m.component).Info("Status manager is not ready to report component statuses.")
+
+		// If we've been given an explicit degraded reason then it should be reported even if readyToMonitor is false,
+		// as this degraded reason may be the reason why we're not ready to monitor.
+		if m.isExplicitlyDegraded() {
+			m.setDegraded(m.degradedReason(), m.degradedMessage())
+		} else {
+			m.clearDegraded()
+		}
 	}
 
-	// We've collected knowledge about the current state of the objects we're monitoring.
-	// Now, use that to update the TigeraStatus object for this manager.
-	if m.IsAvailable() {
-		m.setAvailable("All objects available", "")
-	} else {
-		m.clearAvailable()
-	}
+}
 
-	if m.IsProgressing() {
-		m.setProgressing("Not all pods are ready", m.progressingMessage())
-	} else {
-		m.clearProgressing()
-	}
-
-	if m.IsDegraded() {
-		m.setDegraded(m.degradedReason(), m.degradedMessage())
-	} else {
-		m.clearDegraded()
-	}
+func (m *statusManager) isExplicitlyDegraded() bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.explicitDegradedReason != ""
 }
 
 // Run starts the status manager state monitoring routine.
@@ -161,6 +187,18 @@ func (m *statusManager) Run() {
 			}
 		}
 	}()
+}
+
+// ReadyToMonitor signals that this Status Manager should start evaluating the resources it knows about and report
+// if the availability of the component based on the statuses of those monitored resources.
+//
+// If there are no resources to monitor, then by default this component is available (all 0 resources for this component
+// are healthy). One caveat to the default when there are no resources to monitor is if the component has a degraded
+// status explicitely set.
+func (m *statusManager) ReadyToMonitor() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.readyToMonitor = true
 }
 
 // OnCRFound indicates to the status manager that it should start reporting status. Until called,
@@ -300,10 +338,17 @@ func (m *statusManager) IsAvailable() bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if m.progressing == nil || m.failing == nil {
-		// We haven't learned our state yet. Return false.
+	// If we're not ready to monitor or haven't synced then we're not ready to report a status base on the status of the
+	// known resources.
+	if !m.readyToMonitor || !m.hasSynced {
 		return false
 	}
+
+	if m.degraded {
+		return false
+	}
+
+	// If there are no resources to monitor then this is always true, which is by design.
 	return len(m.failing) == 0 && len(m.progressing) == 0
 }
 
@@ -312,10 +357,12 @@ func (m *statusManager) IsProgressing() bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	if m.progressing == nil || m.failing == nil {
-		// We haven't learned our state yet. Return false.
+	// If we're not ready to monitor or haven't synced then we're not ready to report a status base on the status of the
+	// known resources.
+	if !m.readyToMonitor || !m.hasSynced {
 		return false
 	}
+
 	return len(m.progressing) != 0 && len(m.failing) == 0
 }
 
@@ -324,22 +371,25 @@ func (m *statusManager) IsDegraded() bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	// Controllers can explicitly set us degraded.
+	// Controllers can explicitly set us degraded, which can be set even before we tell the status manager that it
+	// should start monitoring resources.
 	if m.degraded {
 		return true
 	}
 
-	// Otherwise, we might be degraded due to failing pods.
-	if m.progressing == nil || m.failing == nil {
-		// We haven't learned our state yet. Return false.
+	// If we're not ready to monitor or haven't synced then we're not ready to report a status base on the status of the
+	// known resources.
+	if !m.readyToMonitor || !m.hasSynced {
 		return false
 	}
+
+	// We may be degraded due to failing pods.
 	return len(m.failing) != 0
 }
 
-// syncState syncs our internal state with that of the cluster. It returns true if we've synced
-// and returns false if we are still waiting for information.
-func (m *statusManager) syncState() bool {
+// syncState syncs the internal state of the k8s resources that the status manager has been told to monitor with that of
+// the cluster.
+func (m *statusManager) syncState() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	progressing := []string{}
@@ -443,21 +493,9 @@ func (m *statusManager) syncState() bool {
 		}
 	}
 
-	if len(m.deployments)+len(m.daemonsets)+len(m.statefulsets)+len(m.cronjobs) > 0 {
-		// We have been told about the resources we need to watch - set state before unlocking.
-		m.progressing = progressing
-		m.failing = failing
-		return true
-	} else {
-		// We don't know about any resources. Clear internal state to indicate this.
-		m.progressing = nil
-		m.failing = nil
-	}
-
-	// If we don't know about any resources, and we don't have any explicit degraded state set, then
-	// we're not yet ready to report status. However, if we've been given an explicit degraded state, then
-	// we should report it.
-	return m.explicitDegradedReason != ""
+	m.progressing = progressing
+	m.failing = failing
+	m.hasSynced = true
 }
 
 // isInitialized returns true if corresponding CR has been queried

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -190,6 +190,10 @@ func (c componentHandler) CreateOrUpdateOrDelete(ctx context.Context, component 
 	}
 
 	cmpLog.V(1).Info("Done reconciling component")
+	// TODO Get each controller to explicitly call ReadyToMonitor on the status manager instead of doing it here.
+	if status != nil {
+		status.ReadyToMonitor()
+	}
 	return nil
 }
 


### PR DESCRIPTION
This commit adds the ReadyToMonitor function to the StatusManager, and doesn't return false for IsAvailable if "progressing" and "failing" or nil. The purpose of ReadyToMonitor is to tell the status manager that it's OK to start reporting the available state of the resources it's been told about. If it hasn't been told about any resources, then the state is available (so long as there's no explicit degraded reason).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
