### PR TITLE
Fix apiserver deployment on Mirantis

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -233,15 +233,15 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	// Namespaced objects that are common between Calico and Calico Enterprise. They don't need to be explicitly
 	// deleted, since they will be garbage collected on namespace deletion.
 	namespacedObjects := []client.Object{}
+	// Add in image pull secrets.
+	secrets := secret.CopyToNamespace(rmeta.APIServerNamespace(c.installation.Variant), c.pullSecrets...)
+	namespacedObjects = append(namespacedObjects, secret.ToRuntimeObjects(secrets...)...)
+
 	namespacedObjects = append(namespacedObjects,
 		c.apiServerServiceAccount(),
 		c.apiServerDeployment(),
 		c.apiServerService(),
 	)
-
-	// Add in image pull secrets.
-	secrets := secret.CopyToNamespace(rmeta.APIServerNamespace(c.installation.Variant), c.pullSecrets...)
-	namespacedObjects = append(namespacedObjects, secret.ToRuntimeObjects(secrets...)...)
 
 	// Add in certificates for API server TLS.
 	if c.installation.CertificateManagement == nil {


### PR DESCRIPTION
## Description
fix - calico/tigera-apiserver deployment for Mirantis kube-apiserver throwing exception of 
`time="2021-06-23T19:18:49Z" level=error msg="[DCT Signing Policy] error: deployments.apps \"tigera-apiserver\" is forbidden: unable to lookup image pull secret \"tigera-pull-secret\" from namespace \"tigera-system\": secrets \"tigera-pull-secret\" not found"`

because of docker content trust verifies the  calico/tigera-apiserver image we are pulling with the imagepullsecret  

Moving the order of  copying the tigera-pull-secret to the calico/tigera-apiserver namespace first before deploying  calico/tigera-apiserver.   

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
