### PR TITLE
add CNX_AUTH0_ORG_ID

### DIFF
--- a/deploy/scripts/create_kind_cluster.sh
+++ b/deploy/scripts/create_kind_cluster.sh
@@ -65,6 +65,8 @@ kubeadmConfigPatches:
   metadata:
     name: config
   mode: ipvs
+  conntrack:
+    maxPerCore: 0
 EOF
 
 ${kubectl} get no -o wide

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -22,7 +22,7 @@ make release VERSION=${tag}
 echo "Publish release ${tag}"
 make release-publish-images VERSION=${tag}
 
-if [[ ! "$(git rev-parse --abbrev-ref HEAD)" =~ (cloud-dev) ]]; then
+if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ (cloud-dev) ]]; then
 	echo "on 'cloud-dev' branch, do not push to RedHat for certification"
 	exit 0
 fi

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -11,8 +11,8 @@ if [[ ! "${tag}" =~ ^cloud-v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
 	exit 1
 fi
 
-if [[ ! "$(git rev-parse --abbrev-ref HEAD)" =~ (release-v*.*|master|cloud-dev) ]]; then
-	echo "not on 'master', 'cloud-dev', or 'release-vX.Y'"
+if [[ ! "$(git rev-parse --abbrev-ref HEAD)" =~ (release-v*.*|master|cloud-*) ]]; then
+	echo "not on 'master', 'cloud-*', or 'release-vX.Y'"
 	exit 0
 fi
 
@@ -22,8 +22,8 @@ make release VERSION=${tag}
 echo "Publish release ${tag}"
 make release-publish-images VERSION=${tag}
 
-if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ (cloud-dev) ]]; then
-	echo "on 'cloud-dev' branch, do not push to RedHat for certification"
+if [[ "$(git rev-parse --abbrev-ref HEAD)" =~ (cloud-*) ]]; then
+	echo "on 'cloud-*' branch, do not push to RedHat for certification"
 	exit 0
 fi
 

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -489,6 +489,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	} else {
 		render.CloudPortalAPIURL = mgrCfg.Data["portalAPIURL"]
+		render.CloudAuth0OrgID = mgrCfg.Data["auth0OrgID"]
 	}
 
 	// Create a component handler to manage the rendered component.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -85,6 +85,7 @@ const (
 var (
 	CloudManagerConfigOverrideName = "cloud-manager-config"
 	CloudPortalAPIURL              = ""
+	CloudAuth0OrgID                = ""
 )
 
 func Manager(
@@ -514,6 +515,7 @@ func setManagerCloudEnvs(envs []corev1.EnvVar) []corev1.EnvVar {
 		envs = append(envs,
 			v1.EnvVar{Name: "CNX_PORTAL_URL", Value: CloudPortalAPIURL},
 			v1.EnvVar{Name: "ENABLE_PORTAL_SUPPORT", Value: "true"},
+			v1.EnvVar{Name: "CNX_AUTH0_ORG_ID", Value: CloudAuth0OrgID},
 		)
 	}
 	return envs


### PR DESCRIPTION
## Description

Add support for setting a new env var on manager CNX_AUTH0_ORG_ID which is populated based on the cloud-manager-config configmap

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
