### PR TITLE
Only set kubernetes server/port env vars on host-networked pods.

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -131,7 +131,7 @@ func APIServer(k8sServiceEndpoint k8sapi.ServiceEndpoint,
 
 	return &apiServerComponent{
 		installation:                installation,
-		hostNetwork:                 hostNetwork,
+		forceHostNetwork:            hostNetwork,
 		managementCluster:           managementCluster,
 		managementClusterConnection: managementClusterConnection,
 		amazonCloudIntegration:      aci,
@@ -155,7 +155,7 @@ type apiServerComponent struct {
 	pullSecrets                 []*corev1.Secret
 	openshift                   bool
 	isManagement                bool
-	hostNetwork                 bool
+	forceHostNetwork            bool
 	clusterDomain               string
 	apiServerImage              string
 	queryServerImage            string
@@ -783,16 +783,8 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 	}
 
 	var replicas int32 = 1
-	hostNetwork := c.hostNetwork
+	hostNetwork := c.hostNetwork()
 	dnsPolicy := corev1.DNSClusterFirst
-	if c.installation.KubernetesProvider == operatorv1.ProviderEKS &&
-		c.installation.CNI.Type == operatorv1.PluginCalico {
-		// Workaround the fact that webhooks don't work for non-host-networked pods
-		// when in this networking mode on EKS, because the control plane nodes don't run
-		// Calico.
-		hostNetwork = true
-	}
-
 	if hostNetwork {
 		// Adjust DNS policy so we can access in-cluster services.
 		dnsPolicy = corev1.DNSClusterFirstWithHostNet
@@ -860,6 +852,18 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 	return d
 }
 
+func (c *apiServerComponent) hostNetwork() bool {
+	hostNetwork := c.forceHostNetwork
+	if c.installation.KubernetesProvider == operatorv1.ProviderEKS &&
+		c.installation.CNI.Type == operatorv1.PluginCalico {
+		// Workaround the fact that webhooks don't work for non-host-networked pods
+		// when in this networking mode on EKS, because the control plane nodes don't run
+		// Calico.
+		hostNetwork = true
+	}
+	return hostNetwork
+}
+
 // apiServerContainer creates the API server container.
 func (c *apiServerComponent) apiServerContainer() corev1.Container {
 	volumeMounts := []corev1.VolumeMount{}
@@ -894,7 +898,7 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 	}
 
-	env = append(env, c.k8sServiceEp.EnvVars()...)
+	env = append(env, c.k8sServiceEp.EnvVars(c.hostNetwork(), c.installation.KubernetesProvider)...)
 
 	if c.installation.CalicoNetwork != nil && c.installation.CalicoNetwork.MultiInterfaceMode != nil {
 		env = append(env, corev1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.installation.CalicoNetwork.MultiInterfaceMode.Value()})
@@ -976,7 +980,8 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		{Name: "LOGLEVEL", Value: "info"},
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 	}
-	env = append(env, c.k8sServiceEp.EnvVars()...)
+
+	env = append(env, c.k8sServiceEp.EnvVars(c.hostNetwork(), c.installation.KubernetesProvider)...)
 	env = append(env, GetTigeraSecurityGroupEnvVariables(c.amazonCloudIntegration)...)
 
 	if c.installation.CalicoNetwork != nil && c.installation.CalicoNetwork.MultiInterfaceMode != nil {
@@ -1059,7 +1064,7 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 
 // tolerations creates the tolerations used by the API server deployment.
 func (c *apiServerComponent) tolerations() []corev1.Toleration {
-	if c.hostNetwork {
+	if c.hostNetwork() {
 		return rmeta.TolerateAll
 	}
 	return append(c.installation.ControlPlaneTolerations, rmeta.TolerateMaster)

--- a/pkg/render/common/test/testing.go
+++ b/pkg/render/common/test/testing.go
@@ -46,6 +46,21 @@ func ExpectK8sServiceEpEnvVars(podSpec corev1.PodSpec, host, port string) {
 	}
 }
 
+func ExpectNoK8sServiceEpEnvVars(podSpec corev1.PodSpec) {
+	for _, c := range podSpec.Containers {
+		for _, ev := range c.Env {
+			ExpectWithOffset(1, ev.Name).NotTo(Equal("KUBERNETES_SERVICE_HOST"))
+			ExpectWithOffset(1, ev.Name).NotTo(Equal("KUBERNETES_SERVICE_PORT"))
+		}
+	}
+	for _, c := range podSpec.InitContainers {
+		for _, ev := range c.Env {
+			ExpectWithOffset(1, ev.Name).NotTo(Equal("KUBERNETES_SERVICE_HOST"))
+			ExpectWithOffset(1, ev.Name).NotTo(Equal("KUBERNETES_SERVICE_PORT"))
+		}
+	}
+}
+
 func ExpectResourceInList(objs []client.Object, name, ns, group, version, kind string) {
 	type expectedResource struct {
 		Name      string

--- a/pkg/render/kube-controllers.go
+++ b/pkg/render/kube-controllers.go
@@ -324,7 +324,7 @@ func (c *kubeControllersComponent) controllersDeployment() *apps.Deployment {
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 	}
 
-	env = append(env, c.cfg.K8sServiceEp.EnvVars()...)
+	env = append(env, c.cfg.K8sServiceEp.EnvVars(false, c.cfg.Installation.KubernetesProvider)...)
 
 	enabledControllers := []string{"node"}
 	if c.cfg.Installation.Variant == operator.TigeraSecureEnterprise {

--- a/pkg/render/kube-controllers_test.go
+++ b/pkg/render/kube-controllers_test.go
@@ -480,4 +480,19 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		deployment := depResource.(*apps.Deployment)
 		rtest.ExpectK8sServiceEpEnvVars(deployment.Spec.Template.Spec, "k8shost", "1234")
 	})
+
+	It("should not add the KUBERNETES_SERVICE_... variables on docker EE using proxy.local", func() {
+		k8sServiceEp.Host = "proxy.local"
+		k8sServiceEp.Port = "1234"
+		instance.KubernetesProvider = operator.ProviderDockerEE
+
+		component := render.KubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		depResource := rtest.GetResource(resources, "calico-kube-controllers", "calico-system", "apps", "v1", "Deployment")
+		Expect(depResource).ToNot(BeNil())
+		deployment := depResource.(*apps.Deployment)
+		rtest.ExpectNoK8sServiceEpEnvVars(deployment.Spec.Template.Spec)
+	})
 })

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -944,7 +944,7 @@ func (c *nodeComponent) cniEnvvars() []v1.EnvVar {
 		},
 	}
 
-	envVars = append(envVars, c.cfg.K8sServiceEp.EnvVars()...)
+	envVars = append(envVars, c.cfg.K8sServiceEp.EnvVars(true, c.cfg.Installation.KubernetesProvider)...)
 
 	if c.cfg.Installation.Variant == operator.TigeraSecureEnterprise {
 		if c.cfg.Installation.CalicoNetwork != nil && c.cfg.Installation.CalicoNetwork.MultiInterfaceMode != nil {
@@ -1340,7 +1340,7 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 		})
 	}
 
-	nodeEnv = append(nodeEnv, c.cfg.K8sServiceEp.EnvVars()...)
+	nodeEnv = append(nodeEnv, c.cfg.K8sServiceEp.EnvVars(true, c.cfg.Installation.KubernetesProvider)...)
 
 	if c.cfg.BGPLayouts != nil {
 		nodeEnv = append(nodeEnv, v1.EnvVar{

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -565,7 +565,7 @@ func (c *typhaComponent) typhaEnvVars() []v1.EnvVar {
 	}
 
 	typhaEnv = append(typhaEnv, GetTigeraSecurityGroupEnvVariables(c.cfg.AmazonCloudIntegration)...)
-	typhaEnv = append(typhaEnv, c.cfg.K8sServiceEp.EnvVars()...)
+	typhaEnv = append(typhaEnv, c.cfg.K8sServiceEp.EnvVars(true, c.cfg.Installation.KubernetesProvider)...)
 
 	if c.cfg.Installation.TyphaMetricsPort != nil {
 		// If a typha metrics port was given, then enable typha prometheus metrics and set the port.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
In MKE clusters, the API server is only reachable via the MKE proxy from the host namespace because it is implemented as a DNS entry in /etc/hosts on the host.

## For PR author

- [x] Tests for change.

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
