### PR TITLE
Remove eks-log-forwarder deployment for Windows

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -243,10 +243,8 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	if c.filters != nil {
 		objs = append(objs, c.filtersConfigMap())
 	}
-	if c.eksConfig != nil {
-		// Windows PSP does not support allowedHostPaths yet.
-		// See: https://github.com/kubernetes/kubernetes/issues/93165#issuecomment-693049808
-		if c.installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.osType == rmeta.OSTypeLinux {
+	if c.eksConfig != nil && c.osType == rmeta.OSTypeLinux {
+		if c.installation.KubernetesProvider != operatorv1.ProviderOpenShift {
 			objs = append(objs,
 				c.eksLogForwarderClusterRole(),
 				c.eksLogForwarderClusterRoleBinding(),


### PR DESCRIPTION
## Description

The EKS log forwarder isn't needed on Windows because the deployment will already be running on the Linux nodes if EKS log forwarding is enabled, and we only need one to fetch the CloudWatch audit logs.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
