### PR TITLE
Add rights to access packetcaptures/files as tigera-network-admin and…

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1294,6 +1294,11 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			},
 			Verbs: []string{"watch", "list"},
 		},
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"packetcaptures/files"},
+			Verbs:     []string{"get"},
+		},
 		// Additional "list" requests required to view flows.
 		{
 			APIGroups: []string{""},
@@ -1411,6 +1416,11 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 				"packetcaptures",
 			},
 			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
+		},
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"packetcaptures/files"},
+			Verbs:     []string{"get"},
 		},
 		// Additional "list" requests that the Tigera Secure manager needs
 		{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -831,6 +831,11 @@ var (
 			Verbs: []string{"watch", "list"},
 		},
 		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"packetcaptures/files"},
+			Verbs:     []string{"get"},
+		},
+		{
 			APIGroups: []string{""},
 			Resources: []string{"pods"},
 			Verbs:     []string{"list"},
@@ -913,6 +918,11 @@ var (
 				"packetcaptures",
 			},
 			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
+		},
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"packetcaptures/files"},
+			Verbs:     []string{"get"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
… tigera-ui-user

## Description

Allow users that have tigera-network-admin or tigera-ui-user to fetch the capture files.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
