### PR TITLE
Enable TCP stats by default

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1210,6 +1210,7 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 			{Name: "FELIX_FLOWLOGSFILEINCLUDESERVICE", Value: "true"},
 			{Name: "FELIX_FLOWLOGSENABLENETWORKSETS", Value: "true"},
 			{Name: "FELIX_FLOWLOGSCOLLECTPROCESSINFO", Value: "true"},
+			{Name: "FELIX_FLOWLOGSCOLLECTTCPSTATS", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
 		}
@@ -1217,7 +1218,6 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 		if c.cr.CalicoNetwork != nil && c.cr.CalicoNetwork.MultiInterfaceMode != nil {
 			extraNodeEnv = append(extraNodeEnv, v1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cr.CalicoNetwork.MultiInterfaceMode.Value()})
 		}
-
 		nodeEnv = append(nodeEnv, extraNodeEnv...)
 	}
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -713,6 +713,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_FLOWLOGSFILEINCLUDESERVICE", Value: "true"},
 			{Name: "FELIX_FLOWLOGSENABLENETWORKSETS", Value: "true"},
 			{Name: "FELIX_FLOWLOGSCOLLECTPROCESSINFO", Value: "true"},
+			{Name: "FELIX_FLOWLOGSCOLLECTTCPSTATS", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
 			{Name: "MULTI_INTERFACE_MODE", Value: operator.MultiInterfaceModeNone.Value()},
@@ -1770,6 +1771,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_FLOWLOGSFILEINCLUDESERVICE", Value: "true"},
 			{Name: "FELIX_FLOWLOGSENABLENETWORKSETS", Value: "true"},
 			{Name: "FELIX_FLOWLOGSCOLLECTPROCESSINFO", Value: "true"},
+			{Name: "FELIX_FLOWLOGSCOLLECTTCPSTATS", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 			{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
 


### PR DESCRIPTION
## Description
Enable TCP stats collection by default.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
