### PR TITLE
extend timeout to avoid not ready containers 

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1296,6 +1296,9 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 	}
 	rp := &v1.Probe{
 		Handler: v1.Handler{Exec: &v1.ExecAction{Command: readinessCmd}},
+		//period is default but timeout is half to account for some slow machines
+		TimeoutSeconds: 5,
+		PeriodSeconds:  10,
 	}
 	return lp, rp
 }

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1296,7 +1296,8 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*v1.Probe, *v1.Probe) {
 	}
 	rp := &v1.Probe{
 		Handler: v1.Handler{Exec: &v1.ExecAction{Command: readinessCmd}},
-		//period is default but timeout is half to account for some slow machines
+		// Set the TimeoutSeconds greater than the default of 1 to allow additional time on loaded nodes.
+		// This timeout should be less than the PeriodSeconds.
 		TimeoutSeconds: 5,
 		PeriodSeconds:  10,
 	}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -2817,7 +2817,11 @@ var _ = Describe("Node rendering tests", func() {
 // verifyProbes asserts the expected node liveness and readiness probe.
 func verifyProbes(ds *apps.DaemonSet, isOpenshift, isEnterprise bool) {
 	// Verify readiness and liveness probes.
-	expectedReadiness := &v1.Probe{Handler: v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}}}}
+	expectedReadiness := &v1.Probe{
+		Handler:        v1.Handler{Exec: &v1.ExecAction{Command: []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}}},
+		TimeoutSeconds: 5,
+		PeriodSeconds:  10,
+	}
 	expectedLiveness := &v1.Probe{Handler: v1.Handler{
 		HTTPGet: &v1.HTTPGetAction{
 			Host: "localhost",


### PR DESCRIPTION


## Description
This happens when machines are slow/busy. calico-node containers show as unready. 
See issue https://github.com/tigera/operator/issues/1324 but readiness probe timeout seems to be abit short. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
