### PR TITLE
Upstream changes to support Cloud Operator and the new CloudLogStorage controller.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -130,6 +131,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/elastic/cloud-on-k8s v0.0.0-20200811130517-b53162318c20 h1:cUIZoQWZiLha6MsaHL38kNaYPYwKIw3kwXfxk5thrAo=
 github.com/elastic/cloud-on-k8s v0.0.0-20200811130517-b53162318c20/go.mod h1:R/v2ig9AHYXe84jPNq8EtCJRAT1Ec0cYh+JrPSalcHM=
+github.com/elastic/go-sysinfo v1.1.1 h1:ZVlaLDyhVkDfjwPGU55CQRCRolNpc7P0BbyhhQZQmMI=
 github.com/elastic/go-sysinfo v1.1.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-ucfg v0.8.3 h1:leywnFjzr2QneZZWhE6uWd+QN/UpP0sdJRHYyuFvkeo=
 github.com/elastic/go-ucfg v0.8.3/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
@@ -148,6 +150,7 @@ github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQo
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
@@ -222,6 +225,7 @@ github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.6 h1:UHSEyLZUwX9Qoi99vVwvewiMC8mM2bf7XEM2nqvzEn8=
 github.com/go-test/deep v1.0.6/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobuffalo/flect v0.2.1/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
@@ -274,6 +278,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -358,6 +363,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548/go.mod h1:hGT6jSUVzF6no3QaDSMLGLEHtHSBSefs+MgcDWnmhmo=
 github.com/jmoiron/sqlx v0.0.0-20180124204410-05cef0741ade/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=
+github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -379,9 +385,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubernetes-sigs/kube-storage-version-migrator v0.0.0-20191127225502-51849bc15f17/go.mod h1:enH0BVV+4+DAgWdwSlMefG8bBzTfVMTr1lApzdLZ/cc=
 github.com/kylelemons/go-gypsy v0.0.0-20160905020020-08cad365cd28/go.mod h1:T/T7jsxVqf9k/zYOqbgNAsANsjxTd1Yq3htjDhQ1H0c=
@@ -598,9 +606,11 @@ github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhu
 github.com/zmap/zcertificate v0.0.0-20180516150559-0e3d58b1bac4/go.mod h1:5iU54tB79AMBcySS0R2XIyZBAVmeHranShAFELYx7is=
 github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e/go.mod h1:w7kd3qXHh8FNaczNjslXqvFQiv5mMWRXlL9klTUAHc8=
 github.com/zmap/zlint v0.0.0-20190806154020-fd021b4cfbeb/go.mod h1:29UiAJNsiVdvTBFCJW8e3q6dcDbOoPkhMgttOSCIMMY=
+go.elastic.co/apm v1.8.0 h1:AWEKpHwRal0yCMd4K8Oxy1HAa7xid+xq1yy+XjgoVU0=
 go.elastic.co/apm v1.8.0/go.mod h1:tCw6CkOJgkWnzEthFN9HUP1uL3Gjc/Ur6m7gRPLaoH0=
 go.elastic.co/apm/module/apmelasticsearch v1.8.0/go.mod h1:EXBL1ZsGovtvwFax+MFiwMzHYb6vvESvpxqKVfKE0BI=
 go.elastic.co/apm/module/apmhttp v1.8.0/go.mod h1:9LPFlEON51/lRbnWDfqAWErihIiAFDUMfMV27YjoWQ8=
+go.elastic.co/fastjson v1.0.0 h1:ooXV/ABvf+tBul26jcVViPT3sBir0PvXgibYB1IQQzg=
 go.elastic.co/fastjson v1.0.0/go.mod h1:PmeUOMMtLHQr9ZS9J9owrAVg0FkaZDRZJEFTTGHtchs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -618,6 +628,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/automaxprocs v1.3.0/go.mod h1:9CWT6lKIep8U41DDaPiH6eFscnTyjfTANNQNx6LrIcA=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
@@ -863,6 +874,7 @@ gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d h1:TxyelI5cVkbREznMhfzyc
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
@@ -898,6 +910,7 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb h1:jhnBjNi9UFpfpl8YZhA9CrOqpnJdvzuiHsl/dnxl11M=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.19.2 h1:q+/krnHWKsL7OBZg/rxnycsl9569Pud76UJ77MvKXms=
 k8s.io/api v0.19.2/go.mod h1:IQpK0zFQ1xc5iNIQPqzgoOwuFugaYHK4iCknlAQP9nI=

