### PR TITLE
Add deletecollection permissions for deleting ES secrets

### DIFF
--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -234,9 +234,16 @@ func (c *kubeControllersComponent) controllersRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"configmaps", "secrets"},
+				Resources: []string{"configmaps"},
 				Verbs:     []string{"watch", "list", "get", "update", "create"},
 			},
+			// Used for the creation, synchronization and deletion of elasticsearch related secrets.
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"watch", "list", "get", "update", "create", "deletecollection"},
+			},
+
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -204,7 +204,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[1].Secret.SecretName).To(Equal(relasticsearch.PublicCertSecret))
 
 		clusterRole := rtest.GetResource(resources, "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(17))
+		Expect(len(clusterRole.Rules)).To(Equal(18))
 	})
 
 	It("should render all resources for a default configuration using TigeraSecureEnterprise and ClusterType is Management", func() {
@@ -268,7 +268,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 		// Management clusters also have a role for authenticationreviews.
 		clusterRole := rtest.GetResource(resources, "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(18))
+		Expect(len(clusterRole.Rules)).To(Equal(19))
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{"projectcalico.org"},


### PR DESCRIPTION
Adds the clusterrole binding to the kube controllers, so it can clean up unnecessary secrets that it has created previously.