### PR TITLE
Add a packet capture container to tigera-guardian

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -150,13 +150,19 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				},
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(2))
 			dexC := test.GetContainer(d.Spec.Template.Spec.Containers, render.GuardianDeploymentName)
 			Expect(dexC).ToNot(BeNil())
 			Expect(dexC.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentGuardian.Image,
 					components.ComponentGuardian.Version)))
+			packetCapture := test.GetContainer(d.Spec.Template.Spec.Containers, render.PacketCaptureServer)
+			Expect(packetCapture).ToNot(BeNil())
+			Expect(packetCapture.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s:%s",
+					components.ComponentPacketCapture.Image,
+					components.ComponentPacketCapture.Version)))
 		})
 		It("should use images from imageset", func() {
 			Expect(c.Create(ctx, &operatorv1.ImageSet{
@@ -164,6 +170,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				Spec: operatorv1.ImageSetSpec{
 					Images: []operatorv1.Image{
 						{Image: "tigera/guardian", Digest: "sha256:guardianhash"},
+						{Image: "tigera/packetcapture-api", Digest: "sha256:packetcapturehash"},
 					},
 				},
 			})).ToNot(HaveOccurred())
@@ -180,13 +187,19 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				},
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
-			apiserver := test.GetContainer(d.Spec.Template.Spec.Containers, render.GuardianDeploymentName)
-			Expect(apiserver).ToNot(BeNil())
-			Expect(apiserver.Image).To(Equal(
+			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(2))
+			guardian := test.GetContainer(d.Spec.Template.Spec.Containers, render.GuardianDeploymentName)
+			Expect(guardian).ToNot(BeNil())
+			Expect(guardian.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentGuardian.Image,
 					"sha256:guardianhash")))
+			packetCapture := test.GetContainer(d.Spec.Template.Spec.Containers, render.PacketCaptureServer)
+			Expect(packetCapture).ToNot(BeNil())
+			Expect(packetCapture.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s@%s",
+					components.ComponentPacketCapture.Image,
+					"sha256:packetcapturehash")))
 		})
 	})
 })

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -232,6 +232,13 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
+	managementClusterConnection, err := utils.GetManagementClusterConnection(ctx, r.client)
+	if err != nil {
+		log.Error(err, "Error reading ManagementClusterConnection")
+		r.status.SetDegraded("Error reading ManagementClusterConnection", err.Error())
+		return reconcile.Result{}, err
+	}
+
 	esClusterConfig, err := utils.GetElasticsearchClusterConfig(ctx, r.client)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -417,6 +424,7 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		installation,
 		r.clusterDomain,
 		rmeta.OSTypeLinux,
+		managementClusterConnection != nil,
 	)
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
@@ -449,6 +457,7 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 			installation,
 			r.clusterDomain,
 			rmeta.OSTypeWindows,
+			managementClusterConnection != nil,
 		)
 
 		if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -579,7 +579,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 	}
 }
 
-// managerPacketCaptureContainer returns the manager container.
+// managerPacketCaptureContainer returns the packet capture container.
 func (c *managerComponent) managerPacketCaptureContainer() corev1.Container {
 	var volumeMounts []corev1.VolumeMount
 	if c.managementCluster != nil {
@@ -588,6 +588,7 @@ func (c *managerComponent) managerPacketCaptureContainer() corev1.Container {
 
 	env := []v1.EnvVar{
 		{Name: "PACKETCAPTURE_API_LOG_LEVEL", Value: "Info"},
+		{Name: "PACKETCAPTURE_API_ENABLE_MANAGEMENT_CLUSTER", Value: strconv.FormatBool(c.managementCluster != nil)},
 	}
 
 	if c.keyValidatorConfig != nil {


### PR DESCRIPTION
## Description

Add a new container for packet capture on guardian side. In a
multicluster setup, the management cluster will proxy a request via the
tunnel to Guardian. Guardian will forward the request to the packet
capture container. This API will retrieve the files generated by a
packet capture via a pod/exec command. 

Tigera-guardian will be used as a service account to perform all the needed
k8s API calls:
- get packetcaptures
- list fluentd pods
- exec in fluentd pods

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
