### PR TITLE
Watch / propogate Elasticsearch / gateway secrets

### DIFF
--- a/pkg/controller/logstorage/common/common.go
+++ b/pkg/controller/logstorage/common/common.go
@@ -154,27 +154,7 @@ func GetESGatewayCertificateSecrets(ctx context.Context, instl *operatorv1.Insta
 		oprKeyCert.Data[corev1.TLSCertKey] = instl.CertificateManagement.CACert
 		publicCertSecret = render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
 	} else {
-		// Get the es gateway pub secret - might be nil
-		publicCertSecret, err = utils.GetSecret(ctx, cli, relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-		if err != nil {
-			return nil, nil, false, err
-		}
-
-		if publicCertSecret != nil {
-			// If the provided certificate secret (secret) is managed by the operator we need to check if the secret has the expected DNS names.
-			// If it doesn't, delete the public secret so it can get recreated.
-			if !customerProvidedCert {
-				err = utils.SecretHasExpectedDNSNames(publicCertSecret, corev1.TLSCertKey, svcDNSNames)
-				if err == utils.ErrInvalidCertDNSNames {
-					if err := DeleteInvalidECKManagedPublicCertSecret(ctx, publicCertSecret, cli, log); err != nil {
-						return nil, nil, false, err
-					}
-					publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-				}
-			}
-		} else {
-			publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
-		}
+		publicCertSecret = render.CreateCertificateSecret(oprKeyCert.Data[corev1.TLSCertKey], relasticsearch.PublicCertSecret, rmeta.OperatorNamespace())
 	}
 
 	return oprKeyCert, publicCertSecret, customerProvidedCert, nil

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -731,18 +731,18 @@ func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Con
 		certSecret = render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.InternalCertSecret, render.ElasticsearchNamespace)
 	} else {
 		// Get the internal public cert secret - might be nil.
-		internalSecret, err := utils.GetSecret(ctx, r.client, relasticsearch.InternalCertSecret, render.ElasticsearchNamespace)
+		certSecret, err = utils.GetSecret(ctx, r.client, relasticsearch.InternalCertSecret, render.ElasticsearchNamespace)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		if internalSecret != nil {
+		if certSecret != nil {
 			// When the provided certificate secret (secret) is managed by the operator we need to check if the secret that
 			// Elasticsearch creates from that given secret (internalSecret) has the expected DNS name. If it doesn't, delete the
 			// public secret so it can get recreated.
-			err = utils.SecretHasExpectedDNSNames(internalSecret, corev1.TLSCertKey, svcDNSNames)
+			err = utils.SecretHasExpectedDNSNames(certSecret, corev1.TLSCertKey, svcDNSNames)
 			if err == utils.ErrInvalidCertDNSNames {
-				if err := common.DeleteInvalidECKManagedPublicCertSecret(ctx, internalSecret, r.client, log); err != nil {
+				if err := common.DeleteInvalidECKManagedPublicCertSecret(ctx, certSecret, r.client, log); err != nil {
 					return nil, nil, err
 				}
 			}


### PR DESCRIPTION
This commit does 2 things:
1. Always regenerate the public certificate for the gateway, it is just a partial copy of an "internal" one and should always be the same
2. Make sure the certificate for elasticsearch is available to the es-gateway when it renders it's component, so that it can properly set the annotations to restart on change

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
