### PR TITLE
Add VPP support

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -302,6 +302,7 @@ type LinuxDataplaneOption string
 const (
 	LinuxDataplaneIptables LinuxDataplaneOption = "Iptables"
 	LinuxDataplaneBPF      LinuxDataplaneOption = "BPF"
+	LinuxDataplaneVPP      LinuxDataplaneOption = "VPP"
 )
 
 // CalicoNetworkSpec specifies configuration options for Calico provided pod networking.
@@ -311,7 +312,7 @@ type CalicoNetworkSpec struct {
 	// If not specified, iptables mode is used.
 	// Default: Iptables
 	// +optional
-	// +kubebuilder:validation:Enum=Iptables;BPF
+	// +kubebuilder:validation:Enum=Iptables;BPF;VPP
 	LinuxDataplane *LinuxDataplaneOption `json:"linuxDataplane,omitempty"`
 
 	// BGP configures whether or not to enable Calico's BGP capabilities.

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -249,6 +249,9 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 
 		// VPP specific validation
 		if instance.Spec.CalicoNetwork.LinuxDataplane != nil && *instance.Spec.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneVPP {
+			if instance.Spec.Variant != operatorv1.Calico {
+				return fmt.Errorf("The VPP dataplane only supports the Calico variant (configured: %s)", instance.Spec.Variant)
+			}
 			if instance.Spec.CNI.Type != operatorv1.PluginCalico {
 				return fmt.Errorf("The VPP dataplane only supports the Calico CNI (configured: %s)", instance.Spec.CNI.Type)
 			}

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -247,6 +247,16 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 			}
 		}
 
+		// VPP specific validation
+		if instance.Spec.CalicoNetwork.LinuxDataplane != nil && *instance.Spec.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneVPP {
+			if instance.Spec.CNI.Type != operatorv1.PluginCalico {
+				return fmt.Errorf("The VPP dataplane only supports the Calico CNI (configured: %s)", instance.Spec.CNI.Type)
+			}
+			if instance.Spec.CalicoNetwork.BGP == nil || *instance.Spec.CalicoNetwork.BGP == operatorv1.BGPDisabled {
+				return fmt.Errorf("VPP requires BGP to be enabled")
+			}
+		}
+
 		if bpfDataplane && instance.Spec.CalicoNetwork.NodeAddressAutodetectionV4 == nil {
 			return fmt.Errorf("spec.calicoNetwork.nodeAddressAutodetectionV4 is required for the BPF dataplane")
 		}

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -258,6 +258,9 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 			if instance.Spec.CalicoNetwork.BGP == nil || *instance.Spec.CalicoNetwork.BGP == operatorv1.BGPDisabled {
 				return fmt.Errorf("VPP requires BGP to be enabled")
 			}
