### PR TITLE
Enable FELIX_WIRGEUARDHOSTENCRYPTIONENABLED for AKS/EKS

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1240,6 +1240,8 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 			// We also need to configure a non-default trusted DNS server, since there's no kube-dns.
 			nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"})
 		}
+	case operator.ProviderAKS:
+		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
 	}
 
 	switch c.cr.CNI.Type {

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1242,6 +1242,10 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 		}
 	case operator.ProviderAKS:
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
+	case operator.ProviderEKS:
+		if c.cr.CNI.Type == operator.PluginCalico {
+			nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
+		}
 	}
 
 	switch c.cr.CNI.Type {

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1240,6 +1240,7 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 			// We also need to configure a non-default trusted DNS server, since there's no kube-dns.
 			nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"})
 		}
+	// For AKS and EKS/CalicoCNI, we must explicitly ask felix to add host IP's to wireguard ifaces
 	case operator.ProviderAKS:
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
 	case operator.ProviderEKS:

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -867,6 +867,7 @@ var _ = Describe("Node rendering tests", func() {
 					Optional: &optional,
 				},
 			}},
+			{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		// Expect the SECURITY_GROUP env variables to not be set
@@ -1306,6 +1307,7 @@ var _ = Describe("Node rendering tests", func() {
 					Optional: &optional,
 				},
 			}},
+			{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		// Expect the SECURITY_GROUP env variables to not be set


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Felix needs to explicitly add host IP's to wireguard's trusted IP's list in order to work properly on AKS, and also on EKS so that it can properly encrypt cross-host traffic when making requests through services/nodeports.

This change toggles `FELIX_WIREGUARDHOSTENCRYPTIONENABLED` flag when using AKS, or when using EKS with CalicoCNI (EKS CNI still a ways off)

Related Felix PR: https://github.com/projectcalico/felix/pull/2897

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
