### PR TITLE
Extract packet capture as a service

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tigera/operator/pkg/dns"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -120,6 +122,10 @@ func add(mgr manager.Manager, r *ReconcileAPIServer) error {
 		return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
 	}
 	if err = utils.AddSecretsWatch(c, "tigera-apiserver-certs", rmeta.OperatorNamespace()); err != nil {
+		return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
+	}
+
+	if err = utils.AddSecretsWatch(c, render.PacketCaptureCertSecret, rmeta.OperatorNamespace()); err != nil {
 		return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
 	}
 
@@ -284,6 +290,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
+	var components []render.Component
 	component, err := render.APIServer(k8sapi.Endpoint, network, false, managementCluster, managementClusterConnection, amazon, tlsSecret, pullSecrets, r.provider == operatorv1.ProviderOpenShift,
 		tunnelCASecret, r.clusterDomain)
 	if err != nil {
@@ -291,18 +298,70 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		r.status.SetDegraded("Error rendering APIServer", err.Error())
 		return reconcile.Result{}, err
 	}
+	components = append(components, component)
 
-	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
+	if variant == operatorv1.TigeraSecureEnterprise {
+
+		var serverCertSecret *v1.Secret
+		if network.CertificateManagement == nil {
+			serverCertSecret, err = utils.ValidateCertPair(r.client,
+				rmeta.OperatorNamespace(),
+				render.PacketCaptureCertSecret,
+				v1.TLSPrivateKeyKey,
+				v1.TLSCertKey,
+			)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("failed to retrieve / validate %s", render.PacketCaptureCertSecret))
+				r.status.SetDegraded(fmt.Sprintf("failed to retrieve / validate  %s", render.PacketCaptureCertSecret), err.Error())
+				return reconcile.Result{}, err
+			}
+
+			// Create the cert if doesn't exist. If the cert exists, check that the cert
+			// has the expected DNS names. If the cert doesn't and the cert is managed by the
+			// operator, the cert is recreated and returned. If the invalid cert is supplied by
+			// the user, set the component degraded.
+
+			serverCertSecret, err = utils.EnsureCertificateSecret(
+				render.PacketCaptureCertSecret, serverCertSecret, v1.TLSPrivateKeyKey, v1.TLSCertKey, rmeta.DefaultCertificateDuration, dns.GetServiceDNSNames(render.PacketCaptureServiceName, render.PacketCaptureNamespace, r.clusterDomain)...,
+			)
+			if err != nil {
+				r.status.SetDegraded(fmt.Sprintf("Error ensuring packetcapture-api TLS certificate %q exists and has valid DNS names", render.PacketCaptureCertSecret), err.Error())
+				return reconcile.Result{}, err
+			}
+		} else {
+			serverCertSecret = render.CreateCertificateSecret(network.CertificateManagement.CACert, render.PacketCaptureCertSecret, rmeta.OperatorNamespace())
+		}
+
+		// Fetch the Authentication spec. If present, we use to configure user authentication.
+		authenticationCR, err := utils.GetAuthentication(ctx, r.client)
+		if err != nil && !errors.IsNotFound(err) {
+			r.status.SetDegraded("Error querying Authentication", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		keyValidatorConfig, err := utils.GetKeyValidatorConfig(ctx, r.client, authenticationCR, r.clusterDomain)
+		if err != nil {
+			log.Error(err, "Failed to process the authentication CR.")
+			r.status.SetDegraded("Failed to process the authentication CR.", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		var pc = render.PacketCaptureAPI(pullSecrets, r.provider == operatorv1.ProviderOpenShift, network, keyValidatorConfig, serverCertSecret, r.clusterDomain)
+		components = append(components, pc)
+	}
+
+	if err = imageset.ApplyImageSet(ctx, r.client, variant, components...); err != nil {
 		log.Error(err, "Error with images from ImageSet")
 		r.status.SetDegraded("Error with images from ImageSet", err.Error())
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdateOrDelete(context.Background(), component, r.status); err != nil {
-		r.status.SetDegraded("Error creating / updating resource", err.Error())
-		return reconcile.Result{}, err
+	for _, component := range components {
+		if err := handler.CreateOrUpdateOrDelete(context.Background(), component, r.status); err != nil {
+			r.status.SetDegraded("Error creating / updating resource", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
-
 	// Clear the degraded bit if we've reached this far.
 	r.status.ClearDegraded()
 

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -132,6 +132,28 @@ var _ = Describe("apiserver controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentCSRInitContainer.Image,
 					components.ComponentCSRInitContainer.Version)))
+
+			pcDeployment := appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.PacketCaptureName,
+					Namespace: render.PacketCaptureNamespace,
+				},
+			}
+			Expect(test.GetResource(cli, &pcDeployment)).To(BeNil())
+			Expect(pcDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			pcContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.Containers, render.PacketCaptureContainerName)
+			Expect(pcContainer).ToNot(BeNil())
+			Expect(pcContainer.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s:%s",
+					components.ComponentPacketCapture.Image,
+					components.ComponentPacketCapture.Version)))
+			csrinitContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.InitContainers, render.CSRInitContainerName)
+			Expect(csrinitContainer).ToNot(BeNil())
+			Expect(csrinitContainer.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s:%s",
+					components.ComponentCSRInitContainer.Image,
+					components.ComponentCSRInitContainer.Version)))
 		})
 		It("should use images from imageset", func() {
 			Expect(cli.Create(ctx, &operatorv1.ImageSet{
@@ -141,6 +163,7 @@ var _ = Describe("apiserver controller tests", func() {
 						{Image: "tigera/cnx-apiserver", Digest: "sha256:apiserverhash"},
 						{Image: "tigera/cnx-queryserver", Digest: "sha256:queryserverhash"},
 						{Image: "tigera/key-cert-provisioner", Digest: "sha256:calicocsrinithash"},
+						{Image: "tigera/packetcapture-api", Digest: "sha256:packetcapturehash"},
 					},
 				},
 			})).ToNot(HaveOccurred())
@@ -178,6 +201,28 @@ var _ = Describe("apiserver controller tests", func() {
 			csrinit := test.GetContainer(d.Spec.Template.Spec.InitContainers, render.CSRInitContainerName)
 			Expect(csrinit).ToNot(BeNil())
 			Expect(csrinit.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s@%s",
+					components.ComponentCSRInitContainer.Image,
+					"sha256:calicocsrinithash")))
+
+			pcDeployment := appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.PacketCaptureName,
+					Namespace: render.PacketCaptureNamespace,
+				},
+			}
+			Expect(test.GetResource(cli, &pcDeployment)).To(BeNil())
+			Expect(pcDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			pcContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.Containers, render.PacketCaptureContainerName)
+			Expect(pcContainer).ToNot(BeNil())
+			Expect(pcContainer.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s@%s",
+					components.ComponentPacketCapture.Image,
+					"sha256:packetcapturehash")))
+			csrinitContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.InitContainers, render.CSRInitContainerName)
+			Expect(csrinitContainer).ToNot(BeNil())
+			Expect(csrinitContainer.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentCSRInitContainer.Image,
 					"sha256:calicocsrinithash")))

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -91,6 +91,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, render.GuardianSecretName, err)
 	}
 
