### PR TITLE
Adjust fluentd probe timeouts

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -62,8 +62,14 @@ const (
 	SplunkFluentdDefaultCertDir              = "/etc/ssl/splunk/"
 	SplunkFluentdDefaultCertPath             = SplunkFluentdDefaultCertDir + SplunkFluentdSecretCertificateKey
 
-	ProbeTimeoutSeconds = 5
-	ProbePeriodSeconds  = 10
+	probeTimeoutSeconds        int32 = 5
+	probePeriodSeconds         int32 = 5
+	probeWindowsTimeoutSeconds int32 = 10
+	probeWindowsPeriodSeconds  int32 = 10
+
+	// Default failure threshold for probes is 3. For the startupProbe tolerate more failures.
+	probeFailureThreshold        int32 = 3
+	startupProbeFailureThreshold int32 = 10
 
 	fluentdName        = "tigera-fluentd"
 	fluentdWindowsName = "tigera-fluentd-windows"
@@ -103,6 +109,13 @@ func Fluentd(
 	clusterDomain string,
 	osType rmeta.OSType,
 ) Component {
+	timeout := probeTimeoutSeconds
+	period := probePeriodSeconds
+	if osType == rmeta.OSTypeWindows {
+		timeout = probeWindowsTimeoutSeconds
+		period = probeWindowsPeriodSeconds
+	}
+
 	return &fluentdComponent{
 		lc:              lc,
 		esSecrets:       esSecrets,
@@ -115,6 +128,8 @@ func Fluentd(
 		installation:    installation,
 		clusterDomain:   clusterDomain,
 		osType:          osType,
+		probeTimeout:    timeout,
+		probePeriod:     period,
 	}
 }
 
@@ -140,6 +155,8 @@ type fluentdComponent struct {
 	clusterDomain   string
 	osType          rmeta.OSType
 	image           string
+	probeTimeout    int32
+	probePeriod     int32
 }
 
 func (c *fluentdComponent) ResolveImages(is *operatorv1.ImageSet) error {
@@ -608,20 +625,17 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 }
 
 // The startup probe uses the same action as the liveness probe, but with
-// a higher failure threshold and a larger timeout to account for slow networks.
+// a higher failure threshold and double the timeout to account for slow
+// networks.
 func (c *fluentdComponent) startup() *corev1.Probe {
-	// Default failure threshold for probes is 3. For the startup we should
-	// tolerate more failures.
-	var startupProbeFailureThreshold int32 = 10
-
 	return &corev1.Probe{
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
 				Command: c.livenessCmd(),
 			},
 		},
-		TimeoutSeconds:   ProbeTimeoutSeconds * 2,
-		PeriodSeconds:    ProbePeriodSeconds,
+		TimeoutSeconds:   c.probeTimeout * 2,
+		PeriodSeconds:    c.probePeriod * 2,
 		FailureThreshold: startupProbeFailureThreshold,
 	}
 }
@@ -633,8 +647,9 @@ func (c *fluentdComponent) liveness() *corev1.Probe {
 				Command: c.livenessCmd(),
 			},
 		},
-		TimeoutSeconds: ProbeTimeoutSeconds,
-		PeriodSeconds:  ProbePeriodSeconds,
+		TimeoutSeconds:   c.probeTimeout,
+		PeriodSeconds:    c.probePeriod,
+		FailureThreshold: probeFailureThreshold,
 	}
 }
 
@@ -645,7 +660,9 @@ func (c *fluentdComponent) readiness() *corev1.Probe {
 				Command: c.readinessCmd(),
 			},
 		},
-		TimeoutSeconds: ProbeTimeoutSeconds,
+		TimeoutSeconds:   c.probeTimeout,
+		PeriodSeconds:    c.probePeriod,
+		FailureThreshold: probeFailureThreshold,
 	}
 }
 

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -100,6 +100,23 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		for _, expected := range expectedEnvs {
 			Expect(envs).To(ContainElement(expected))
 		}
+
+		container := ds.Spec.Template.Spec.Containers[0]
+
+		Expect(container.ReadinessProbe.Exec.Command).To(ConsistOf([]string{"sh", "-c", "/bin/readiness.sh"}))
+		Expect(container.ReadinessProbe.TimeoutSeconds).To(BeEquivalentTo(5))
+		Expect(container.ReadinessProbe.PeriodSeconds).To(BeEquivalentTo(5))
+		Expect(container.ReadinessProbe.FailureThreshold).To(BeEquivalentTo(3))
+
+		Expect(container.LivenessProbe.Exec.Command).To(ConsistOf([]string{"sh", "-c", "/bin/liveness.sh"}))
+		Expect(container.LivenessProbe.TimeoutSeconds).To(BeEquivalentTo(5))
+		Expect(container.LivenessProbe.PeriodSeconds).To(BeEquivalentTo(5))
+		Expect(container.LivenessProbe.FailureThreshold).To(BeEquivalentTo(3))
+
+		Expect(container.StartupProbe.Exec.Command).To(ConsistOf([]string{"sh", "-c", "/bin/liveness.sh"}))
+		Expect(container.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(10))
+		Expect(container.StartupProbe.PeriodSeconds).To(BeEquivalentTo(10))
+		Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(10))
 	})
 
 	It("should render for Windows nodes", func() {
@@ -169,6 +186,23 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		for _, expected := range expectedEnvs {
 			Expect(envs).To(ContainElement(expected))
 		}
+
+		container := ds.Spec.Template.Spec.Containers[0]
+
+		Expect(container.ReadinessProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/readiness.sh`}))
+		Expect(container.ReadinessProbe.TimeoutSeconds).To(BeEquivalentTo(10))
+		Expect(container.ReadinessProbe.PeriodSeconds).To(BeEquivalentTo(10))
+		Expect(container.ReadinessProbe.FailureThreshold).To(BeEquivalentTo(3))
+
+		Expect(container.LivenessProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}))
+		Expect(container.LivenessProbe.TimeoutSeconds).To(BeEquivalentTo(10))
+		Expect(container.LivenessProbe.PeriodSeconds).To(BeEquivalentTo(10))
+		Expect(container.LivenessProbe.FailureThreshold).To(BeEquivalentTo(3))
+
+		Expect(container.StartupProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}))
+		Expect(container.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(20))
+		Expect(container.StartupProbe.PeriodSeconds).To(BeEquivalentTo(20))
+		Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(10))
 	})
 
 	It("should render with S3 configuration", func() {


### PR DESCRIPTION
## Description

This PR fixes some issues with the fluentd probes, mostly for Windows
- The startup probe on Windows can fail due to slow startup. This PR doubles the startup probe period and timeout to 20s.
- The readiness probe period was not set so it defaults to 10s while the timeout is 5s.
- Sets the failure threshold explicitly
- Adds some tests

I've tested these changes on a cluster with somewhat underprovisioned Windows nodes.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
