### PR TITLE
Move Prometheus ClusterRole to Role

### DIFF
--- a/pkg/render/monitor.go
+++ b/pkg/render/monitor.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -37,12 +38,14 @@ import (
 const (
 	MonitoringAPIVersion = "monitoring.coreos.com/v1"
 
-	CalicoNodeAlertmanager = "calico-node-alertmanager"
-	CalicoNodeMonitor      = "calico-node-monitor"
-	CalicoNodePrometheus   = "calico-node-prometheus"
-	ElasticsearchMetrics   = "elasticearch-metrics"
-	FluentdMetrics         = "fluentd-metrics"
-	TigeraPrometheusDPRate = "tigera-prometheus-dp-rate"
+	CalicoNodeAlertmanager      = "calico-node-alertmanager"
+	CalicoNodeMonitor           = "calico-node-monitor"
+	CalicoNodePrometheus        = "calico-node-prometheus"
+	ElasticsearchMetrics        = "elasticearch-metrics"
+	FluentdMetrics              = "fluentd-metrics"
+	TigeraPrometheusDPRate      = "tigera-prometheus-dp-rate"
+	TigeraPrometheusRole        = "tigera-prometheus-role"
+	TigeraPrometheusRoleBinding = "tigera-prometheus-role-binding"
 )
 
 func Monitor(
@@ -97,6 +100,8 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.pullSecrets...)...)...)
 
 	objs = append(objs,
+		mc.role(),
+		mc.roleBinding(),
 		mc.alertmanager(),
 		mc.prometheus(),
 		mc.prometheusRule(),
@@ -264,6 +269,61 @@ func (mc *monitorComponent) serviceMonitorElasicsearch() *monitoringv1.ServiceMo
 					Port:          "metrics-port",
 					ScrapeTimeout: "5s",
 				},
+			},
+		},
+	}
+}
+
+func (mc *monitorComponent) role() *rbacv1.Role {
+	// Even though list and watch verbs are listed here, they are still cluster scoped
+	// due to the fact that watches are by default non-namespaced in controller-runtime.
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TigeraPrometheusRole,
+			Namespace: common.TigeraPrometheusNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"monitoring.coreos.com"},
+				Resources: []string{
+					"alertmanagers",
+					"podmonitors",
+					"prometheuses",
+					"prometheusrules",
+					"servicemonitors",
+					"thanosrulers",
+				},
+				Verbs: []string{
+					"create",
+					"delete",
+					"get",
+					"list",
+					"update",
+					"watch",
+				},
+			},
+		},
+	}
+}
+
+func (mc *monitorComponent) roleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TigeraPrometheusRoleBinding,
+			Namespace: common.TigeraPrometheusNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     TigeraPrometheusRole,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "tigera-operator",
+				Namespace: rmeta.OperatorNamespace(),
 			},
 		},
 	}

--- a/pkg/render/monitor_test.go
+++ b/pkg/render/monitor_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,6 +31,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 )
 
@@ -57,6 +59,8 @@ var _ = Describe("monitor rendering tests", func() {
 		}{
 			{common.TigeraPrometheusNamespace, "", "", "v1", "Namespace"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
+			{render.TigeraPrometheusRole, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
+			{render.TigeraPrometheusRoleBinding, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{render.CalicoNodeAlertmanager, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
 			{render.CalicoNodePrometheus, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind},
 			{render.TigeraPrometheusDPRate, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusRuleKind},
@@ -170,5 +174,41 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(Equal("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(Equal("5s"))
+
+		// Role
+		roleObj, ok := rtest.GetResource(toCreate, render.TigeraPrometheusRole, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
+		Expect(ok).To(BeTrue())
+		Expect(roleObj.Rules).To(HaveLen(1))
+		Expect(roleObj.Rules[0].APIGroups).To(HaveLen(1))
+		Expect(roleObj.Rules[0].APIGroups[0]).To(Equal("monitoring.coreos.com"))
+		Expect(roleObj.Rules[0].Resources).To(HaveLen(6))
+		Expect(roleObj.Rules[0].Resources).To(BeEquivalentTo([]string{
+			"alertmanagers",
+			"podmonitors",
+			"prometheuses",
+			"prometheusrules",
+			"servicemonitors",
+			"thanosrulers",
+		}))
+		Expect(roleObj.Rules[0].Verbs).To(HaveLen(6))
+		Expect(roleObj.Rules[0].Verbs).To(BeEquivalentTo([]string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"update",
+			"watch",
+		}))
+
+		// RoleBinding
+		rolebindingObj, ok := rtest.GetResource(toCreate, render.TigeraPrometheusRoleBinding, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+		Expect(ok).To(BeTrue())
+		Expect(rolebindingObj.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+		Expect(rolebindingObj.RoleRef.Kind).To(Equal("Role"))
+		Expect(rolebindingObj.RoleRef.Name).To(Equal(render.TigeraPrometheusRole))
+		Expect(rolebindingObj.Subjects).To(HaveLen(1))
+		Expect(rolebindingObj.Subjects[0].Kind).To(Equal("ServiceAccount"))
+		Expect(rolebindingObj.Subjects[0].Name).To(Equal("tigera-operator"))
+		Expect(rolebindingObj.Subjects[0].Namespace).To(Equal(rmeta.OperatorNamespace()))
 	})
 })


### PR DESCRIPTION
Move `ClusterRole`s in API group `monitoring.coreos.com` to `tigera-prometheus`
namespaced `Role`s. Note that we still keep `list` and `watch` to be cluster
scoped due to the fact that watches are by default non-namespaced in
`controller-runtime`.

Tested on GCP kubernetes and AWs Openshift clusters.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
