### PR TITLE
Prevent release image from being overwritten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ release-publish-images: release-prereqs
 	@echo "Checking if $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) exists already"; \
 	if docker manifest inspect $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) >/dev/null; \
 		then echo "Image $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) already exists"; \
-		false; \
+		exit 1; \
 	else \
 		echo "Image tag check passed; image does not exist"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -392,14 +392,16 @@ release-verify: release-prereqs
 	# Check the reported version is correct for each release artifact.
 	if ! docker run $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version | grep '^Operator: $(VERSION)$$'; then echo "Reported version:" `docker run $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version ` "\nExpected version: $(VERSION)"; false; else echo "\nVersion check passed\n"; fi
 
-release-publish-images: release-prereqs
+release-check-image-exists: release-prereqs
 	@echo "Checking if $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) exists already"; \
 	if docker manifest inspect $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) >/dev/null; \
 		then echo "Image $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) already exists"; \
 		exit 1; \
 	else \
-		echo "Image tag check passed; image does not exist"; \
+		echo "Image tag check passed; image does not already exist"; \
 	fi
+
+release-publish-images: release-prereqs release-check-image-exists
 	# Push images.
 	$(MAKE) push-all push-manifests push-non-manifests RELEASE=true IMAGETAG=$(VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -393,6 +393,13 @@ release-verify: release-prereqs
 	if ! docker run $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version | grep '^Operator: $(VERSION)$$'; then echo "Reported version:" `docker run $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION)-$(ARCH) --version ` "\nExpected version: $(VERSION)"; false; else echo "\nVersion check passed\n"; fi
 
 release-publish-images: release-prereqs
+	@echo "Checking if $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) exists already"; \
+	if docker manifest inspect $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) >/dev/null; \
+		then echo "Image $(IMAGE_REGISTRY)/$(BUILD_IMAGE):$(VERSION) already exists"; \
+		false; \
+	else \
+		echo "Image tag check passed; image does not exist"; \
+	fi
 	# Push images.
 	$(MAKE) push-all push-manifests push-non-manifests RELEASE=true IMAGETAG=$(VERSION)
 

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -16,6 +16,13 @@ if [[ ! "$(git rev-parse --abbrev-ref HEAD)" =~ (release-v*.*|master) ]]; then
 	exit 0
 fi
 
+# Skip releasing if the image already exists. No guarantee that a tagged build will only be run once. We want the build to
+# pass in the case where the image exists.
+if ! make release-check-image-exists; then
+	echo "Image tag already exists, no need to release"
+	exit 0
+fi
+
 echo "On a git tag - building release: ${tag}"
 make release VERSION=${tag}
 


### PR DESCRIPTION
## Description

If the semaphore job for a release tag is rerun we overwrite the release tags in quay.

This PR makes sure that the image doesn't already exist in quay.io before pushing.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