--- a/pkg/controller/logstorage/common/common.go
+++ b/pkg/controller/logstorage/common/common.go
@@ -1,0 +1,203 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/crypto/bcrypt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/crypto"
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/render"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
+)
+
+const (
+	TigeraElasticsearchUserSecretLabel = "tigera-elasticsearch-user"
+	DefaultElasticsearchShards         = 1
+
+	// ESGatewaySelectorLabel is used to mark any secret containing credentials for ES gateway with this label key/value.
+	// This will allow ES gateway to watch only the relevant secrets it needs.
+	ESGatewaySelectorLabel      = "esgateway.tigera.io/secrets"
+	ESGatewaySelectorLabelValue = "credentials"
+)
+
+// CreateKubeControllersSecrets checks for the existence of the secrets necessary for Kube controllers to access Elasticsearch through ES gateway and
+// creates them if they are missing. Kube controllers no longer uses admin credentials to make requests directly to Elasticsearch. Instead, gateway credentials
+// are generated and stored in the user secret, a hashed version of the credentials is stored in the tigera-elasticsearch namespace for ES Gateway to retrieve and use to compare
+// the gateway credentials, and a secret containing real admin level credentials is created and stored in the tigera-elasticsearch namespace to be swapped in once
+// ES Gateway has confirmed that the gateway credentials match.
+func CreateKubeControllersSecrets(ctx context.Context, esAdminUserSecret *corev1.Secret, cli client.Client) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
+	kubeControllersGatewaySecret, err := utils.GetSecret(ctx, cli, render.ElasticsearchKubeControllersUserSecret, rmeta.OperatorNamespace())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if kubeControllersGatewaySecret == nil {
+		password := crypto.GeneratePassword(16)
+		kubeControllersGatewaySecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchKubeControllersUserSecret,
+				Namespace: rmeta.OperatorNamespace(),
+			},
+			Data: map[string][]byte{
+				"username": []byte(render.ElasticsearchKubeControllersUserName),
+				"password": []byte(password),
+			},
+		}
+	}
+	hashedPassword, err := bcrypt.GenerateFromPassword(kubeControllersGatewaySecret.Data["password"], bcrypt.MinCost)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	kubeControllersVerificationSecret, err := utils.GetSecret(ctx, cli, render.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if kubeControllersVerificationSecret == nil {
+		kubeControllersVerificationSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchKubeControllersVerificationUserSecret,
+				Namespace: render.ElasticsearchNamespace,
+				Labels: map[string]string{
+					ESGatewaySelectorLabel: ESGatewaySelectorLabelValue,
+				},
+			},
+			Data: map[string][]byte{
+				"username": []byte(render.ElasticsearchKubeControllersUserName),
+				"password": hashedPassword,
+			},
+		}
+	}
+
+	kubeControllersSecureUserSecret, err := utils.GetSecret(ctx, cli, render.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if kubeControllersSecureUserSecret == nil {
+		kubeControllersSecureUserSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchKubeControllersSecureUserSecret,
+				Namespace: render.ElasticsearchNamespace,
+				Labels: map[string]string{
+					ESGatewaySelectorLabel: ESGatewaySelectorLabelValue,
+				},
+			},
+			Data: map[string][]byte{
+				"username": []byte("elastic"),
+				"password": esAdminUserSecret.Data["elastic"],
+			},
+		}
+	}
+
+	return kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, nil
+}
+
+// GetESGatewayCertificateSecrets retrieves certificate secrets needed for ES Gateway to run or for
+// components to communicate with Elasticsearch/Kibana through ES Gateway. The order of the secrets returned are:
+// 1) The certificate/key secret to be mounted by ES Gateway and used to authenticate requests before
+// proxying to Elasticsearch/Kibana (in the operator namespace). If the user didn't create this secret, it is created.
+// 2) The certificate mounted by other clients that connect to Elasticsearch/Kibana through ES Gateway (in the operator namespace).
+// The final return value is used to indicate that the certificate secret was provided by the customer. This
+// ensures that we do not re-render the secret in the Operator Namespace and overwrite the OwnerReference.
+func GetESGatewayCertificateSecrets(ctx context.Context, instl *operatorv1.InstallationSpec, cli client.Client, clusterDomain string, log logr.Logger) (*corev1.Secret, *corev1.Secret, bool, error) {
+	var publicCertSecret *corev1.Secret
+
+	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, clusterDomain)
+	svcDNSNames = append(svcDNSNames, dns.GetServiceDNSNames(esgateway.ServiceName, render.ElasticsearchNamespace, clusterDomain)...)
+
+	// Get the secret - might be nil
+	oprKeyCert, err := utils.GetSecret(ctx, cli, render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace())
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	// Ensure that cert is valid.
+	oprKeyCert, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, oprKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	// Three different certificate issuers are possible:
+	// - The operator self-signed certificate
+	// - A user's BYO keypair for Elastic (uncommon)
+	// - The issuer that is provided through the certificate management feature.
+	keyCertIssuer, err := utils.GetCertificateIssuer(oprKeyCert.Data[corev1.TLSCertKey])
+	if err != nil {
+		return nil, nil, false, err
+	}
+	customerProvidedCert := !utils.IsOperatorIssued(keyCertIssuer)
+
+	// If Certificate management is enabled, we only want to trust the CA cert and let the init container handle private key generation.
+	if instl.CertificateManagement != nil {
+		cmCa := instl.CertificateManagement.CACert
+		cmIssuer, err := utils.GetCertificateIssuer(cmCa)
+		if err != nil {
+			return nil, nil, false, err
+		}
+
+		// If the issuer of the current secret is not the same as the certificate management issuer and also is not
+		// issued by the tigera-operator, it means that it is added to this cluster by the customer. This is not supported
+		// in combination with certificate management.
+		if customerProvidedCert && cmIssuer != keyCertIssuer {
+			return nil, nil, false, fmt.Errorf("certificate management does not support custom Elasticsearch secrets, please delete secret %s/%s or disable certificate management", oprKeyCert.Namespace, oprKeyCert.Name)
+		}
+
+		oprKeyCert.Data[corev1.TLSCertKey] = instl.CertificateManagement.CACert
+		publicCertSecret = render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+	} else {
+		// Get the es gateway pub secret - might be nil
+		publicCertSecret, err = utils.GetSecret(ctx, cli, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+		if err != nil {
+			return nil, nil, false, err
+		}
+
+		if publicCertSecret != nil {
+			// If the provided certificate secret (secret) is managed by the operator we need to check if the secret has the expected DNS names.
+			// If it doesn't, delete the public secret so it can get recreated.
+			if !customerProvidedCert {
+				err = utils.SecretHasExpectedDNSNames(publicCertSecret, corev1.TLSCertKey, svcDNSNames)
+				if err == utils.ErrInvalidCertDNSNames {
+					if err := DeleteInvalidECKManagedPublicCertSecret(ctx, publicCertSecret, cli, log); err != nil {
+						return nil, nil, false, err
+					}
+					publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+				}
+			}
+		} else {
+			publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
+		}
+	}
+
+	return oprKeyCert, publicCertSecret, customerProvidedCert, nil
+}
+
+// DeleteInvalidECKManagedPublicCertSecret deletes the given ECK managed cert secret.
+func DeleteInvalidECKManagedPublicCertSecret(ctx context.Context, secret *corev1.Secret, cli client.Client, log logr.Logger) error {
+	log.Info(fmt.Sprintf("Deleting invalid cert secret %q in %q namespace", secret.Name, secret.Namespace))
+	return cli.Delete(ctx, secret)
+}
+
+func CalculateFlowShards(nodesSpecifications *operatorv1.Nodes, defaultShards int) int {
+	if nodesSpecifications == nil || nodesSpecifications.ResourceRequirements == nil || nodesSpecifications.ResourceRequirements.Requests == nil {
+		return defaultShards
+	}
+
+	var nodes = nodesSpecifications.Count
+	var cores, _ = nodesSpecifications.ResourceRequirements.Requests.Cpu().AsInt64()
+	var shardPerNode = int(cores) / 4
+
+	if nodes <= 0 || shardPerNode <= 0 {
+		return defaultShards
+	}
+
+	return int(nodes) * shardPerNode
+}

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -18,14 +18,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/tigera/operator/pkg/crypto"
-
 	cmnv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	"golang.org/x/crypto/bcrypt"
