### PR TITLE
Default FelixConfiguration RouteTableRange when using AWS CNI

### DIFF
--- a/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
+++ b/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
@@ -213,7 +213,7 @@ type FelixConfigurationSpec struct {
 	// set to false. This reduces the number of metrics reported, reducing Prometheus load. [Default: true]
 	PrometheusProcessMetricsEnabled *bool `json:"prometheusProcessMetricsEnabled,omitempty"`
 	// PrometheusReporterPort specifies the TCP port on which to report denied packet metrics.
-	PrometheusReporterPort *int `json:"prometheusReporterPort"`
+	PrometheusReporterPort *int `json:"prometheusReporterPort,omitempty"`
 
 	// FailsafeInboundHostPorts is a comma-delimited list of UDP/TCP ports that Felix will allow incoming traffic to host endpoints
 	// on irrespective of the security policy. This is useful to avoid accidentally cutting off a host with incorrect configuration. Each

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -215,6 +215,12 @@ func add(mgr manager.Manager, r *ReconcileInstallation) error {
 		return fmt.Errorf("tigera-installation-controller failed to watch KubeControllersConfiguration resource: %w", err)
 	}
 
+	// Watch for changes to FelixConfiguration.
+	err = c.Watch(&source.Kind{Type: &crdv1.FelixConfiguration{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("tigera-installation-controller failed to watch FelixConfiguration resource: %w", err)
+	}
+
 	if r.enterpriseCRDsExist {
 		// Watch for changes to primary resource ManagementCluster
 		err = c.Watch(&source.Kind{Type: &operator.ManagementCluster{}}, &handler.EnqueueRequestForObject{})
@@ -258,6 +264,12 @@ func add(mgr manager.Manager, r *ReconcileInstallation) error {
 		err = c.Watch(&source.Kind{Type: &crdv1.FelixConfiguration{}}, &handler.EnqueueRequestForObject{})
 		if err != nil {
 			return fmt.Errorf("tigera-installation-controller failed to watch FelixConfiguration resource: %w", err)
+		}
+
+		//watch for change to primary resource LogCollector
+		err = c.Watch(&source.Kind{Type: &operator.LogCollector{}}, &handler.EnqueueRequestForObject{})
+		if err != nil {
+			return fmt.Errorf("tigera-installation-controller failed to watch primary resource: %v", err)
 		}
 	}
 
@@ -988,19 +1000,24 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
+	// Fetch any existing default FelixConfiguration object.
+	felixConfiguration := &crdv1.FelixConfiguration{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: "default"}, felixConfiguration)
+	if err != nil && !apierrors.IsNotFound(err) {
+		r.SetDegraded("Unable to read FelixConfiguration", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	if err = r.setDefaultsOnFelixConfiguration(ctx, instance, felixConfiguration, reqLogger); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// nodeReporterMetricsPort is a port used in Enterprise to host internal metrics.
 	// Operator is responsible for creating a service which maps to that port.
 	// Here, we'll check the default felixconfiguration to see if the user is specifying
 	// a non-default port, and use that value if they are.
 	nodeReporterMetricsPort := defaultNodeReporterPort
 	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
-		// Query the FelixConfiguration object. We'll use this to help configure felix.
-		felixConfiguration := &crdv1.FelixConfiguration{}
-		err = r.client.Get(ctx, types.NamespacedName{Name: "default"}, felixConfiguration)
-		if err != nil && !apierrors.IsNotFound(err) {
-			r.SetDegraded("Unable to read FelixConfiguration", err, reqLogger)
-			return reconcile.Result{}, err
-		}
 
 		// Determine the port to use for nodeReporter metrics.
 		if felixConfiguration.Spec.PrometheusReporterPort != nil {
@@ -1337,6 +1354,59 @@ func (r *ReconcileInstallation) validateTyphaCAConfigMap() (*corev1.ConfigMap, e
 	}
 
 	return cm, nil
+}
+
+// setDefaultOnFelixConfiguration will take the passed in fc and add any defaulting needed
+// based on the install config. If the FelixConfig ResourceVersion is empty,
+// then the FelixConfig default will be created, otherwise a patch will be performed.
+func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Context, install *operator.Installation, fc *crdv1.FelixConfiguration, log logr.Logger) error {
+	patchFrom := client.MergeFrom(fc.DeepCopy())
+	fc.ObjectMeta.Name = "default"
+	updated := false
+
+	switch install.Spec.CNI.Type {
+	// If we're using the AWS CNI plugin we need to ensure the route tables that calico-node
+	// uses do not conflict with the ones the AWS CNI plugin uses so default them
+	// in the FelixConfiguration if they are not already set.
+	case operator.PluginAmazonVPC:
+		if fc.Spec.RouteTableRange == nil {
+			updated = true
+			// Defaulting based on that AWS might be using the following:
+			// - The ENI device number + 1
+			//   Currently the max number of ENIs for any host is 15.
+			//   p4d.24xlarge is reported to support 4x15 ENI but it uses 4 cards
+			//   and AWS CNI only uses ENIs on card 0.
+			// - The VLAN table ID + 100 (there is doubt if this is true)
+			fc.Spec.RouteTableRange = &crdv1.RouteTableRange{
+				Min: 65,
+				Max: 99,
+			}
+		}
+	case operator.PluginGKE:
+		if fc.Spec.RouteTableRange == nil {
+			updated = true
+			// Don't conflict with the GKE CNI plugin's routes.
+			fc.Spec.RouteTableRange = &crdv1.RouteTableRange{
+				Min: 10,
+				Max: 250,
+			}
+		}
+	}
+	if !updated {
+		return nil
+	}
+	if fc.ResourceVersion == "" {
+		if err := r.client.Create(ctx, fc); err != nil {
+			r.SetDegraded("Unable to Create default FelixConfiguration", err, log)
+			return err
+		}
+	} else {
+		if err := r.client.Patch(ctx, fc, patchFrom); err != nil {
+			r.SetDegraded("Unable to Patch default FelixConfiguration", err, log)
+			return err
+		}
+	}
+	return nil
 }
 
 func getConfigMap(client client.Client, cmName string) (*corev1.ConfigMap, error) {

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -25,6 +25,7 @@ import (
 	schedv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -39,6 +40,7 @@ import (
 	osconfigv1 "github.com/openshift/api/config/v1"
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/status"
@@ -757,6 +759,175 @@ var _ = Describe("Testing core-controller installation", func() {
 			dnsNames = append(dnsNames, "localhost")
 			Expect(test.GetResource(c, internalManagerTLSSecret)).To(BeNil())
 			test.VerifyCert(internalManagerTLSSecret, render.ManagerInternalSecretKeyName, render.ManagerInternalSecretCertName, dnsNames...)
+		})
+	})
+	Context("Reconcile tests", func() {
+		var c client.Client
+		var cs *kfake.Clientset
+		var ctx context.Context
+		var r ReconcileInstallation
+		var scheme *runtime.Scheme
+		var mockStatus *status.MockStatus
+
+		var cr *operator.Installation
+
+		BeforeEach(func() {
+			// The schema contains all objects that should be known to the fake client when the test runs.
+			scheme = runtime.NewScheme()
+			Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+			Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(schedv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(operator.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+			// Create a client that will have a crud interface of k8s objects.
+			c = fake.NewFakeClientWithScheme(scheme)
+			ctx = context.Background()
+
+			// Create a fake clientset for the autoscaler.
+			var replicas int32 = 1
+			objs := []runtime.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node1",
+						Labels: map[string]string{"kubernetes.io/os": "linux"},
+					},
+					Spec: corev1.NodeSpec{},
+				},
+				&appsv1.Deployment{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+				},
+			}
+			cs = kfake.NewSimpleClientset(objs...)
+
+			// Create an object we can use throughout the test to do the compliance reconcile loops.
+			mockStatus = &status.MockStatus{}
+			mockStatus.On("AddDaemonsets", mock.Anything).Return()
+			mockStatus.On("AddDeployments", mock.Anything).Return()
+			mockStatus.On("AddStatefulSets", mock.Anything).Return()
+			mockStatus.On("AddCronJobs", mock.Anything)
+			mockStatus.On("IsAvailable").Return(true)
+			mockStatus.On("OnCRFound").Return()
+			mockStatus.On("ClearDegraded")
+			mockStatus.On("AddCertificateSigningRequests", mock.Anything)
+			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
+			mockStatus.On("ReadyToMonitor")
+
+			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
+			r = ReconcileInstallation{
+				config:               nil, // there is no fake for config
+				client:               c,
+				scheme:               scheme,
+				autoDetectedProvider: operator.ProviderNone,
+				status:               mockStatus,
+				typhaAutoscaler:      newTyphaAutoscaler(cs, nodeListWatch{cs}, typhaListWatch{cs}, mockStatus),
+				namespaceMigration:   &fakeNamespaceMigration{},
+				amazonCRDExists:      true,
+				enterpriseCRDsExist:  true,
+				migrationChecked:     true,
+			}
+			r.typhaAutoscaler.start()
+
+			// We start off with a 'standard' installation, with nothing special
+			cr = &operator.Installation{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: operator.InstallationSpec{
+					Variant:               operator.TigeraSecureEnterprise,
+					Registry:              "some.registry.org/",
+					CertificateManagement: &operator.CertificateManagement{},
+				},
+			}
+		})
+
+		It("should Reconcile with default config", func() {
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check that with non-AWS CNI no FelixConfiguration is created
+			fc := &crdv1.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("should Reconcile with AWS CNI config", func() {
+			cr.Spec.CNI = &operator.CNISpec{Type: operator.PluginAmazonVPC}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check that FelixConfiguration is created with RouteTableRange
+			fc := &crdv1.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.RouteTableRange).NotTo(BeNil())
+			Expect(*fc.Spec.RouteTableRange).To(Equal(crdv1.RouteTableRange{Min: 65, Max: 99}))
+		})
+
+		It("should Reconcile with GKE CNI config", func() {
+			cr.Spec.CNI = &operator.CNISpec{Type: operator.PluginGKE}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check that FelixConfiguration is created with RouteTableRange
+			fc := &crdv1.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.RouteTableRange).NotTo(BeNil())
+			Expect(*fc.Spec.RouteTableRange).To(Equal(crdv1.RouteTableRange{Min: 10, Max: 250}))
+		})
+
+		It("should Reconcile with AWS CNI and not change existing FelixConfig", func() {
+			fc := &crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: crdv1.FelixConfigurationSpec{
+					RouteTableRange:   &crdv1.RouteTableRange{Min: 15, Max: 55},
+					LogSeverityScreen: "Error",
+				},
+			}
+			err := c.Create(ctx, fc)
+			cr.Spec.CNI = &operator.CNISpec{Type: operator.PluginAmazonVPC}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check that FelixConfiguration has not changed
+			fc = &crdv1.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.RouteTableRange).NotTo(BeNil())
+			Expect(*fc.Spec.RouteTableRange).To(Equal(crdv1.RouteTableRange{Min: 15, Max: 55}))
+			Expect(fc.Spec.LogSeverityScreen).To(Equal("Error"))
+		})
+
+		It("should Reconcile with AWS CNI and update existing FelixConfig", func() {
+			fc := &crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+				Spec: crdv1.FelixConfigurationSpec{
+					LogSeverityScreen: "Error",
+				},
+			}
+			err := c.Create(ctx, fc)
+			cr.Spec.CNI = &operator.CNISpec{Type: operator.PluginAmazonVPC}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check that FelixConfiguration is created with RouteTableRange
+			fc = &crdv1.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.RouteTableRange).NotTo(BeNil())
+			Expect(*fc.Spec.RouteTableRange).To(Equal(crdv1.RouteTableRange{Min: 65, Max: 99}))
+			Expect(fc.Spec.LogSeverityScreen).To(Equal("Error"))
 		})
 	})
 })

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1252,8 +1252,6 @@ func (c *nodeComponent) nodeEnvVars() []v1.EnvVar {
 		// The GKE CNI plugin has its own iptables rules. Defer to them after ours.
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"})
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_IPTABLESFILTERALLOWACTION", Value: "Return"})
-		// Don't conflict with the GKE CNI plugin's routes.
-		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_ROUTETABLERANGE", Value: "10-250"})
 	case operator.PluginAzureVNET:
 		nodeEnv = append(nodeEnv, v1.EnvVar{Name: "FELIX_INTERFACEPREFIX", Value: "azv"})
 	}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1152,7 +1152,6 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_INTERFACEPREFIX", Value: "gke"},
 			{Name: "FELIX_IPTABLESMANGLEALLOWACTION", Value: "Return"},
 			{Name: "FELIX_IPTABLESFILTERALLOWACTION", Value: "Return"},
-			{Name: "FELIX_ROUTETABLERANGE", Value: "10-250"},
 		}),
 		Entry("AmazonVPC", operator.PluginAmazonVPC, operator.IPAMPluginAmazonVPC, []v1.EnvVar{
 			{Name: "FELIX_INTERFACEPREFIX", Value: "eni"},


### PR DESCRIPTION
Cherry-pick to add this fix for 3.8 (1.19)

* Move GKE ROUTETABLERANGE to be set like for AWS
* Move FelixConfig to watch for all variants

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
