### PR TITLE
Cherrypick ECK 1.3.2 and EK 7.11.2 upgrade to release 1.21

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -34,7 +34,7 @@ components:
     image: tigera/es-gateway
     version: release-calient-v3.9
   eck-kibana:
-    version: 7.10.1
+    version: 7.11.2
   dex:
     image: tigera/dex
     version: release-calient-v3.9
@@ -42,7 +42,7 @@ components:
     image: tigera/kibana
     version: release-calient-v3.9
   eck-elasticsearch:
-    version: 7.10.1
+    version: 7.11.2
   elasticsearch:
     image: tigera/elasticsearch
     version: release-calient-v3.9
@@ -92,7 +92,7 @@ components:
   # quay.io/tigera so all enterprise images come from the same repository and org.
   elasticsearch-operator:
     image: tigera/eck-operator
-    version: 1.2.1
+    version: 1.3.2
   prometheus:
     image: tigera/prometheus
     version: v2.17.2

--- a/deploy/crds/elastic/apmserver-crd.yaml
+++ b/deploy/crds/elastic/apmserver-crd.yaml
@@ -3,35 +3,34 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.0
     "helm.sh/hook": "crd-install"
-  creationTimestamp: null
   name: apmservers.apm.k8s.elastic.co
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: APM version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: APM version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: apm.k8s.elastic.co
   names:
     categories:
-      - elastic
+    - elastic
     kind: ApmServer
     listKind: ApmServerList
     plural: apmservers
     shortNames:
-      - apm
+    - apm
     singular: apmserver
   scope: Namespaced
   subresources:
@@ -74,7 +73,7 @@ spec:
                     to the current namespace.
                   type: string
               required:
-                - name
+              - name
               type: object
             http:
               description: HTTP holds the HTTP layer configuration for the APM Server
@@ -179,6 +178,15 @@ spec:
                             description: ServicePort contains information on service's
                               port.
                             properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. Field
+                                  can be enabled with ServiceAppProtocol feature gate.
+                                type: string
                               name:
                                 description: The name of this port within the service.
                                   This must be a DNS_LABEL. All ports within a ServiceSpec
@@ -208,8 +216,8 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                  - type: integer
-                                  - type: string
+                                - type: integer
+                                - type: string
                                 description: 'Number or name of the port to access
                                   on the pods targeted by the service. Number must
                                   be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
@@ -221,7 +229,7 @@ spec:
                                   omitted or set equal to the ''port'' field. More
                                   info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                             required:
-                              - port
+                            - port
                             type: object
                           type: array
                         publishNotReadyAddresses:
@@ -391,14 +399,14 @@ spec:
                             contain any ".." components.
                           type: string
                       required:
-                        - key
+                      - key
                       type: object
                     type: array
                   secretName:
                     description: SecretName is the name of the secret.
                     type: string
                 required:
-                  - secretName
+                - secretName
                 type: object
               type: array
             serviceAccountName:
@@ -416,6 +424,8 @@ spec:
           description: ApmServerStatus defines the observed state of ApmServer
           properties:
             availableNodes:
+              description: AvailableNodes is the number of available replicas in the
+                deployment.
               format: int32
               type: integer
             elasticsearchAssociationStatus:
@@ -423,8 +433,7 @@ spec:
                 to Elasticsearch clusters.
               type: string
             health:
-              description: ApmServerHealth expresses the status of the Apm Server
-                instances.
+              description: Health of the deployment.
               type: string
             kibanaAssociationStatus:
               description: KibanaAssociationStatus is the status of any auto-linking
@@ -438,18 +447,23 @@ spec:
               description: ExternalService is the name of the service the agents should
                 connect to.
               type: string
+            version:
+              description: 'Version of the stack resource currently running. During
+                version upgrades, multiple versions may run in parallel: this value
+                specifies the lowest version currently running.'
+              type: string
           type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
-    - name: v1beta1
-      served: true
-      storage: false
-    - name: v1alpha1
-      served: false
-      storage: false
+  - name: v1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1alpha1
+    served: false
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/deploy/crds/elastic/beat-crd.yaml
+++ b/deploy/crds/elastic/beat-crd.yaml
@@ -3,43 +3,42 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.0
     "helm.sh/hook": "crd-install"
-  creationTimestamp: null
   name: beats.beat.k8s.elastic.co
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: available
-      type: integer
-    - JSONPath: .status.expectedNodes
-      description: Expected nodes
-      name: expected
-      type: integer
-    - JSONPath: .spec.type
-      description: Beat type
-      name: type
-      type: string
-    - JSONPath: .spec.version
-      description: Beat version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: available
+    type: integer
+  - JSONPath: .status.expectedNodes
+    description: Expected nodes
+    name: expected
+    type: integer
+  - JSONPath: .spec.type
+    description: Beat type
+    name: type
+    type: string
+  - JSONPath: .status.version
+    description: Beat version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: beat.k8s.elastic.co
   names:
     categories:
