### PR TITLE
Update tigera-manager role to include felixconfiguration, heps, events and nodes for service graph processing

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -685,13 +685,30 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 				Verbs: []string{"get", "list"},
 			},
 			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"hostendpoints",
+				},
+				Verbs: []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"felixconfigurations",
+				},
+				ResourceNames: []string{
+					"default",
+				},
+				Verbs: []string{"get"},
+			},
+			{
 				APIGroups: []string{"networking.k8s.io"},
 				Resources: []string{"networkpolicies"},
 				Verbs:     []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces"},
+				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events"},
 				Verbs:     []string{"list"},
 			},
 			// When a request is made in the manager UI, they are proxied through the Voltron backend server. If the

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -155,13 +155,30 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				Verbs: []string{"get", "list"},
 			},
 			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"hostendpoints",
+				},
+				Verbs: []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"felixconfigurations",
+				},
+				ResourceNames: []string{
+					"default",
+				},
+				Verbs: []string{"get"},
+			},
+			{
 				APIGroups: []string{"networking.k8s.io"},
 				Resources: []string{"networkpolicies"},
 				Verbs:     []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces"},
+				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events"},
 				Verbs:     []string{"list"},
 			},
 			{
@@ -310,13 +327,30 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				Verbs: []string{"get", "list"},
 			},
 			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"hostendpoints",
+				},
+				Verbs: []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"felixconfigurations",
+				},
+				ResourceNames: []string{
+					"default",
+				},
+				Verbs: []string{"get"},
+			},
+			{
 				APIGroups: []string{"networking.k8s.io"},
 				Resources: []string{"networkpolicies"},
 				Verbs:     []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces"},
+				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events"},
 				Verbs:     []string{"list"},
 			},
 			{


### PR DESCRIPTION
## Description

Service graph needs felix configuration (default) to get the flow flush interval and node list to get the node labels for host aggregation selectors, heps to map hep name to host name and events to show k8s warning event types.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
