### PR TITLE
Adding container for packet capture api to tigera manager

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -90,3 +90,6 @@ components:
   alertmanager:
     image: tigera/alertmanager
     version: v0.20.0
+  packetcapture:
+    image: tigera/packetcapture-api
+    version: master

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -142,6 +142,12 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components "packetcapture" }}
+	ComponentPacketCapture = component{
+		Version: "{{ .Version }}",
+		Image:   "{{ .Image }}",
+	}
+{{- end }}
 {{ with index .Components "prometheus" }}
 	ComponentPrometheus = component{
 		Version: "{{ .Version }}",
@@ -219,6 +225,7 @@ var (
 		ComponentManager,
 		ComponentDex,
 		ComponentManagerProxy,
+		ComponentPacketCapture,
 		ComponentPrometheus,
 		ComponentPrometheusAlertmanager,
 		ComponentQueryServer,

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -122,6 +122,11 @@ var (
 		Image:   "tigera/voltron",
 	}
 
+	ComponentPacketCapture = component{
+		Version: "master",
+		Image:   "tigera/packetcapture-api",
+	}
+
 	ComponentPrometheus = component{
 		Version: "v2.17.2",
 		Image:   "tigera/prometheus",
@@ -189,6 +194,7 @@ var (
 		ComponentManager,
 		ComponentDex,
 		ComponentManagerProxy,
+		ComponentPacketCapture,
 		ComponentPrometheus,
 		ComponentPrometheusAlertmanager,
 		ComponentQueryServer,

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -431,7 +431,7 @@ var _ = Describe("Manager controller tests", func() {
 				},
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
+			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(4))
 			mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
 			Expect(mgr).ToNot(BeNil())
 			Expect(mgr.Image).To(Equal(
@@ -450,6 +450,12 @@ var _ = Describe("Manager controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentManagerProxy.Image,
 					components.ComponentManagerProxy.Version)))
+			packetCapture := test.GetContainer(d.Spec.Template.Spec.Containers, render.PacketCaptureServer)
+			Expect(packetCapture).ToNot(BeNil())
+			Expect(packetCapture.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s:%s",
+					components.ComponentPacketCapture.Image,
+					components.ComponentPacketCapture.Version)))
 		})
 		It("should use images from imageset", func() {
 			Expect(c.Create(ctx, &operatorv1.ImageSet{
@@ -459,6 +465,7 @@ var _ = Describe("Manager controller tests", func() {
 						{Image: "tigera/cnx-manager", Digest: "sha256:cnxmanagerhash"},
 						{Image: "tigera/es-proxy", Digest: "sha256:esproxyhash"},
 						{Image: "tigera/voltron", Digest: "sha256:voltronhash"},
+						{Image: "tigera/packetcapture-api", Digest: "sha256:packetcapturehash"},
 					},
 				},
 			})).ToNot(HaveOccurred())
@@ -473,7 +480,7 @@ var _ = Describe("Manager controller tests", func() {
 				},
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
+			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(4))
 			mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
 			Expect(mgr).ToNot(BeNil())
 			Expect(mgr.Image).To(Equal(
@@ -492,6 +499,12 @@ var _ = Describe("Manager controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentManagerProxy.Image,
 					"sha256:voltronhash")))
+			packetCapture := test.GetContainer(d.Spec.Template.Spec.Containers, render.PacketCaptureServer)
+			Expect(packetCapture).ToNot(BeNil())
+			Expect(packetCapture.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s@%s",
+					components.ComponentPacketCapture.Image,
+					"sha256:packetcapturehash")))
 		})
 	})
 })

--- a/pkg/controller/utils/auth.go
+++ b/pkg/controller/utils/auth.go
@@ -9,7 +9,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/render"
 	rauth "github.com/tigera/operator/pkg/render/common/authentication"
-	"github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
+	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -79,6 +79,9 @@ const (
 
 	eksLogForwarderName        = "eks-log-forwarder"
 	eksLogForwarderWindowsName = "eks-log-forwarder-windows"
+
+	PacketCaptureAPIRole        = "packetcapture-api-role"
+	PacketCaptureAPIRoleBinding = "packetcapture-api-role-binding"
 )
 
 type FluentdFilters struct {
@@ -273,6 +276,7 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.esSecrets...)...)...)
 	objs = append(objs, c.fluentdServiceAccount())
+	objs = append(objs, c.packetCaptureApiRole(), c.packetCaptureApiRoleBinding())
 	objs = append(objs, c.daemonset())
 
 	return objs, nil