-      - elastic
+    - elastic
     kind: Beat
     listKind: BeatList
     plural: beats
     shortNames:
-      - beat
+    - beat
     singular: beat
   scope: Namespaced
   subresources:
@@ -91,6 +90,54 @@ spec:
                 replicas:
                   format: int32
                   type: integer
+                strategy:
+                  description: DeploymentStrategy describes how to replace existing
+                    pods with new ones.
+                  properties:
+                    rollingUpdate:
+                      description: 'Rolling update config params. Present only if
+                        DeploymentStrategyType = RollingUpdate. --- TODO: Update this
+                        to follow our convention for oneOf, whatever we decide it
+                        to be.'
+                      properties:
+                        maxSurge:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be scheduled
+                            above the desired number of pods. Value can be an absolute
+                            number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0. Absolute number
+                            is calculated from percentage by rounding up. Defaults
+                            to 25%. Example: when this is set to 30%, the new ReplicaSet
+                            can be scaled up immediately when the rolling update starts,
+                            such that the total number of old and new pods do not
+                            exceed 130% of desired pods. Once old pods have been killed,
+                            new ReplicaSet can be scaled up further, ensuring that
+                            total number of pods running at any time during the update
+                            is at most 130% of desired pods.'
+                        maxUnavailable:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'The maximum number of pods that can be unavailable
+                            during the update. Value can be an absolute number (ex:
+                            5) or a percentage of desired pods (ex: 10%). Absolute
+                            number is calculated from percentage by rounding down.
+                            This can not be 0 if MaxSurge is 0. Defaults to 25%. Example:
+                            when this is set to 30%, the old ReplicaSet can be scaled
+                            down to 70% of desired pods immediately when the rolling
+                            update starts. Once new pods are ready, old ReplicaSet
+                            can be scaled down further, followed by scaling up the
+                            new ReplicaSet, ensuring that the total number of pods
+                            available at all times during the update is at least 70%
+                            of desired pods.'
+                      type: object
+                    type:
+                      description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                        Default is RollingUpdate.
+                      type: string
+                  type: object
               type: object
             elasticsearchRef:
               description: ElasticsearchRef is a reference to an Elasticsearch cluster
@@ -104,7 +151,7 @@ spec:
                     to the current namespace.
                   type: string
               required:
-                - name
+              - name
               type: object
             image:
               description: Image is the Beat Docker image to deploy. Version and Type
@@ -123,7 +170,7 @@ spec:
                     to the current namespace.
                   type: string
               required:
-                - name
+              - name
               type: object
             secureSettings:
               description: SecureSettings is a list of references to Kubernetes Secrets
@@ -153,14 +200,14 @@ spec:
                             contain any ".." components.
                           type: string
                       required:
-                        - key
+                      - key
                       type: object
                     type: array
                   secretName:
                     description: SecretName is the name of the secret.
                     type: string
                 required:
-                  - secretName
+                - secretName
                 type: object
               type: array
             serviceAccountName:
@@ -181,8 +228,8 @@ spec:
               description: Version of the Beat.
               type: string
           required:
-            - type
-            - version
+          - type
+          - version
           type: object
         status:
           description: BeatStatus defines the observed state of a Beat.
@@ -201,12 +248,17 @@ spec:
             kibanaAssociationStatus:
               description: AssociationStatus is the status of an association resource.
               type: string
+            version:
+              description: 'Version of the stack resource currently running. During
+                version upgrades, multiple versions may run in parallel: this value
+                specifies the lowest version currently running.'
+              type: string
           type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/deploy/crds/elastic/elasticsearch-crd.yaml
+++ b/deploy/crds/elastic/elasticsearch-crd.yaml
@@ -3,37 +3,37 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.0
+    "helm.sh/hook": "crd-install"
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: Elasticsearch version
-      name: version
-      type: string
-    - JSONPath: .status.phase
-      name: phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: Elasticsearch version
+    name: version
+    type: string
+  - JSONPath: .status.phase
+    name: phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: elasticsearch.k8s.elastic.co
   names:
     categories:
-      - elastic
+    - elastic
     kind: Elasticsearch
     listKind: ElasticsearchList
     plural: elasticsearches
     shortNames:
-      - es
+    - es
     singular: elasticsearch
   scope: Namespaced
   subresources:
@@ -188,6 +188,15 @@ spec:
                             description: ServicePort contains information on service's
                               port.
                             properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. Field
