### PR TITLE
Automated cherry pick of #1375: Adding status RBAC for globalthreatfeeds for apiserver

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1152,6 +1152,7 @@ func (c *apiServerComponent) tigeraCustomResourcesClusterRole() *rbacv1.ClusterR
 				"globalalerts",
 				"globalalerttemplates",
 				"globalthreatfeeds",
+				"globalthreatfeeds/status",
 				"globalreporttypes",
 				"globalreports",
 				"remoteclusterconfigurations",


### PR DESCRIPTION
Cherry pick of #1375 on release-v1.19.

#1375: Adding status RBAC for globalthreatfeeds for apiserver