@@ -355,6 +359,56 @@ func (c *fluentdComponent) fluentdServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: c.fluentdNodeName(), Namespace: LogCollectorNamespace},
+	}
+}
+
+// packetCaptureApiRole creates a role in the tigera-fluentd namespace to allow pod/exec
+// only from fluentd pods. This is being used by the PacketCapture API and created
+// by the operator after the namespace tigera-fluentd is created.
+func (c *fluentdComponent) packetCaptureApiRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PacketCaptureAPIRole,
+			Namespace: LogCollectorNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/exec"},
+				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"list"},
+			},
+		},
+	}
+}
+
+// packetCaptureApiRoleBinding creates a role binding within the tigera-fluentd namespace between the pod/exec role
+// the service account tigera-manager. This is being used by the PacketCapture API and created
+// by the operator after the namespace tigera-fluentd is created
+func (c *fluentdComponent) packetCaptureApiRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PacketCaptureAPIRoleBinding,
+			Namespace: LogCollectorNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     PacketCaptureAPIRole,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      ManagerServiceAccount,
+				Namespace: ManagerNamespace,
+			},
+		},
 	}
 }
 

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -20,6 +20,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/dns"
@@ -65,6 +66,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
@@ -117,6 +120,29 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		Expect(container.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(container.StartupProbe.PeriodSeconds).To(BeEquivalentTo(10))
 		Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(10))
+
+		podExecRole := rtest.GetResource(resources, render.PacketCaptureAPIRole, render.LogCollectorNamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
+		Expect(podExecRole.Rules).To(ConsistOf([]rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods/exec"},
+				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"list"},
+			},
+		}))
+		podExecRoleBinding := rtest.GetResource(resources, render.PacketCaptureAPIRoleBinding, render.LogCollectorNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+		Expect(podExecRoleBinding.RoleRef.Name).To(Equal(render.PacketCaptureAPIRole))
+		Expect(podExecRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      render.ManagerServiceAccount,
+				Namespace: render.ManagerNamespace,
+			},
+		}))
 	})
 
 	It("should render for Windows nodes", func() {
@@ -129,6 +155,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
 			{name: "fluentd-node-windows", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "fluentd-node-windows", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
@@ -231,6 +259,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
@@ -293,6 +323,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
@@ -387,6 +419,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
@@ -468,6 +502,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
@@ -537,6 +573,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
@@ -578,6 +616,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			// Daemonset
 			{name: "fluentd-node", ns: "tigera-fluentd", group: "apps", version: "v1", kind: "DaemonSet"},
 		}

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -69,6 +69,8 @@ const (
 
 	KibanaTLSHashAnnotation         = "hash.operator.tigera.io/kibana-secrets"
 	ElasticsearchUserHashAnnotation = "hash.operator.tigera.io/elasticsearch-user"
+
+	PacketCaptureServer = "tigera-packetcapture-server"
 )
 
 // ManagementClusterConnection configuration constants
@@ -160,6 +162,7 @@ type managerComponent struct {
 	managerImage               string
 	proxyImage                 string
 	esProxyImage               string
+	packetCaptureImage         string
 	csrInitImage               string
 }
 
@@ -180,6 +183,11 @@ func (c *managerComponent) ResolveImages(is *operator.ImageSet) error {
 	}
 
 	c.esProxyImage, err = components.GetReference(components.ComponentEsProxy, reg, path, prefix, is)
+	if err != nil {
+		errMsgs = append(errMsgs, err.Error())
+	}
+
+	c.packetCaptureImage, err = components.GetReference(components.ComponentPacketCapture, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
@@ -306,6 +314,7 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 				relasticsearch.ContainerDecorate(c.managerContainer(), c.esClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.clusterDomain, c.SupportedOSType()),
 				relasticsearch.ContainerDecorate(c.managerEsProxyContainer(), c.esClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.clusterDomain, c.SupportedOSType()),
 				c.managerProxyContainer(),
+				c.managerPacketCaptureContainer(),
 			},
 			Volumes: c.managerVolumes(),
 		}),
@@ -470,6 +479,21 @@ func (c *managerComponent) managerProxyProbe() *v1.Probe {
 	}
 }
 