+                                  can be enabled with ServiceAppProtocol feature gate.
+                                type: string
                               name:
                                 description: The name of this port within the service.
                                   This must be a DNS_LABEL. All ports within a ServiceSpec
@@ -418,16 +427,21 @@ spec:
                                 type: string
                               type: array
                             dataSource:
-                              description: This field requires the VolumeSnapshotDataSource
-                                alpha feature gate to be enabled and currently VolumeSnapshot
-                                is the only supported data source. If the provisioner
-                                can support VolumeSnapshot data source, it will create
-                                a new volume and data will be restored to the volume
-                                at the same time. If the provisioner does not support
-                                VolumeSnapshot data source, volume will not be created
-                                and the failure will be reported as an event. In the
-                                future, we plan to support more data source types
-                                and the behavior of the provisioner may change.
+                              description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                - Beta) * An existing PVC (PersistentVolumeClaim)
+                                * An existing custom resource/object that implements
+                                data population (Alpha) In order to use VolumeSnapshot
+                                object types, the appropriate feature gate must be
+                                enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                If the provisioner or an external controller can support
+                                the specified data source, it will create a new volume
+                                based on the contents of the specified data source.
+                                If the specified data source is not supported, the
+                                volume will not be created and the failure will be
+                                reported as an event. In the future, we plan to support
+                                more data source types and the behavior of the provisioner
+                                may change.'
                               properties:
                                 apiGroup:
                                   description: APIGroup is the group for the resource
@@ -527,7 +541,7 @@ spec:
                             volumeMode:
                               description: volumeMode defines what type of volume
                                 is required by the claim. Value of Filesystem is implied
-                                when not included in claim spec. This is a beta feature.
+                                when not included in claim spec.
                               type: string
                             volumeName:
                               description: VolumeName is the binding reference to
@@ -856,6 +870,15 @@ spec:
                             description: ServicePort contains information on service's
                               port.
                             properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. Field
+                                  can be enabled with ServiceAppProtocol feature gate.
+                                type: string
                               name:
                                 description: The name of this port within the service.
                                   This must be a DNS_LABEL. All ports within a ServiceSpec
@@ -1016,6 +1039,7 @@ spec:
           description: ElasticsearchStatus defines the observed state of Elasticsearch
           properties:
             availableNodes:
+              description: AvailableNodes is the number of available instances.
               format: int32
               type: integer
             health:
@@ -1025,6 +1049,11 @@ spec:
             phase:
               description: ElasticsearchOrchestrationPhase is the phase Elasticsearch
                 is in from the controller point of view.
+              type: string
+            version:
+              description: 'Version of the stack resource currently running. During
+                version upgrades, multiple versions may run in parallel: this value
+                specifies the lowest version currently running.'
               type: string
           type: object
   version: v1

--- a/deploy/crds/elastic/enterprisesearch-crd.yaml
+++ b/deploy/crds/elastic/enterprisesearch-crd.yaml
@@ -3,35 +3,34 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.4.0
     "helm.sh/hook": "crd-install"
-  creationTimestamp: null
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: Enterprise Search version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: Enterprise Search version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: enterprisesearch.k8s.elastic.co
   names:
     categories:
-      - elastic
+    - elastic
     kind: EnterpriseSearch
     listKind: EnterpriseSearchList
     plural: enterprisesearches
     shortNames:
-      - ent
+    - ent
     singular: enterprisesearch
   scope: Namespaced
   subresources:
@@ -85,7 +84,7 @@ spec:
                     to the current namespace.
                   type: string
               required:
-                - name
+              - name
               type: object
             http:
               description: HTTP holds the HTTP layer configuration for Enterprise
@@ -190,6 +189,15 @@ spec:
                             description: ServicePort contains information on service's
                               port.
                             properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. Field
+                                  can be enabled with ServiceAppProtocol feature gate.
+                                type: string
                               name:
                                 description: The name of this port within the service.
                                   This must be a DNS_LABEL. All ports within a ServiceSpec
@@ -219,8 +227,8 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                  - type: integer
-                                  - type: string
+                                - type: integer
+                                - type: string
                                 description: 'Number or name of the port to access
                                   on the pods targeted by the service. Number must
                                   be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
@@ -232,7 +240,7 @@ spec:
                                   omitted or set equal to the ''port'' field. More
                                   info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                             required:
-                              - port
+                            - port
                             type: object
                           type: array
                         publishNotReadyAddresses:
@@ -379,22 +387,28 @@ spec:
                 clusters.
               type: string
             availableNodes:
+              description: AvailableNodes is the number of available replicas in the
+                deployment.
               format: int32
               type: integer
             health:
