### PR TITLE
Allow calico-node to update packetcaptures

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -384,6 +384,14 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{"create"},
 			},
+			{
+				// Tigera Secure updates status for packet captures.
+				APIGroups: []string{"crd.projectcalico.org"},
+				Resources: []string{
+					"packetcaptures",
+				},
+				Verbs: []string{"update"},
+			},
 		}
 		role.Rules = append(role.Rules, extraRules...)
 	}


### PR DESCRIPTION
## Description

Enhance calico-node clusterrole to update packetures CRs with their status.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
