### PR TITLE
Implement Operator logic to install ES Gateway

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -30,6 +30,9 @@ components:
   es-proxy:
     image: tigera/es-proxy
     version: master
+  es-gateway:
+    image: tigera/es-gateway
+    version: master
   eck-kibana:
     version: 7.10.1
   dex:

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tigera/api v0.0.0-20210210003744-476f909e3f8f
 	go.uber.org/zap v1.15.0
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -94,6 +94,12 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components "es-gateway" }}
+	ComponentESGateway = component{
+		Version: "{{ .Version }}",
+		Image:   "{{ .Image }}",
+	}
+{{- end }}
 {{ with .Components.fluentd }}
 	ComponentFluentd = component{
 		Version: "{{ .Version }}",
@@ -235,5 +241,6 @@ var (
 		ComponentTigeraCNI,
 		ComponentCloudControllers,
 		ComponentElasticsearchMetrics,
+		ComponentESGateway,
 	}
 )

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -82,6 +82,11 @@ var (
 		Image:   "tigera/es-proxy",
 	}
 
+	ComponentESGateway = component{
+		Version: "master",
+		Image:   "tigera/es-gateway",
+	}
+
 	ComponentFluentd = component{
 		Version: "master",
 		Image:   "tigera/fluentd",
@@ -204,5 +209,6 @@ var (
 		ComponentTigeraCNI,
 		ComponentCloudControllers,
 		ComponentElasticsearchMetrics,
+		ComponentESGateway,
 	}
 )

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -905,11 +905,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
-	var esAdminSecret *v1.Secret
+	var kubeControllersGatewaySecret *v1.Secret
 	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
-		// Kube controllers needs the admin secret copied to it's namespace as it has administrative tasks to run on
-		// Elasticsearch.
-		esAdminSecret, err = utils.GetSecret(ctx, r.client, render.ElasticsearchAdminUserSecret, rmeta.OperatorNamespace())
+		kubeControllersGatewaySecret, err = utils.GetSecret(ctx, r.client, render.ElasticsearchKubeControllersUserSecret, rmeta.OperatorNamespace())
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -1058,7 +1056,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		nodeAppArmorProfile,
 		r.clusterDomain,
 		enableESOIDCWorkaround,
