### PR TITLE
[cherry-pick]Fix! Enable authentication for packet capture (#1453)

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -115,6 +115,12 @@ func add(mgr manager.Manager, r *ReconcileAPIServer) error {
 				return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
 			}
 		}
+
+		// Watch for changes to authentication
+		err = c.Watch(&source.Kind{Type: &operatorv1.Authentication{}}, &handler.EnqueueRequestForObject{})
+		if err != nil {
+			return fmt.Errorf("apiserver-controller failed to watch resource: %w", err)
+		}
 	}
 
 	// Watch for certificate changes. We watch both secrets in case the user is switching between variants.

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -166,6 +166,15 @@ func (c *GuardianComponent) clusterRole() client.Object {
 				Resources: []string{"users", "groups", "serviceaccounts"},
 				Verbs:     []string{"impersonate"},
 			},
+			{
+				// Guardian forwards its token when sending the request to other services
+				// PacketCapture will authenticate the token from the request and check if impersonation is allowed
+				// AuthenticationReview API can authenticate a bearer token from the request if the token can create
+				// authenticationreviews
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"authenticationreviews"},
+				Verbs:     []string{"create"},
+			},
 		},
 	}
 }

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -313,7 +313,7 @@ func (pc *packetCaptureApiComponent) healthProbe() *corev1.Probe {
 				Scheme: corev1.URISchemeHTTPS,
 			},
 		},
-		InitialDelaySeconds: 90,
+		InitialDelaySeconds: 30,
 		PeriodSeconds:       10,
 	}
 }

--- a/pkg/render/packetcapture_api_test.go
+++ b/pkg/render/packetcapture_api_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 							Scheme: corev1.URISchemeHTTPS,
 						},
 					},
-					InitialDelaySeconds: 90,
+					InitialDelaySeconds: 30,
 					PeriodSeconds:       10,
 				},
 				LivenessProbe: &corev1.Probe{
@@ -216,7 +216,7 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 							Scheme: corev1.URISchemeHTTPS,
 						},
 					},
-					InitialDelaySeconds: 90,
+					InitialDelaySeconds: 30,
 					PeriodSeconds:       10,
 				},
 				Env:          envVars,


### PR DESCRIPTION
* Fix! Enable authentication for packet capture

- For a multicluster setup, tigera-guardian service account needs to be
allowed to create authentication reviews inside the managed cluster
- For an OIDC setup, api controller needs to be notified when
authentication CR is created
- Reduce initial delay time for readiness probe

* [Code review] Added comments

Co-authored-by: Alina Militaru <asincu@users.noreply.github.com>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