+	// Watch for changes to the secrets associated with the PacketCapture APIs.
+	if err = utils.AddSecretsWatch(c, render.PacketCaptureCertSecret, rmeta.OperatorNamespace()); err != nil {
+		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, render.PacketCaptureCertSecret, err)
+	}
+
 	if err = utils.AddNetworkWatch(c); err != nil {
 		return fmt.Errorf("%s failed to watch Network resource: %w", controllerName, err)
 	}
@@ -165,11 +170,28 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 	tunnelSecret := &corev1.Secret{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: render.GuardianSecretName, Namespace: rmeta.OperatorNamespace()}, tunnelSecret)
 	if err != nil {
-		r.status.SetDegraded("Error copying secrets to the guardian namespace", err.Error())
+		r.status.SetDegraded("Error retrieving secrets to the guardian namespace", err.Error())
 		if !k8serrors.IsNotFound(err) {
 			return result, nil
 		}
 		return result, err
+	}
+
+	var packetCaptureServerCertSecret *corev1.Secret
+	packetCaptureServerCertSecret, err = utils.ValidateCertPair(r.Client,
+		rmeta.OperatorNamespace(),
+		render.PacketCaptureCertSecret,
+		"", // We don't need the key.
+		corev1.TLSCertKey,
+	)
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("failed to retrieve %s", render.PacketCaptureCertSecret))
+		r.status.SetDegraded(fmt.Sprintf("Failed to retrieve %s", render.PacketCaptureCertSecret), err.Error())
+		return reconcile.Result{}, err
+	} else if packetCaptureServerCertSecret == nil {
+		reqLogger.Info(fmt.Sprintf("Waiting for secret '%s' to become available", render.PacketCaptureCertSecret))
+		r.status.SetDegraded(fmt.Sprintf("Waiting for secret '%s' to become available", render.PacketCaptureCertSecret), "")
+		return reconcile.Result{}, nil
 	}
 
 	ch := utils.NewComponentHandler(log, r.Client, r.Scheme, managementClusterConnection)
@@ -179,6 +201,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		r.Provider == operatorv1.ProviderOpenShift,
 		instl,
 		tunnelSecret,
+		packetCaptureServerCertSecret,
 	)
 
 	if err = imageset.ApplyImageSet(ctx, r.Client, variant, component); err != nil {

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -170,7 +170,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 	tunnelSecret := &corev1.Secret{}
 	err = r.Client.Get(ctx, types.NamespacedName{Name: render.GuardianSecretName, Namespace: rmeta.OperatorNamespace()}, tunnelSecret)
 	if err != nil {
-		r.status.SetDegraded("Error retrieving secrets to the guardian namespace", err.Error())
+		r.status.SetDegraded("Error retrieving secrets from guardian namespace", err.Error())
 		if !k8serrors.IsNotFound(err) {
 			return result, nil
 		}

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -69,6 +69,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		mockStatus.On("AddStatefulSets", mock.Anything)
 		mockStatus.On("AddCronJobs", mock.Anything)
 		mockStatus.On("ClearDegraded", mock.Anything)
+		mockStatus.On("SetDegraded", mock.Anything)
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ReadyToMonitor")
 
@@ -91,6 +92,17 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 			},
 		}
 		c.Create(ctx, secret)
+		pcSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.PacketCaptureCertSecret,
+				Namespace: rmeta.OperatorNamespace(),
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("foo"),
+				"tls.key": []byte("bar"),
+			},
+		}
+		c.Create(ctx, pcSecret)
 
 		By("applying the required prerequisites")
 		// Create a ManagementClusterConnection in the k8s client.

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -99,6 +99,7 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("OnCRFound").Return()
 			mockStatus.On("ClearDegraded")
 			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+			mockStatus.On("SetDegraded", "Waiting for secret 'tigera-packetcapture-server-tls' to become available", "").Return().Maybe()
 			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
@@ -160,6 +161,17 @@ var _ = Describe("Manager controller tests", func() {
 			Expect(c.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      render.ComplianceServerCertSecret,
+					Namespace: rmeta.OperatorNamespace(),
+				},
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				Data: map[string][]byte{
+					"tls.crt": []byte("crt"),
+					"tls.key": []byte("crt"),
+				},
+			})).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.PacketCaptureCertSecret,
 					Namespace: rmeta.OperatorNamespace(),
 				},
 				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
@@ -325,6 +337,7 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("OnCRFound").Return()
 			mockStatus.On("ClearDegraded")
 			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+			mockStatus.On("SetDegraded", "Waiting for secret 'tigera-packetcapture-server-tls' to become available", "").Return().Maybe()
 			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
@@ -393,6 +406,17 @@ var _ = Describe("Manager controller tests", func() {
 					"tls.key": []byte("crt"),
 				},
 			})).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.PacketCaptureCertSecret,
