### PR TITLE
[SAAS-1454] Ignore all kubectl generated annotation during the Installation conversion

### DIFF
--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -12,6 +12,7 @@ import (
 )
 
 var toBeIgnoredAnnotationKeyRegExps []*regexp.Regexp
+
 func init() {
 	log.Info("Compiling regular expressions for annotation keys to be ignored...")
 	toBeIgnoredAnnotationKeyRegExps = make([]*regexp.Regexp, 0)

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -218,7 +218,7 @@ func addResources(install *operatorv1.Installation, compName operatorv1.Componen
 // since Operator does not support setting custom annotations on components, these annotations
 // would otherwise be dropped.
 func handleAnnotations(c *components, _ *operatorv1.Installation) error {
-	kubectlGenerated := []string {"^kubectl\\.kubernetes\\.io"}
+	kubectlGenerated := []string{"^kubectl\\.kubernetes\\.io"}
 	if a := removeExpectedAnnotations(c.node.Annotations, map[string]string{}, kubectlGenerated); len(a) != 0 {
 		return ErrIncompatibleAnnotation(a, ComponentCalicoNode)
 	}
@@ -270,8 +270,7 @@ func removeExpectedAnnotations(existing, ignoreWithValue map[string]string, igno
 	}
 
 	for key, val := range existing {
-		if key == "kubectl.kubernetes.io/last-applied-configuration" ||
-			key == "deprecated.daemonset.template.generation" ||
+		if key == "deprecated.daemonset.template.generation" ||
 			key == "deployment.kubernetes.io/revision" ||
 			key == "scheduler.alpha.kubernetes.io/critical-pod" {
 			delete(a, key)

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -217,7 +218,8 @@ func addResources(install *operatorv1.Installation, compName operatorv1.Componen
 // since Operator does not support setting custom annotations on components, these annotations
 // would otherwise be dropped.
 func handleAnnotations(c *components, _ *operatorv1.Installation) error {
-	if a := removeExpectedAnnotations(c.node.Annotations, map[string]string{}); len(a) != 0 {
+	kubectlGenerated := []string {"^kubectl\\.kubernetes\\.io"}
+	if a := removeExpectedAnnotations(c.node.Annotations, map[string]string{}, kubectlGenerated); len(a) != 0 {
 		return ErrIncompatibleAnnotation(a, ComponentCalicoNode)
 	}
 
@@ -227,26 +229,26 @@ func handleAnnotations(c *components, _ *operatorv1.Installation) error {
 	// we ignore it.
 	if a := removeExpectedAnnotations(c.node.Spec.Template.Annotations, map[string]string{
 		"cluster-autoscaler.kubernetes.io/daemonset-pod": "true",
-	}); len(a) != 0 {
+	}, kubectlGenerated); len(a) != 0 {
 		return ErrIncompatibleAnnotation(a, ComponentCalicoNode+" podTemplateSpec")
 	}
 
 	if c.kubeControllers != nil {
-		if a := removeExpectedAnnotations(c.kubeControllers.Annotations, map[string]string{}); len(a) != 0 {
+		if a := removeExpectedAnnotations(c.kubeControllers.Annotations, map[string]string{}, kubectlGenerated); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentKubeControllers)
 		}
-		if a := removeExpectedAnnotations(c.kubeControllers.Spec.Template.Annotations, map[string]string{}); len(a) != 0 {
+		if a := removeExpectedAnnotations(c.kubeControllers.Spec.Template.Annotations, map[string]string{}, kubectlGenerated); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentKubeControllers+" podTemplateSpec")
 		}
 	}
 
 	if c.typha != nil {
-		if a := removeExpectedAnnotations(c.typha.Annotations, map[string]string{}); len(a) != 0 {
+		if a := removeExpectedAnnotations(c.typha.Annotations, map[string]string{}, kubectlGenerated); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentTypha)
 		}
 		if a := removeExpectedAnnotations(c.typha.Spec.Template.Annotations, map[string]string{
 			"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
-		}); len(a) != 0 {
+		}, kubectlGenerated); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentTypha+" podTemplateSpec")
 		}
 	}
@@ -255,8 +257,18 @@ func handleAnnotations(c *components, _ *operatorv1.Installation) error {
 
 // removeExpectedAnnotations returns the given annotations with common k8s-native annotations removed.
 // this function also accepts a second argument of additional annotations to remove.
-func removeExpectedAnnotations(existing, ignore map[string]string) map[string]string {
+func removeExpectedAnnotations(existing, ignoreWithValue map[string]string, ignoreNoMatterWhatValue []string) map[string]string {
 	a := existing
+	annotationKeyRegexps := make([]*regexp.Regexp, 0)
+	for _, annotationKey := range ignoreNoMatterWhatValue {
+		annotationKeyRegexp, err := regexp.Compile(annotationKey)
+		if err != nil {
+			log.Error(fmt.Errorf("%s is not a valid regular expression", annotationKey), "Error when removing expected annotations")
+			continue
+		}
+		annotationKeyRegexps = append(annotationKeyRegexps, annotationKeyRegexp)
+	}
+
 	for key, val := range existing {
 		if key == "kubectl.kubernetes.io/last-applied-configuration" ||
 			key == "deprecated.daemonset.template.generation" ||
@@ -266,8 +278,15 @@ func removeExpectedAnnotations(existing, ignore map[string]string) map[string]st
 			continue
 		}
 
-		if v, ok := ignore[key]; ok && v == val {
+		if v, ok := ignoreWithValue[key]; ok && v == val {
 			delete(a, key)
+		}
+
+		for _, annotationKeyRegexp := range annotationKeyRegexps {
+			if annotationKeyRegexp.MatchString(key) {
+				delete(a, key)
+				break
+			}
 		}
 	}
 

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -11,6 +11,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+var toBeIgnoredAnnotationKeyRegExps []*regexp.Regexp
+func init() {
+	log.Info("Compiling regular expressions for annotation keys to be ignored...")
+	toBeIgnoredAnnotationKeyRegExps = make([]*regexp.Regexp, 0)
+	for _, annotationKey := range []string{"^kubectl\\.kubernetes\\.io"} {
+		annotationKeyRegexp, err := regexp.Compile(annotationKey)
+		if err != nil {
+			log.Error(fmt.Errorf("%s is not a valid regular expression", annotationKey), "Error when removing expected annotations")
+			continue
+		}
+		toBeIgnoredAnnotationKeyRegExps = append(toBeIgnoredAnnotationKeyRegExps, annotationKeyRegexp)
+	}
+}
+
 func handleCore(c *components, install *operatorv1.Installation) error {
 	dsType, err := c.node.getEnv(ctx, c.client, "calico-node", "DATASTORE_TYPE")
 	if err != nil {
@@ -218,8 +232,7 @@ func addResources(install *operatorv1.Installation, compName operatorv1.Componen
 // since Operator does not support setting custom annotations on components, these annotations
 // would otherwise be dropped.
 func handleAnnotations(c *components, _ *operatorv1.Installation) error {
-	ignoredAnnotationKeyRegExps := []string{"^kubectl\\.kubernetes\\.io"}
-	if a := removeExpectedAnnotations(c.node.Annotations, map[string]string{}, ignoredAnnotationKeyRegExps); len(a) != 0 {
+	if a := removeExpectedAnnotations(c.node.Annotations, map[string]string{}, toBeIgnoredAnnotationKeyRegExps); len(a) != 0 {
 		return ErrIncompatibleAnnotation(a, ComponentCalicoNode)
 	}
 
@@ -229,26 +242,26 @@ func handleAnnotations(c *components, _ *operatorv1.Installation) error {
 	// we ignore it.
 	if a := removeExpectedAnnotations(c.node.Spec.Template.Annotations, map[string]string{
 		"cluster-autoscaler.kubernetes.io/daemonset-pod": "true",
-	}, ignoredAnnotationKeyRegExps); len(a) != 0 {
+	}, toBeIgnoredAnnotationKeyRegExps); len(a) != 0 {
 		return ErrIncompatibleAnnotation(a, ComponentCalicoNode+" podTemplateSpec")
 	}
 
 	if c.kubeControllers != nil {
-		if a := removeExpectedAnnotations(c.kubeControllers.Annotations, map[string]string{}, ignoredAnnotationKeyRegExps); len(a) != 0 {
+		if a := removeExpectedAnnotations(c.kubeControllers.Annotations, map[string]string{}, toBeIgnoredAnnotationKeyRegExps); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentKubeControllers)
 		}
-		if a := removeExpectedAnnotations(c.kubeControllers.Spec.Template.Annotations, map[string]string{}, ignoredAnnotationKeyRegExps); len(a) != 0 {
+		if a := removeExpectedAnnotations(c.kubeControllers.Spec.Template.Annotations, map[string]string{}, toBeIgnoredAnnotationKeyRegExps); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentKubeControllers+" podTemplateSpec")
 		}
 	}
 
 	if c.typha != nil {
-		if a := removeExpectedAnnotations(c.typha.Annotations, map[string]string{}, ignoredAnnotationKeyRegExps); len(a) != 0 {
+		if a := removeExpectedAnnotations(c.typha.Annotations, map[string]string{}, toBeIgnoredAnnotationKeyRegExps); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentTypha)
 		}
 		if a := removeExpectedAnnotations(c.typha.Spec.Template.Annotations, map[string]string{
 			"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
-		}, ignoredAnnotationKeyRegExps); len(a) != 0 {
+		}, toBeIgnoredAnnotationKeyRegExps); len(a) != 0 {
 			return ErrIncompatibleAnnotation(a, ComponentTypha+" podTemplateSpec")
 		}
 	}
@@ -257,17 +270,8 @@ func handleAnnotations(c *components, _ *operatorv1.Installation) error {
 
 // removeExpectedAnnotations returns the given annotations with common k8s-native annotations removed.
 // this function also accepts a second argument of additional annotations to remove.
-func removeExpectedAnnotations(existing, ignoreWithValue map[string]string, ignoreNoMatterWhatValue []string) map[string]string {
+func removeExpectedAnnotations(existing, ignoreWithValue map[string]string, toBeIgnoredAnnotationKeyRegExps []*regexp.Regexp) map[string]string {
 	a := existing
-	annotationKeyRegexps := make([]*regexp.Regexp, 0)
-	for _, annotationKey := range ignoreNoMatterWhatValue {
-		annotationKeyRegexp, err := regexp.Compile(annotationKey)
-		if err != nil {
-			log.Error(fmt.Errorf("%s is not a valid regular expression", annotationKey), "Error when removing expected annotations")
-			continue
-		}
-		annotationKeyRegexps = append(annotationKeyRegexps, annotationKeyRegexp)
-	}
 
 	for key, val := range existing {
 		if key == "deprecated.daemonset.template.generation" ||
@@ -282,7 +286,7 @@ func removeExpectedAnnotations(existing, ignoreWithValue map[string]string, igno
 			continue
 		}
 
-		for _, annotationKeyRegexp := range annotationKeyRegexps {
+		for _, annotationKeyRegexp := range toBeIgnoredAnnotationKeyRegExps {
 			if annotationKeyRegexp.MatchString(key) {
 				delete(a, key)
 				break

--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -458,8 +458,8 @@ var _ = Describe("core handler", func() {
 			It("should not error for acceptable annotations", func() {
 				updateAnnotations(map[string]string{
 					"kubectl.kubernetes.io/last-applied-configuration": "{}",
-					"kubectl.kubernetes.io/restartedAt": time.Now().String(),
-					"kubectl.kubernetes.io/whatever": "whatever",
+					"kubectl.kubernetes.io/restartedAt":                time.Now().String(),
+					"kubectl.kubernetes.io/whatever":                   "whatever",
 				})
 				Expect(handleAnnotations(&comps, i)).ToNot(HaveOccurred())
 			})

--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -3,6 +3,7 @@ package convert
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -455,7 +456,11 @@ var _ = Describe("core handler", func() {
 				Expect(handleAnnotations(&comps, i)).To(HaveOccurred())
 			})
 			It("should not error for acceptable annotations", func() {
-				updateAnnotations(map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{}"})
+				updateAnnotations(map[string]string{
+					"kubectl.kubernetes.io/last-applied-configuration": "{}",
+					"kubectl.kubernetes.io/restartedAt": time.Now().String(),
+					"kubectl.kubernetes.io/whatever": "whatever",
+				})
 				Expect(handleAnnotations(&comps, i)).ToNot(HaveOccurred())
 			})
 			It("should not panic for nil annotations", func() {

--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -1,9 +1,10 @@
 package convert
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
When the operator is first applied on a Calico cluster which is not managed by tigera-operator before, it will try to convert the cluster into an installation managed by the operator. One of the steps is it checks if the cluster's components has any incompatible annotation. During this check we need to ignore those annotations generated by kubectl, i.e. all the annotations start with `kubernetes.kubectl.io`.