### PR TITLE
Move Prometheus ClusterRole to Role

### DIFF
--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -130,7 +130,6 @@ func (r *ReconcileMonitor) getMonitor(ctx context.Context) (*operatorv1.Monitor,
 func (r *ReconcileMonitor) setDegraded(reqLogger logr.Logger, err error, msg string) {
 	reqLogger.Error(err, msg)
 	r.status.SetDegraded(msg, err.Error())
-
 }
 
 func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controller/monitor/prometheus.go
+++ b/pkg/controller/monitor/prometheus.go
@@ -74,6 +74,35 @@ func addServiceMonitorElasticsearchWatch(c controller.Controller) error {
 	})
 }
 
+func addWatch(c controller.Controller) error {
+	var err error
+	if err = addAlertmanagerWatch(c); err != nil {
+		return fmt.Errorf("failed to watch Alertmanager resource: %w", err)
+	}
+
+	if err = addPrometheusWatch(c); err != nil {
+		return fmt.Errorf("failed to watch Prometheus resource: %w", err)
+	}
+
+	if err = addPrometheusRuleWatch(c); err != nil {
+		return fmt.Errorf("failed to watch PrometheusRule resource: %w", err)
+	}
+
+	if err = addServiceMonitorCalicoNodeWatch(c); err != nil {
+		return fmt.Errorf("failed to watch ServiceMonitor calico-node-monitor resource: %w", err)
+	}
+
+	if err = addServiceMonitorElasticsearchWatch(c); err != nil {
+		return fmt.Errorf("failed to watch ServiceMonitor elasticsearch-metrics resource: %w", err)
+	}
+
+	if err = addPodMonitorWatch(c); err != nil {
+		return fmt.Errorf("failed to watch PodMonitor resource: %w", err)
+	}
+
+	return err
+}
+
 func requiresPrometheusResources(client kubernetes.Interface) error {
 	resources, err := client.Discovery().ServerResourcesForGroupVersion("monitoring.coreos.com/v1")
 	if err != nil {
@@ -99,7 +128,7 @@ func requiresPrometheusResources(client kubernetes.Interface) error {
 
 	for k, v := range expectedResources {
 		if !v {
-			return fmt.Errorf("expected Prometheus related resource %s not found", k)
+			return fmt.Errorf("failed to find Prometheus resource: %s", k)
 		}
 	}
 
@@ -121,37 +150,15 @@ func waitToAddWatch(c controller.Controller, client kubernetes.Interface, log lo
 
 	for {
 		if err := requiresPrometheusResources(client); err != nil {
-			log.Info("failed to find Prometheus related resources. Will retry.")
+			log.Info("%v. monitor-controller will retry.", err)
 		} else {
-			var err error
-
 			// watch for prometheus resource changes
-			if err = addAlertmanagerWatch(c); err != nil {
-				return fmt.Errorf("failed to watch Alertmanager resource: %w", err)
+			if err := addWatch(c); err != nil {
+				log.Info("%v. monitor-controller will retry.", err)
+			} else {
+				readyFlag.MarkAsReady()
+				return nil
 			}
-
-			if err = addPrometheusWatch(c); err != nil {
-				return fmt.Errorf("failed to watch Prometheus resource: %w", err)
-			}
-
-			if err = addPrometheusRuleWatch(c); err != nil {
-				return fmt.Errorf("failed to watch PrometheusRule resource: %w", err)
-			}
-
-			if err = addServiceMonitorCalicoNodeWatch(c); err != nil {
-				return fmt.Errorf("failed to watch ServiceMonitor calico-node-monitor resource: %w", err)
-			}
-
-			if err = addServiceMonitorElasticsearchWatch(c); err != nil {
-				return fmt.Errorf("failed to watch ServiceMonitor elasticsearch-metrics resource: %w", err)
-			}
-
-			if err = addPodMonitorWatch(c); err != nil {
-				return fmt.Errorf("failed to watch PodMonitor resource: %w", err)
-			}
-
-			readyFlag.MarkAsReady()
-			return nil
 		}
 
 		<-backoffMgr.Backoff().C()

--- a/pkg/render/monitor_test.go
+++ b/pkg/render/monitor_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,6 +31,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 )
 
@@ -57,6 +59,8 @@ var _ = Describe("monitor rendering tests", func() {
 		}{
 			{common.TigeraPrometheusNamespace, "", "", "v1", "Namespace"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
+			{render.TigeraPrometheusRole, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
+			{render.TigeraPrometheusRoleBinding, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{render.CalicoNodeAlertmanager, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
 			{render.CalicoNodePrometheus, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind},
 			{render.TigeraPrometheusDPRate, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusRuleKind},
@@ -170,5 +174,41 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(Equal("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(Equal("5s"))
+
+		// Role
+		roleObj, ok := rtest.GetResource(toCreate, render.TigeraPrometheusRole, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
+		Expect(ok).To(BeTrue())
+		Expect(roleObj.Rules).To(HaveLen(1))
+		Expect(roleObj.Rules[0].APIGroups).To(HaveLen(1))
+		Expect(roleObj.Rules[0].APIGroups[0]).To(Equal("monitoring.coreos.com"))
+		Expect(roleObj.Rules[0].Resources).To(HaveLen(6))
+		Expect(roleObj.Rules[0].Resources).To(BeEquivalentTo([]string{
+			"alertmanagers",
+			"podmonitors",
+			"prometheuses",
+			"prometheusrules",
+			"servicemonitors",
+			"thanosrulers",
+		}))
+		Expect(roleObj.Rules[0].Verbs).To(HaveLen(6))
+		Expect(roleObj.Rules[0].Verbs).To(BeEquivalentTo([]string{
+			"create",
+			"delete",
+			"get",
+			"list",
+			"update",
+			"watch",
+		}))
+
+		// RoleBinding
+		rolebindingObj, ok := rtest.GetResource(toCreate, render.TigeraPrometheusRoleBinding, common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+		Expect(ok).To(BeTrue())
+		Expect(rolebindingObj.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+		Expect(rolebindingObj.RoleRef.Kind).To(Equal("Role"))
+		Expect(rolebindingObj.RoleRef.Name).To(Equal(render.TigeraPrometheusRole))
+		Expect(rolebindingObj.Subjects).To(HaveLen(1))
+		Expect(rolebindingObj.Subjects[0].Kind).To(Equal("ServiceAccount"))
+		Expect(rolebindingObj.Subjects[0].Name).To(Equal("tigera-operator"))
+		Expect(rolebindingObj.Subjects[0].Namespace).To(Equal(rmeta.OperatorNamespace()))
 	})
 })


### PR DESCRIPTION
Move `ClusterRole`s in API group `monitoring.coreos.com` to `tigera-prometheus`
namespaced `Role`s. Note that we still keep `list` and `watch` to be cluster
scoped because watches we added in the monitor controller are non-namespaced.

Tested on GCP kubernetes cluster and AWS Openshift cluster with modified operator role yaml and operator image.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
