### PR TITLE
Update ES Gateway render code to avoid re-rendering a customer provid…

### DIFF
--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -60,7 +60,8 @@ func EsGateway(
 	clusterDomain string,
 ) render.Component {
 	var certSecretsESCopy []*corev1.Secret
-	secrets := certSecrets
+	// Only render the public cert secret in the Operator namespace.
+	secrets := []*corev1.Secret{certSecrets[1]}
 
 	// Copy the Operator namespaced cert secrets to the Elasticsearch namespace.
 	certSecretsESCopy = append(certSecretsESCopy, secret.CopyToNamespace(render.ElasticsearchNamespace, certSecrets...)...)

--- a/pkg/render/logstorage/esgateway/esgateway_test.go
+++ b/pkg/render/logstorage/esgateway/esgateway_test.go
@@ -55,7 +55,6 @@ var _ = Describe("ES Gateway rendering tests", func() {
 
 		It("should render an ES Gateway deployment and all supporting resources", func() {
 			expectedResources := []resourceTestObj{
-				{render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace(), &corev1.Secret{}, nil},
 				{relasticsearch.PublicCertSecret, rmeta.OperatorNamespace(), &corev1.Secret{}, nil},
 				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 				{relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
@@ -96,7 +95,6 @@ var _ = Describe("ES Gateway rendering tests", func() {
 		It("should render an ES Gateway deployment and all supporting resources when CertificateManagement is enabled", func() {
 			installation.CertificateManagement = &operatorv1.CertificateManagement{}
 			expectedResources := []resourceTestObj{
-				{render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace(), &corev1.Secret{}, nil},
 				{relasticsearch.PublicCertSecret, rmeta.OperatorNamespace(), &corev1.Secret{}, nil},
 				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 				{relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},


### PR DESCRIPTION
Currently if a customer provides a cert secret for es-gateway, the render code overwrites the OwnerReference on that secret. This PR adds a flag that can be used to check if the cert is provided by the customer, and if it is, then it will not be re-rendered in the Operator namespace (only copied to the Elasticsearch namespace).