### PR TITLE
Automated cherry pick of #1337: Always manage CNI config from calico/node

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -933,6 +933,10 @@ func (c *nodeComponent) nodeVolumeMounts() []v1.VolumeMount {
 		nodeVolumeMounts = append(nodeVolumeMounts, cniLogMount)
 	}
 
+	if c.cr.CNI.Type == operator.PluginCalico {
+		nodeVolumeMounts = append(nodeVolumeMounts, v1.VolumeMount{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"})
+	}
+
 	if c.birdTemplates != nil {
 		// create a volume mount for each bird template, but sort them alphabetically first,
 		// otherwise, since map iteration is random, they'll be added to the list of volumes in a random order,
@@ -1050,6 +1054,11 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 				Optional: ptr.BoolToPtr(true),
 			},
 		}},
+	}
+
+	if c.cr.CNI != nil && c.cr.CNI.Type == operator.PluginCalico {
+		// If using Calico CNI, we need to manage CNI credential rotation on the host.
+		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "CALICO_MANAGE_CNI", Value: "true"})
 	}
 
 	if c.cr.CNI != nil && c.cr.CNI.Type == operator.PluginAmazonVPC {

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -177,6 +177,7 @@ var _ = Describe("Node rendering tests", func() {
 		expectedNodeEnv := []v1.EnvVar{
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
 			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,bgp"},
@@ -285,6 +286,7 @@ var _ = Describe("Node rendering tests", func() {
 		// Verify volume mounts.
 		expectedNodeVolumeMounts := []v1.VolumeMount{
 			{MountPath: "/lib/modules", Name: "lib-modules", ReadOnly: true},
+			{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
 			{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
 			{MountPath: "/var/run/calico", Name: "var-run-calico"},
 			{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
@@ -417,6 +419,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,bgp"},
 			{Name: "IP", Value: "autodetect"},
@@ -528,6 +531,7 @@ var _ = Describe("Node rendering tests", func() {
 		// Verify volume mounts.
 		expectedNodeVolumeMounts := []v1.VolumeMount{
 			{MountPath: "/lib/modules", Name: "lib-modules", ReadOnly: true},
+			{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
 			{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
 			{MountPath: "/var/run/calico", Name: "var-run-calico"},
 			{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
@@ -653,6 +657,7 @@ var _ = Describe("Node rendering tests", func() {
 			// Default envvars.
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,bgp"},
 			{Name: "IP", Value: "autodetect"},
@@ -815,6 +820,7 @@ var _ = Describe("Node rendering tests", func() {
 		expectedNodeEnv := []v1.EnvVar{
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "vxlan"},
 			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,ecs"},
@@ -923,6 +929,7 @@ var _ = Describe("Node rendering tests", func() {
 		// Verify volume mounts.
 		expectedNodeVolumeMounts := []v1.VolumeMount{
 			{MountPath: "/lib/modules", Name: "lib-modules", ReadOnly: true},
+			{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
 			{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
 			{MountPath: "/var/run/calico", Name: "var-run-calico"},
 			{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
@@ -1252,6 +1259,7 @@ var _ = Describe("Node rendering tests", func() {
 		expectedNodeEnv := []v1.EnvVar{
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "vxlan"},
 			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,ecs"},
@@ -1360,6 +1368,7 @@ var _ = Describe("Node rendering tests", func() {
 		// Verify volume mounts.
 		expectedNodeVolumeMounts := []v1.VolumeMount{
 			{MountPath: "/lib/modules", Name: "lib-modules", ReadOnly: true},
+			{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
 			{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
 			{MountPath: "/var/run/calico", Name: "var-run-calico"},
 			{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
@@ -1608,6 +1617,7 @@ var _ = Describe("Node rendering tests", func() {
 			// Default envvars.
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,openshift,bgp"},
 			{Name: "IP", Value: "autodetect"},
@@ -1704,6 +1714,7 @@ var _ = Describe("Node rendering tests", func() {
 			// Default envvars.
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator,openshift,bgp"},
 			{Name: "IP", Value: "autodetect"},
@@ -2599,6 +2610,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "none"},
+			{Name: "CALICO_MANAGE_CNI", Value: "true"},
 			{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "true"},
 			{Name: "CLUSTER_TYPE", Value: "k8s,operator"},
 			{Name: "IP", Value: "autodetect"},


### PR DESCRIPTION
Cherry pick of #1337 on release-v1.18.

#1337: Always manage CNI config from calico/node