+					Namespace: rmeta.OperatorNamespace(),
+				},
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				Data: map[string][]byte{
+					"tls.crt": []byte("crt"),
+					"tls.key": []byte("crt"),
+				},
+			})).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      render.ECKLicenseConfigMapName,
@@ -422,7 +446,7 @@ var _ = Describe("Manager controller tests", func() {
 				},
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(4))
+			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
 			mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
 			Expect(mgr).ToNot(BeNil())
 			Expect(mgr.Image).To(Equal(
@@ -441,12 +465,6 @@ var _ = Describe("Manager controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentManagerProxy.Image,
 					components.ComponentManagerProxy.Version)))
-			packetCapture := test.GetContainer(d.Spec.Template.Spec.Containers, render.PacketCaptureServer)
-			Expect(packetCapture).ToNot(BeNil())
-			Expect(packetCapture.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s:%s",
-					components.ComponentPacketCapture.Image,
-					components.ComponentPacketCapture.Version)))
 		})
 		It("should use images from imageset", func() {
 			Expect(c.Create(ctx, &operatorv1.ImageSet{
@@ -456,7 +474,6 @@ var _ = Describe("Manager controller tests", func() {
 						{Image: "tigera/cnx-manager", Digest: "sha256:cnxmanagerhash"},
 						{Image: "tigera/es-proxy", Digest: "sha256:esproxyhash"},
 						{Image: "tigera/voltron", Digest: "sha256:voltronhash"},
-						{Image: "tigera/packetcapture-api", Digest: "sha256:packetcapturehash"},
 					},
 				},
 			})).ToNot(HaveOccurred())
@@ -471,7 +488,7 @@ var _ = Describe("Manager controller tests", func() {
 				},
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(4))
+			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
 			mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
 			Expect(mgr).ToNot(BeNil())
 			Expect(mgr.Image).To(Equal(
@@ -490,12 +507,6 @@ var _ = Describe("Manager controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentManagerProxy.Image,
 					"sha256:voltronhash")))
-			packetCapture := test.GetContainer(d.Spec.Template.Spec.Containers, render.PacketCaptureServer)
-			Expect(packetCapture).ToNot(BeNil())
-			Expect(packetCapture.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s@%s",
-					components.ComponentPacketCapture.Image,
-					"sha256:packetcapturehash")))
 		})
 	})
 })

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -395,8 +395,8 @@ func (c *fluentdComponent) packetCaptureApiRoleBinding() *rbacv1.RoleBinding {
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      ManagerServiceAccount,
-				Namespace: ManagerNamespace,
+				Name:      PacketCaptureServiceAccountName,
+				Namespace: PacketCaptureNamespace,
 			},
 		},
 	}

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -139,8 +139,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		Expect(podExecRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      render.ManagerServiceAccount,
-				Namespace: render.ManagerNamespace,
+				Name:      render.PacketCaptureServiceAccountName,
+				Namespace: render.PacketCaptureNamespace,
 			},
 		}))
 	})

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -46,6 +46,17 @@ var _ = Describe("Rendering tests", func() {
 				"key":  []byte("bar"),
 			},
 		}