-
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/logstorage/common"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -60,15 +57,8 @@ import (
 var log = logf.Log.WithName("controller_logstorage")
 
 const (
-	tigeraElasticsearchUserSecretLabel = "tigera-elasticsearch-user"
-	defaultElasticsearchShards         = 1
-	defaultEckOperatorMemorySetting    = "512Mi"
-	DefaultElasticsearchStorageClass   = "tigera-elasticsearch"
-
-	// Mark any secret containing credentials for ES gateway with this label key/value. This will allow ES gateway to watch only the
-	// releveant secrets it needs.
-	ESGatewaySelectorLabel      = "esgateway.tigera.io/secrets"
-	ESGatewaySelectorLabelValue = "credentials"
+	defaultEckOperatorMemorySetting  = "512Mi"
+	DefaultElasticsearchStorageClass = "tigera-elasticsearch"
 )
 
 // Add creates a new LogStorage Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -157,15 +147,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// the utils folder where the other watch logic is.
 	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, &predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			_, hasLabel := e.Object.GetLabels()[tigeraElasticsearchUserSecretLabel]
+			_, hasLabel := e.Object.GetLabels()[common.TigeraElasticsearchUserSecretLabel]
 			return e.Object.GetNamespace() == rmeta.OperatorNamespace() && hasLabel
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			_, hasLabel := e.ObjectNew.GetLabels()[tigeraElasticsearchUserSecretLabel]
+			_, hasLabel := e.ObjectNew.GetLabels()[common.TigeraElasticsearchUserSecretLabel]
 			return e.ObjectNew.GetNamespace() == rmeta.OperatorNamespace() && hasLabel
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			_, hasLabel := e.Object.GetLabels()[tigeraElasticsearchUserSecretLabel]
+			_, hasLabel := e.Object.GetLabels()[common.TigeraElasticsearchUserSecretLabel]
 			return e.Object.GetNamespace() == rmeta.OperatorNamespace() && hasLabel
 		},
 	})