-              description: EnterpriseSearchHealth expresses the health of the Enterprise
-                Search instances.
+              description: Health of the deployment.
               type: string
             service:
               description: ExternalService is the name of the service associated to
                 the Enterprise Search Pods.
               type: string
+            version:
+              description: 'Version of the stack resource currently running. During
+                version upgrades, multiple versions may run in parallel: this value
+                specifies the lowest version currently running.'
+              type: string
           type: object
   version: v1beta1
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
+  - name: v1beta1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/deploy/crds/elastic/kibana-crd.yaml
+++ b/deploy/crds/elastic/kibana-crd.yaml
@@ -3,34 +3,34 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.0
+    "helm.sh/hook": "crd-install"
   name: kibanas.kibana.k8s.elastic.co
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.health
-      name: health
-      type: string
-    - JSONPath: .status.availableNodes
-      description: Available nodes
-      name: nodes
-      type: integer
-    - JSONPath: .spec.version
-      description: Kibana version
-      name: version
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: age
-      type: date
+  - JSONPath: .status.health
+    name: health
+    type: string
+  - JSONPath: .status.availableNodes
+    description: Available nodes
+    name: nodes
+    type: integer
+  - JSONPath: .status.version
+    description: Kibana version
+    name: version
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: kibana.k8s.elastic.co
   names:
     categories:
-      - elastic
+    - elastic
     kind: Kibana
     listKind: KibanaList
     plural: kibanas
     shortNames:
-      - kb
+    - kb
     singular: kibana
   scope: Namespaced
   subresources:
@@ -73,7 +73,7 @@ spec:
                     to the current namespace.
                   type: string
               required:
-                - name
+              - name
               type: object
             http:
               description: HTTP holds the HTTP layer configuration for Kibana.
@@ -177,6 +177,15 @@ spec:
                             description: ServicePort contains information on service's
                               port.
                             properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. Field
+                                  can be enabled with ServiceAppProtocol feature gate.
+                                type: string
                               name:
                                 description: The name of this port within the service.
                                   This must be a DNS_LABEL. All ports within a ServiceSpec
@@ -206,8 +215,8 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                  - type: integer
-                                  - type: string
+                                - type: integer
+                                - type: string
                                 description: 'Number or name of the port to access
                                   on the pods targeted by the service. Number must
                                   be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
@@ -219,7 +228,7 @@ spec:
                                   omitted or set equal to the ''port'' field. More
                                   info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                             required:
-                              - port
+                            - port
                             type: object
                           type: array
                         publishNotReadyAddresses:
@@ -374,14 +383,14 @@ spec:
                             contain any ".." components.
                           type: string
                       required:
-                        - key
+                      - key
                       type: object
                     type: array
                   secretName:
                     description: SecretName is the name of the secret.
                     type: string
                 required:
-                  - secretName
+                - secretName
                 type: object
               type: array
             serviceAccountName:
@@ -393,7 +402,7 @@ spec:
               description: Version of Kibana.
               type: string
           required:
-            - version
+          - version
           type: object
         status:
           description: KibanaStatus defines the observed state of Kibana
@@ -402,23 +411,30 @@ spec:
               description: AssociationStatus is the status of an association resource.
               type: string
             availableNodes:
+              description: AvailableNodes is the number of available replicas in the
+                deployment.
               format: int32
               type: integer
             health:
-              description: KibanaHealth expresses the status of the Kibana instances.
+              description: Health of the deployment.
+              type: string
+            version:
+              description: 'Version of the stack resource currently running. During
+                version upgrades, multiple versions may run in parallel: this value
+                specifies the lowest version currently running.'
               type: string
           type: object
   version: v1
   versions:
-    - name: v1
-      served: true
-      storage: true
-    - name: v1beta1
-      served: true
-      storage: false
-    - name: v1alpha1
-      served: false
-      storage: false
+  - name: v1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1alpha1
+    served: false
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -48,12 +48,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = component{
-		Version: "7.10.1",
+		Version: "7.11.2",
 		Image:   "tigera/elasticsearch",
 	}
 
 	ComponentEckKibana = component{
-		Version: "7.10.1",
+		Version: "7.11.2",
 		Image:   "tigera/kibana",
 	}
 
@@ -68,7 +68,7 @@ var (
 	}
 
 	ComponentElasticsearchOperator = component{
-		Version: "1.2.1",
+		Version: "1.3.2",
 		Image:   "tigera/eck-operator",
 	}
 


### PR DESCRIPTION
ECK is required to upgrade to 1.3.2 minimum to support ES 7.11. More
discussions in [1].

[1] https://github.com/elastic/cloud-on-k8s/issues/4234

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
