### PR TITLE
Add comment for felix and CLUSTER_TYPE env var

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -986,7 +986,8 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 	// Set the clusterType.
 	clusterType := "k8s,operator"
 
-	// Felix relies on the CLUSTER_TYPE env var containing the kubernetes provider.
+	// Note: Felix now activates certain special-case logic based on the provider in the cluster type;
+	// avoid changing these unless you also update Felix's parsing logic.
 	switch c.cr.KubernetesProvider {
 	case operator.ProviderOpenShift:
 		clusterType = clusterType + ",openshift"

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -986,6 +986,7 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 	// Set the clusterType.
 	clusterType := "k8s,operator"
 
+	// Felix relies on the CLUSTER_TYPE env var containing the kubernetes provider.
 	switch c.cr.KubernetesProvider {
 	case operator.ProviderOpenShift:
 		clusterType = clusterType + ",openshift"

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -986,8 +986,8 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 	// Set the clusterType.
 	clusterType := "k8s,operator"
 
-	// Note: Felix now activates certain special-case logic based on the provider in the cluster type;
-	// avoid changing these unless you also update Felix's parsing logic.
+	// Note: Felix now activates certain special-case logic based on the provider in the cluster type; avoid changing
+	// these unless you also update Felix's parsing logic.
 	switch c.cr.KubernetesProvider {
 	case operator.ProviderOpenShift:
 		clusterType = clusterType + ",openshift"


### PR DESCRIPTION
## Description

As changed [here](https://github.com/projectcalico/felix/pull/2840), Felix now parses the CLUSTER_TYPE env var to get the Kubernetes provider, so that it can set the MTU accordingly.
Adding a comment in Operator so that people are cognisant of this when they change the Operator code. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