+		packetCaptureSecret := &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.PacketCaptureCertSecret,
+				Namespace: rmeta.OperatorNamespace(),
+			},
+			Data: map[string][]byte{
+				"tls.crt": []byte("foo"),
+				"tls.key": []byte("bar"),
+			},
+		}
 		g = render.Guardian(
 			addr,
 			[]*corev1.Secret{{
@@ -58,6 +69,7 @@ var _ = Describe("Rendering tests", func() {
 			false,
 			&i,
 			secret,
+			packetCaptureSecret,
 		)
 		Expect(g.ResolveImages(nil)).To(BeNil())
 		resources, _ = g.Objects()
@@ -84,6 +96,7 @@ var _ = Describe("Rendering tests", func() {
 			{name: render.GuardianDeploymentName, ns: render.GuardianNamespace, group: "apps", version: "v1", kind: "Deployment"},
 			{name: render.GuardianServiceName, ns: render.GuardianNamespace, group: "", version: "", kind: ""},
 			{name: render.GuardianSecretName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.PacketCaptureCertSecret, ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: render.ManagerNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -68,8 +68,6 @@ const (
 
 	KibanaTLSHashAnnotation         = "hash.operator.tigera.io/kibana-secrets"
 	ElasticsearchUserHashAnnotation = "hash.operator.tigera.io/elasticsearch-user"
-
-	PacketCaptureServer = "tigera-packetcapture-server"
 )
 
 // ManagementClusterConnection configuration constants
@@ -88,6 +86,7 @@ func Manager(
 	esSecrets []*corev1.Secret,
 	kibanaSecrets []*corev1.Secret,
 	complianceServerCertSecret *corev1.Secret,
+	packetCaptureServerCertSecret *corev1.Secret,
 	esClusterConfig *relasticsearch.ClusterConfig,
 	tlsKeyPair *corev1.Secret,
 	pullSecrets []*corev1.Secret,
@@ -128,41 +127,42 @@ func Manager(
 		tlsAnnotations[ManagerInternalTLSHashAnnotation] = rmeta.AnnotationHash(internalTrafficSecret.Data)
 	}
 	return &managerComponent{
-		keyValidatorConfig:         keyValidatorConfig,
-		esSecrets:                  esSecrets,
-		kibanaSecrets:              kibanaSecrets,
-		complianceServerCertSecret: complianceServerCertSecret,
-		esClusterConfig:            esClusterConfig,
-		tlsSecrets:                 tlsSecrets,
-		tlsAnnotations:             tlsAnnotations,
-		pullSecrets:                pullSecrets,
-		openshift:                  openshift,
-		clusterDomain:              clusterDomain,
-		installation:               installation,
-		managementCluster:          managementCluster,
-		esLicenseType:              esLicenseType,
+		keyValidatorConfig:            keyValidatorConfig,
+		esSecrets:                     esSecrets,
+		kibanaSecrets:                 kibanaSecrets,
+		complianceServerCertSecret:    complianceServerCertSecret,
+		packetCaptureServerCertSecret: packetCaptureServerCertSecret,
+		esClusterConfig:               esClusterConfig,
+		tlsSecrets:                    tlsSecrets,
+		tlsAnnotations:                tlsAnnotations,
+		pullSecrets:                   pullSecrets,
+		openshift:                     openshift,
+		clusterDomain:                 clusterDomain,
+		installation:                  installation,
+		managementCluster:             managementCluster,
+		esLicenseType:                 esLicenseType,
 	}, nil
 }
 
 type managerComponent struct {
-	keyValidatorConfig         authentication.KeyValidatorConfig
-	esSecrets                  []*corev1.Secret
-	kibanaSecrets              []*corev1.Secret
-	complianceServerCertSecret *corev1.Secret
-	esClusterConfig            *relasticsearch.ClusterConfig
-	tlsSecrets                 []*corev1.Secret
-	tlsAnnotations             map[string]string
-	pullSecrets                []*corev1.Secret
-	openshift                  bool
-	clusterDomain              string
-	installation               *operator.InstallationSpec
-	managementCluster          *operator.ManagementCluster
-	esLicenseType              ElasticsearchLicenseType
-	managerImage               string
-	proxyImage                 string
-	esProxyImage               string
-	packetCaptureImage         string
-	csrInitImage               string
+	keyValidatorConfig            authentication.KeyValidatorConfig
+	esSecrets                     []*corev1.Secret
+	kibanaSecrets                 []*corev1.Secret
+	complianceServerCertSecret    *corev1.Secret
+	packetCaptureServerCertSecret *corev1.Secret
+	esClusterConfig               *relasticsearch.ClusterConfig
+	tlsSecrets                    []*corev1.Secret
+	tlsAnnotations                map[string]string
+	pullSecrets                   []*corev1.Secret
+	openshift                     bool
+	clusterDomain                 string
+	installation                  *operator.InstallationSpec
+	managementCluster             *operator.ManagementCluster
+	esLicenseType                 ElasticsearchLicenseType
+	managerImage                  string
+	proxyImage                    string
+	esProxyImage                  string
+	csrInitImage                  string
 }
 
 func (c *managerComponent) ResolveImages(is *operator.ImageSet) error {
@@ -182,11 +182,6 @@ func (c *managerComponent) ResolveImages(is *operator.ImageSet) error {
 	}
 
 	c.esProxyImage, err = components.GetReference(components.ComponentEsProxy, reg, path, prefix, is)
-	if err != nil {
-		errMsgs = append(errMsgs, err.Error())
-	}
-
-	c.packetCaptureImage, err = components.GetReference(components.ComponentPacketCapture, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
@@ -236,6 +231,9 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	if c.complianceServerCertSecret != nil {
 		objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ManagerNamespace, c.complianceServerCertSecret)...)...)
 	}
+	if c.packetCaptureServerCertSecret != nil {
+		objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ManagerNamespace, c.packetCaptureServerCertSecret)...)...)
+	}
 	objs = append(objs, c.managerDeployment())
 	if c.keyValidatorConfig != nil {
 		objs = append(objs, configmap.ToRuntimeObjects(c.keyValidatorConfig.RequiredConfigMaps(ManagerNamespace)...)...)
@@ -270,6 +268,10 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 
 	if c.complianceServerCertSecret != nil {
 		annotations[complianceServerTLSHashAnnotation] = rmeta.AnnotationHash(c.complianceServerCertSecret.Data)
+	}
+
+	if c.packetCaptureServerCertSecret != nil {
+		annotations[PacketCaptureTLSHashAnnotation] = rmeta.AnnotationHash(c.packetCaptureServerCertSecret.Data)
 	}
 
 	// Add a hash of the Secret to ensure if it changes the manager will be
@@ -313,7 +315,6 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 				relasticsearch.ContainerDecorate(c.managerContainer(), c.esClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.clusterDomain, c.SupportedOSType()),
 				relasticsearch.ContainerDecorate(c.managerEsProxyContainer(), c.esClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.clusterDomain, c.SupportedOSType()),
 				c.managerProxyContainer(),
-				c.managerPacketCaptureContainer(),
 			},
 			Volumes: c.managerVolumes(),
 		}),
@@ -384,6 +385,21 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 						Path: "tls.crt",
 					}},
 					SecretName: ComplianceServerCertSecret,
+				},
+			},
+		})
+	}
+
+	if c.packetCaptureServerCertSecret != nil {
+		v = append(v, v1.Volume{
+			Name: PacketCaptureCertSecret,
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					Items: []v1.KeyToPath{{
+						Key:  "tls.crt",
+						Path: "tls.crt",
+					}},
+					SecretName: PacketCaptureCertSecret,
 				},
 			},
 		})
@@ -478,21 +494,6 @@ func (c *managerComponent) managerProxyProbe() *v1.Probe {
 	}
 }
 
