### PR TITLE
Add label for ES gateway secrets

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -64,6 +64,11 @@ const (
 	defaultElasticsearchShards         = 1
 	defaultEckOperatorMemorySetting    = "512Mi"
 	DefaultElasticsearchStorageClass   = "tigera-elasticsearch"
+
+	// Mark any secret containing credentials for ES gateway with this label key/value. This will allow ES gateway to watch only the
+	// releveant secrets it needs.
+	ESGatewaySelectorLabel      = "esgateway.tigera.io/secrets"
+	ESGatewaySelectorLabelValue = "credentials"
 )
 
 // Add creates a new LogStorage Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -740,6 +745,9 @@ func (r *ReconcileLogStorage) createKubeControllersSecrets(ctx context.Context, 
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      render.ElasticsearchKubeControllersVerificationUserSecret,
 				Namespace: render.ElasticsearchNamespace,
+				Labels: map[string]string{
+					ESGatewaySelectorLabel: ESGatewaySelectorLabelValue,
+				},
 			},
 			Data: map[string][]byte{
 				"username": []byte(render.ElasticsearchKubeControllersUserName),
@@ -757,6 +765,9 @@ func (r *ReconcileLogStorage) createKubeControllersSecrets(ctx context.Context, 
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      render.ElasticsearchKubeControllersSecureUserSecret,
 				Namespace: render.ElasticsearchNamespace,
+				Labels: map[string]string{
+					ESGatewaySelectorLabel: ESGatewaySelectorLabelValue,
+				},
 			},
 			Data: map[string][]byte{
 				"username": []byte("elastic"),

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -132,7 +132,7 @@ func (e esGateway) esGatewayRole() *rbacv1.Role {
 				APIGroups:     []string{""},
 				Resources:     []string{"secrets"},
 				ResourceNames: []string{},
-				Verbs:         []string{"get"},
+				Verbs:         []string{"get", "list", "watch"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
- Adding new label for credential secrets that go to Tigera Elasticsearch namespace for ES gateway (so that it can easily filter to only the relevant secrets it needs to watch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