-		esAdminSecret,
+		kubeControllersGatewaySecret,
 		kubeControllersMetricsPort,
 		nodeReporterMetricsPort,
 		bgpLayout,

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -133,7 +133,7 @@ func add(mgr manager.Manager, c controller.Controller) error {
 	for _, secretName := range []string{
 		relasticsearch.PublicCertSecret, render.ElasticsearchIntrusionDetectionUserSecret,
 		render.ElasticsearchIntrusionDetectionJobUserSecret, render.ElasticsearchADJobUserSecret,
-		render.KibanaPublicCertSecret, render.ManagerInternalTLSSecretName,
+		render.ManagerInternalTLSSecretName,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, rmeta.OperatorNamespace()); err != nil {
 			return fmt.Errorf("intrusiondetection-controller failed to watch the Secret resource: %v", err)
@@ -141,6 +141,11 @@ func add(mgr manager.Manager, c controller.Controller) error {
 	}
 
 	if err = utils.AddSecretsWatch(c, render.ManagerInternalTLSSecretName, render.IntrusionDetectionNamespace); err != nil {
+		return fmt.Errorf("intrusiondetection-controller failed to watch the Secret resource: %v", err)
+	}
+
+	// These watches are here to catch a modification to the resources we create in reconcile so the changes would be corrected.
+	if err = utils.AddSecretsWatch(c, relasticsearch.PublicCertSecret, render.IntrusionDetectionNamespace); err != nil {
 		return fmt.Errorf("intrusiondetection-controller failed to watch the Secret resource: %v", err)
 	}
 

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
@@ -133,10 +133,6 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      render.ElasticsearchADJobUserSecret,
 				Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
-		Expect(c.Create(ctx, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      render.KibanaPublicCertSecret,
-				Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
 		Expect(c.Create(ctx, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      render.ECKLicenseConfigMapName,

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tigera/operator/pkg/crypto"
+
 	cmnv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"golang.org/x/crypto/bcrypt"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/options"
@@ -32,6 +35,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rsecret "github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 
 	apps "k8s.io/api/apps/v1"
@@ -167,10 +171,19 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch all the secrets created by this controller so we can regenerate any that are deleted
 	for _, secretName := range []string{
 		render.TigeraElasticsearchCertSecret, render.TigeraKibanaCertSecret,
-		render.OIDCSecretName, render.DexObjectName} {
+		render.OIDCSecretName, render.DexObjectName, relasticsearch.PublicCertSecret} {
 		if err = utils.AddSecretsWatch(c, secretName, rmeta.OperatorNamespace()); err != nil {
 			return fmt.Errorf("log-storage-controller failed to watch the Secret resource: %w", err)
 		}
+	}
+
+	// Catch if something modifies the certs that this controller creates.
+	if err = utils.AddSecretsWatch(c, relasticsearch.PublicCertSecret, render.ElasticsearchNamespace); err != nil {
+		return fmt.Errorf("log-storage-controller failed to watch the Secret resource: %w", err)
+	}
+
+	if err = utils.AddSecretsWatch(c, render.TigeraElasticsearchInternalCertSecret, render.ElasticsearchNamespace); err != nil {
+		return fmt.Errorf("log-storage-controller failed to watch the Secret resource: %w", err)
 	}
 
 	if err = utils.AddConfigMapWatch(c, relasticsearch.ClusterConfigConfigMapName, rmeta.OperatorNamespace()); err != nil {
@@ -182,6 +195,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	if err := utils.AddServiceWatch(c, render.ElasticsearchServiceName, render.ElasticsearchNamespace); err != nil {
+		return fmt.Errorf("log-storage-controller failed to watch the Service resource: %w", err)
+	}
+
+	if err := utils.AddServiceWatch(c, esgateway.ServiceName, render.ElasticsearchNamespace); err != nil {
 		return fmt.Errorf("log-storage-controller failed to watch the Service resource: %w", err)
 	}
 
@@ -404,7 +421,8 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	var esCertSecret, esCertSecretESCopy, esPubCertSecret, esAdminUserSecret *corev1.Secret
+	var gatewayCertSecret, publicCertSecret *corev1.Secret
+	var esInternalCertSecret, esAdminUserSecret, esCertSecret *corev1.Secret
 	var kibanaSecrets, curatorSecrets []*corev1.Secret
 	var clusterConfig *relasticsearch.ClusterConfig
 	var esLicenseType render.ElasticsearchLicenseType
@@ -427,6 +445,12 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, nil
 		}
 
+		if gatewayCertSecret, publicCertSecret, err = r.getESGatewayCertificateSecrets(ctx, install); err != nil {
+			reqLogger.Error(err, err.Error())
+			r.status.SetDegraded("Failed to create Elasticsearch Gateway secrets", err.Error())
+			return reconcile.Result{}, err
+		}
+
 		// Get the admin user secret to copy to the operator namespace.
 		esAdminUserSecret, err = utils.GetSecret(ctx, r.client, render.ElasticsearchAdminUserSecret, render.ElasticsearchNamespace)
 		if err != nil {
@@ -436,13 +460,13 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			esAdminUserSecret = rsecret.CopyToNamespace(rmeta.OperatorNamespace(), esAdminUserSecret)[0]
 		}
 
-		if esCertSecret, esCertSecretESCopy, esPubCertSecret, err = r.getElasticsearchCertificateSecrets(ctx, install); err != nil {
+		if esCertSecret, esInternalCertSecret, err = r.getElasticsearchCertificateSecrets(ctx, install); err != nil {
 			reqLogger.Error(err, err.Error())
-			r.status.SetDegraded("Failed to create elasticsearch secrets", err.Error())
+			r.status.SetDegraded("Failed to create Elasticsearch secrets", err.Error())
 			return reconcile.Result{}, err
 		}
 
-		if kibanaSecrets, err = r.kibanaSecrets(ctx, install); err != nil {
+		if kibanaSecrets, err = r.kibanaInternalSecrets(ctx, install); err != nil {
 			reqLogger.Error(err, err.Error())
 			r.status.SetDegraded("Failed to create kibana secrets", err.Error())
 			return reconcile.Result{}, err
@@ -526,7 +550,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		elasticsearch,
 		kibana,
 		clusterConfig,
-		[]*corev1.Secret{esCertSecret, esCertSecretESCopy, esPubCertSecret, esAdminUserSecret},
+		[]*corev1.Secret{esCertSecret, esInternalCertSecret, esAdminUserSecret},
 		kibanaSecrets,
 		pullSecrets,
 		r.provider,
@@ -559,6 +583,42 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		if kibana == nil || kibana.Status.AssociationStatus != cmnv1.AssociationEstablished {
 			r.status.SetDegraded("Waiting for Kibana cluster to be operational", "")
 			return reconcile.Result{}, nil
+		}
+
+		kibanaInternalCertSecret, err := utils.GetSecret(ctx, r.client, render.KibanaInternalCertSecret, rmeta.OperatorNamespace())
+		if err != nil {
+			reqLogger.Error(err, err.Error())
+			r.status.SetDegraded("Waiting for internal Kibana tls certificate secret to be available", "")
+			return reconcile.Result{}, err
+		}
+
+		kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, err := r.createKubeControllersSecrets(ctx, esAdminUserSecret)
+		if err != nil {
+			reqLogger.Error(err, err.Error())
+			r.status.SetDegraded("Failed to create kube-controllers secrets for Elasticsearch gateway", "")
+			return reconcile.Result{}, err
+		}
+
+		esGatewayComponent := esgateway.EsGateway(
+			install,
+			pullSecrets,
+			[]*corev1.Secret{gatewayCertSecret, publicCertSecret},
+			[]*corev1.Secret{kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret},
+			kibanaInternalCertSecret,
+			esInternalCertSecret,
+			r.clusterDomain,
+		)
+
+		if err = imageset.ApplyImageSet(ctx, r.client, variant, esGatewayComponent); err != nil {
+			reqLogger.Error(err, "Error with images from ImageSet")
+			r.status.SetDegraded("Error with images from ImageSet", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		if err := hdler.CreateOrUpdateOrDelete(ctx, esGatewayComponent, r.status); err != nil {
+			reqLogger.Error(err, err.Error())
+			r.status.SetDegraded("Error creating / updating resource", err.Error())
+			return reconcile.Result{}, err
 		}
 
 		if len(curatorSecrets) == 0 {
@@ -600,12 +660,16 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, nil
 		}
 
-		if esPubCertSecret == nil {
+		publicCertSecretESCopy, err := utils.GetSecret(context.Background(), r.client, relasticsearch.PublicCertSecret, render.ElasticsearchNamespace)
+		if err != nil {
+			r.status.SetDegraded("Failed to retrieve Elasticsearch public cert secret.", err.Error())
+			return reconcile.Result{}, err
+		} else if publicCertSecretESCopy == nil {
 			r.status.SetDegraded("Waiting for elasticsearch public cert secret to become available", "")
 			return reconcile.Result{}, nil
 		}
 
-		esMetricsComponent := esmetrics.ElasticsearchMetrics(install, pullSecrets, clusterConfig, esMetricsSecret, esPubCertSecret, r.clusterDomain)
+		esMetricsComponent := esmetrics.ElasticsearchMetrics(install, pullSecrets, clusterConfig, esMetricsSecret, publicCertSecretESCopy, r.clusterDomain)
 		if err = imageset.ApplyImageSet(ctx, r.client, variant, esMetricsComponent); err != nil {
 			reqLogger.Error(err, "Error with images from ImageSet")
 			r.status.SetDegraded("Error with images from ImageSet", err.Error())
@@ -639,25 +703,92 @@ func (r *ReconcileLogStorage) deleteInvalidECKManagedPublicCertSecret(ctx contex
 	return r.client.Delete(ctx, secret)
 }
 
-// getElasticsearchCertificateSecrets retrieves Elasticsearch certificate secrets needed for Elasticsearch to run or for
-// components to communicate with Elasticsearch. The order of the secrets returned are:
-// 1) The certificate secret needed for Elasticsearch (in the operator namespace). If the user didn't create this it is
-//    created.
-// 2) The certificate secret needed for Elasticsearch (in the Elasticsearch namespace).
-// 3) The certificate mounted by other clients that connect to Elasticsearch.
-func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) (oprKeyCert *corev1.Secret, esKeyCert *corev1.Secret, certSecret *corev1.Secret, err error) {
-	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
-
-	// Get the secret - might be nil
-	oprKeyCert, err = utils.GetSecret(ctx, r.client, render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace())
+// createKubeControllersSecrets checks for the existence of the secrets necessary for Kube controllers to access Elasticsearch through ES gateway and
+// creates them if they are missing. Kube controllers no longer uses admin credentials to make requests directly to Elasticsearch. Instead, gateway credentials
+// are generated and stored in the user secret, a hashed version of the credentials is stored in the tigera-elasticsearch namespace for ES Gateway to retrieve and use to compare
+// the gateway credentials, and a secret containing real admin level credentials is created and stored in the tigera-elasticsearch namespace to be swapped in once
+// ES Gateway has confirmed that the gateway credentials match.
+func (r *ReconcileLogStorage) createKubeControllersSecrets(ctx context.Context, esAdminUserSecret *corev1.Secret) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
+	kubeControllersGatewaySecret, err := utils.GetSecret(ctx, r.client, render.ElasticsearchKubeControllersUserSecret, rmeta.OperatorNamespace())
 	if err != nil {
 		return nil, nil, nil, err
+	}
+	if kubeControllersGatewaySecret == nil {
+		password := crypto.GeneratePassword(16)
+		kubeControllersGatewaySecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchKubeControllersUserSecret,
+				Namespace: rmeta.OperatorNamespace(),
+			},
+			Data: map[string][]byte{
+				"username": []byte(render.ElasticsearchKubeControllersUserName),
+				"password": []byte(password),
+			},
+		}
+	}
+	hashedPassword, err := bcrypt.GenerateFromPassword(kubeControllersGatewaySecret.Data["password"], bcrypt.MinCost)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	kubeControllersVerificationSecret, err := utils.GetSecret(ctx, r.client, render.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if kubeControllersVerificationSecret == nil {
+		kubeControllersVerificationSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchKubeControllersVerificationUserSecret,
+				Namespace: render.ElasticsearchNamespace,
+			},
+			Data: map[string][]byte{
+				"username": []byte(render.ElasticsearchKubeControllersUserName),
+				"password": hashedPassword,
+			},
+		}
+	}
+
+	kubeControllersSecureUserSecret, err := utils.GetSecret(ctx, r.client, render.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if kubeControllersSecureUserSecret == nil {
+		kubeControllersSecureUserSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchKubeControllersSecureUserSecret,
+				Namespace: render.ElasticsearchNamespace,
+			},
+			Data: map[string][]byte{
+				"username": []byte("elastic"),
+				"password": esAdminUserSecret.Data["elastic"],
+			},
+		}
+	}
+
+	return kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, nil
+}
+
+// getESGatewayCertificateSecrets retrieves certificate secrets needed for ES Gateway to run or for
+// components to communicate with Elasticsearch/Kibana through ES Gateway. The order of the secrets returned are:
+// 1) The certificate/key secret to be mounted by ES Gateway and used to authenticate requests before
+// proxying to Elasticsearch/Kibana (in the operator namespace). If the user didn't create this secret, it is created.
+// 2) The certificate mounted by other clients that connect to Elasticsearch/Kibana through ES Gateway (in the operator namespace).
+func (r *ReconcileLogStorage) getESGatewayCertificateSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) (*corev1.Secret, *corev1.Secret, error) {
+	var publicCertSecret *corev1.Secret
+
+	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
+	svcDNSNames = append(svcDNSNames, dns.GetServiceDNSNames(esgateway.ServiceName, render.ElasticsearchNamespace, r.clusterDomain)...)
+
+	// Get the secret - might be nil
+	oprKeyCert, err := utils.GetSecret(ctx, r.client, render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace())
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Ensure that cert is valid.
 	oprKeyCert, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, oprKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	// Three different certificate issuers are possible:
@@ -666,7 +797,85 @@ func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Con
 	// - The issuer that is provided through the certificate management feature.
 	keyCertIssuer, err := utils.GetCertificateIssuer(oprKeyCert.Data[corev1.TLSCertKey])
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
+	}
+	customerProvidedCert := !utils.IsOperatorIssued(keyCertIssuer)
+
+	// If Certificate management is enabled, we only want to trust the CA cert and let the init container handle private key generation.
+	if instl.CertificateManagement != nil {
+		cmCa := instl.CertificateManagement.CACert
+		cmIssuer, err := utils.GetCertificateIssuer(cmCa)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// If the issuer of the current secret is not the same as the certificate management issuer and also is not
+		// issued by the tigera-operator, it means that it is added to this cluster by the customer. This is not supported
+		// in combination with certificate management.
+		if customerProvidedCert && cmIssuer != keyCertIssuer {
+			return nil, nil, fmt.Errorf("certificate management does not support custom Elasticsearch secrets, please delete secret %s/%s or disable certificate management", oprKeyCert.Namespace, oprKeyCert.Name)
+		}
+
+		oprKeyCert.Data[corev1.TLSCertKey] = instl.CertificateManagement.CACert
+		publicCertSecret = render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+	} else {
+		// Get the es gateway pub secret - might be nil
+		publicCertSecret, err = utils.GetSecret(ctx, r.client, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if publicCertSecret != nil {
+			// If the provided certificate secret (secret) is managed by the operator we need to check if the secret has the expected DNS names.
+			// If it doesn't, delete the public secret so it can get recreated.
+			if !customerProvidedCert {
+				err = utils.SecretHasExpectedDNSNames(publicCertSecret, corev1.TLSCertKey, svcDNSNames)
+				if err == utils.ErrInvalidCertDNSNames {
+					if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, publicCertSecret); err != nil {
+						return nil, nil, err
+					}
+					publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+				}
+			}
+		} else {
+			publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+		}
+	}
+
+	return oprKeyCert, publicCertSecret, nil
+}
+
+// getElasticsearchCertificateSecrets retrieves Elasticsearch certificate secrets needed for Elasticsearch to run or for
+// ES gateway to communicate with Elasticsearch. The order of the secrets returned are:
+// 1) The certificate secret needed for Elasticsearch (in the Elasticsearch namespace). If the user didn't create this it is
+//    created.
+// 2) The certificate mounted by ES gateway to connect to Elasticsearch.
+func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) (*corev1.Secret, *corev1.Secret, error) {
+	var esKeyCert, certSecret *corev1.Secret
+	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
+
+	// Get the secret - might be nil
+	esKeyCert, err := utils.GetSecret(ctx, r.client, render.TigeraElasticsearchInternalCertSecret, render.ElasticsearchNamespace)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Ensure that cert is valid.
+	esKeyCert, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchInternalCertSecret, esKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Override the Operator namespace set by utils.EnsureCertificateSecret.
+	esKeyCert.Namespace = render.ElasticsearchNamespace
+
+	// Three different certificate issuers are possible:
+	// - The operator self-signed certificate
+	// - A user's BYO keypair for Elastic (uncommon)
+	// - The issuer that is provided through the certificate management feature.
+	keyCertIssuer, err := utils.GetCertificateIssuer(esKeyCert.Data[corev1.TLSCertKey])
+	if err != nil {
+		return nil, nil, err
 	}
 	customerProvidedCert := !utils.IsOperatorIssued(keyCertIssuer)
 
@@ -675,49 +884,46 @@ func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Con
 		cmCa := instl.CertificateManagement.CACert
 		cmIssuer, err := utils.GetCertificateIssuer(cmCa)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
 		// If the issuer of the current secret is not the same as the certificate management issuer and also is not
 		// issued by the tigera-operator, it means that it is added to this cluster by the customer. This is not supported
 		// in combination with certificate management.
 		if customerProvidedCert && cmIssuer != keyCertIssuer {
-			return nil, nil, nil, fmt.Errorf("certificate management does not support custom Elasticsearch secrets, please delete secret %s/%s or disable certificate management", oprKeyCert.Namespace, oprKeyCert.Name)
+			return nil, nil, fmt.Errorf("certificate management does not support custom Elasticsearch secrets, please delete secret %s/%s or disable certificate management", esKeyCert.Namespace, esKeyCert.Name)
 		}
 
-		oprKeyCert.Data[corev1.TLSCertKey] = instl.CertificateManagement.CACert
-		esKeyCert = rsecret.CopyToNamespace(render.ElasticsearchNamespace, oprKeyCert)[0]
-		certSecret = render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-
+		esKeyCert.Data[corev1.TLSCertKey] = instl.CertificateManagement.CACert
+		certSecret = render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.InternalCertSecret, render.ElasticsearchNamespace)
 	} else {
-		esKeyCert = rsecret.CopyToNamespace(render.ElasticsearchNamespace, oprKeyCert)[0]
-		// Get the pub secret - might be nil
-		pubSecret, err := utils.GetSecret(ctx, r.client, relasticsearch.PublicCertSecret, render.ElasticsearchNamespace)
+		// Get the internal public cert secret - might be nil
+		internalSecret, err := utils.GetSecret(ctx, r.client, relasticsearch.InternalCertSecret, render.ElasticsearchNamespace)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
-		if pubSecret != nil {
+		if internalSecret != nil {
 			// If the provided certificate secret (secret) is managed by the operator we need to check if the secret that
 			// Elasticsearch creates from that given secret (pubSecret) has the expected DNS name. If it doesn't, delete the
 			// public secret so it can get recreated.
 			if !customerProvidedCert {
-				err = utils.SecretHasExpectedDNSNames(pubSecret, corev1.TLSCertKey, svcDNSNames)
+				err = utils.SecretHasExpectedDNSNames(internalSecret, corev1.TLSCertKey, svcDNSNames)
 				if err == utils.ErrInvalidCertDNSNames {
-					if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
-						return nil, nil, nil, err
+					if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, internalSecret); err != nil {
+						return nil, nil, err
 					}
 				}
 			}
-
-			certSecret = rsecret.CopyToNamespace(rmeta.OperatorNamespace(), pubSecret)[0]
+		} else {
+			certSecret = render.CreateCertificateSecret(esKeyCert.Data[corev1.TLSCertKey], relasticsearch.InternalCertSecret, render.ElasticsearchNamespace)
 		}
 	}
 
-	return oprKeyCert, esKeyCert, certSecret, err
+	return esKeyCert, certSecret, err
 }
 
-func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) ([]*corev1.Secret, error) {
+func (r *ReconcileLogStorage) kibanaInternalSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) ([]*corev1.Secret, error) {
 
 	var secrets []*corev1.Secret
 	svcDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
@@ -738,21 +944,21 @@ func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context, instl *operator
 		return []*corev1.Secret{
 			secret,
 			rsecret.CopyToNamespace(render.KibanaNamespace, secret)[0],
-			render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.PublicCertSecret, render.KibanaNamespace),
-			render.CreateCertificateSecret(instl.CertificateManagement.CACert, render.KibanaPublicCertSecret, rmeta.OperatorNamespace()),
+			render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.InternalCertSecret, render.KibanaNamespace),
+			render.CreateCertificateSecret(instl.CertificateManagement.CACert, render.KibanaInternalCertSecret, rmeta.OperatorNamespace()),
 		}, nil
 	}
 
 	secrets = append(secrets, secret, rsecret.CopyToNamespace(render.KibanaNamespace, secret)[0])
 
 	// Get the pub secret - might be nil