@@ -434,8 +424,8 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 	customerProvidedCert := false
 
 	if managementClusterConnection == nil {
-		var flowShards = calculateFlowShards(ls.Spec.Nodes, defaultElasticsearchShards)
-		clusterConfig = relasticsearch.NewClusterConfig(render.DefaultElasticsearchClusterName, ls.Replicas(), defaultElasticsearchShards, flowShards)
+		var flowShards = common.CalculateFlowShards(ls.Spec.Nodes, common.DefaultElasticsearchShards)
+		clusterConfig = relasticsearch.NewClusterConfig(render.DefaultElasticsearchClusterName, ls.Replicas(), common.DefaultElasticsearchShards, flowShards)
 
 		// Check if there is a StorageClass available to run Elasticsearch on.
 		if err := r.client.Get(ctx, client.ObjectKey{Name: ls.Spec.StorageClassName}, &storagev1.StorageClass{}); err != nil {
@@ -451,7 +441,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, nil
 		}
 
-		if gatewayCertSecret, publicCertSecret, customerProvidedCert, err = r.getESGatewayCertificateSecrets(ctx, install); err != nil {
+		if gatewayCertSecret, publicCertSecret, customerProvidedCert, err = common.GetESGatewayCertificateSecrets(ctx, install, r.client, r.clusterDomain, log); err != nil {
 			reqLogger.Error(err, err.Error())
 			r.status.SetDegraded("Failed to create Elasticsearch Gateway secrets", err.Error())
 			return reconcile.Result{}, err
@@ -598,7 +588,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, err
 		}
 
-		kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, err := r.createKubeControllersSecrets(ctx, esAdminUserSecret)
+		kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, err := common.CreateKubeControllersSecrets(ctx, esAdminUserSecret, r.client)
 		if err != nil {
 			reqLogger.Error(err, err.Error())
 			r.status.SetDegraded("Failed to create kube-controllers secrets for Elasticsearch gateway", "")
@@ -711,162 +701,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 	return reconcile.Result{}, nil
 }
 
-// Deletes the given ECK managed cert secret.
-func (r *ReconcileLogStorage) deleteInvalidECKManagedPublicCertSecret(ctx context.Context, secret *corev1.Secret) error {
-	log.Info(fmt.Sprintf("Deleting invalid cert secret %q in %q namespace", secret.Name, secret.Namespace))
-	return r.client.Delete(ctx, secret)
-}
-
-// createKubeControllersSecrets checks for the existence of the secrets necessary for Kube controllers to access Elasticsearch through ES gateway and
-// creates them if they are missing. Kube controllers no longer uses admin credentials to make requests directly to Elasticsearch. Instead, gateway credentials
-// are generated and stored in the user secret, a hashed version of the credentials is stored in the tigera-elasticsearch namespace for ES Gateway to retrieve and use to compare
-// the gateway credentials, and a secret containing real admin level credentials is created and stored in the tigera-elasticsearch namespace to be swapped in once
-// ES Gateway has confirmed that the gateway credentials match.
-func (r *ReconcileLogStorage) createKubeControllersSecrets(ctx context.Context, esAdminUserSecret *corev1.Secret) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
-	kubeControllersGatewaySecret, err := utils.GetSecret(ctx, r.client, render.ElasticsearchKubeControllersUserSecret, rmeta.OperatorNamespace())
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if kubeControllersGatewaySecret == nil {
-		password := crypto.GeneratePassword(16)
-		kubeControllersGatewaySecret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      render.ElasticsearchKubeControllersUserSecret,
-				Namespace: rmeta.OperatorNamespace(),
-			},
-			Data: map[string][]byte{
-				"username": []byte(render.ElasticsearchKubeControllersUserName),
-				"password": []byte(password),
-			},
-		}
-	}
-	hashedPassword, err := bcrypt.GenerateFromPassword(kubeControllersGatewaySecret.Data["password"], bcrypt.MinCost)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	kubeControllersVerificationSecret, err := utils.GetSecret(ctx, r.client, render.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if kubeControllersVerificationSecret == nil {
-		kubeControllersVerificationSecret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      render.ElasticsearchKubeControllersVerificationUserSecret,
-				Namespace: render.ElasticsearchNamespace,
-				Labels: map[string]string{
-					ESGatewaySelectorLabel: ESGatewaySelectorLabelValue,
-				},
-			},
-			Data: map[string][]byte{
-				"username": []byte(render.ElasticsearchKubeControllersUserName),
-				"password": hashedPassword,
-			},
-		}
-	}
-
-	kubeControllersSecureUserSecret, err := utils.GetSecret(ctx, r.client, render.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if kubeControllersSecureUserSecret == nil {
-		kubeControllersSecureUserSecret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      render.ElasticsearchKubeControllersSecureUserSecret,
-				Namespace: render.ElasticsearchNamespace,
-				Labels: map[string]string{
-					ESGatewaySelectorLabel: ESGatewaySelectorLabelValue,
-				},
-			},
-			Data: map[string][]byte{
-				"username": []byte("elastic"),
-				"password": esAdminUserSecret.Data["elastic"],
-			},
-		}
-	}
-
-	return kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, nil
-}
-
-// getESGatewayCertificateSecrets retrieves certificate secrets needed for ES Gateway to run or for
-// components to communicate with Elasticsearch/Kibana through ES Gateway. The order of the secrets returned are:
-// 1) The certificate/key secret to be mounted by ES Gateway and used to authenticate requests before
-// proxying to Elasticsearch/Kibana (in the operator namespace). If the user didn't create this secret, it is created.
-// 2) The certificate mounted by other clients that connect to Elasticsearch/Kibana through ES Gateway (in the operator namespace).
-// The final return value is used to indicate that the certificate secret was provided by the customer. This
-// ensures that we do not re-render the secret in the Operator Namespace and overwrite the OwnerReference.
-func (r *ReconcileLogStorage) getESGatewayCertificateSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) (*corev1.Secret, *corev1.Secret, bool, error) {
-	var publicCertSecret *corev1.Secret
-
-	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
-	svcDNSNames = append(svcDNSNames, dns.GetServiceDNSNames(esgateway.ServiceName, render.ElasticsearchNamespace, r.clusterDomain)...)
-
-	// Get the secret - might be nil
-	oprKeyCert, err := utils.GetSecret(ctx, r.client, render.TigeraElasticsearchCertSecret, rmeta.OperatorNamespace())
-	if err != nil {
-		return nil, nil, false, err
-	}
-
-	// Ensure that cert is valid.
-	oprKeyCert, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, oprKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
-	if err != nil {
-		return nil, nil, false, err
-	}
-
-	// Three different certificate issuers are possible:
-	// - The operator self-signed certificate
-	// - A user's BYO keypair for Elastic (uncommon)
-	// - The issuer that is provided through the certificate management feature.
-	keyCertIssuer, err := utils.GetCertificateIssuer(oprKeyCert.Data[corev1.TLSCertKey])
-	if err != nil {
-		return nil, nil, false, err
-	}
-	customerProvidedCert := !utils.IsOperatorIssued(keyCertIssuer)
-
-	// If Certificate management is enabled, we only want to trust the CA cert and let the init container handle private key generation.
-	if instl.CertificateManagement != nil {
-		cmCa := instl.CertificateManagement.CACert
-		cmIssuer, err := utils.GetCertificateIssuer(cmCa)
-		if err != nil {
-			return nil, nil, false, err
-		}
-
-		// If the issuer of the current secret is not the same as the certificate management issuer and also is not
-		// issued by the tigera-operator, it means that it is added to this cluster by the customer. This is not supported
-		// in combination with certificate management.
-		if customerProvidedCert && cmIssuer != keyCertIssuer {
-			return nil, nil, false, fmt.Errorf("certificate management does not support custom Elasticsearch secrets, please delete secret %s/%s or disable certificate management", oprKeyCert.Namespace, oprKeyCert.Name)
-		}
-
-		oprKeyCert.Data[corev1.TLSCertKey] = instl.CertificateManagement.CACert
-		publicCertSecret = render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-	} else {
-		// Get the es gateway pub secret - might be nil
-		publicCertSecret, err = utils.GetSecret(ctx, r.client, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-		if err != nil {
-			return nil, nil, false, err
-		}
-
-		if publicCertSecret != nil {
-			// If the provided certificate secret (secret) is managed by the operator we need to check if the secret has the expected DNS names.
-			// If it doesn't, delete the public secret so it can get recreated.
-			if !customerProvidedCert {
-				err = utils.SecretHasExpectedDNSNames(publicCertSecret, corev1.TLSCertKey, svcDNSNames)
-				if err == utils.ErrInvalidCertDNSNames {
-					if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, publicCertSecret); err != nil {
-						return nil, nil, false, err
-					}
-					publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-				}
-			}
-		} else {
-			publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-		}
-	}
-
-	return oprKeyCert, publicCertSecret, customerProvidedCert, nil
-}
-
 // getElasticsearchCertificateSecrets retrieves Elasticsearch certificate secrets needed for Elasticsearch to run or for
 // ES gateway to communicate with Elasticsearch. The order of the secrets returned are:
 // 1) The certificate secret needed for Elasticsearch (in the Elasticsearch namespace). If the user didn't create this it is
