### PR TITLE
Update priority class logic

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -15,9 +15,10 @@
 package common
 
 const (
-	CalicoNamespace     = "calico-system"
-	TyphaDeploymentName = "calico-typha"
-	NodeDaemonSetName   = "calico-node"
+	CalicoNamespace               = "calico-system"
+	TyphaDeploymentName           = "calico-typha"
+	NodeDaemonSetName             = "calico-node"
+	KubeControllersDeploymentName = "calico-kube-controllers"
 
 	// Monitor + Prometheus related const
 	TigeraPrometheusNamespace = "tigera-prometheus"

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/ptr"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -41,7 +41,7 @@ const (
 	credentialSecretHashAnnotation       = "hash.operator.tigera.io/credential-secret"
 )
 
-func AmazonCloudIntegration(aci *operator.AmazonCloudIntegration, installation *operator.InstallationSpec, cred *AmazonCredential, ps []*corev1.Secret, openshift bool) (Component, error) {
+func AmazonCloudIntegration(aci *operatorv1.AmazonCloudIntegration, installation *operatorv1.InstallationSpec, cred *AmazonCredential, ps []*corev1.Secret, openshift bool) (Component, error) {
 	return &amazonCloudIntegrationComponent{
 		amazonCloudIntegration: aci,
 		installation:           installation,
@@ -52,15 +52,15 @@ func AmazonCloudIntegration(aci *operator.AmazonCloudIntegration, installation *
 }
 
 type amazonCloudIntegrationComponent struct {
-	amazonCloudIntegration *operator.AmazonCloudIntegration
-	installation           *operator.InstallationSpec
+	amazonCloudIntegration *operatorv1.AmazonCloudIntegration
+	installation           *operatorv1.InstallationSpec
 	credentials            *AmazonCredential
 	pullSecrets            []*corev1.Secret
 	openshift              bool
 	image                  string
 }
 
-func (c *amazonCloudIntegrationComponent) ResolveImages(is *operator.ImageSet) error {
+func (c *amazonCloudIntegrationComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.installation.Registry
 	path := c.installation.ImagePath
 	prefix := c.installation.ImagePrefix
@@ -227,7 +227,7 @@ func (c *amazonCloudIntegrationComponent) deployment() *appsv1.Deployment {
 	annotations[credentialSecretHashAnnotation] = rmeta.AnnotationHash(c.credentials)
 
 	d := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      AmazonCloudIntegrationComponentName,
 			Namespace: AmazonCloudIntegrationNamespace,
@@ -262,7 +262,7 @@ func (c *amazonCloudIntegrationComponent) deployment() *appsv1.Deployment {
 			},
 		},
 	}
-	setCriticalPod(&d.Spec.Template)
+	setClusterCriticalPod(&d.Spec.Template)
 
 	return d
 }
@@ -296,7 +296,7 @@ func (c *amazonCloudIntegrationComponent) container() corev1.Container {
 		}},
 	}
 
-	if c.amazonCloudIntegration.Spec.DefaultPodMetadataAccess == operator.MetadataAccessAllowed {
+	if c.amazonCloudIntegration.Spec.DefaultPodMetadataAccess == operatorv1.MetadataAccessAllowed {
 		env = append(env, corev1.EnvVar{Name: "ALLOW_POD_METADATA_ACCESS", Value: "true"})
 	}
 
@@ -325,7 +325,7 @@ func (c *amazonCloudIntegrationComponent) container() corev1.Container {
 	}
 }
 
-func GetTigeraSecurityGroupEnvVariables(aci *operator.AmazonCloudIntegration) []corev1.EnvVar {
+func GetTigeraSecurityGroupEnvVariables(aci *operatorv1.AmazonCloudIntegration) []corev1.EnvVar {
 	envs := []corev1.EnvVar{}
 	if aci == nil {
 		return envs

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -1114,7 +1113,7 @@ func (c *apiServerComponent) apiServerPodSecurityPolicy() (client.Object, client
 //
 // Calico only.
 func (c *apiServerComponent) networkPolicy() *netv1.NetworkPolicy {
-	tcp := v1.ProtocolTCP
+	tcp := corev1.ProtocolTCP
 	p := intstr.FromInt(5443)
 	return &netv1.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "networking.k8s.io/v1"},

--- a/pkg/render/aws-securitygroup-setup.go
+++ b/pkg/render/aws-securitygroup-setup.go
@@ -21,19 +21,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podsecuritycontext"
 )
 
-func AWSSecurityGroupSetup(ps []corev1.LocalObjectReference, installcr *operator.InstallationSpec) (Component, error) {
+func AWSSecurityGroupSetup(ps []corev1.LocalObjectReference, installcr *operatorv1.InstallationSpec) (Component, error) {
 	return &awsSGSetupComponent{pullSecrets: ps, installcr: installcr}, nil
 }
 
 type awsSGSetupComponent struct {
 	pullSecrets []corev1.LocalObjectReference
-	installcr   *operator.InstallationSpec
+	installcr   *operatorv1.InstallationSpec
 	image       string
 }
 
@@ -41,7 +41,7 @@ func (c *awsSGSetupComponent) SupportedOSType() rmeta.OSType {
 	return rmeta.OSTypeLinux
 }
 
-func (c *awsSGSetupComponent) ResolveImages(is *operator.ImageSet) error {
+func (c *awsSGSetupComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.installcr.Registry
 	path := c.installcr.ImagePath
 	prefix := c.installcr.ImagePrefix

--- a/pkg/render/component.go
+++ b/pkg/render/component.go
@@ -15,7 +15,7 @@
 package render
 
 import (
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,7 +25,7 @@ type Component interface {
 	// needs, passing 'is' to the GetReference call and if there are any errors those
 	// are returned. It is valid to pass nil for 'is' as GetReference accepts the value.
 	// ResolveImages must be called before Objects is called for the component.
-	ResolveImages(is *operator.ImageSet) error
+	ResolveImages(is *operatorv1.ImageSet) error
 
 	// Objects returns the lists of objects in this component that should be created and/or deleted during
 	// rendering.

--- a/pkg/render/csr.go
+++ b/pkg/render/csr.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 )
 
 const (
@@ -39,7 +39,7 @@ const (
 // CreateCSRInitContainer creates an init container that can be added to a pod spec in order to create a CSR for its
 // TLS certificates. It uses the provided params and the k8s downward api to be able to specify certificate subject information.
 func CreateCSRInitContainer(
-	certificateManagement *operator.CertificateManagement,
+	certificateManagement *operatorv1.CertificateManagement,
 	image string,
 	mountName string,
 	commonName string,
@@ -89,7 +89,7 @@ func CreateCSRInitContainer(
 }
 
 // ResolveCsrInitImage resolves the image needed for the CSR init image taking into account the specified ImageSet
-func ResolveCSRInitImage(inst *operator.InstallationSpec, is *operator.ImageSet) (string, error) {
+func ResolveCSRInitImage(inst *operatorv1.InstallationSpec, is *operatorv1.ImageSet) (string, error) {
 	return components.GetReference(
 		components.ComponentCSRInitContainer,
 		inst.Registry,
@@ -142,7 +142,7 @@ func CSRClusterRoleBinding(name, namespace string) *rbacv1.ClusterRoleBinding {
 	return crb
 }
 
-func certificateVolumeSource(certificateManagement *operator.CertificateManagement, secretName string) corev1.VolumeSource {
+func certificateVolumeSource(certificateManagement *operatorv1.CertificateManagement, secretName string) corev1.VolumeSource {
 	var defaultMode int32 = 420
 	if certificateManagement != nil {
 		return corev1.VolumeSource{

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	oprv1 "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/dns"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -54,7 +54,7 @@ const (
 func Dex(
 	pullSecrets []*corev1.Secret,
 	openshift bool,
-	installation *oprv1.InstallationSpec,
+	installation *operatorv1.InstallationSpec,
 	dexConfig DexConfig,
 	clusterDomain string,
 	deleteDex bool,
@@ -75,7 +75,7 @@ type dexComponent struct {
 	dexConfig     DexConfig
 	pullSecrets   []*corev1.Secret
 	openshift     bool
-	installation  *oprv1.InstallationSpec
+	installation  *operatorv1.InstallationSpec
 	connector     map[string]interface{}
 	image         string
 	csrInitImage  string
@@ -83,7 +83,7 @@ type dexComponent struct {
 	deleteDex     bool
 }
 
-func (c *dexComponent) ResolveImages(is *oprv1.ImageSet) error {
+func (c *dexComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.installation.Registry
 	path := c.installation.ImagePath
 	prefix := c.installation.ImagePrefix

--- a/pkg/render/fixtures_test.go
+++ b/pkg/render/fixtures_test.go
@@ -17,11 +17,11 @@ package render_test
 import (
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var internalManagerTLSSecret = v1.Secret{
+var internalManagerTLSSecret = corev1.Secret{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Secret",
 		APIVersion: "v1",
@@ -36,7 +36,7 @@ var internalManagerTLSSecret = v1.Secret{
 	},
 }
 
-var elasticsearchSecret = v1.Secret{
+var elasticsearchSecret = corev1.Secret{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Secret",
 		APIVersion: "v1",
@@ -51,7 +51,7 @@ var elasticsearchSecret = v1.Secret{
 	},
 }
 
-var kubeControllersUserSecret = v1.Secret{
+var kubeControllersUserSecret = corev1.Secret{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Secret",
 		APIVersion: "v1",
@@ -66,7 +66,7 @@ var kubeControllersUserSecret = v1.Secret{
 	},
 }
 
-var kibanaSecret = v1.Secret{
+var kibanaSecret = corev1.Secret{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Secret",
 		APIVersion: "v1",
@@ -80,7 +80,7 @@ var kibanaSecret = v1.Secret{
 		"key":  []byte("key"),
 	},
 }
-var voltronTunnelSecret = v1.Secret{
+var voltronTunnelSecret = corev1.Secret{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "Secret",
 		APIVersion: "v1",

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -453,7 +453,7 @@ func (c *fluentdComponent) daemonset() *appsv1.DaemonSet {
 		},
 	}
 
-	setCriticalPod(&(ds.Spec.Template))
+	setNodeCriticalPod(&(ds.Spec.Template))
 	return ds
 }
 

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -25,7 +25,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
-	apps "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -82,7 +82,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Volumes[0].VolumeSource.HostPath.Path).To(Equal("/var/log/calico"))
 		envs := ds.Spec.Template.Spec.Containers[0].Env
 
@@ -171,7 +171,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		ds := rtest.GetResource(resources, "fluentd-node-windows", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds := rtest.GetResource(resources, "fluentd-node-windows", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Volumes[0].VolumeSource.HostPath.Path).To(Equal("c:/TigeraCalico"))
 
 		envs := ds.Spec.Template.Spec.Containers[0].Env
@@ -194,7 +194,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			Expect(envs).To(ContainElement(expected))
 		}
 
-		ds = rtest.GetResource(resources, "fluentd-node-windows", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds = rtest.GetResource(resources, "fluentd-node-windows", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		envs = ds.Spec.Template.Spec.Containers[0].Env
 
 		expectedEnvs = []corev1.EnvVar{
@@ -275,7 +275,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Annotations).To(HaveKey("hash.operator.tigera.io/s3-credentials"))
 		envs := ds.Spec.Template.Spec.Containers[0].Env
@@ -351,7 +351,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		envs := ds.Spec.Template.Spec.Containers[0].Env
@@ -435,7 +435,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(3))
 
@@ -518,7 +518,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		envs := ds.Spec.Template.Spec.Containers[0].Env
 
@@ -589,7 +589,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*apps.DaemonSet)
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Annotations).To(HaveKey("hash.operator.tigera.io/fluentd-filters"))
 		envs := ds.Spec.Template.Spec.Containers[0].Env
@@ -650,7 +650,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			i++
 		}
 
-		deploy := rtest.GetResource(resources, "eks-log-forwarder", "tigera-fluentd", "apps", "v1", "Deployment").(*apps.Deployment)
+		deploy := rtest.GetResource(resources, "eks-log-forwarder", "tigera-fluentd", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 		Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(deploy.Spec.Template.Annotations).To(HaveKey("hash.operator.tigera.io/eks-cloudwatch-log-credentials"))

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -19,7 +19,6 @@ package render
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -65,7 +64,7 @@ func Guardian(
 
 type GuardianComponent struct {
 	url                 string
-	pullSecrets         []*v1.Secret
+	pullSecrets         []*corev1.Secret
 	openshift           bool
 	installation        *operatorv1.InstallationSpec
 	tunnelSecret        *corev1.Secret
@@ -148,7 +147,7 @@ func (c *GuardianComponent) service() *corev1.Service {
 }
 
 func (c *GuardianComponent) serviceAccount() client.Object {
-	return &v1.ServiceAccount{
+	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: GuardianServiceAccountName, Namespace: GuardianNamespace},
 	}
@@ -242,21 +241,21 @@ func (c *GuardianComponent) deployment() client.Object {
 	}
 }
 
-func (c *GuardianComponent) volumes() []v1.Volume {
-	return []v1.Volume{
+func (c *GuardianComponent) volumes() []corev1.Volume {
+	return []corev1.Volume{
 		{
 			Name: GuardianVolumeName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: GuardianSecretName,
 				},
 			},
 		},
 		{
 			Name: PacketCaptureCertSecret,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					Items: []v1.KeyToPath{{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					Items: []corev1.KeyToPath{{
 						Key:  "tls.crt",
 						Path: "tls.crt",
 					}},
@@ -267,7 +266,7 @@ func (c *GuardianComponent) volumes() []v1.Volume {
 	}
 }
 
-func (c *GuardianComponent) container() []v1.Container {
+func (c *GuardianComponent) container() []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:  GuardianDeploymentName,
@@ -303,7 +302,7 @@ func (c *GuardianComponent) container() []v1.Container {
 	}
 }
 
-func (c *GuardianComponent) volumeMounts() []v1.VolumeMount {
+func (c *GuardianComponent) volumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
 			Name:      GuardianVolumeName,

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -17,7 +17,7 @@ package render_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -33,7 +33,7 @@ var _ = Describe("Rendering tests", func() {
 	var g render.Component
 	var resources []client.Object
 
-	var renderGuardian = func(i operator.InstallationSpec) {
+	var renderGuardian = func(i operatorv1.InstallationSpec) {
 		addr := "127.0.0.1:1234"
 		secret := &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
@@ -77,7 +77,7 @@ var _ = Describe("Rendering tests", func() {
 	}
 
 	BeforeEach(func() {
-		renderGuardian(operator.InstallationSpec{Registry: "my-reg/"})
+		renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"})
 	})
 
 	It("should render all resources for a managed cluster", func() {
@@ -117,7 +117,7 @@ var _ = Describe("Rendering tests", func() {
 			Operator: corev1.TolerationOpEqual,
 			Value:    "bar",
 		}
-		renderGuardian(operator.InstallationSpec{
+		renderGuardian(operatorv1.InstallationSpec{
 			ControlPlaneTolerations: []corev1.Toleration{t},
 		})
 		deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
-	apps "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -66,7 +66,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Deployment"},
+			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "batch", version: "v1", kind: "Job"},
 			{name: "policy.pod", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
 			{name: "policy.globalnetworkpolicy", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
@@ -93,7 +93,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		}
 
 		// Should mount ManagerTLSSecret for non-managed clusters
-		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
+		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(idc.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
 		Expect(idc.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/manager-tls"))
 		Expect(idc.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
@@ -154,7 +154,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Deployment"},
+			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "batch", version: "v1", kind: "Job"},
 			{name: "policy.pod", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
 			{name: "policy.globalnetworkpolicy", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
@@ -180,7 +180,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			}
 		}
 
-		dp := rtest.GetResource(resources, "intrusion-detection-controller", "tigera-intrusion-detection", "", "v1", "Deployment").(*apps.Deployment)
+		dp := rtest.GetResource(resources, "intrusion-detection-controller", "tigera-intrusion-detection", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		envs := dp.Spec.Template.Spec.Containers[0].Env
 
 		expectedEnvs := []struct {
@@ -237,7 +237,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Deployment"},
+			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "policy.pod", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
 			{name: "policy.globalnetworkpolicy", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
 			{name: "policy.globalnetworkset", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
@@ -262,7 +262,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			}
 		}
 
-		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
+		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(idc.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "DISABLE_ALERTS", Value: "yes"}))
 
 		clusterRole := rtest.GetResource(resources, "intrusion-detection-controller", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
@@ -291,7 +291,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			nil,
 		)
 		resources, _ := component.Objects()
-		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
+		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		job := rtest.GetResource(resources, render.IntrusionDetectionInstallerJobName, render.IntrusionDetectionNamespace, "batch", "v1", "Job").(*batchv1.Job)
 		Expect(idc.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 		Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
@@ -309,7 +309,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			},
 			&relasticsearch.ClusterConfig{}, nil, false, dns.DefaultClusterDomain, render.ElasticsearchLicenseTypeUnknown, notManagedCluster, false, nil)
 		resources, _ := component.Objects()
-		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "", "v1", "Deployment").(*apps.Deployment)
+		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		job := rtest.GetResource(resources, render.IntrusionDetectionInstallerJobName, render.IntrusionDetectionNamespace, "batch", "v1", "Job").(*batchv1.Job)
 		Expect(idc.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
 		Expect(job.Spec.Template.Spec.Tolerations).To(ConsistOf(t))

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -26,14 +26,13 @@ import (
 	"github.com/tigera/operator/pkg/render/common/configmap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/dns"
@@ -91,8 +90,8 @@ func Manager(
 	tlsKeyPair *corev1.Secret,
 	pullSecrets []*corev1.Secret,
 	openshift bool,
-	installation *operator.InstallationSpec,
-	managementCluster *operator.ManagementCluster,
+	installation *operatorv1.InstallationSpec,
+	managementCluster *operatorv1.ManagementCluster,
 	tunnelSecret *corev1.Secret,
 	internalTrafficSecret *corev1.Secret,
 	clusterDomain string,
@@ -156,8 +155,8 @@ type managerComponent struct {
 	pullSecrets                   []*corev1.Secret
 	openshift                     bool
 	clusterDomain                 string
-	installation                  *operator.InstallationSpec
-	managementCluster             *operator.ManagementCluster
+	installation                  *operatorv1.InstallationSpec
+	managementCluster             *operatorv1.ManagementCluster
 	esLicenseType                 ElasticsearchLicenseType
 	managerImage                  string
 	proxyImage                    string
@@ -165,7 +164,7 @@ type managerComponent struct {
 	csrInitImage                  string
 }
 
-func (c *managerComponent) ResolveImages(is *operator.ImageSet) error {
+func (c *managerComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.installation.Registry
 	path := c.installation.ImagePath
 	prefix := c.installation.ImagePrefix
@@ -321,7 +320,7 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 	}, c.esClusterConfig, c.esSecrets).(*corev1.PodTemplateSpec)
 
 	d := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tigera-manager",
 			Namespace: ManagerNamespace,
@@ -346,29 +345,29 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 }
 
 // managerVolumes returns the volumes for the Tigera Secure manager component.
-func (c *managerComponent) managerVolumeMounts() []v1.VolumeMount {
+func (c *managerComponent) managerVolumeMounts() []corev1.VolumeMount {
 	if c.keyValidatorConfig != nil {
 		return c.keyValidatorConfig.RequiredVolumeMounts()
 	}
-	return []v1.VolumeMount{}
+	return []corev1.VolumeMount{}
 }
 
 // managerVolumes returns the volumes for the Tigera Secure manager component.
-func (c *managerComponent) managerVolumes() []v1.Volume {
-	var certificateManagement *operator.CertificateManagement
+func (c *managerComponent) managerVolumes() []corev1.Volume {
+	var certificateManagement *operatorv1.CertificateManagement
 	if c.installation.CertificateManagement != nil {
 		certificateManagement = c.installation.CertificateManagement
 	}
 	tlsVolumeSource := certificateVolumeSource(certificateManagement, ManagerTLSSecretName)
-	v := []v1.Volume{
+	v := []corev1.Volume{
 		{
 			Name:         ManagerTLSSecretName,
 			VolumeSource: tlsVolumeSource,
 		},
 		{
 			Name: KibanaPublicCertSecret,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: KibanaPublicCertSecret,
 				},
 			},
@@ -376,11 +375,11 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 	}
 
 	if c.complianceServerCertSecret != nil {
-		v = append(v, v1.Volume{
+		v = append(v, corev1.Volume{
 			Name: ComplianceServerCertSecret,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					Items: []v1.KeyToPath{{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					Items: []corev1.KeyToPath{{
 						Key:  "tls.crt",
 						Path: "tls.crt",
 					}},
@@ -391,11 +390,11 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 	}
 
 	if c.packetCaptureServerCertSecret != nil {
-		v = append(v, v1.Volume{
+		v = append(v, corev1.Volume{
 			Name: PacketCaptureCertSecret,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
-					Items: []v1.KeyToPath{{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					Items: []corev1.KeyToPath{{
 						Key:  "tls.crt",
 						Path: "tls.crt",
 					}},
@@ -407,13 +406,13 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 
 	if c.managementCluster != nil {
 		v = append(v,
-			v1.Volume{
+			corev1.Volume{
 				// We only want to mount the cert, not the private key to es-proxy to establish a connection with voltron.
 				Name: ManagerInternalTLSSecretCertName,
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: ManagerInternalTLSSecretName,
-						Items: []v1.KeyToPath{
+						Items: []corev1.KeyToPath{
 							{
 								Key:  "cert",
 								Path: "cert",
@@ -422,20 +421,20 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 					},
 				},
 			},
-			v1.Volume{
+			corev1.Volume{
 				// We mount the full secret to be shared with Voltron.
 				Name: ManagerInternalTLSSecretName,
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: ManagerInternalTLSSecretName,
 					},
 				},
 			},
-			v1.Volume{
+			corev1.Volume{
 				// Append volume for tunnel certificate
 				Name: VoltronTunnelSecretName,
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
 						SecretName: VoltronTunnelSecretName,
 					},
 				},
@@ -450,7 +449,7 @@ func (c *managerComponent) managerVolumes() []v1.Volume {
 }
 
 // managerProbe returns the probe for the manager container.
-func (c *managerComponent) managerProbe() *v1.Probe {
+func (c *managerComponent) managerProbe() *corev1.Probe {
 	return &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -465,7 +464,7 @@ func (c *managerComponent) managerProbe() *v1.Probe {
 }
 
 // managerEsProxyProbe returns the probe for the ES proxy container.
-func (c *managerComponent) managerEsProxyProbe() *v1.Probe {
+func (c *managerComponent) managerEsProxyProbe() *corev1.Probe {
 	return &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -480,7 +479,7 @@ func (c *managerComponent) managerEsProxyProbe() *v1.Probe {
 }
 
 // managerProxyProbe returns the probe for the proxy container.
-func (c *managerComponent) managerProxyProbe() *v1.Probe {
+func (c *managerComponent) managerProxyProbe() *corev1.Probe {
 	return &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -495,8 +494,8 @@ func (c *managerComponent) managerProxyProbe() *v1.Probe {
 }
 
 // managerEnvVars returns the envvars for the manager container.
-func (c *managerComponent) managerEnvVars() []v1.EnvVar {
-	envs := []v1.EnvVar{
+func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
+	envs := []corev1.EnvVar{
 		{Name: "CNX_PROMETHEUS_API_URL", Value: fmt.Sprintf("/api/v1/namespaces/%s/services/calico-node-prometheus:9090/proxy/api/v1", common.TigeraPrometheusNamespace)},
 		{Name: "CNX_COMPLIANCE_REPORTS_API_URL", Value: "/compliance/reports"},
 		{Name: "CNX_QUERY_API_URL", Value: "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy"},
@@ -528,7 +527,7 @@ func (c *managerComponent) managerContainer() corev1.Container {
 }
 
 // managerOAuth2EnvVars returns the OAuth2/OIDC envvars depending on the authentication type.
-func (c *managerComponent) managerOAuth2EnvVars() []v1.EnvVar {
+func (c *managerComponent) managerOAuth2EnvVars() []corev1.EnvVar {
 	var envs []corev1.EnvVar
 
 	if c.keyValidatorConfig == nil {
@@ -580,7 +579,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 	}
 }
 
-func (c *managerComponent) volumeMountsForProxyManager() []v1.VolumeMount {
+func (c *managerComponent) volumeMountsForProxyManager() []corev1.VolumeMount {
 	var mounts = []corev1.VolumeMount{
 		{Name: ManagerTLSSecretName, MountPath: "/certs/https", ReadOnly: true},
 		{Name: KibanaPublicCertSecret, MountPath: "/certs/kibana", ReadOnly: true},
@@ -613,7 +612,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{Name: ManagerInternalTLSSecretCertName, MountPath: "/manager-tls", ReadOnly: true})
 	}
 
-	env := []v1.EnvVar{
+	env := []corev1.EnvVar{
 		{Name: "ELASTIC_LICENSE_TYPE", Value: string(c.esLicenseType)},
 		{Name: "ELASTIC_VERSION", Value: components.ComponentEckElasticsearch.Version},
 		{Name: "ELASTIC_KIBANA_ENDPOINT", Value: rkibana.HTTPSEndpoint(c.SupportedOSType(), c.clusterDomain)},
@@ -635,12 +634,12 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 }
 
 // managerTolerations returns the tolerations for the Tigera Secure manager deployment pods.
-func (c *managerComponent) managerTolerations() []v1.Toleration {
+func (c *managerComponent) managerTolerations() []corev1.Toleration {
 	return append(c.installation.ControlPlaneTolerations, rmeta.TolerateMaster, rmeta.TolerateCriticalAddonsOnly)
 }
 
 // managerService returns the service exposing the Tigera Secure web app.
-func (c *managerComponent) managerService() *v1.Service {
+func (c *managerComponent) managerService() *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -663,8 +662,8 @@ func (c *managerComponent) managerService() *v1.Service {
 }
 
 // managerServiceAccount creates the serviceaccount used by the Tigera Secure web app.
-func managerServiceAccount() *v1.ServiceAccount {
-	return &v1.ServiceAccount{
+func managerServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: ManagerServiceAccount, Namespace: ManagerNamespace},
 	}

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -25,12 +25,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/render"
 )
 
@@ -40,7 +39,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Value:     "",
 		ValueFrom: nil,
 	}
-	installation := &operator.InstallationSpec{}
+	installation := &operatorv1.InstallationSpec{}
 	const expectedResourcesNumber = 11
 
 	expectedDNSNames := dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, dns.DefaultClusterDomain)
@@ -67,7 +66,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: render.ComplianceServerCertSecret, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: render.PacketCaptureCertSecret, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
-			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Deployment"},
+			{name: "tigera-manager", ns: render.ManagerNamespace, group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		i := 0
@@ -77,7 +76,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
-		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
+		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(components.TigeraRegistry + "tigera/cnx-manager:" + components.ComponentManager.Version))
 		Expect(deployment.Spec.Template.Spec.Containers[1].Image).Should(Equal(components.TigeraRegistry + "tigera/es-proxy:" + components.ComponentEsProxy.Version))
 		Expect(deployment.Spec.Template.Spec.Containers[2].Image).Should(Equal(components.TigeraRegistry + "tigera/voltron:" + components.ComponentManagerProxy.Version))
@@ -119,9 +118,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
 		// Should render the correct resource based on test case.
-		Expect(rtest.GetResource(resources, "tigera-manager", "tigera-manager", "", "v1", "Deployment")).ToNot(BeNil())
+		Expect(rtest.GetResource(resources, "tigera-manager", "tigera-manager", "apps", "v1", "Deployment")).ToNot(BeNil())
 
-		d := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
+		d := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 
 		Expect(len(d.Spec.Template.Spec.Containers)).To(Equal(3))
 		Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-manager"))
@@ -212,7 +211,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		// Should render the correct resource based on test case.
 		resources := renderObjects(true, nil, installation, true)
 		Expect(len(resources)).To(Equal(expectedResourcesNumber + 1)) //Extra tls secret was added.
-		d := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
+		d := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
 		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(6))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
@@ -220,7 +219,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	})
 
 	It("should render multicluster settings properly", func() {
-		resources := renderObjects(false, &operator.ManagementCluster{}, installation, true)
+		resources := renderObjects(false, &operatorv1.ManagementCluster{}, installation, true)
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -242,7 +241,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: render.ComplianceServerCertSecret, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
 			{name: render.PacketCaptureCertSecret, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
-			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Deployment"},
+			{name: "tigera-manager", ns: "tigera-manager", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -254,7 +253,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 
 		By("configuring the manager deployment")
-		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
+		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		manager := deployment.Spec.Template.Spec.Containers[0]
 		Expect(manager.Name).To(Equal("tigera-manager"))
 		rtest.ExpectEnv(manager.Env, "ENABLE_MULTI_CLUSTER_MANAGEMENT", "true")
@@ -389,7 +388,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 	// renderManager passes in as few parameters as possible to render.Manager without it
 	// panicing. It accepts variations on the installspec for testing purposes.
-	renderManager := func(i *operator.InstallationSpec) *v1.Deployment {
+	renderManager := func(i *operatorv1.InstallationSpec) *appsv1.Deployment {
 		component, err := render.Manager(nil, nil, nil,
 			rtest.CreateCertSecret(render.ComplianceServerCertSecret, rmeta.OperatorNamespace()),
 			rtest.CreateCertSecret(render.PacketCaptureCertSecret, rmeta.OperatorNamespace()),
@@ -400,11 +399,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			nil, nil, nil, "", render.ElasticsearchLicenseTypeUnknown)
 		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 		resources, _ := component.Objects()
-		return rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
+		return rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 	}
 
 	It("should apply controlPlaneNodeSelectors", func() {
-		deployment := renderManager(&operator.InstallationSpec{
+		deployment := renderManager(&operatorv1.InstallationSpec{
 			ControlPlaneNodeSelector: map[string]string{
 				"foo": "bar",
 			},
@@ -417,14 +416,14 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			Operator: corev1.TolerationOpEqual,
 			Value:    "bar",
 		}
-		deployment := renderManager(&operator.InstallationSpec{
+		deployment := renderManager(&operatorv1.InstallationSpec{
 			ControlPlaneTolerations: []corev1.Toleration{t},
 		})
 		Expect(deployment.Spec.Template.Spec.Tolerations).To(ContainElements(t, rmeta.TolerateMaster, rmeta.TolerateCriticalAddonsOnly))
 	})
 
 	It("should render all resources for certificate management", func() {
-		resources := renderObjects(false, nil, &operator.InstallationSpec{CertificateManagement: &operator.CertificateManagement{}}, false)
+		resources := renderObjects(false, nil, &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{}}, false)
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -442,7 +441,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: render.ComplianceServerCertSecret, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: render.PacketCaptureCertSecret, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
-			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Deployment"},
+			{name: "tigera-manager", ns: render.ManagerNamespace, group: "apps", version: "v1", kind: "Deployment"},
 			{"tigera-manager:csr-creator", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 		}
 
@@ -452,7 +451,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 
-		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "", "v1", "Deployment").(*appsv1.Deployment)
+		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 
 		Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 		csrInitContainer := deployment.Spec.Template.Spec.InitContainers[0]
@@ -465,14 +464,14 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	})
 })
 
-func renderObjects(oidc bool, managementCluster *operator.ManagementCluster, installation *operator.InstallationSpec, includeManagerTLSSecret bool) []client.Object {
+func renderObjects(oidc bool, managementCluster *operatorv1.ManagementCluster, installation *operatorv1.InstallationSpec, includeManagerTLSSecret bool) []client.Object {
 	var dexCfg authentication.KeyValidatorConfig
 	if oidc {
-		var authentication *operator.Authentication
-		authentication = &operator.Authentication{
-			Spec: operator.AuthenticationSpec{
+		var authentication *operatorv1.Authentication
+		authentication = &operatorv1.Authentication{
+			Spec: operatorv1.AuthenticationSpec{
 				ManagerDomain: "https://127.0.0.1",
-				OIDC:          &operator.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
+				OIDC:          &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
 
 		dexCfg = render.NewDexKeyValidatorConfig(authentication, nil, render.CreateDexTLSSecret("cn"), dns.DefaultClusterDomain)
 	}

--- a/pkg/render/namespaces_test.go
+++ b/pkg/render/namespaces_test.go
@@ -17,7 +17,7 @@ package render_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/tigera/operator/pkg/render"
@@ -25,9 +25,9 @@ import (
 )
 
 var _ = Describe("Namespace rendering tests", func() {
-	var installation *v1.InstallationSpec
+	var installation *operatorv1.InstallationSpec
 	BeforeEach(func() {
-		installation = &v1.InstallationSpec{Variant: v1.Calico, KubernetesProvider: v1.ProviderNone}
+		installation = &operatorv1.InstallationSpec{Variant: operatorv1.Calico, KubernetesProvider: operatorv1.ProviderNone}
 	})
 
 	It("should render a namespace", func() {
@@ -43,7 +43,7 @@ var _ = Describe("Namespace rendering tests", func() {
 	})
 
 	It("should render a namespace for openshift", func() {
-		installation.KubernetesProvider = v1.ProviderOpenShift
+		installation.KubernetesProvider = operatorv1.ProviderOpenShift
 		component := render.Namespaces(installation, nil)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(1))
@@ -55,7 +55,7 @@ var _ = Describe("Namespace rendering tests", func() {
 	})
 
 	It("should render a namespace for aks", func() {
-		installation.KubernetesProvider = v1.ProviderAKS
+		installation.KubernetesProvider = operatorv1.ProviderAKS
 		component := render.Namespaces(installation, nil)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(1))
@@ -66,7 +66,7 @@ var _ = Describe("Namespace rendering tests", func() {
 	})
 
 	It("should render a namespace for tigera-dex on EE", func() {
-		installation.Variant = v1.TigeraSecureEnterprise
+		installation.Variant = operatorv1.TigeraSecureEnterprise
 		component := render.Namespaces(installation, nil)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(2))
@@ -78,8 +78,8 @@ var _ = Describe("Namespace rendering tests", func() {
 	})
 
 	It("should render a namespace for tigera-dex for openshift on EE", func() {
-		installation.Variant = v1.TigeraSecureEnterprise
-		installation.KubernetesProvider = v1.ProviderOpenShift
+		installation.Variant = operatorv1.TigeraSecureEnterprise
+		installation.KubernetesProvider = operatorv1.ProviderOpenShift
 		component := render.Namespaces(installation, nil)
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(2))

--- a/pkg/render/packetcapture_api_test.go
+++ b/pkg/render/packetcapture_api_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/ptr"
@@ -60,10 +60,10 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 		},
 	}}
 	// Installation with minimal setup
-	var defaultInstallation = operator.InstallationSpec{}
+	var defaultInstallation = operatorv1.InstallationSpec{}
 
 	// Rendering packet capture resources
-	var renderPacketCapture = func(i operator.InstallationSpec, config authentication.KeyValidatorConfig) (resources []client.Object) {
+	var renderPacketCapture = func(i operatorv1.InstallationSpec, config authentication.KeyValidatorConfig) (resources []client.Object) {
 		var pc = render.PacketCaptureAPI(
 			pullSecrets,
 			false,
@@ -342,7 +342,7 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 			Operator: corev1.TolerationOpEqual,
 			Value:    "bar",
 		}
-		var resources = renderPacketCapture(operator.InstallationSpec{
+		var resources = renderPacketCapture(operatorv1.InstallationSpec{
 			ControlPlaneTolerations: []corev1.Toleration{t},
 		}, nil)
 
@@ -354,17 +354,17 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 	})
 
 	It("should render all resources for an installation with certificate management", func() {
-		var resources = renderPacketCapture(operator.InstallationSpec{CertificateManagement: &operator.CertificateManagement{}}, nil)
+		var resources = renderPacketCapture(operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{}}, nil)
 
 		checkPacketCaptureResources(resources, true, false)
 	})
 
 	It("should render all resources for an installation with oidc configured", func() {
-		var authentication *operator.Authentication
-		authentication = &operator.Authentication{
-			Spec: operator.AuthenticationSpec{
+		var authentication *operatorv1.Authentication
+		authentication = &operatorv1.Authentication{
+			Spec: operatorv1.AuthenticationSpec{
 				ManagerDomain: "https://127.0.0.1",
-				OIDC:          &operator.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
+				OIDC:          &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
 
 		var dexCfg = render.NewDexKeyValidatorConfig(authentication, nil, render.CreateDexTLSSecret("cn"), dns.DefaultClusterDomain)
 		var resources = renderPacketCapture(defaultInstallation, dexCfg)

--- a/pkg/render/passthru.go
+++ b/pkg/render/passthru.go
@@ -1,7 +1,7 @@
 package render
 
 import (
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -20,7 +20,7 @@ type passthroughComponent struct {
 // needs, passing 'is' to the GetReference call and if there are any errors those
 // are returned. It is valid to pass nil for 'is' as GetReference accepts the value.
 // ResolveImages must be called before Objects is called for the component.
-func (p *passthroughComponent) ResolveImages(is *operator.ImageSet) error {
+func (p *passthroughComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	return nil
 }
 

--- a/pkg/render/prometheus_api.go
+++ b/pkg/render/prometheus_api.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 	"strconv"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -53,7 +53,7 @@ const (
 	tigeraPrometheusAPIListenPortFieldName = "tigeraPrometheusAPIListenPort"
 )
 
-func TigeraPrometheusAPI(cr *operator.InstallationSpec, pullSecrets []*corev1.Secret, configMap *corev1.ConfigMap) (Component, error) {
+func TigeraPrometheusAPI(cr *operatorv1.InstallationSpec, pullSecrets []*corev1.Secret, configMap *corev1.ConfigMap) (Component, error) {
 
 	return &tigeraPrometheusAPIComponent{
 		configMap:    configMap,
@@ -64,12 +64,12 @@ func TigeraPrometheusAPI(cr *operator.InstallationSpec, pullSecrets []*corev1.Se
 
 type tigeraPrometheusAPIComponent struct {
 	configMap              *corev1.ConfigMap
-	installation           *operator.InstallationSpec
+	installation           *operatorv1.InstallationSpec
 	pullSecrets            []*corev1.Secret
 	prometheusServiceImage string
 }
 
-func (p *tigeraPrometheusAPIComponent) ResolveImages(is *operator.ImageSet) error {
+func (p *tigeraPrometheusAPIComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := p.installation.Registry
 	path := p.installation.ImagePath
 	prefix := p.installation.ImagePrefix
@@ -109,7 +109,7 @@ func (p *tigeraPrometheusAPIComponent) Objects() (objsToCreate, objsToDelete []c
 	}
 
 	// openshift will use the default restricted SCCs if one is not provided
-	if p.installation.KubernetesProvider != operator.ProviderOpenShift {
+	if p.installation.KubernetesProvider != operatorv1.ProviderOpenShift {
 		namespacedObjects = append(namespacedObjects, p.podSecurityPolicy())
 	}
 
@@ -186,8 +186,8 @@ func (p *tigeraPrometheusAPIComponent) deployment(prometheusServiceListenPort in
 	// set to host networked if cluster is on EKS using Calico CNI since the EKS managed Kubernetes APIserver
 	// cannot reach the pod network in this configuration. This is because Calico cannot manage
 	// the managed control plane nodes' network
-	if p.installation.KubernetesProvider == operator.ProviderEKS &&
-		p.installation.CNI.Type == operator.PluginCalico {
+	if p.installation.KubernetesProvider == operatorv1.ProviderEKS &&
+		p.installation.CNI.Type == operatorv1.PluginCalico {
 		podHostNetworked = true
 		// corresponding dns policy for hostnetwoked pods to resolve the service hostname urls
 		podDnsPolicy = corev1.DNSClusterFirstWithHostNet

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -16,15 +16,16 @@ package render
 
 import (
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
-	CommonName        = "common-name"
-	URISAN            = "uri-san"
-	TyphaCommonName   = "typha-server"
-	FelixCommonName   = "typha-client"
-	PriorityClassName = "calico-priority"
+	CommonName               = "common-name"
+	URISAN                   = "uri-san"
+	TyphaCommonName          = "typha-server"
+	FelixCommonName          = "typha-client"
+	NodePriorityClassName    = "system-node-critical"
+	ClusterPriorityClassName = "system-cluster-critical"
 )
 
 // A Renderer is capable of generating components to be installed on the cluster.
@@ -32,17 +33,14 @@ type Renderer interface {
 	Render() []Component
 }
 
-func appendNotNil(components []Component, c Component) []Component {
-	if c != nil {
-		components = append(components, c)
-	}
-	return components
-}
-
 func SetTestLogger(l logr.Logger) {
 	log = l
 }
 
-func setCriticalPod(t *v1.PodTemplateSpec) {
-	t.Spec.PriorityClassName = PriorityClassName
+func setNodeCriticalPod(t *corev1.PodTemplateSpec) {
+	t.Spec.PriorityClassName = NodePriorityClassName
+}
+
+func setClusterCriticalPod(t *corev1.PodTemplateSpec) {
+	t.Spec.PriorityClassName = ClusterPriorityClassName
 }

--- a/pkg/render/secrets.go
+++ b/pkg/render/secrets.go
@@ -19,7 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 )
 
 func Secrets(secrets []*corev1.Secret) Component {
@@ -30,7 +30,7 @@ type secretsComponent struct {
 	secrets []*corev1.Secret
 }
 
-func (c *secretsComponent) ResolveImages(is *operator.ImageSet) error {
+func (c *secretsComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	// No images to resolve
 	return nil
 }

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -19,12 +19,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operator "github.com/tigera/operator/api/v1"
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/render"
@@ -33,7 +33,7 @@ import (
 
 var _ = Describe("Typha rendering tests", func() {
 	const defaultClusterDomain = "svc.cluster.local"
-	var installation *operator.InstallationSpec
+	var installation *operatorv1.InstallationSpec
 	var registry string
 	var typhaNodeTLS *render.TyphaNodeTLS
 	k8sServiceEp := k8sapi.ServiceEndpoint{}
@@ -42,18 +42,18 @@ var _ = Describe("Typha rendering tests", func() {
 		registry = "test.registry.com/org"
 		// Initialize a default installation to use. Each test can override this to its
 		// desired configuration.
-		installation = &operator.InstallationSpec{
-			KubernetesProvider: operator.ProviderNone,
+		installation = &operatorv1.InstallationSpec{
+			KubernetesProvider: operatorv1.ProviderNone,
 			//Variant ProductVariant `json:"variant,omitempty"`
 			Registry: registry,
-			CNI: &operator.CNISpec{
-				Type: operator.PluginCalico,
+			CNI: &operatorv1.CNISpec{
+				Type: operatorv1.PluginCalico,
 			},
 		}
 		typhaNodeTLS = &render.TyphaNodeTLS{
-			CAConfigMap: &v1.ConfigMap{},
-			TyphaSecret: &v1.Secret{},
-			NodeSecret:  &v1.Secret{},
+			CAConfigMap: &corev1.ConfigMap{},
+			TyphaSecret: &corev1.Secret{},
+			NodeSecret:  &corev1.Secret{},
 		}
 		typhaNodeTLS.TyphaSecret.Name = "typha-certs"
 		typhaNodeTLS.TyphaSecret.Namespace = "tigera-operator"
@@ -84,7 +84,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "calico-system", group: "policy", version: "v1beta1", kind: "PodDisruptionBudget"},
 			{name: "typha-certs", ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-typha", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
-			{name: "calico-typha", ns: "calico-system", group: "", version: "v1", kind: "Deployment"},
+			{name: "calico-typha", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		component := render.Typha(&cfg)
@@ -98,9 +98,9 @@ var _ = Describe("Typha rendering tests", func() {
 			i++
 		}
 
-		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(dResource).ToNot(BeNil())
-		d := dResource.(*apps.Deployment)
+		d := dResource.(*appsv1.Deployment)
 		tc := d.Spec.Template.Spec.Containers[0]
 		Expect(tc.Name).To(Equal("calico-typha"))
 		// Expect the SECURITY_GROUP env variables to not be set
@@ -124,7 +124,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "calico-system", group: "policy", version: "v1beta1", kind: "PodDisruptionBudget"},
 			{name: "typha-certs", ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-typha", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
-			{name: "calico-typha", ns: "calico-system", group: "", version: "v1", kind: "Deployment"},
+			{name: "calico-typha", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		cfg.MigrateNamespaces = true
@@ -132,13 +132,13 @@ var _ = Describe("Typha rendering tests", func() {
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
-		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(dResource).ToNot(BeNil())
 
 		// The DaemonSet should have the correct configuration.
-		d := dResource.(*apps.Deployment)
+		d := dResource.(*appsv1.Deployment)
 		paa := d.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-		Expect(paa).To(ContainElement(v1.PodAffinityTerm{
+		Expect(paa).To(ContainElement(corev1.PodAffinityTerm{
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"k8s-app": "calico-typha"},
 			},
@@ -162,11 +162,11 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "calico-system", group: "policy", version: "v1beta1", kind: "PodDisruptionBudget"},
 			{name: "typha-certs", ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-typha", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
-			{name: "calico-typha", ns: "calico-system", group: "", version: "v1", kind: "Deployment"},
+			{name: "calico-typha", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
-		cfg.AmazonCloudIntegration = &operator.AmazonCloudIntegration{
-			Spec: operator.AmazonCloudIntegrationSpec{
+		cfg.AmazonCloudIntegration = &operatorv1.AmazonCloudIntegration{
+			Spec: operatorv1.AmazonCloudIntegrationSpec{
 				NodeSecurityGroupIDs: []string{"sg-nodeid", "sg-masterid"},
 				PodSecurityGroupID:   "sg-podsgid",
 			},
@@ -175,14 +175,14 @@ var _ = Describe("Typha rendering tests", func() {
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
-		deploymentResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		deploymentResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(deploymentResource).ToNot(BeNil())
-		d := deploymentResource.(*apps.Deployment)
+		d := deploymentResource.(*appsv1.Deployment)
 		tc := d.Spec.Template.Spec.Containers[0]
 		Expect(tc.Name).To(Equal("calico-typha"))
 
 		// Assert on expected env vars.
-		expectedEnvVars := []v1.EnvVar{
+		expectedEnvVars := []corev1.EnvVar{
 			{Name: "TIGERA_DEFAULT_SECURITY_GROUPS", Value: "sg-nodeid,sg-masterid"},
 			{Name: "TIGERA_POD_SECURITY_GROUP", Value: "sg-podsgid"},
 		}
@@ -192,20 +192,20 @@ var _ = Describe("Typha rendering tests", func() {
 	})
 
 	It("should render resourcerequirements", func() {
-		rr := &v1.ResourceRequirements{
-			Requests: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("250m"),
-				v1.ResourceMemory: resource.MustParse("64Mi"),
+		rr := &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
 			},
-			Limits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("500m"),
-				v1.ResourceMemory: resource.MustParse("500Mi"),
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
 			},
 		}
 
-		installation.ComponentResources = []operator.ComponentResource{
+		installation.ComponentResources = []operatorv1.ComponentResource{
 			{
-				ComponentName:        operator.ComponentNameTypha,
+				ComponentName:        operatorv1.ComponentNameTypha,
 				ResourceRequirements: rr,
 			},
 		}
@@ -213,9 +213,9 @@ var _ = Describe("Typha rendering tests", func() {
 		component := render.Typha(&cfg)
 		resources, _ := component.Objects()
 
-		depResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		depResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(depResource).ToNot(BeNil())
-		deployment := depResource.(*apps.Deployment)
+		deployment := depResource.(*appsv1.Deployment)
 
 		passed := false
 		for _, container := range deployment.Spec.Template.Spec.Containers {
@@ -228,56 +228,56 @@ var _ = Describe("Typha rendering tests", func() {
 	})
 
 	It("should render Preferred typha affinity when set by user", func() {
-		pfts := []v1.PreferredSchedulingTerm{{
+		pfts := []corev1.PreferredSchedulingTerm{{
 			Weight: 100,
-			Preference: v1.NodeSelectorTerm{
-				MatchFields: []v1.NodeSelectorRequirement{{
+			Preference: corev1.NodeSelectorTerm{
+				MatchFields: []corev1.NodeSelectorRequirement{{
 					Key:      "foo",
 					Operator: "in",
 					Values:   []string{"foo", "bar"},
 				}},
 			},
 		}}
-		installation.TyphaAffinity = &operator.TyphaAffinity{
-			NodeAffinity: &operator.NodeAffinity{
+		installation.TyphaAffinity = &operatorv1.TyphaAffinity{
+			NodeAffinity: &operatorv1.NodeAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: pfts,
 			},
 		}
 		component := render.Typha(&cfg)
 		resources, _ := component.Objects()
-		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(dResource).ToNot(BeNil())
-		d := dResource.(*apps.Deployment)
+		d := dResource.(*appsv1.Deployment)
 		na := d.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 		Expect(na).To(Equal(pfts))
 	})
 
 	It("should render Required typha affinity when set by user", func() {
-		rst := &v1.NodeSelector{
-			NodeSelectorTerms: []v1.NodeSelectorTerm{{
-				MatchExpressions: []v1.NodeSelectorRequirement{{
+		rst := &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+				MatchExpressions: []corev1.NodeSelectorRequirement{{
 					Key:      "test",
-					Operator: v1.NodeSelectorOpIn,
+					Operator: corev1.NodeSelectorOpIn,
 					Values:   []string{"myTestNode"},
 				}},
 			}},
 		}
-		installation.TyphaAffinity = &operator.TyphaAffinity{
-			NodeAffinity: &operator.NodeAffinity{
+		installation.TyphaAffinity = &operatorv1.TyphaAffinity{
+			NodeAffinity: &operatorv1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: rst,
 			},
 		}
 		component := render.Typha(&cfg)
 		resources, _ := component.Objects()
-		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(dResource).ToNot(BeNil())
-		d := dResource.(*apps.Deployment)
+		d := dResource.(*appsv1.Deployment)
 		na := d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 		Expect(na).To(Equal(rst))
 	})
 
 	It("should render all resources when certificate management is enabled", func() {
-		installation.CertificateManagement = &operator.CertificateManagement{CACert: []byte("<ca>"), SignerName: "a.b/c"}
+		installation.CertificateManagement = &operatorv1.CertificateManagement{CACert: []byte("<ca>"), SignerName: "a.b/c"}
 		expectedResources := []struct {
 			name    string
 			ns      string
@@ -294,7 +294,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "typha-certs", ns: "calico-system", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-typha", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "calico-typha:csr-creator", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "calico-typha", ns: "calico-system", group: "", version: "v1", kind: "Deployment"},
+			{name: "calico-typha", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		component := render.Typha(&cfg)
@@ -308,45 +308,45 @@ var _ = Describe("Typha rendering tests", func() {
 			i++
 		}
 
-		dep := rtest.GetResource(resources, common.TyphaDeploymentName, common.CalicoNamespace, "", "v1", "Deployment")
+		dep := rtest.GetResource(resources, common.TyphaDeploymentName, common.CalicoNamespace, "apps", "v1", "Deployment")
 		Expect(dep).ToNot(BeNil())
-		deploy, ok := dep.(*apps.Deployment)
+		deploy, ok := dep.(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 		Expect(deploy.Spec.Template.Spec.InitContainers[0].Name).To(Equal(render.CSRInitContainerName))
 		rtest.ExpectEnv(deploy.Spec.Template.Spec.InitContainers[0].Env, "SIGNER", "a.b/c")
 	})
 	It("should not enable prometheus metrics if TyphaMetricsPort is nil", func() {
-		installation.Variant = operator.TigeraSecureEnterprise
+		installation.Variant = operatorv1.TigeraSecureEnterprise
 		installation.TyphaMetricsPort = nil
 		component := render.Typha(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
-		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(dResource).ToNot(BeNil())
 
-		notExpectedEnvVar := v1.EnvVar{Name: "TYPHA_PROMETHEUSMETRICSENABLED"}
-		d := dResource.(*apps.Deployment)
+		notExpectedEnvVar := corev1.EnvVar{Name: "TYPHA_PROMETHEUSMETRICSENABLED"}
+		d := dResource.(*appsv1.Deployment)
 		Expect(d.Spec.Template.Spec.Containers[0].Env).ToNot(ContainElement(notExpectedEnvVar))
 	})
 
 	It("should set TYPHA_PROMETHEUSMETRICSPORT with a custom value if TyphaMetricsPort is set", func() {
 		var typhaMetricsPort int32 = 1234
-		installation.Variant = operator.TigeraSecureEnterprise
+		installation.Variant = operatorv1.TigeraSecureEnterprise
 		installation.TyphaMetricsPort = &typhaMetricsPort
 		component := render.Typha(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
-		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "", "v1", "Deployment")
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
 		Expect(dResource).ToNot(BeNil())
 
-		d := dResource.(*apps.Deployment)
+		d := dResource.(*appsv1.Deployment)
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
-			v1.EnvVar{Name: "TYPHA_PROMETHEUSMETRICSPORT", Value: "1234"}))
+			corev1.EnvVar{Name: "TYPHA_PROMETHEUSMETRICSPORT", Value: "1234"}))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
-			v1.EnvVar{Name: "TYPHA_PROMETHEUSMETRICSENABLED", Value: "true"}))
+			corev1.EnvVar{Name: "TYPHA_PROMETHEUSMETRICSENABLED", Value: "true"}))
 
 		// Assert we set annotations properly.
 		Expect(d.Spec.Template.Annotations["prometheus.io/scrape"]).To(Equal("true"))


### PR DESCRIPTION
## Description

Use the Kubernetes [system priority classes](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/), `system-node-critical` & `system-cluster-critical`, for Calico pods so they have the highest possible priority.

I've fixed the metadata API for deployments in the _render_ package where it was incorrectly set to `v1` instead of the correct `apps/v1` (this issue is also present in the _controllers_ package). This was correctly set for some deployments but not all of them.

I've also normalised the K8s imports in the _render_ packages as there were warnings showing up about duplicate imports.

Fixes #1428.

## For PR author

- [X] Tests for change.
- [x] ~~If changing pkg/apis/, run `make gen-files`~~
- [x] ~~If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
