### PR TITLE
Make Docker Image Multi-Arch Compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ $(BINDIR)/operator-$(ARCH): $(SRC_FILES)
 	mkdir -p $(BINDIR)
 	$(CONTAINERIZED) \
 	sh -c '$(GIT_CONFIG_SSH) \
-	go build -v -i -o $(BINDIR)/operator-$(ARCH) -ldflags "-X $(PACKAGE_NAME)/version.VERSION=$(GIT_VERSION) -s -w" ./main.go'
+	GOARCH=$(ARCH) go build -v -i -o $(BINDIR)/operator-$(ARCH) -ldflags "-X $(PACKAGE_NAME)/version.VERSION=$(GIT_VERSION) -s -w" ./main.go'
 
 .PHONY: image
 image: build $(BUILD_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -216,9 +216,6 @@ sub-image-%:
 $(BUILD_IMAGE): $(BUILD_IMAGE)-$(ARCH)
 $(BUILD_IMAGE)-$(ARCH): $(BINDIR)/operator-$(ARCH)
 	docker build --pull -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg GIT_VERSION=$(GIT_VERSION) --build-arg ARCH=$(ARCH) -f ./build/Dockerfile .
-ifeq ($(ARCH),amd64)
-	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(BUILD_IMAGE):latest
-endif
 
 build/init/bin/kubectl:
 	mkdir -p build/init/bin

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: fmt vet ut
 # The target architecture is select by setting the ARCH variable.
 # When ARCH is undefined it is set to the detected host architecture.
 # When ARCH differs from the host architecture a crossbuild will be performed.
-ARCHES=$(patsubst build/Dockerfile.%,%,$(wildcard build/Dockerfile.*))
+ARCHES= amd64 arm64
 
 # BUILDARCH is the host architecture
 # ARCH is the target architecture
@@ -215,7 +215,7 @@ sub-image-%:
 
 $(BUILD_IMAGE): $(BUILD_IMAGE)-$(ARCH)
 $(BUILD_IMAGE)-$(ARCH): $(BINDIR)/operator-$(ARCH)
-	docker build --pull -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./build/Dockerfile.$(ARCH) .
+	docker build --pull -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg GIT_VERSION=$(GIT_VERSION) --build-arg ARCH=$(ARCH) -f ./build/Dockerfile .
 ifeq ($(ARCH),amd64)
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(BUILD_IMAGE):latest
 endif

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,1 +1,0 @@
-Dockerfile.amd64

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+ARG ARCH=amd64
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2-301.1592810506 AS ubi
 
 # Update base packages to get security updates.
@@ -27,6 +27,7 @@ COPY --from=ubi /etc/pki /etc/pki
 COPY --from=ubi /usr/share/pki /usr/share/pki
 
 ARG GIT_VERSION=unknown
+ARG ARCH
 LABEL name="Calico Operator" \
       vendor="Project Calico" \
       version=$GIT_VERSION \
@@ -39,7 +40,7 @@ ENV OPERATOR=/usr/local/bin/operator \
     USER_UID=1001
 
 # install operator binary
-COPY build/_output/bin/operator-amd64 ${OPERATOR}
+COPY build/_output/bin/operator-${ARCH} ${OPERATOR}
 
 # The exec form of ENTRYPOINT does not invoke a command shell.
 # This means that normal shell processing does not happen, so will not


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Addresses #1246 This PR attempts to take a first crack at making the docker image for `tigera/operator` multi-arch compatible. This is my first time in the community here (👋🏾 hi, by the way!), so I don't have a lot of insight into how things work around here!

I took the path of least resistance: since we're building a simple `FROM scratch` image for the most part, I took the `Dockerfile` and made just a single one with an ARCH arg for building. Then, instead of deriving `ARCHES` from the host machine, I put a static list of "supported" (i.e. just the ones I was interested in...) arches. `make images-all` then produces two tagged images: `tigera/operator:latest-amd64` and `tigera/operator:latest-arm64`.

There's a couple issues I need some feedback on:
- I don't have a lot of experience with `manifest-tool`: will it properly set the architecture for the images? Without heavy refactoring to use `docker buildx`, I don't have a ton of experience in how to make `docker build` write out the `arm64` image as actually being for `arm64` (even if the binary itself build from go _is_).
- How would you like the final manifest to be built? I removed the architecture-less generic tag from the `Makefile` in preparation of making the fat manifest, but that's where my inexperience with `manifest-tool` comes in.


Thanks!

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