@@ -908,7 +742,7 @@ func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Con
 			// public secret so it can get recreated.
 			err = utils.SecretHasExpectedDNSNames(internalSecret, corev1.TLSCertKey, svcDNSNames)
 			if err == utils.ErrInvalidCertDNSNames {
-				if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, internalSecret); err != nil {
+				if err := common.DeleteInvalidECKManagedPublicCertSecret(ctx, internalSecret, r.client, log); err != nil {
 					return nil, nil, err
 				}
 			}
@@ -967,7 +801,7 @@ func (r *ReconcileLogStorage) kibanaInternalSecrets(ctx context.Context, instl *
 	if utils.IsOperatorIssued(issuer) {
 		err = utils.SecretHasExpectedDNSNames(internalSecret, corev1.TLSCertKey, svcDNSNames)
 		if err == utils.ErrInvalidCertDNSNames {
-			if err := r.deleteInvalidECKManagedPublicCertSecret(ctx, internalSecret); err != nil {
+			if err := common.DeleteInvalidECKManagedPublicCertSecret(ctx, internalSecret, r.client, log); err != nil {
 				return nil, err
 			}
 		}
@@ -1035,20 +869,4 @@ func (r *ReconcileLogStorage) checkOIDCUsersEsResource(ctx context.Context) erro
 		return err
 	}
 	return nil
-}
-
-func calculateFlowShards(nodesSpecifications *operatorv1.Nodes, defaultShards int) int {
-	if nodesSpecifications == nil || nodesSpecifications.ResourceRequirements == nil || nodesSpecifications.ResourceRequirements.Requests == nil {
-		return defaultShards
-	}
-
-	var nodes = nodesSpecifications.Count
-	var cores, _ = nodesSpecifications.ResourceRequirements.Requests.Cpu().AsInt64()
-	var shardPerNode = int(cores) / 4
-
-	if nodes <= 0 || shardPerNode <= 0 {
-		return defaultShards
-	}
-
-	return int(nodes) * shardPerNode
 }

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -106,7 +106,7 @@ func ConvertSecretToCredential(s *corev1.Secret) (*AmazonCredential, error) {
 
 func (c *amazonCloudIntegrationComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(AmazonCloudIntegrationNamespace, c.installation.KubernetesProvider),
+		CreateNamespace(AmazonCloudIntegrationNamespace, c.installation.KubernetesProvider),
 	}
 	secrets := secret.CopyToNamespace(AmazonCloudIntegrationNamespace, c.pullSecrets...)
 	objs = append(objs, secret.ToRuntimeObjects(secrets...)...)

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -254,7 +254,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 
 	// Global enterprise-only objects.
 	globalEnterpriseObjects := []client.Object{
-		createNamespace(rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise), c.installation.KubernetesProvider),
+		CreateNamespace(rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise), c.installation.KubernetesProvider),
 		c.tigeraCustomResourcesClusterRole(),
 		c.tigeraCustomResourcesClusterRoleBinding(),
 		c.tierGetterClusterRole(),
@@ -272,7 +272,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 
 	// Global OSS-only objects.
 	globalCalicoObjects := []client.Object{
-		createNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.installation.KubernetesProvider),
+		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.installation.KubernetesProvider),
 	}
 
 	// Compile the final arrays based on the variant.

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -166,7 +166,7 @@ func (c *complianceComponent) SupportedOSType() rmeta.OSType {
 
 func (c *complianceComponent) Objects() ([]client.Object, []client.Object) {
 	complianceObjs := append(
-		[]client.Object{createNamespace(ComplianceNamespace, c.installation.KubernetesProvider)},
+		[]client.Object{CreateNamespace(ComplianceNamespace, c.installation.KubernetesProvider)},
 		secret.ToRuntimeObjects(secret.CopyToNamespace(ComplianceNamespace, c.pullSecrets...)...)...,
 	)
 	complianceObjs = append(complianceObjs,

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -230,7 +230,7 @@ func (c *fluentdComponent) path(path string) string {
 func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	var objs []client.Object
 	objs = append(objs,
-		createNamespace(
+		CreateNamespace(
 			LogCollectorNamespace,
 			c.installation.KubernetesProvider))
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.pullSecrets...)...)...)

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -88,7 +88,7 @@ func (c *GuardianComponent) SupportedOSType() rmeta.OSType {
 
 func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(GuardianNamespace, c.installation.KubernetesProvider),
+		CreateNamespace(GuardianNamespace, c.installation.KubernetesProvider),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(GuardianNamespace, c.pullSecrets...)...)...)
 	objs = append(objs,
@@ -100,7 +100,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		secret.CopyToNamespace(GuardianNamespace, c.tunnelSecret)[0],
 		secret.CopyToNamespace(GuardianNamespace, c.packetCaptureSecret)[0],
 		// Add tigera-manager service account for impersonation
-		createNamespace(ManagerNamespace, c.installation.KubernetesProvider),
+		CreateNamespace(ManagerNamespace, c.installation.KubernetesProvider),
 		managerServiceAccount(),
 		managerClusterRole(false, true, c.openshift),
 		managerClusterRoleBinding(),

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -125,7 +125,7 @@ func (c *intrusionDetectionComponent) SupportedOSType() rmeta.OSType {
 }
 
 func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Object) {
-	objs := []client.Object{createNamespace(IntrusionDetectionNamespace, c.installation.KubernetesProvider)}
+	objs := []client.Object{CreateNamespace(IntrusionDetectionNamespace, c.installation.KubernetesProvider)}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.pullSecrets...)...)...)
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.esSecrets...)...)...)
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.kibanaCertSecret)...)...)

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -320,7 +320,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 
 		// ECK CRs
 		toCreate = append(toCreate,
-			createNamespace(ECKOperatorNamespace, es.installation.KubernetesProvider),
+			CreateNamespace(ECKOperatorNamespace, es.installation.KubernetesProvider),
 		)
 
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ECKOperatorNamespace, es.pullSecrets...)...)...)
@@ -351,7 +351,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.eckOperatorStatefulSet())
 
 		// Elasticsearch CRs