+// managerPacketCaptureLivenessProbe returns the probe for the PacketCapture API container.
+func (c *managerComponent) managerPacketCaptureLivenessProbe() *v1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/packetcapture/health",
+				Port:   intstr.FromInt(managerPort),
+				Scheme: corev1.URISchemeHTTPS,
+			},
+		},
+		InitialDelaySeconds: 90,
+		PeriodSeconds:       10,
+	}
+}
+
 // managerEnvVars returns the envvars for the manager container.
 func (c *managerComponent) managerEnvVars() []v1.EnvVar {
 	envs := []v1.EnvVar{
@@ -552,6 +576,32 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		VolumeMounts:    c.volumeMountsForProxyManager(),
 		LivenessProbe:   c.managerProxyProbe(),
 		SecurityContext: podsecuritycontext.NewBaseContext(),
+	}
+}
+
+// managerPacketCaptureContainer returns the manager container.
+func (c *managerComponent) managerPacketCaptureContainer() corev1.Container {
+	var volumeMounts []corev1.VolumeMount
+	if c.managementCluster != nil {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: ManagerInternalTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true})
+	}
+
+	env := []v1.EnvVar{
+		{Name: "PACKETCAPTURE_API_LOG_LEVEL", Value: "Info"},
+	}
+
+	if c.keyValidatorConfig != nil {
+		env = append(env, c.keyValidatorConfig.RequiredEnv("PACKETCAPTURE_API")...)
+		volumeMounts = append(volumeMounts, c.keyValidatorConfig.RequiredVolumeMounts()...)
+	}
+
+	return corev1.Container{
+		Name:            PacketCaptureServer,
+		Image:           c.packetCaptureImage,
+		LivenessProbe:   c.managerPacketCaptureLivenessProbe(),
+		SecurityContext: podsecuritycontext.NewBaseContext(),
+		Env:             env,
+		VolumeMounts:    volumeMounts,
 	}
 }
 
@@ -681,6 +731,13 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
+					"packetcaptures",
+				},
+				Verbs: []string{"get"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
 					"hostendpoints",
 				},
 				Verbs: []string{"list"},
@@ -726,10 +783,12 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 		)
 	}
 
-	if managementCluster {
+	if !managedCluster {
 		// For cross-cluster requests an authentication review will be done for authenticating the tigera-manager.
 		// Requests on behalf of the tigera-manager will be sent to Voltron, where an authentication review will
 		// take place with its bearer token.
+		// In addition, PacketCapture API uses authentication reviews to authenticate the users and then perform
+		// SubjectAccessReviews in order to enforce RBAC on this API
 		cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"authenticationreviews"},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(components.TigeraRegistry + "tigera/cnx-manager:" + components.ComponentManager.Version))
 		Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal(components.TigeraRegistry + "tigera/es-proxy:" + components.ComponentEsProxy.Version))
 		Expect(deployment.Spec.Template.Spec.Containers[2].Image).Should(Equal(components.TigeraRegistry + "tigera/voltron:" + components.ComponentManagerProxy.Version))
+		Expect(deployment.Spec.Template.Spec.Containers[3].Image).Should(Equal(components.TigeraRegistry + "tigera/packetcapture-api:" + components.ComponentPacketCapture.Version))
 
 		// Expect 1 volume mounts for es proxy
 		var esProxy = deployment.Spec.Template.Spec.Containers[1]
@@ -107,6 +108,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Volumes[2].Secret.SecretName).To(Equal(render.ComplianceServerCertSecret))
 		Expect(deployment.Spec.Template.Spec.Volumes[3].Name).To(Equal("elastic-ca-cert-volume"))
 		Expect(deployment.Spec.Template.Spec.Volumes[3].Secret.SecretName).To(Equal(relasticsearch.PublicCertSecret))
+
+		// Expect no volume mounts for packetcapture-api
+		var packetcapture = deployment.Spec.Template.Spec.Containers[3]
+		Expect(len(packetcapture.VolumeMounts)).To(Equal(0))
 	})
 
 	It("should ensure cnx policy recommendation support is always set to true", func() {
@@ -118,7 +123,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		d := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
 
-		Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(3))
+		Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(4))
 		Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-manager"))
 		Expect(d.Spec.Template.Spec.Containers[0].Env[8].Name).To(Equal("CNX_POLICY_RECOMMENDATION_SUPPORT"))
 		Expect(d.Spec.Template.Spec.Containers[0].Env[8].Value).To(Equal("true"))
@@ -153,6 +158,13 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 					"tiers",
 				},
 				Verbs: []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"packetcaptures",
