### PR TITLE
Set FELIX_ROUTETABLERANGE to 31-250 for AWS CNI

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1246,6 +1246,8 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 	case operator.PluginAmazonVPC:
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_INTERFACEPREFIX", Value: "eni"})
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"})
+		// Don't conflict with the AWS CNI plugin's routes.
+		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_ROUTETABLERANGE", Value: "31-250"})
 	case operator.PluginGKE:
 		// The GKE CNI plugin uses its own interface prefix.
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_INTERFACEPREFIX", Value: "gke"})

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1043,6 +1043,7 @@ var _ = Describe("Node rendering tests", func() {
 			}},
 			{Name: "FELIX_INTERFACEPREFIX", Value: "eni"},
 			{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"},
+			{Name: "FELIX_ROUTETABLERANGE", Value: "31-250"},
 			{Name: "FELIX_ROUTESOURCE", Value: "WorkloadIPs"},
 			{Name: "FELIX_BPFEXTTOSERVICECONNMARK", Value: "0x80"},
 		}
@@ -1481,6 +1482,7 @@ var _ = Describe("Node rendering tests", func() {
 			}},
 			{Name: "FELIX_INTERFACEPREFIX", Value: "eni"},
 			{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"},
+			{Name: "FELIX_ROUTETABLERANGE", Value: "31-250"},
 			{Name: "FELIX_ROUTESOURCE", Value: "WorkloadIPs"},
 			{Name: "FELIX_BPFEXTTOSERVICECONNMARK", Value: "0x80"},
 		}


### PR DESCRIPTION
AWS CNI will create routing tables with indexes from 2-15, so this
configuration will instruct Felix to no longer manage routing tables
in the range AWS CNI is using.

## Description

This change fixes this [bug](https://tigera.atlassian.net/browse/APP-95).

I'm unsure yet whether this change should be applied only for EKS with AWS CNI, or for all AWS CNI environments. I suspect this will be a problem on all AWS CNI environments.

I have not tested this fix yet, just putting it up for early feedback.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