-		toCreate = append(toCreate, createNamespace(ElasticsearchNamespace, es.installation.KubernetesProvider))
+		toCreate = append(toCreate, CreateNamespace(ElasticsearchNamespace, es.installation.KubernetesProvider))
 
 		if len(es.pullSecrets) > 0 {
 			toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ElasticsearchNamespace, es.pullSecrets...)...)...)
@@ -372,7 +372,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.elasticsearchCluster(len(secureSettings.Data) > 0))
 
 		// Kibana CRs
-		toCreate = append(toCreate, createNamespace(KibanaNamespace, es.installation.KubernetesProvider))
+		toCreate = append(toCreate, CreateNamespace(KibanaNamespace, es.installation.KubernetesProvider))
 		toCreate = append(toCreate, es.kibanaServiceAccount())
 
 		if len(es.pullSecrets) > 0 {
@@ -416,7 +416,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		}
 	} else {
 		toCreate = append(toCreate,
-			createNamespace(ElasticsearchNamespace, es.installation.KubernetesProvider),
+			CreateNamespace(ElasticsearchNamespace, es.installation.KubernetesProvider),
 			es.elasticsearchExternalService(),
 		)
 	}

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -205,7 +205,7 @@ func (c *managerComponent) SupportedOSType() rmeta.OSType {
 
 func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(ManagerNamespace, c.installation.KubernetesProvider),
+		CreateNamespace(ManagerNamespace, c.installation.KubernetesProvider),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ManagerNamespace, c.pullSecrets...)...)...)
 