+				},
+				Verbs: []string{"get"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -196,6 +208,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				APIGroups: []string{""},
 				Resources: []string{"users", "groups", "serviceaccounts"},
 				Verbs:     []string{"impersonate"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"authenticationreviews"},
+				Verbs:     []string{"create"},
 			},
 		}))
 	})
@@ -255,6 +272,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		voltron := deployment.Spec.Template.Spec.Containers[2]
 		esProxy := deployment.Spec.Template.Spec.Containers[1]
+		packetcapture := deployment.Spec.Template.Spec.Containers[3]
 		Expect(voltron.Name).To(Equal("tigera-voltron"))
 		rtest.ExpectEnv(voltron.Env, "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
 
@@ -295,6 +313,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Volumes[6].Name).To(Equal("elastic-ca-cert-volume"))
 		Expect(deployment.Spec.Template.Spec.Volumes[6].Secret.SecretName).To(Equal(relasticsearch.PublicCertSecret))
 
+		// Expect 1 volume mounts for packetcapture
+		Expect(len(packetcapture.VolumeMounts)).To(Equal(1))
+		Expect(packetcapture.VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretCertName))
+		Expect(packetcapture.VolumeMounts[0].MountPath).To(Equal("/manager-tls"))
+
 		clusterRole := rtest.GetResource(resources, render.ManagerClusterRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(clusterRole.Rules).To(ConsistOf([]rbacv1.PolicyRule{
 			{
@@ -325,6 +348,13 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 					"tiers",
 				},
 				Verbs: []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"packetcaptures",
+				},
+				Verbs: []string{"get"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},


### PR DESCRIPTION
## Description

PacketCapture Download API exposes the API to retrieve pcap files generated by a PacketCapture. This enables personas
like DevOps or Platform Engineers to retrieve files backed by a namespace RBAC.  

PacketCapture API is a service that is deployed as container part of tigera-manager deployment. By default, it is
installed by Tigera operator. This service will only be deployed only for Standalone and Management clusters, and requests
will be routed to the appropriate managed clusters.

Voltron container has route defined for any requests that starts with `/packet-capture/` prefix. It will strip away that 
prefix and forward it to the container where this service resides.

## Configuration and permissions

| ENV        | Default value          | Description  |
| ------------- |:-------------:| -----:|
| PACKETCAPTURE_API_PORT      | `8444` | Local Port to start the service |
| PACKETCAPTURE_API_HOST      | <empty>, defaults to localhost      |   Host for the service |
| PACKETCAPTURE_API_LOG_LEVEL | `Info`      |    Log Level across service |
| PACKETCAPTURE_API_DEX_ENABLED | `False`      |    Enable Dex for authentication |
| PACKETCAPTURE_API_DEX_ISSUER | `https://127.0.0.1:5556/dex`      |    Dex Setup Configuration |
| PACKETCAPTURE_API_DEX_CLIENT_ID | `tigera-manager`      |    Dex Setup Configuration |
| PACKETCAPTURE_API_DEX_JWK_URL | `https://tigera-dex.tigera-dex.svc.cluster.local:5556/dex/keys`     |    Dex Setup Configuration |
| PACKETCAPTURE_API_DEX_USER_CLAIM | `email`      |    Dex Setup Configuration |
| PACKETCAPTURE_API_DEX_GROUPS_CLAIM | <empty>      |    Dex Setup Configuration |
| PACKETCAPTURE_API_DEX_USERNAME_PREFIX | <empty>      |    Dex Setup Configuration |
| PACKETCAPTURE_API_DEX_GROUPS_PREFIX | <empty>      |    Dex Setup Configuration |
| PACKETCAPTURE_API_MULTI_CLUSTER_FORWARDING_CA | `/manager-tls/cert`      |    CA certificate for multicluster communication |
| PACKETCAPTURE_API_MULTI_CLUSTER_FORWARDING_ENDPOINT | `https://localhost:9443`      |    CA endpoint for multicluster communication |


This API makes use of tigera-manager service account and requires the following permissions:
- GET for api group `projectcalico.org` for resource `packetcaptures`
- CREATE for api group `projectcalico.org` for resource `authenticationreviews`
- LIST,WATCH,GET for api group `projectcalico.org` for resource `managedclusters`
- LIST for core v1 group for resource `pods`
- CREATE for core v1 group for subresource `pods/exec`
- CREATE for api group `authorization.k8s.io` for resource `subjectaccessreviews`

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