+			if instance.Spec.CalicoNetwork.HostPorts != nil && *instance.Spec.CalicoNetwork.HostPorts == operatorv1.HostPortsDisabled {
+				return fmt.Errorf("VPP doesn't support disabling HostPorts")
+			}
 		}
 
 		if bpfDataplane && instance.Spec.CalicoNetwork.NodeAddressAutodetectionV4 == nil {

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -147,6 +147,22 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should not allow HostPorts to be disabled with VPP", func() {
+		vpp := operator.LinuxDataplaneVPP
+		bgp := operator.BGPEnabled
+		en := operator.HostPortsEnabled
+		dis := operator.HostPortsDisabled
+		instance.Spec.CalicoNetwork.LinuxDataplane = &vpp
+		instance.Spec.CalicoNetwork.BGP = &bgp
+		instance.Spec.CNI.Type = operator.PluginCalico
+		instance.Spec.CalicoNetwork.HostPorts = &dis
+		err := validateCustomResource(instance)
+		Expect(err).To(HaveOccurred())
+		instance.Spec.CalicoNetwork.HostPorts = &en
+		err = validateCustomResource(instance)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should prevent IPIP if BGP is disabled", func() {
 		disabled := operator.BGPDisabled
 		instance.Spec.CalicoNetwork.BGP = &disabled

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -107,6 +107,33 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should not allow VPP to be used with a CNI other than Calico", func() {
+		vpp := operator.LinuxDataplaneVPP
+		en := operator.BGPEnabled
+		instance.Spec.CalicoNetwork.LinuxDataplane = &vpp
+		instance.Spec.CalicoNetwork.BGP = &en
+		instance.Spec.CNI.Type = operator.PluginAmazonVPC
+		err := validateCustomResource(instance)
+		Expect(err).To(HaveOccurred())
+		instance.Spec.CNI.Type = operator.PluginCalico
+		err = validateCustomResource(instance)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not allow VPP to be used if BGP is not enabled", func() {
+		vpp := operator.LinuxDataplaneVPP
+		en := operator.BGPEnabled
+		dis := operator.BGPDisabled
+		instance.Spec.CalicoNetwork.LinuxDataplane = &vpp
+		instance.Spec.CNI.Type = operator.PluginCalico
+		instance.Spec.CalicoNetwork.BGP = &dis
+		err := validateCustomResource(instance)
+		Expect(err).To(HaveOccurred())
+		instance.Spec.CalicoNetwork.BGP = &en
+		err = validateCustomResource(instance)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should prevent IPIP if BGP is disabled", func() {
 		disabled := operator.BGPDisabled
 		instance.Spec.CalicoNetwork.BGP = &disabled

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -107,6 +107,19 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should not allow VPP to be used with a variant other than Calico", func() {
+		vpp := operator.LinuxDataplaneVPP
+		en := operator.BGPEnabled
+		instance.Spec.CalicoNetwork.LinuxDataplane = &vpp
+		instance.Spec.CalicoNetwork.BGP = &en
+		instance.Spec.CNI.Type = operator.PluginCalico
+		err := validateCustomResource(instance)
+		Expect(err).NotTo(HaveOccurred())
+		instance.Spec.Variant = operator.TigeraSecureEnterprise
+		err = validateCustomResource(instance)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should not allow VPP to be used with a CNI other than Calico", func() {
 		vpp := operator.LinuxDataplaneVPP
 		en := operator.BGPEnabled

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -116,6 +116,7 @@ spec:
                     enum:
                     - Iptables
                     - BPF
+                    - VPP
                     type: string
                   mtu:
                     description: MTU specifies the maximum transmission unit to use
@@ -846,6 +847,7 @@ spec:
                         enum:
                         - Iptables
                         - BPF
+                        - VPP
                         type: string
                       mtu:
                         description: MTU specifies the maximum transmission unit to

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1260,9 +1260,6 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 			nodeEnv = append(nodeEnv, corev1.EnvVar{
 				Name:  "FELIX_AWSSRCDSTCHECK",
 				Value: "Disable",
-			}, corev1.EnvVar{
-				Name:  "IP_AUTODETECTION_METHOD",
-				Value: "interface=eth0",
 			})
 		}
 	}