-// managerPacketCaptureLivenessProbe returns the probe for the PacketCapture API container.
-func (c *managerComponent) managerPacketCaptureLivenessProbe() *v1.Probe {
-	return &corev1.Probe{
-		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path:   "/packetcapture/health",
-				Port:   intstr.FromInt(managerPort),
-				Scheme: corev1.URISchemeHTTPS,
-			},
-		},
-		InitialDelaySeconds: 90,
-		PeriodSeconds:       10,
-	}
-}
-
 // managerEnvVars returns the envvars for the manager container.
 func (c *managerComponent) managerEnvVars() []v1.EnvVar {
 	envs := []v1.EnvVar{
@@ -552,7 +553,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 	env := []corev1.EnvVar{
 		{Name: "VOLTRON_PORT", Value: defaultVoltronPort},
 		{Name: "VOLTRON_COMPLIANCE_ENDPOINT", Value: fmt.Sprintf("https://compliance.%s.svc.%s", ComplianceNamespace, c.clusterDomain)},
-		{Name: "VOLTRON_LOGLEVEL", Value: "info"},
+		{Name: "VOLTRON_LOGLEVEL", Value: "Info"},
 		{Name: "VOLTRON_KIBANA_ENDPOINT", Value: rkibana.HTTPSEndpoint(c.SupportedOSType(), c.clusterDomain)},
 		{Name: "VOLTRON_KIBANA_BASE_PATH", Value: fmt.Sprintf("/%s/", KibanaBasePath)},
 		{Name: "VOLTRON_KIBANA_CA_BUNDLE_PATH", Value: "/certs/kibana/tls.crt"},
@@ -579,32 +580,6 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 	}
 }
 
-// managerPacketCaptureContainer returns the manager container.
-func (c *managerComponent) managerPacketCaptureContainer() corev1.Container {
-	var volumeMounts []corev1.VolumeMount
-	if c.managementCluster != nil {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: ManagerInternalTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true})
-	}
-
-	env := []v1.EnvVar{
-		{Name: "PACKETCAPTURE_API_LOG_LEVEL", Value: "Info"},
-	}
-
-	if c.keyValidatorConfig != nil {
-		env = append(env, c.keyValidatorConfig.RequiredEnv("PACKETCAPTURE_API")...)
-		volumeMounts = append(volumeMounts, c.keyValidatorConfig.RequiredVolumeMounts()...)
-	}
-
-	return corev1.Container{
-		Name:            PacketCaptureServer,
-		Image:           c.packetCaptureImage,
-		LivenessProbe:   c.managerPacketCaptureLivenessProbe(),
-		SecurityContext: podsecuritycontext.NewBaseContext(),
-		Env:             env,
-		VolumeMounts:    volumeMounts,
-	}
-}
-
 func (c *managerComponent) volumeMountsForProxyManager() []v1.VolumeMount {
 	var mounts = []corev1.VolumeMount{
 		{Name: ManagerTLSSecretName, MountPath: "/certs/https", ReadOnly: true},
@@ -613,6 +588,10 @@ func (c *managerComponent) volumeMountsForProxyManager() []v1.VolumeMount {
 
 	if c.complianceServerCertSecret != nil {
 		mounts = append(mounts, corev1.VolumeMount{Name: ComplianceServerCertSecret, MountPath: "/certs/compliance", ReadOnly: true})
+	}
+
+	if c.packetCaptureServerCertSecret != nil {
+		mounts = append(mounts, corev1.VolumeMount{Name: PacketCaptureCertSecret, MountPath: "/certs/packetcapture", ReadOnly: true})
 	}
 
 	if c.managementCluster != nil {
@@ -731,13 +710,6 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
-					"packetcaptures",
-				},
-				Verbs: []string{"get"},
-			},
-			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{
 					"hostendpoints",
 				},
 				Verbs: []string{"list"},
@@ -783,12 +755,10 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 		)
 	}
 