-	pubSecret, err := utils.GetSecret(ctx, r.client, render.KibanaPublicCertSecret, render.KibanaNamespace)
+	internalSecret, err := utils.GetSecret(ctx, r.client, render.KibanaInternalCertSecret, render.KibanaNamespace)
 	if err != nil {
 		return nil, err
 	}
 
-	if pubSecret == nil {
-		log.Info(fmt.Sprintf("Public cert secret %q not found yet", render.KibanaPublicCertSecret))
+	if internalSecret == nil {
+		log.Info(fmt.Sprintf("Internal cert secret %q not found yet", render.KibanaInternalCertSecret))
 		return secrets, nil
 	}
 
@@ -762,15 +968,15 @@ func (r *ReconcileLogStorage) kibanaSecrets(ctx context.Context, instl *operator
 	}
 
 	if utils.IsOperatorIssued(issuer) {
-		err = utils.SecretHasExpectedDNSNames(pubSecret, corev1.TLSCertKey, svcDNSNames)
+		err = utils.SecretHasExpectedDNSNames(internalSecret, corev1.TLSCertKey, svcDNSNames)
 		if err == utils.ErrInvalidCertDNSNames {
-			if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, pubSecret); err != nil {
+			if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, internalSecret); err != nil {
 				return nil, err
 			}
 		}
 	}
 	// If the cert was not deleted, copy the valid cert to operator namespace.