@@ -1301,6 +1298,7 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 	} else {
 		// BGP is enabled.
 		if c.vppDataplaneEnabled() {
+			// VPP comes with its own BGP daemon, so bird should be disabled
 			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_NETWORKING_BACKEND", Value: "none"})
 		} else {
 			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"})

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -488,6 +488,15 @@ func (c *nodeComponent) nodeCNIConfigMap() *corev1.ConfigMap {
 		k8sAPIRoot = fmt.Sprintf("\n          \"k8s_api_root\":\"%s\",", apiRoot)
 	}
 
+	var externalDataplane string = ""
+	if c.vppDataplaneEnabled() {
+		externalDataplane = `,
+      "dataplane_options": {
+        "type": "grpc",
+        "socket": "unix:///var/run/calico/cni-server.sock"
+      }`
+	}
+
 	// Build the CNI configuration json.
 	var config = fmt.Sprintf(`{
   "name": "k8s-pod-network",
@@ -509,14 +518,14 @@ func (c *nodeComponent) nodeCNIConfigMap() *corev1.ConfigMap {
       },
       "kubernetes": {%s
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
-      }
+      }%s
     },
     {
       "type": "bandwidth",
       "capabilities": {"bandwidth": true}
     }%s
   ]
-}`, mtu, nodenameFileOptional, ipam, ipForward, k8sAPIRoot, portmap)
+}`, mtu, nodenameFileOptional, ipam, ipForward, k8sAPIRoot, externalDataplane, portmap)
 
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
@@ -787,6 +796,13 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 		)
 	}
 
+	if c.vppDataplaneEnabled() {
+		volumes = append(volumes,
+			// Volume that contains the felix dataplane binary
+			corev1.Volume{Name: "felix-plugins", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/calico/felix-plugins"}}},
+		)
+	}
+
 	// If needed for this configuration, then include the CNI volumes.
 	if c.cfg.Installation.CNI.Type == operatorv1.PluginCalico {
 		// Determine directories to use for CNI artifacts based on the provider.
@@ -850,6 +866,12 @@ func (c *nodeComponent) bpfDataplaneEnabled() bool {
 	return c.cfg.Installation.CalicoNetwork != nil &&
 		c.cfg.Installation.CalicoNetwork.LinuxDataplane != nil &&
 		*c.cfg.Installation.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneBPF
+}
+
+func (c *nodeComponent) vppDataplaneEnabled() bool {
+	return c.cfg.Installation.CalicoNetwork != nil &&
+		c.cfg.Installation.CalicoNetwork.LinuxDataplane != nil &&
+		*c.cfg.Installation.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneVPP
 }
 
 func (c *nodeComponent) collectProcessPathEnabled() bool {
@@ -1023,6 +1045,9 @@ func (c *nodeComponent) nodeVolumeMounts() []corev1.VolumeMount {
 	}
 	if c.bpfDataplaneEnabled() {
 		nodeVolumeMounts = append(nodeVolumeMounts, corev1.VolumeMount{MountPath: "/sys/fs/bpf", Name: "bpffs"})
+	}
+	if c.vppDataplaneEnabled() {
+		nodeVolumeMounts = append(nodeVolumeMounts, corev1.VolumeMount{MountPath: "/usr/local/bin/felix-plugins", Name: "felix-plugins", ReadOnly: true})
 	}
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		extraNodeMounts := []corev1.VolumeMount{
@@ -1220,6 +1245,27 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 	if c.bpfDataplaneEnabled() {
 		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_BPFENABLED", Value: "true"})
 	}
+	if c.vppDataplaneEnabled() {
+		nodeEnv = append(nodeEnv, corev1.EnvVar{
+			Name:  "FELIX_USEINTERNALDATAPLANEDRIVER",
+			Value: "false",
+		}, corev1.EnvVar{
+			Name:  "FELIX_DATAPLANEDRIVER",
+			Value: "/usr/local/bin/felix-plugins/felix-api-proxy",
+		}, corev1.EnvVar{
+			Name:  "FELIX_XDPENABLED",
+			Value: "false",
+		})
+		if c.cfg.Installation.KubernetesProvider == operatorv1.ProviderEKS {
+			nodeEnv = append(nodeEnv, corev1.EnvVar{
+				Name:  "FELIX_AWSSRCDSTCHECK",
+				Value: "Disable",
+			}, corev1.EnvVar{
+				Name:  "IP_AUTODETECTION_METHOD",
+				Value: "interface=eth0",
+			})
+		}
+	}
 
 	if c.collectProcessPathEnabled() {
 		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_FLOWLOGSCOLLECTPROCESSPATH", Value: "true"})
@@ -1254,7 +1300,11 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		}
 	} else {
 		// BGP is enabled.
-		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"})
+		if c.vppDataplaneEnabled() {
+			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_NETWORKING_BACKEND", Value: "none"})
+		} else {
+			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"})
+		}
 		if mtu != nil {
 			ipipMtu := strconv.Itoa(int(*mtu))
 			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_IPINIPMTU", Value: ipipMtu})
@@ -1406,8 +1456,8 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Pr
 		readinessCmd = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
 	}
 
-	// If not using BGP, don't check bird status (or bgp metrics server for enterprise).
-	if !bgpEnabled(c.cfg.Installation) {
+	// If not using BGP or using VPP, don't check bird status (or bgp metrics server for enterprise).
+	if !bgpEnabled(c.cfg.Installation) || c.vppDataplaneEnabled() {
 		readinessCmd = []string{"/bin/calico-node", "-felix-ready"}
 	}
 


### PR DESCRIPTION
## Description

This PR adds support for VPP in the operator. We hope that it will enable the operator to become the primary way of managing Calico installations with the VPP dataplane enabled.
It should have no impact when VPP-specific configuration is not added. It changes the Installation object to add `VPP` as an option for `linuxDataplane`, and adds all the VPP-specific options in a `vpp` object under the `CalicoNetwork` object. 

It has been tested manually on VM, baremetal and EKS clusters, which are the 3 deployments currently officially supported by VPP.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
