### PR TITLE
Automated cherry pick of #1408: Fix kube-proxy crashloopback for kind cluster

### DIFF
--- a/deploy/scripts/create_kind_cluster.sh
+++ b/deploy/scripts/create_kind_cluster.sh
@@ -65,6 +65,8 @@ kubeadmConfigPatches:
   metadata:
     name: config
   mode: ipvs
+  conntrack:
+    maxPerCore: 0
 EOF
 
 ${kubectl} get no -o wide


### PR DESCRIPTION
Cherry pick of #1408 on release-v1.15.

#1408: Fix kube-proxy crashloopback for kind cluster