-	secrets = append(secrets, rsecret.CopyToNamespace(rmeta.OperatorNamespace(), pubSecret)...)
+	secrets = append(secrets, rsecret.CopyToNamespace(rmeta.OperatorNamespace(), internalSecret)...)
 
 	return secrets, nil
 }

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -159,11 +159,6 @@ var _ = Describe("Manager controller tests", func() {
 					Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.KibanaPublicCertSecret,
-					Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
-
-			Expect(c.Create(ctx, &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
 					Name:      render.ComplianceServerCertSecret,
 					Namespace: rmeta.OperatorNamespace(),
 				},
@@ -385,10 +380,6 @@ var _ = Describe("Manager controller tests", func() {
 			Expect(c.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      render.ElasticsearchManagerUserSecret,
-					Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.KibanaPublicCertSecret,
 					Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
 
 			Expect(c.Create(ctx, &corev1.Secret{

--- a/pkg/render/common/elasticsearch/decorator_test.go
+++ b/pkg/render/common/elasticsearch/decorator_test.go
@@ -55,9 +55,9 @@ var _ = Describe("Elasticsearch decorator tests", func() {
 				Expect(c.Env).To(ContainElement(expected))
 			}
 		},
-			Entry("linux", dns.DefaultClusterDomain, "tigera-secure-es-http.tigera-elasticsearch.svc", rmeta.OSTypeLinux),
-			Entry("linux ignores cluster domain", "does.not.matter", "tigera-secure-es-http.tigera-elasticsearch.svc", rmeta.OSTypeLinux),
-			Entry("windows", "acme.internal", "tigera-secure-es-http.tigera-elasticsearch.svc.acme.internal", rmeta.OSTypeWindows),
+			Entry("linux", dns.DefaultClusterDomain, "tigera-secure-es-gateway-http.tigera-elasticsearch.svc", rmeta.OSTypeLinux),
+			Entry("linux ignores cluster domain", "does.not.matter", "tigera-secure-es-gateway-http.tigera-elasticsearch.svc", rmeta.OSTypeLinux),
+			Entry("windows", "acme.internal", "tigera-secure-es-gateway-http.tigera-elasticsearch.svc.acme.internal", rmeta.OSTypeWindows),
 		)
 	})
 })

--- a/pkg/render/common/elasticsearch/service.go
+++ b/pkg/render/common/elasticsearch/service.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	httpsEndpoint     = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
-	httpsFQDNEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc.%s:9200"
+	httpsEndpoint     = "https://tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"
+	httpsFQDNEndpoint = "https://tigera-secure-es-gateway-http.tigera-elasticsearch.svc.%s:9200"
 )
 
 // HTTPSEndpoint returns the endpoint for the Elasticsearch service. For

--- a/pkg/render/common/elasticsearch/tls.go
+++ b/pkg/render/common/elasticsearch/tls.go
@@ -1,5 +1,6 @@
 package elasticsearch
 
 const (
-	PublicCertSecret = "tigera-secure-es-http-certs-public"
+	PublicCertSecret   = "tigera-secure-es-gateway-http-certs-public"
+	InternalCertSecret = "tigera-secure-es-http-certs-public"
 )

--- a/pkg/render/common/kibana/service.go
+++ b/pkg/render/common/kibana/service.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	httpsEndpoint     = "https://tigera-secure-kb-http.tigera-kibana.svc:5601"
-	httpsFQDNEndpoint = "https://tigera-secure-kb-http.tigera-kibana.svc.%s:5601"
+	httpsEndpoint     = "https://tigera-secure-es-gateway-http.tigera-elasticsearch.svc:5601"
+	httpsFQDNEndpoint = "https://tigera-secure-es-gateway-http.tigera-elasticsearch.svc.%s:5601"
 )
 
 // HTTPSEndpoint returns the full endpoint for the Kibana service. For

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -122,7 +122,7 @@ var _ = Describe("compliance rendering tests", func() {
 			envs := d.Spec.Template.Spec.Containers[0].Env
 
 			expectedEnvs := []corev1.EnvVar{
-				{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
+				{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
 				{Name: "ELASTIC_PORT", Value: "9200"},
 			}
 			for _, expected := range expectedEnvs {

--- a/pkg/render/fixtures_test.go
+++ b/pkg/render/fixtures_test.go
@@ -51,17 +51,18 @@ var elasticsearchSecret = v1.Secret{
 	},
 }
 
-var elasticsearchAdminUserSecret = v1.Secret{
+var kubeControllersUserSecret = v1.Secret{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Secret",
 		APIVersion: "v1",
 	},
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      render.ElasticsearchAdminUserSecret,
+		Name:      render.ElasticsearchKubeControllersUserSecret,
 		Namespace: rmeta.OperatorNamespace(),
 	},
 	Data: map[string][]byte{
-		"elastic": []byte("password"),
+		"username": []byte("password"),
+		"password": []byte("password"),
 	},
 }
 

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{Name: "FLOW_LOG_FILE", Value: "/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "/var/log/calico/dnslogs/dns.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
-			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
+			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
 			{Name: "ELASTIC_PORT", Value: "9200"},
 			{
 				Name: "NODENAME",
@@ -181,7 +181,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{Name: "FLOW_LOG_FILE", Value: "c:/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "c:/var/log/calico/dnslogs/dns.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
-			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"},
+			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc.cluster.local"},
 			{Name: "ELASTIC_PORT", Value: "9200"},
 			{
 				Name: "NODENAME",
@@ -202,7 +202,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{Name: "FLOW_LOG_FILE", Value: "c:/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "c:/var/log/calico/dnslogs/dns.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
-			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc.cluster.local"},
+			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc.cluster.local"},
 			{Name: "ELASTIC_PORT", Value: "9200"},
 			{
 				Name: "NODENAME",
@@ -658,7 +658,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		envs := deploy.Spec.Template.Spec.Containers[0].Env
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "K8S_PLATFORM", Value: "eks"}))
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "AWS_REGION", Value: eksConfig.AwsRegion}))
-		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"}))
+		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"}))
 
 		fetchIntervalVal := "900"
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "EKS_CLOUDWATCH_LOG_FETCH_INTERVAL", Value: fetchIntervalVal}))

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -20,9 +20,6 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/dns"
 
-	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	rtest "github.com/tigera/operator/pkg/render/common/test"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -32,7 +29,9 @@ import (
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/render"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	rtest "github.com/tigera/operator/pkg/render/common/test"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -45,7 +44,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 	var esEnvs = []v1.EnvVar{
 		{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
 		{Name: "ELASTIC_SCHEME", Value: "https"},
-		{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
+		{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
 		{Name: "ELASTIC_PORT", Value: "9200", ValueFrom: nil},
 		{Name: "ELASTIC_ACCESS_MODE", Value: "serviceuser"},
 		{Name: "ELASTIC_SSL_VERIFY", Value: "true"},
@@ -111,11 +110,12 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			{name: "calico-kube-controllers", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "calico-kube-controllers", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "calico-kube-controllers", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
+			{name: render.ElasticsearchKubeControllersUserSecret, ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-kube-controllers", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		component := render.KubeControllers(k8sServiceEp, instance, false, nil, nil, nil, nil, nil, nil,
-			false, dns.DefaultClusterDomain, nil, 0)
+			false, dns.DefaultClusterDomain, &kubeControllersUserSecret, 0)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -161,7 +161,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			{name: "calico-kube-controllers", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: render.ManagerInternalTLSSecretName, ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: render.TigeraElasticsearchCertSecret, ns: "calico-system", group: "", version: "v1", kind: "Secret"},
-			{name: render.ElasticsearchKubeControllersUserSecret, ns: "calico-system", group: "", version: "", kind: ""},
+			{name: render.ElasticsearchKubeControllersUserSecret, ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-kube-controllers", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "calico-kube-controllers-metrics", ns: common.CalicoNamespace, group: "", version: "v1", kind: "Service"},
 		}
@@ -169,7 +169,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		instance.Variant = operator.TigeraSecureEnterprise
 
 		component := render.KubeControllers(k8sServiceEp, instance, true, nil, nil, &internalManagerTLSSecret, &elasticsearchSecret, &kibanaSecret, nil,
-			true, dns.DefaultClusterDomain, &elasticsearchAdminUserSecret, 9094)
+			true, dns.DefaultClusterDomain, &kubeControllersUserSecret, 9094)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -221,7 +221,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			{name: "calico-kube-controllers", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: render.ManagerInternalTLSSecretName, ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: render.TigeraElasticsearchCertSecret, ns: "calico-system", group: "", version: "v1", kind: "Secret"},
-			{name: render.ElasticsearchKubeControllersUserSecret, ns: "calico-system", group: "", version: "", kind: ""},
+			{name: render.ElasticsearchKubeControllersUserSecret, ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-kube-controllers", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "calico-kube-controllers-metrics", ns: common.CalicoNamespace, group: "", version: "v1", kind: "Service"},
 		}
@@ -230,7 +230,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 		component := render.KubeControllers(k8sServiceEp, instance, true, &operator.ManagementCluster{}, nil,
 			&internalManagerTLSSecret, &elasticsearchSecret, &kibanaSecret, nil, true,
-			dns.DefaultClusterDomain, &elasticsearchAdminUserSecret, 9094)
+			dns.DefaultClusterDomain, &kubeControllersUserSecret, 9094)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -275,7 +275,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				Resources: []string{"authenticationreviews"},
 				Verbs:     []string{"create"},
 			}))
-
 	})
 
 	It("should include a ControlPlaneNodeSelector when specified", func() {
@@ -371,7 +370,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		}}
 
 		component := render.KubeControllers(k8sServiceEp, instance, true, nil, nil, nil, &elasticsearchSecret, nil, authentication,
-			false, dns.DefaultClusterDomain, &elasticsearchAdminUserSecret, 0)
+			false, dns.DefaultClusterDomain, &kubeControllersUserSecret, 0)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
@@ -400,7 +399,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		It("should set the ENABLE_ELASTICSEARCH_OIDC_WORKAROUND env variable to true", func() {
 			instance.Variant = operator.TigeraSecureEnterprise
 			component := render.KubeControllers(k8sServiceEp, instance, true, nil, nil, nil, &elasticsearchSecret, nil,
-				nil, true, dns.DefaultClusterDomain, &elasticsearchAdminUserSecret, 0)
+				nil, true, dns.DefaultClusterDomain, &kubeControllersUserSecret, 0)
 			resources, _ := component.Objects()
 
 			depResource := rtest.GetResource(resources, "calico-kube-controllers", "calico-system", "apps", "v1", "Deployment")

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -60,7 +60,8 @@ const (
 
 	ElasticsearchNamespace = "tigera-elasticsearch"
 
-	TigeraElasticsearchCertSecret = "tigera-secure-elasticsearch-cert"
+	TigeraElasticsearchCertSecret         = "tigera-secure-elasticsearch-cert"
+	TigeraElasticsearchInternalCertSecret = "tigera-secure-internal-elasticsearch-cert"
 
 	ElasticsearchName                     = "tigera-secure"
 	ElasticsearchServiceName              = "tigera-secure-es-http"
@@ -68,15 +69,15 @@ const (
 	ElasticsearchOperatorUserSecret       = "tigera-ee-operator-elasticsearch-access"
 	ElasticsearchAdminUserSecret          = "tigera-secure-es-elastic-user"
 
-	KibanaHTTPSEndpoint    = "https://tigera-secure-kb-http.tigera-kibana.svc.%s:5601"
-	KibanaName             = "tigera-secure"
-	KibanaNamespace        = "tigera-kibana"
-	KibanaPublicCertSecret = "tigera-secure-kb-http-certs-public"
-	TigeraKibanaCertSecret = "tigera-secure-kibana-cert"
-	KibanaDefaultCertPath  = "/etc/ssl/kibana/ca.pem"
-	KibanaBasePath         = "tigera-kibana"
-	KibanaServiceName      = "tigera-secure-kb-http"
-	KibanaDefaultRoute     = "/app/kibana#/dashboards?%s&title=%s"
+	KibanaName               = "tigera-secure"
+	KibanaNamespace          = "tigera-kibana"
+	KibanaPublicCertSecret   = "tigera-secure-es-gateway-http-certs-public"
+	KibanaInternalCertSecret = "tigera-secure-kb-http-certs-public"
+	TigeraKibanaCertSecret   = "tigera-secure-kibana-cert"
+	KibanaDefaultCertPath    = "/etc/ssl/kibana/ca.pem"
+	KibanaBasePath           = "tigera-kibana"
+	KibanaServiceName        = "tigera-secure-kb-http"
+	KibanaDefaultRoute       = "/app/kibana#/dashboards?%s&title=%s"
 
 	DefaultElasticsearchClusterName = "cluster"
 	DefaultElasticsearchReplicas    = 0
@@ -188,7 +189,6 @@ func LogStorage(
 	dexCfg DexRelyingPartyConfig,
 	elasticLicenseType ElasticsearchLicenseType,
 ) Component {
-
 	return &elasticsearchComponent{
 		logStorage:                  logStorage,
 		installation:                installation,
@@ -416,9 +416,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 	} else {
 		toCreate = append(toCreate,
 			createNamespace(ElasticsearchNamespace, es.installation.KubernetesProvider),
-			createNamespace(KibanaNamespace, es.installation.KubernetesProvider),
 			es.elasticsearchExternalService(),
-			es.kibanaExternalService(),
 		)
 	}
 
@@ -842,7 +840,7 @@ func (es elasticsearchComponent) elasticsearchCluster(secureSettings bool) *esv1
 			HTTP: cmnv1.HTTPConfig{
 				TLS: cmnv1.TLSOptions{
 					Certificate: cmnv1.SecretRef{
-						SecretName: TigeraElasticsearchCertSecret,
+						SecretName: TigeraElasticsearchInternalCertSecret,
 					},
 				},
 			},

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -1,0 +1,313 @@
+package esgateway
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/render"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/secret"
+)
+
+const (
+	DeploymentName        = "tigera-secure-es-gateway"
+	ServiceAccountName    = "tigera-secure-es-gateway"
+	RoleName              = "tigera-secure-es-gateway"
+	VolumeName            = "tigera-secure-es-gateway-certs"
+	ServiceName           = "tigera-secure-es-gateway-http"
+	ElasticsearchPortName = "es-gateway-elasticsearch-port"
+	KibanaPortName        = "es-gateway-kibana-port"
+	Port                  = 5554
+
+	ElasticsearchHTTPSEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
+	ElasticsearchPort          = 9200
+	KibanaHTTPSEndpoint        = "https://tigera-secure-kb-http.tigera-kibana.svc:5601"
+	KibanaPort                 = 5601
+)
+
+func EsGateway(
+	installation *operatorv1.InstallationSpec,
+	pullSecrets []*corev1.Secret,
+	certSecrets []*corev1.Secret,
+	kubeControllersUserSecrets []*corev1.Secret,
+	kibanaInternalCertSecret *corev1.Secret,
+	esInternalCertSecret *corev1.Secret,
+	clusterDomain string,
+) render.Component {
+	var certSecretsESCopy []*corev1.Secret
+	secrets := certSecrets
+
+	// Copy the Operator namespaced cert secrets to the Elasticsearch namespace.
+	for _, s := range certSecrets {
+		certSecretsESCopy = append(certSecretsESCopy, secret.CopyToNamespace(render.ElasticsearchNamespace, s)...)
+	}
+	tlsAnnotations := map[string]string{render.ElasticsearchTLSHashAnnotation: rmeta.SecretsAnnotationHash(append(certSecretsESCopy, esInternalCertSecret)...)}
+
+	secrets = append(secrets, certSecretsESCopy...)
+
+	// tigera-secure-kb-http-certs-public, mounted by ES Gateway.
+	secrets = append(secrets, secret.CopyToNamespace(render.ElasticsearchNamespace, kibanaInternalCertSecret)...)
+	tlsAnnotations[render.KibanaTLSAnnotationHash] = rmeta.SecretsAnnotationHash(kibanaInternalCertSecret)
+
+	secrets = append(secrets, kubeControllersUserSecrets...)
+	return &esGateway{
+		installation:   installation,
+		pullSecrets:    pullSecrets,
+		secrets:        secrets,
+		tlsAnnotations: tlsAnnotations,
+		clusterDomain:  clusterDomain,
+	}
+}
+
+type esGateway struct {
+	installation   *operatorv1.InstallationSpec
+	pullSecrets    []*corev1.Secret
+	secrets        []*corev1.Secret
+	tlsAnnotations map[string]string
+	clusterDomain  string
+	csrImage       string
+	esGatewayImage string
+}
+
+func (e *esGateway) ResolveImages(is *operatorv1.ImageSet) error {
+	reg := e.installation.Registry
+	path := e.installation.ImagePath
+	prefix := e.installation.ImagePrefix
+	var err error
+	errMsgs := []string{}
+
+	e.esGatewayImage, err = components.GetReference(components.ComponentESGateway, reg, path, prefix, is)
+	if err != nil {
+		errMsgs = append(errMsgs, err.Error())
+	}
+	if e.installation.CertificateManagement != nil {
+		e.csrImage, err = render.ResolveCSRInitImage(e.installation, is)
+		if err != nil {
+			errMsgs = append(errMsgs, err.Error())
+		}
+	}
+	if len(errMsgs) != 0 {
+		return fmt.Errorf(strings.Join(errMsgs, ","))
+	}
+	return nil
+}
+
+func (e *esGateway) Objects() (toCreate, toDelete []client.Object) {
+	toCreate = append(toCreate, e.esGatewaySecrets()...)
+	toCreate = append(toCreate, e.esGatewayService())
+	toCreate = append(toCreate, e.esGatewayRole())
+	toCreate = append(toCreate, e.esGatewayRoleBinding())
+	toCreate = append(toCreate, e.esGatewayServiceAccount())
+	toCreate = append(toCreate, e.esGatewayDeployment())
+	return toCreate, toDelete
+}
+
+func (e *esGateway) Ready() bool {
+	return true
+}
+
+func (e *esGateway) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeLinux
+}
+
+func (e esGateway) esGatewayRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				ResourceNames: []string{},
+				Verbs:         []string{"get"},
+			},
+		},
+	}
+}
+
+func (e esGateway) esGatewayRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     RoleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      ServiceAccountName,
+				Namespace: render.ElasticsearchNamespace,
+			},
+		},
+	}
+}
+
+func (e esGateway) esGatewayDeployment() *appsv1.Deployment {
+	replicas := int32(2)
+
+	envVars := []corev1.EnvVar{
+		{Name: "ES_GATEWAY_LOG_LEVEL", Value: "INFO"},
+		{Name: "ES_GATEWAY_ELASTIC_ENDPOINT", Value: ElasticsearchHTTPSEndpoint},
+		{Name: "ES_GATEWAY_KIBANA_ENDPOINT", Value: KibanaHTTPSEndpoint},
+		{Name: "ES_GATEWAY_HTTPS_CERT", Value: "/certs/https/tls.crt"},
+		{Name: "ES_GATEWAY_HTTPS_KEY", Value: "/certs/https/tls.key"},
+		{Name: "ES_GATEWAY_ELASTIC_USERNAME", Value: "elastic"},
+		{Name: "ES_GATEWAY_ELASTIC_PASSWORD", ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: render.ElasticsearchAdminUserSecret,
+				},
+				Key: "elastic",
+			},
+		}},
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name: VolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: render.TigeraElasticsearchCertSecret,
+				},
+			},
+		},
+		{
+			Name: render.KibanaInternalCertSecret,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: render.KibanaInternalCertSecret,
+				},
+			},
+		},
+		{
+			Name: relasticsearch.InternalCertSecret,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: relasticsearch.InternalCertSecret,
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: VolumeName, MountPath: "/certs/https", ReadOnly: true},
+		{Name: render.KibanaInternalCertSecret, MountPath: "/certs/kibana", ReadOnly: true},
+		{Name: relasticsearch.InternalCertSecret, MountPath: "/certs/elasticsearch", ReadOnly: true},
+	}
+
+	podTemplate := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: render.ElasticsearchNamespace,
+			Labels: map[string]string{
+				"k8s-app": DeploymentName,
+			},
+			Annotations: e.tlsAnnotations,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: ServiceAccountName,
+			ImagePullSecrets:   secret.GetReferenceList(e.pullSecrets),
+			Volumes:            volumes,
+			Containers: []corev1.Container{
+				{
+					Name:         DeploymentName,
+					Image:        e.esGatewayImage,
+					Env:          envVars,
+					VolumeMounts: volumeMounts,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/health",
+								Port:   intstr.FromInt(Port),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       5,
+					},
+				},
+			},
+		},
+	}
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: render.ElasticsearchNamespace,
+			Labels: map[string]string{
+				"k8s-app": DeploymentName,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": DeploymentName}},
+			Template: *podTemplate,
+			Replicas: &replicas,
+		},
+	}
+}
+
+func (e esGateway) esGatewayServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceAccountName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+	}
+}
+
+func (e esGateway) esGatewaySecrets() []client.Object {
+	objs := []client.Object{}
+	for _, s := range e.secrets {
+		objs = append(objs, s)
+	}
+	return objs
+}
+
+func (e esGateway) esGatewayService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"k8s-app": DeploymentName},
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       ElasticsearchPortName,
+					Port:       int32(ElasticsearchPort),
+					TargetPort: intstr.FromInt(Port),
+					Protocol:   corev1.ProtocolTCP,
+				},
+				{
+					Name:       KibanaPortName,
+					Port:       int32(KibanaPort),
+					TargetPort: intstr.FromInt(Port),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}

