### PR TITLE
Add default route to kibana

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"net/url"
 	"strings"
 
 	cmnv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
@@ -75,6 +76,7 @@ const (
 	KibanaDefaultCertPath  = "/etc/ssl/kibana/ca.pem"
 	KibanaBasePath         = "tigera-kibana"
 	KibanaServiceName      = "tigera-secure-kb-http"
+	KibanaDefaultRoute     = "/app/kibana#/dashboards?%s&title=%s"
 
 	DefaultElasticsearchClusterName = "cluster"
 	DefaultElasticsearchReplicas    = 0
@@ -118,6 +120,9 @@ const (
 
 	KibanaTLSAnnotationHash        = "hash.operator.tigera.io/kb-secrets"
 	ElasticsearchTLSHashAnnotation = "hash.operator.tigera.io/es-secrets"
+
+	TimeFilter         = "_g=(time:(from:now-24h,to:now))"
+	FlowsDashboardName = "Tigera Secure EE Flow Logs"
 )
 
 const (
@@ -1276,6 +1281,7 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 		"server": map[string]interface{}{
 			"basePath":        fmt.Sprintf("/%s", KibanaBasePath),
 			"rewriteBasePath": true,
+			"defaultRoute":    fmt.Sprintf(KibanaDefaultRoute, TimeFilter, url.PathEscape(FlowsDashboardName)),
 		},
 		"elasticsearch.ssl.certificateAuthorities": []string{"/usr/share/kibana/config/elasticsearch-certs/tls.crt"},
 		"tigera": map[string]interface{}{


### PR DESCRIPTION
## Description

Issue: 
Logging into Kibana with either OIDC (In Calico Enterprise version older than 3.6) or OIDC workaround (In Calico Enterprise v3.6 and above) doesn't land on dashboard page.
Explicitly redirecting to Kibana dashboard after login doesn’t work, it always lands on default home page (`app/home`). 

During basic authentication, Kibana lands on dashboard page after login this is because Kibana is opened with the dashboard url as `next` param (like `https://<>:9443/tigera-kibana/login?next=%2Ftigera-kibana%2Fapp%2Fkibana#/dashboards?_g=(time:(from:now-24h,to:now))&title=Tigera%20Secure%20EE%20Flow%20Logs`), it is not possible to redirect from manager UI to dashboard using the `next` parameter. 

Set the [default route in Kibana config](https://www.elastic.co/guide/en/kibana/current/advanced-options.html#defaultroute) to always land on dashboard when opening Kibana.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