-	if !managedCluster {
+	if managementCluster {
 		// For cross-cluster requests an authentication review will be done for authenticating the tigera-manager.
 		// Requests on behalf of the tigera-manager will be sent to Voltron, where an authentication review will
 		// take place with its bearer token.
-		// In addition, PacketCapture API uses authentication reviews to authenticate the users and then perform
-		// SubjectAccessReviews in order to enforce RBAC on this API
 		cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"authenticationreviews"},

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -1,0 +1,340 @@
+// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/render/common/authentication"
+	"github.com/tigera/operator/pkg/render/common/configmap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/podsecuritycontext"
+	"github.com/tigera/operator/pkg/render/common/secret"
+)
+
+// The names of the components related to the PacketCapture APIs related rendered objects.
+const (
+	PacketCaptureContainerName          = "tigera-packetcapture-server"
+	PacketCaptureName                   = "tigera-packetcapture"
+	PacketCaptureNamespace              = PacketCaptureName
+	PacketCaptureServiceAccountName     = PacketCaptureName
+	PacketCaptureClusterRoleName        = PacketCaptureName
+	PacketCaptureClusterRoleBindingName = PacketCaptureName
+	PacketCaptureDeploymentName         = PacketCaptureName
+	PacketCaptureServiceName            = PacketCaptureName
+
+	PacketCaptureCertSecret        = "tigera-packetcapture-server-tls"
+	PacketCaptureTLSHashAnnotation = "hash.operator.tigera.io/packetcapture-certificate"
+)
+
+type packetCaptureApiComponent struct {
+	pullSecrets        []*v1.Secret
+	openshift          bool
+	installation       *operatorv1.InstallationSpec
+	image              string
+	csrInitImage       string
+	keyValidatorConfig authentication.KeyValidatorConfig
+	serverCertSecret   *corev1.Secret
+	clusterDomain      string
+}
+
+func PacketCaptureAPI(pullSecrets []*v1.Secret, openshift bool,
+	installation *operatorv1.InstallationSpec,
+	keyValidatorConfig authentication.KeyValidatorConfig,
+	serverCertSecret *corev1.Secret,
+	clusterDomain string) Component {
+
+	return &packetCaptureApiComponent{
+		pullSecrets:        pullSecrets,
+		openshift:          openshift,
+		installation:       installation,
+		keyValidatorConfig: keyValidatorConfig,
+		serverCertSecret:   serverCertSecret,
+		clusterDomain:      clusterDomain,
+	}
+}
+
+func (pc *packetCaptureApiComponent) ResolveImages(is *operatorv1.ImageSet) error {
+	reg := pc.installation.Registry
+	path := pc.installation.ImagePath
+	prefix := pc.installation.ImagePrefix
+
+	var err error
+	var errMsg []string
+	pc.image, err = components.GetReference(components.ComponentPacketCapture, reg, path, prefix, is)
+	if err != nil {
+		errMsg = append(errMsg, err.Error())
+	}
+
+	if pc.installation.CertificateManagement != nil {
+		pc.csrInitImage, err = ResolveCSRInitImage(pc.installation, is)
+		if err != nil {
+			errMsg = append(errMsg, err.Error())
+		}
+	}
+
+	if len(errMsg) != 0 {
+		return fmt.Errorf(strings.Join(errMsg, ","))
+	}
+
+	return nil
+}
+
+func (pc *packetCaptureApiComponent) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeLinux
+}
+
+func (pc *packetCaptureApiComponent) Objects() ([]client.Object, []client.Object) {
+	objs := []client.Object{
+		createNamespace(PacketCaptureNamespace, pc.installation.KubernetesProvider),
+	}
+	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(PacketCaptureNamespace, pc.pullSecrets...)...)...)
+	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(PacketCaptureNamespace, pc.serverCertSecret)...)...)
+
+	objs = append(objs,
+		pc.serviceAccount(),
+		pc.clusterRole(),
+		pc.clusterRoleBinding(),
+		pc.deployment(),
+		pc.service(),
+	)
+
+	if pc.keyValidatorConfig != nil {
+		objs = append(objs, secret.ToRuntimeObjects(pc.keyValidatorConfig.RequiredSecrets(PacketCaptureNamespace)...)...)
+		objs = append(objs, configmap.ToRuntimeObjects(pc.keyValidatorConfig.RequiredConfigMaps(PacketCaptureNamespace)...)...)
+	}
+
+	if pc.installation.CertificateManagement != nil {
+		objs = append(objs, CsrClusterRoleBinding(PacketCaptureServiceName, PacketCaptureNamespace))
+	}
+
+	return objs, nil
+}
+
+func (pc *packetCaptureApiComponent) Ready() bool {
+	return true
+}
+
+func (pc *packetCaptureApiComponent) service() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PacketCaptureServiceName,
+			Namespace: PacketCaptureNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"k8s-app": PacketCaptureName,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       PacketCaptureName,
+					Port:       443,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(8444),
+				},
+			},
+		},
+	}
+}
+
+func (pc *packetCaptureApiComponent) serviceAccount() client.Object {
+	return &v1.ServiceAccount{
+		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: PacketCaptureServiceAccountName, Namespace: PacketCaptureNamespace},
+	}
+}
+
+func (pc *packetCaptureApiComponent) clusterRole() client.Object {
+
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"authorization.k8s.io"},
+			Resources: []string{"subjectaccessreviews"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"authenticationreviews"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"packetcaptures"},
+			Verbs:     []string{"get"},
+		},
+	}
+
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: PacketCaptureClusterRoleName,
+		},
+		Rules: rules,
+	}
+}
+
+func (pc *packetCaptureApiComponent) clusterRoleBinding() client.Object {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: PacketCaptureClusterRoleBindingName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     PacketCaptureClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      PacketCaptureServiceAccountName,
+				Namespace: PacketCaptureNamespace,
+			},
+		},
+	}
+}
+
+func (pc *packetCaptureApiComponent) deployment() client.Object {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PacketCaptureDeploymentName,
+			Namespace: PacketCaptureNamespace,
+			Labels: map[string]string{
+				"k8s-app": PacketCaptureName,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k8s-app": PacketCaptureName,
+				},
+			},
+			Replicas: &replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PacketCaptureDeploymentName,
+					Namespace: PacketCaptureNamespace,
+					Labels: map[string]string{
+						"k8s-app": PacketCaptureName,
+					},
+					Annotations: pc.annotations(),
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector:       pc.installation.ControlPlaneNodeSelector,
+					ServiceAccountName: PacketCaptureServiceAccountName,
+					Tolerations:        append(pc.installation.ControlPlaneTolerations, rmeta.TolerateMaster, rmeta.TolerateCriticalAddonsOnly),
+					ImagePullSecrets:   secret.GetReferenceList(pc.pullSecrets),
+					InitContainers:     pc.initContainers(),
+					Containers:         []corev1.Container{pc.container()},
+					Volumes:            pc.volumes(),
+				},
+			},
+		},
+	}
+}
+
+func (pc *packetCaptureApiComponent) initContainers() []v1.Container {
+	var initContainers []corev1.Container
+	if pc.installation.CertificateManagement != nil {
+		initContainers = append(initContainers, CreateCSRInitContainer(
+			pc.installation.CertificateManagement,
+			pc.csrInitImage,
+			PacketCaptureCertSecret,
+			PacketCaptureServiceName,
+			APIServerSecretKeyName,
+			APIServerSecretCertName,
+			dns.GetServiceDNSNames(PacketCaptureServiceName, PacketCaptureNamespace, pc.clusterDomain),
+			PacketCaptureNamespace))
+	}
+	return initContainers
+}
+
+func (pc *packetCaptureApiComponent) container() corev1.Container {
+	var volumeMounts = []corev1.VolumeMount{{
+		Name:      PacketCaptureCertSecret,
+		MountPath: "/certs/https",
+		ReadOnly:  true,
+	}}
+	env := []v1.EnvVar{
+		{Name: "PACKETCAPTURE_API_LOG_LEVEL", Value: "Info"},
+	}
+
+	if pc.keyValidatorConfig != nil {
+		env = append(env, pc.keyValidatorConfig.RequiredEnv("PACKETCAPTURE_API_")...)
+		volumeMounts = append(volumeMounts, pc.keyValidatorConfig.RequiredVolumeMounts()...)
+	}
+
+	return corev1.Container{
+		Name:            PacketCaptureContainerName,
+		Image:           pc.image,
+		LivenessProbe:   pc.healthProbe(),
+		ReadinessProbe:  pc.healthProbe(),
+		SecurityContext: podsecuritycontext.NewBaseContext(),
+		Env:             env,
+		VolumeMounts:    volumeMounts,
+	}
+}
+
+func (pc *packetCaptureApiComponent) healthProbe() *v1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/health",
+				Port:   intstr.FromInt(8444),
+				Scheme: corev1.URISchemeHTTPS,
+			},
+		},
+		InitialDelaySeconds: 90,
+		PeriodSeconds:       10,
+	}
+}
+
+func (pc *packetCaptureApiComponent) volumes() []corev1.Volume {
+	var volumes = []corev1.Volume{{
+		Name:         PacketCaptureCertSecret,
+		VolumeSource: certificateVolumeSource(pc.installation.CertificateManagement, PacketCaptureCertSecret),
+	}}
+
+	if pc.keyValidatorConfig != nil {
+		volumes = append(volumes, pc.keyValidatorConfig.RequiredVolumes()...)
+	}
+
+	return volumes
+}
+
+func (pc *packetCaptureApiComponent) annotations() map[string]string {
+	var annotations = map[string]string{
+		PacketCaptureTLSHashAnnotation: rmeta.AnnotationHash(pc.serverCertSecret.Data),
+	}
+
+	return annotations
+}

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/packetcapture_api_test.go
+++ b/pkg/render/packetcapture_api_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/packetcapture_api_test.go
+++ b/pkg/render/packetcapture_api_test.go
@@ -1,0 +1,373 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render_test
+
+import (
+	"fmt"
+
+	"github.com/tigera/operator/pkg/dns"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	operator "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/ptr"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/authentication"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	rtest "github.com/tigera/operator/pkg/render/common/test"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Rendering tests for PacketCapture API component", func() {
+
+	// Certificate secret
+	var secret = &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.PacketCaptureCertSecret,
+			Namespace: rmeta.OperatorNamespace(),
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte("foo"),
+			"tls.key": []byte("bar"),
+		},
+	}
+	// Pull secret
+	var pullSecrets = []*corev1.Secret{{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pull-secret",
+			Namespace: rmeta.OperatorNamespace(),
+		},
+	}}
+	// Installation with minimal setup
+	var defaultInstallation = operator.InstallationSpec{}
+
+	// Rendering packet capture resources
+	var renderPacketCapture = func(i operator.InstallationSpec, config authentication.KeyValidatorConfig) (resources []client.Object) {
+		var pc = render.PacketCaptureAPI(
+			pullSecrets,
+			false,
+			&i,
+			config,
+			secret,
+			"",
+		)
+		Expect(pc.ResolveImages(nil)).To(BeNil())
+		resources, _ = pc.Objects()
+		return resources
+	}
+
+	type expectedResource struct {
+		name    string
+		ns      string
+		group   string
+		version string
+		kind    string
+	}
+	// Generate expected resources
+	var expectedResources = func(useCSR, enableOIDC bool) []expectedResource {
+		var resources = []expectedResource{
+			{name: render.PacketCaptureNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: "pull-secret", ns: render.PacketCaptureNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.PacketCaptureCertSecret, ns: render.PacketCaptureNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.PacketCaptureServiceAccountName, ns: render.PacketCaptureNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+			{name: render.PacketCaptureClusterRoleName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: render.PacketCaptureClusterRoleBindingName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: render.PacketCaptureDeploymentName, ns: render.PacketCaptureNamespace, group: "apps", version: "v1", kind: "Deployment"},
+			{name: render.PacketCaptureServiceName, ns: render.PacketCaptureNamespace, group: "", version: "v1", kind: "Service"},
+		}
+
+		if enableOIDC {
+			var oidc = []expectedResource{
+				{name: "tigera-dex-tls", ns: render.PacketCaptureNamespace, group: "", version: "v1", kind: "Secret"},
+			}
+			resources = append(resources, oidc...)
+		}
+
+		if useCSR {
+			resources = append(resources, expectedResource{"tigera-packetcapture:csr-creator", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"})
+		}
+
+		return resources
+
+	}
+
+	// Generate expected environment variables
+	var expectedEnvVars = func(enableOIDC bool) []corev1.EnvVar {
+		var envVars = []corev1.EnvVar{
+			{Name: "PACKETCAPTURE_API_LOG_LEVEL", Value: "Info"},
+		}
+
+		if enableOIDC {
+			envVars = append(envVars, []corev1.EnvVar{
+				{
+					Name:  "PACKETCAPTURE_API_DEX_ENABLED",
+					Value: "true",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_DEX_URL",
+					Value: "https://tigera-dex.tigera-dex.svc.cluster.local:5556/",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_ENABLED",
+					Value: "true",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_ISSUER",
+					Value: "https://127.0.0.1/dex",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_JWKSURL",
+					Value: "https://tigera-dex.tigera-dex.svc.cluster.local:5556/dex/keys",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_CLIENT_ID",
+					Value: "tigera-manager",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_USERNAME_CLAIM",
+					Value: "email",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_GROUPS_CLAIM",
+					Value: "groups",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_USERNAME_PREFIX",
+					Value: "",
+				},
+				{
+					Name:  "PACKETCAPTURE_API_OIDC_AUTH_GROUPS_PREFIX",
+					Value: "",
+				},
+			}...)
+		}
+
+		return envVars
+	}
+
+	// Generate expected volume mounts
+	var expectedVolumeMounts = func(enableOIDC bool) []corev1.VolumeMount {
+		var volumeMounts = []corev1.VolumeMount{
+			{
+				Name:      render.PacketCaptureCertSecret,
+				MountPath: "/certs/https",
+				ReadOnly:  true,
+			},
+		}
+		if enableOIDC {
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      "tigera-dex-tls-crt",
+				ReadOnly:  false,
+				MountPath: "/etc/ssl/certs",
+			})
+		}
+		return volumeMounts
+	}
+	// Generate expected containers
+	var expectedContainers = func(enableOIDC bool) []corev1.Container {
+		var volumeMounts = expectedVolumeMounts(enableOIDC)
+		var envVars = expectedEnvVars(enableOIDC)
+
+		return []corev1.Container{
+			{
+				Name:  render.PacketCaptureContainerName,
+				Image: fmt.Sprintf("%s%s:%s", components.TigeraRegistry, components.ComponentPacketCapture.Image, components.ComponentPacketCapture.Version),
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot:             ptr.BoolToPtr(true),
+					AllowPrivilegeEscalation: ptr.BoolToPtr(false),
+				},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/health",
+							Port:   intstr.FromInt(8444),
+							Scheme: corev1.URISchemeHTTPS,
+						},
+					},
+					InitialDelaySeconds: 90,
+					PeriodSeconds:       10,
+				},
+				LivenessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/health",
+							Port:   intstr.FromInt(8444),
+							Scheme: corev1.URISchemeHTTPS,
+						},
+					},
+					InitialDelaySeconds: 90,
+					PeriodSeconds:       10,
+				},
+				Env:          envVars,
+				VolumeMounts: volumeMounts,
+			},
+		}
+	}
+
+	// Generate expected volumes
+	var expectedVolumes = func(useCSR, enableOIDC bool) []corev1.Volume {
+		var volumes []corev1.Volume
+		if useCSR {
+			volumes = append(volumes, corev1.Volume{
+				Name: render.PacketCaptureCertSecret,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			})
+		} else {
+
+			volumes = append(volumes, corev1.Volume{
+				Name: render.PacketCaptureCertSecret,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  render.PacketCaptureCertSecret,
+						DefaultMode: ptr.Int32ToPtr(420),
+					},
+				},
+			})
+
+		}
+		if enableOIDC {
+			volumes = append(volumes, corev1.Volume{
+				Name: render.DexCertSecretName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: render.DexCertSecretName,
+						Items: []corev1.KeyToPath{
+							{Key: corev1.TLSCertKey, Path: "tls-dex.crt"},
+						},
+					},
+				},
+			})
+		}
+
+		return volumes
+	}
+
+	var checkPacketCaptureResources = func(resources []client.Object, useCSR, enableOIDC bool) {
+		for i, expectedRes := range expectedResources(useCSR, enableOIDC) {
+			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+		}
+		Expect(len(resources)).To(Equal(len(expectedResources(useCSR, enableOIDC))))
+
+		// Check deployment
+		deployment := rtest.GetResource(resources, render.PacketCaptureDeploymentName, render.PacketCaptureNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deployment).NotTo(BeNil())
+
+		// Check containers
+		Expect(deployment.Spec.Template.Spec.Containers).To(ConsistOf(expectedContainers(enableOIDC)))
+
+		// Check init containers
+		if useCSR {
+			Expect(len(deployment.Spec.Template.Spec.InitContainers)).To(Equal(1))
+			Expect(deployment.Spec.Template.Spec.InitContainers[0].Name).To(Equal(render.CSRInitContainerName))
+		}
+
+		// Check volumes
+		Expect(deployment.Spec.Template.Spec.Volumes).To(ConsistOf(expectedVolumes(useCSR, enableOIDC)))
+
+		// Check annotations
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(render.PacketCaptureTLSHashAnnotation, Not(BeEmpty())))
+
+		// Check permissions
+		clusterRole := rtest.GetResource(resources, render.PacketCaptureClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(clusterRole.Rules).To(ConsistOf([]rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"authenticationreviews"},
+				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"packetcaptures"},
+				Verbs:     []string{"get"},
+			},
+		}))
+		clusterRoleBinding := rtest.GetResource(resources, render.PacketCaptureClusterRoleBindingName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+		Expect(clusterRoleBinding.RoleRef.Name).To(Equal(render.PacketCaptureClusterRoleName))
+		Expect(clusterRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      render.PacketCaptureServiceAccountName,
+				Namespace: render.PacketCaptureNamespace,
+			},
+		}))
+
+		// Check service
+		service := rtest.GetResource(resources, render.PacketCaptureServiceName, render.PacketCaptureNamespace, "", "v1", "Service").(*corev1.Service)
+		Expect(service.Spec.Ports).To(ConsistOf([]corev1.ServicePort{
+			{
+				Name:       render.PacketCaptureName,
+				Port:       443,
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt(8444),
+			}}))
+	}
+
+	It("should render all resources for default installation", func() {
+		var resources = renderPacketCapture(defaultInstallation, nil)
+
+		checkPacketCaptureResources(resources, false, false)
+	})
+
+	It("should render controlPlaneTolerations", func() {
+		t := corev1.Toleration{
+			Key:      "foo",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "bar",
+		}
+		var resources = renderPacketCapture(operator.InstallationSpec{
+			ControlPlaneTolerations: []corev1.Toleration{t},
+		}, nil)
+
+		checkPacketCaptureResources(resources, false, false)
+
+		deployment := rtest.GetResource(resources, render.PacketCaptureDeploymentName, render.PacketCaptureNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deployment).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Tolerations).Should(ContainElements(t, rmeta.TolerateCriticalAddonsOnly, rmeta.TolerateMaster))
+	})
+
+	It("should render all resources for an installation with certificate management", func() {
+		var resources = renderPacketCapture(operator.InstallationSpec{CertificateManagement: &operator.CertificateManagement{}}, nil)
+
+		checkPacketCaptureResources(resources, true, false)
+	})
+
+	It("should render all resources for an installation with oidc configured", func() {
+		var authentication *operator.Authentication
+		authentication = &operator.Authentication{
+			Spec: operator.AuthenticationSpec{
+				ManagerDomain: "https://127.0.0.1",
+				OIDC:          &operator.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
+
+		var dexCfg = render.NewDexKeyValidatorConfig(authentication, nil, render.CreateDexTLSSecret("cn"), dns.DefaultClusterDomain)
+		var resources = renderPacketCapture(defaultInstallation, dexCfg)
+
+		checkPacketCaptureResources(resources, false, true)
+	})
+})

--- a/pkg/render/packetcapture_api_test.go
+++ b/pkg/render/packetcapture_api_test.go
@@ -17,17 +17,18 @@ package render_test
 import (
 	"fmt"
 
-	"github.com/tigera/operator/pkg/dns"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/authentication"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"


### PR DESCRIPTION
## Description

PacketCapture will be exposed as its own service and deployment.
Rendering these new resources will be triggered by the API server
installation resource. The Api server controller will create a new
namespace, service account, service, cluster role, clusterrolebinding,
and deployment. The service will be accesible via HTTPS. Generating
certificates will be done either via certificate management init
container or by providing a certificate in new added secret.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
