### PR TITLE
Publish operator bundles in OCP 4.8

### DIFF
--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -65,7 +65,7 @@ sed -i 's/\(operators\.operatorframework\.\io\.bundle\.package\.v1\)=operator/\1
 
 # Add in required labels
 cat <<EOF >> bundle.Dockerfile
-LABEL com.redhat.openshift.versions="v4.5-v4.7"
+LABEL com.redhat.openshift.versions="v4.5-v4.8"
 LABEL com.redhat.delivery.backport=true
 LABEL com.redhat.delivery.operator.bundle=true
 EOF


### PR DESCRIPTION
## Description

Update the bundle image metadata so that the operator CSV is also published in OCP 4.8. Documentation on the bundle image metadata is here: https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
Note that the page suggests that setting the label com.redhat.openshift.versions="v4.5" will apply to v4.8 but that does not seem to be the case (at the very least, the certification tests are not run against v4.8). So we explicitly set the versions range.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