--- a/pkg/render/logstorage/esgateway/esgateway_suite_test.go
+++ b/pkg/render/logstorage/esgateway/esgateway_suite_test.go
@@ -1,0 +1,16 @@
+package esgateway
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestRender(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../../report/esgateway_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/logstorage/esgateway Suite", []Reporter{junitReporter})
+}

--- a/pkg/render/logstorage/esgateway/esgateway_test.go
+++ b/pkg/render/logstorage/esgateway/esgateway_test.go
@@ -1,0 +1,99 @@
+package esgateway
+
+import (
+	"fmt"
+
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type resourceTestObj struct {
+	name string
+	ns   string
+	typ  runtime.Object
+	f    func(resource runtime.Object)
+}
+
+var _ = Describe("ES Gateway rendering tests", func() {
+	Context("ES Gateway deployment", func() {
+		var installation *operatorv1.InstallationSpec
+		clusterDomain := "cluster.local"
+
+		BeforeEach(func() {
+			installation = &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderNone,
+				Registry:           "testregistry.com/",
+			}
+		})
+
+		It("should render an ES Gateway deployment and all supporting resources", func() {
+			expectedResources := []resourceTestObj{
+				{render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace(), &corev1.Secret{}, nil},
+				{relasticsearch.PublicCertSecret, rmeta.OperatorNamespace(), &corev1.Secret{}, nil},
+				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{render.KibanaInternalCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{render.ElasticsearchKubeControllersUserSecret, rmeta.OperatorNamespace(), &corev1.Secret{}, nil},
+				{render.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{render.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{ServiceName, render.ElasticsearchNamespace, &corev1.Service{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
+				{ServiceAccountName, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
+				{DeploymentName, render.ElasticsearchNamespace, &appsv1.Deployment{}, nil},
+			}
+
+			component := EsGateway(
+				installation,
+				[]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
+				},
+				[]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: rmeta.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: rmeta.OperatorNamespace()}},
+				},
+				[]*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchKubeControllersUserSecret, Namespace: rmeta.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
+					{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
+				},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: rmeta.OperatorNamespace()}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
+				clusterDomain,
+			)
+
+			createResources, _ := component.Objects()
+			compareResources(createResources, expectedResources)
+		})
+
+	})
+})
+
+func compareResources(resources []client.Object, expectedResources []resourceTestObj) {
+	Expect(len(resources)).To(Equal(len(expectedResources)))
+	for i, expectedResource := range expectedResources {
+		resource := resources[i]
+		actualName := resource.(metav1.ObjectMetaAccessor).GetObjectMeta().GetName()
+		actualNS := resource.(metav1.ObjectMetaAccessor).GetObjectMeta().GetNamespace()
+
+		Expect(actualName).To(Equal(expectedResource.name), fmt.Sprintf("Rendered resource has wrong name (position %d, name %s, namespace %s)", i, actualName, actualNS))
+		Expect(actualNS).To(Equal(expectedResource.ns), fmt.Sprintf("Rendered resource has wrong namespace (position %d, name %s, namespace %s)", i, actualName, actualNS))
+		Expect(resource).Should(BeAssignableToTypeOf(expectedResource.typ))
+		if expectedResource.f != nil {
+			expectedResource.f(resource)
+		}
+	}
+}

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 									Env: []corev1.EnvVar{
 										{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
 										{Name: "ELASTIC_SCHEME", Value: "https"},
-										{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
+										{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
 										{Name: "ELASTIC_PORT", Value: "9200"},
 										{Name: "ELASTIC_ACCESS_MODE", Value: "serviceuser"},
 										{Name: "ELASTIC_SSL_VERIFY", Value: "true"},
@@ -152,7 +152,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 									Name: "elastic-ca-cert-volume",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "tigera-secure-es-http-certs-public",
+											SecretName: "tigera-secure-es-gateway-http-certs-public",
 											Items:      []corev1.KeyToPath{{Key: "tls.crt", Path: "ca.pem"}},
 										},
 									},

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -757,14 +757,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			It("creates Managed cluster logstorage components", func() {
 				expectedCreateResources := []resourceTestObj{
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
-					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
 					{render.ElasticsearchServiceName, render.ElasticsearchNamespace, &corev1.Service{}, func(resource runtime.Object) {
-						svc := resource.(*corev1.Service)
-
-						Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
-						Expect(svc.Spec.ExternalName).Should(Equal(fmt.Sprintf("%s.%s.svc.%s", render.GuardianServiceName, render.GuardianNamespace, dns.DefaultClusterDomain)))
-					}},
-					{render.KibanaServiceName, render.KibanaNamespace, &corev1.Service{}, func(resource runtime.Object) {
 						svc := resource.(*corev1.Service)
 
 						Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -21,9 +21,8 @@ import (
 
 	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
 
-	"github.com/tigera/operator/pkg/render/common/authentication"
-
 	ocsv1 "github.com/openshift/api/security/v1"
+	"github.com/tigera/operator/pkg/render/common/authentication"
 	"github.com/tigera/operator/pkg/render/common/configmap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -559,6 +558,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		{Name: "VOLTRON_KIBANA_CA_BUNDLE_PATH", Value: "/certs/kibana/tls.crt"},
 		{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.managementCluster != nil)},
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
+		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"},
 	}
 
 	if c.keyValidatorConfig != nil {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -80,7 +80,7 @@ func Calico(
 	nodeAppArmorProfile string,
 	clusterDomain string,
 	enableESOIDCWorkaround bool,
-	esAdminSecret *corev1.Secret,
+	kubeControllersGatewaySecret *corev1.Secret,
 	kubeControllersMetricsPort int,
 	nodeReporterMetricsPort int,
 	bgpLayout *corev1.ConfigMap,
@@ -141,30 +141,30 @@ func Calico(
 	}
 
 	return calicoRenderer{
-		k8sServiceEp:                k8sServiceEp,
-		installation:                cr,
-		logStorageExists:            logStorageExists,
-		managementCluster:           managementCluster,
-		managementClusterConnection: managementClusterConnection,
-		pullSecrets:                 pullSecrets,
-		typhaNodeTLS:                typhaNodeTLS,
-		configMaps:                  cms,
-		tlsSecrets:                  tss,
-		elasticsearchSecret:         elasticsearchSecret,
-		kibanaSecret:                kibanaSecret,
-		managerInternalTLSecret:     managerInternalTLSSecret,
-		birdTemplates:               bt,
-		provider:                    p,
-		amazonCloudInt:              aci,
-		upgrade:                     up,
-		authentication:              authentication,
-		nodeAppArmorProfile:         nodeAppArmorProfile,
-		enableESOIDCWorkaround:      enableESOIDCWorkaround,
-		clusterDomain:               clusterDomain,
-		esAdminSecret:               esAdminSecret,
-		kubeControllersMetricsPort:  kubeControllersMetricsPort,
-		nodeReporterMetricsPort:     nodeReporterMetricsPort,
-		bgpLayoutHash:               bgpLayoutHash,
+		k8sServiceEp:                 k8sServiceEp,
+		installation:                 cr,
+		logStorageExists:             logStorageExists,
+		managementCluster:            managementCluster,
+		managementClusterConnection:  managementClusterConnection,
+		pullSecrets:                  pullSecrets,
+		typhaNodeTLS:                 typhaNodeTLS,
+		configMaps:                   cms,
+		tlsSecrets:                   tss,
+		elasticsearchSecret:          elasticsearchSecret,
+		kibanaSecret:                 kibanaSecret,
+		managerInternalTLSecret:      managerInternalTLSSecret,
+		birdTemplates:                bt,
+		provider:                     p,
+		amazonCloudInt:               aci,
+		upgrade:                      up,
+		authentication:               authentication,
+		nodeAppArmorProfile:          nodeAppArmorProfile,
+		enableESOIDCWorkaround:       enableESOIDCWorkaround,
+		clusterDomain:                clusterDomain,
+		kubeControllersGatewaySecret: kubeControllersGatewaySecret,
+		kubeControllersMetricsPort:   kubeControllersMetricsPort,
+		nodeReporterMetricsPort:      nodeReporterMetricsPort,
+		bgpLayoutHash:                bgpLayoutHash,
 	}, nil
 }
 
@@ -227,30 +227,30 @@ func createTLS() (*TyphaNodeTLS, error) {
 }
 
 type calicoRenderer struct {
-	k8sServiceEp                k8sapi.ServiceEndpoint
-	installation                *operator.InstallationSpec
-	logStorageExists            bool
-	managementCluster           *operator.ManagementCluster
-	managementClusterConnection *operator.ManagementClusterConnection
-	pullSecrets                 []*corev1.Secret
-	typhaNodeTLS                *TyphaNodeTLS
-	configMaps                  []*corev1.ConfigMap
-	tlsSecrets                  []*corev1.Secret
-	managerInternalTLSecret     *corev1.Secret
-	elasticsearchSecret         *corev1.Secret
-	kibanaSecret                *corev1.Secret
-	birdTemplates               map[string]string
-	provider                    operator.Provider
-	amazonCloudInt              *operator.AmazonCloudIntegration
-	upgrade                     bool
-	authentication              *operator.Authentication
-	nodeAppArmorProfile         string
-	clusterDomain               string
-	enableESOIDCWorkaround      bool
-	esAdminSecret               *corev1.Secret
-	kubeControllersMetricsPort  int
-	nodeReporterMetricsPort     int
-	bgpLayoutHash               string
+	k8sServiceEp                 k8sapi.ServiceEndpoint
+	installation                 *operator.InstallationSpec
+	logStorageExists             bool
+	managementCluster            *operator.ManagementCluster
+	managementClusterConnection  *operator.ManagementClusterConnection
+	pullSecrets                  []*corev1.Secret
+	typhaNodeTLS                 *TyphaNodeTLS
+	configMaps                   []*corev1.ConfigMap
+	tlsSecrets                   []*corev1.Secret
+	managerInternalTLSecret      *corev1.Secret
+	elasticsearchSecret          *corev1.Secret
+	kibanaSecret                 *corev1.Secret
+	birdTemplates                map[string]string
+	provider                     operator.Provider
+	amazonCloudInt               *operator.AmazonCloudIntegration
+	upgrade                      bool
+	authentication               *operator.Authentication
+	nodeAppArmorProfile          string
+	clusterDomain                string
+	enableESOIDCWorkaround       bool
+	kubeControllersGatewaySecret *corev1.Secret
+	kubeControllersMetricsPort   int
+	nodeReporterMetricsPort      int
+	bgpLayoutHash                string
 }
 
 func (r calicoRenderer) Render() []Component {
@@ -263,7 +263,7 @@ func (r calicoRenderer) Render() []Component {
 	components = appendNotNil(components, Node(r.k8sServiceEp, r.installation, r.birdTemplates, r.typhaNodeTLS, r.amazonCloudInt, r.upgrade, r.nodeAppArmorProfile, r.clusterDomain, r.nodeReporterMetricsPort, r.bgpLayoutHash))
 	components = appendNotNil(components, KubeControllers(r.k8sServiceEp, r.installation, r.logStorageExists, r.managementCluster,
 		r.managementClusterConnection, r.managerInternalTLSecret, r.elasticsearchSecret, r.kibanaSecret, r.authentication,
-		r.enableESOIDCWorkaround, r.clusterDomain, r.esAdminSecret, r.kubeControllersMetricsPort))
+		r.enableESOIDCWorkaround, r.clusterDomain, r.kubeControllersGatewaySecret, r.kubeControllersMetricsPort))
 	return components
 }
 

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 4 secrets for Typha comms (2 in operator namespace and 2 in calico namespace)
 		// - 2 ConfigMap for Typha comms (1 in operator namespace and 1 in calico namespace)
 		// - 7 typha resources (Service, SA, Role, Binding, Deployment, PodDisruptionBudget, PodSecurityPolicy)
-		// - 6 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment, PodSecurityPolicy, Service)
+		// - 6 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment, PodSecurityPolicy, Service, Secret)
 		// - 1 namespace
 		// - 1 PriorityClass
 		c, err := render.Calico(k8sServiceEp, instance, false, nil, nil, nil, nil, typhaNodeTLS, nil, nil, nil, nil, operator.ProviderNone, nil, false, "", dns.DefaultClusterDomain, false, nil, 9094, 0, nil)


### PR DESCRIPTION
## Description
This PR enables Operator to install ES Gateway. The ES Gateway sits behind the `tigera-secure-es-http` and `tigera-secure-kb-http` services (previously created by eckOperator/kibana, now managed by the Operator directly) and proxies traffic to the `tigera-secure-internal-es-http` and `tigera-secure-internal-kb-http` services (the services that are now created by eckOperator/kibana).

## TODO

- [x] Unit tests.
- [x] Docs PR for network policy update.
- [x] Propagating the cert to a Managed cluster when there is version skew.
- [x] Readiness Probe