--- a/pkg/render/monitor.go
+++ b/pkg/render/monitor.go
@@ -98,7 +98,7 @@ func (mc *monitorComponent) SupportedOSType() rmeta.OSType {
 
 func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 	toCreate := []client.Object{
-		createNamespace(common.TigeraPrometheusNamespace, mc.installation.KubernetesProvider),
+		CreateNamespace(common.TigeraPrometheusNamespace, mc.installation.KubernetesProvider),
 	}
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.pullSecrets...)...)...)
 	toCreate = append(toCreate,

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -48,11 +48,11 @@ func (c *namespaceComponent) SupportedOSType() rmeta.OSType {
 
 func (c *namespaceComponent) Objects() ([]client.Object, []client.Object) {
 	ns := []client.Object{
-		createNamespace(common.CalicoNamespace, c.installation.KubernetesProvider),
+		CreateNamespace(common.CalicoNamespace, c.installation.KubernetesProvider),
 	}
 	if c.installation.Variant == operatorv1.TigeraSecureEnterprise {
 		// We need to always have ns tigera-dex even when the Authentication CR is not present, so policies can be added to this namespace.
-		ns = append(ns, createNamespace(DexObjectName, c.installation.KubernetesProvider))
+		ns = append(ns, CreateNamespace(DexObjectName, c.installation.KubernetesProvider))
 	}
 	if len(c.pullSecrets) > 0 {
 		ns = append(ns, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.pullSecrets...)...)...)
@@ -65,7 +65,7 @@ func (c *namespaceComponent) Ready() bool {
 	return true
 }
 
-func createNamespace(name string, provider operatorv1.Provider) *corev1.Namespace {
+func CreateNamespace(name string, provider operatorv1.Provider) *corev1.Namespace {
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -110,7 +110,7 @@ func (pc *packetCaptureApiComponent) SupportedOSType() rmeta.OSType {
 
 func (pc *packetCaptureApiComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		createNamespace(PacketCaptureNamespace, pc.installation.KubernetesProvider),
+		CreateNamespace(PacketCaptureNamespace, pc.installation.KubernetesProvider),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(PacketCaptureNamespace, pc.pullSecrets...)...)...)
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(PacketCaptureNamespace, pc.serverCertSecret)...)...)


### PR DESCRIPTION
The CloudLogStorage controller along with EsGateway in the Cloud Operator repo needs to access various helper functions and constants that are currently unexported or would cause an import cycle. This refactor is done upstream to reduce potential merge conflicts in the future.