### PR TITLE
Support control plane replicas in Installation

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -105,6 +105,11 @@ type InstallationSpec struct {
 	// +optional
 	ControlPlaneTolerations []v1.Toleration `json:"controlPlaneTolerations,omitempty"`
 
+	// ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed.
+	// This field applies to all control plane components that support High Availability. Defaults to 2.
+	// +optional
+	ControlPlaneReplicas *int32 `json:"controlPlaneReplicas,omitempty"`
+
 	// NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not enabled.
 	// If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then
 	// prometheus metrics may still be configured through FelixConfiguration.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -947,6 +947,11 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ControlPlaneReplicas != nil {
+		in, out := &in.ControlPlaneReplicas, &out.ControlPlaneReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.NodeMetricsPort != nil {
 		in, out := &in.NodeMetricsPort, &out.NodeMetricsPort
 		*out = new(int32)

--- a/config/crd/bases/operator.tigera.io_installations.yaml
+++ b/config/crd/bases/operator.tigera.io_installations.yaml
@@ -343,6 +343,13 @@ spec:
                   nodes on which to run Calico components. This is globally applied
                   to all resources created by the operator excluding daemonsets.
                 type: object
+              controlPlaneReplicas:
+                description: ControlPlaneReplicas defines how many replicas of the
+                  control plane core components will be deployed. This field applies
+                  to all control plane components that support High Availability.
+                  Defaults to 2.
+                format: int32
+                type: integer
               controlPlaneTolerations:
                 description: ControlPlaneTolerations specify tolerations which are
                   then globally applied to all resources created by the operator.
@@ -1038,6 +1045,13 @@ spec:
                       plane nodes on which to run Calico components. This is globally
                       applied to all resources created by the operator excluding daemonsets.
                     type: object
+                  controlPlaneReplicas:
+                    description: ControlPlaneReplicas defines how many replicas of
+                      the control plane core components will be deployed. This field
+                      applies to all control plane components that support High Availability.
+                      Defaults to 2.
+                    format: int32
+                    type: integer
                   controlPlaneTolerations:
                     description: ControlPlaneTolerations specify tolerations which
                       are then globally applied to all resources created by the operator.

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -72,6 +72,7 @@ var _ = Describe("apiserver controller tests", func() {
 		mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
 		mockStatus.On("ReadyToMonitor")
 
+		var replicas int32 = 2
 		Expect(cli.Create(ctx, &operatorv1.Installation{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "default",
@@ -81,6 +82,7 @@ var _ = Describe("apiserver controller tests", func() {
 				Computed: &operatorv1.InstallationSpec{},
 			},
 			Spec: operatorv1.InstallationSpec{
+				ControlPlaneReplicas:  &replicas,
 				Variant:               operatorv1.TigeraSecureEnterprise,
 				Registry:              "some.registry.org/",
 				CertificateManagement: &operatorv1.CertificateManagement{},

--- a/pkg/controller/authentication/authentication_controller_test.go
+++ b/pkg/controller/authentication/authentication_controller_test.go
@@ -52,6 +52,7 @@ var _ = Describe("authentication controller tests", func() {
 		mockStatus *status.MockStatus
 		idpSecret  *corev1.Secret
 		auth       *operatorv1.Authentication
+		replicas   int32
 	)
 
 	BeforeEach(func() {
@@ -92,6 +93,8 @@ var _ = Describe("authentication controller tests", func() {
 				ManagerDomain: "https://example.com",
 			},
 		}
+
+		replicas = 2
 	})
 
 	Context("OIDC connector config options", func() {
@@ -106,7 +109,8 @@ var _ = Describe("authentication controller tests", func() {
 					Computed: &operatorv1.InstallationSpec{},
 				},
 				Spec: operatorv1.InstallationSpec{
-					Variant: operatorv1.TigeraSecureEnterprise,
+					ControlPlaneReplicas: &replicas,
+					Variant:              operatorv1.TigeraSecureEnterprise,
 				},
 			})).ToNot(HaveOccurred())
 
@@ -147,8 +151,9 @@ var _ = Describe("authentication controller tests", func() {
 					Computed: &operatorv1.InstallationSpec{},
 				},
 				Spec: operatorv1.InstallationSpec{
-					Variant:  operatorv1.TigeraSecureEnterprise,
-					Registry: "some.registry.org/",
+					ControlPlaneReplicas: &replicas,
+					Variant:              operatorv1.TigeraSecureEnterprise,
+					Registry:             "some.registry.org/",
 				},
 			})).To(BeNil())
 			Expect(cli.Create(ctx, &operatorv1.Authentication{
@@ -252,7 +257,8 @@ var _ = Describe("authentication controller tests", func() {
 				Computed: &operatorv1.InstallationSpec{},
 			},
 			Spec: operatorv1.InstallationSpec{
-				Variant: operatorv1.TigeraSecureEnterprise,
+				ControlPlaneReplicas: &replicas,
+				Variant:              operatorv1.TigeraSecureEnterprise,
 			},
 		})).ToNot(HaveOccurred())
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -588,6 +588,12 @@ func fillDefaults(instance *operator.Installation) error {
 		}
 	}
 
+	// If not specified by the user, set the default control plane replicas to 2.
+	if instance.Spec.ControlPlaneReplicas == nil {
+		var replicas int32 = 2
+		instance.Spec.ControlPlaneReplicas = &replicas
+	}
+
 	// If not specified by the user, set the flex volume plugin location based on platform.
 	if len(instance.Spec.FlexVolumePath) == 0 {
 		if instance.Spec.KubernetesProvider == operator.ProviderOpenShift {

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(instance.Spec.CalicoNetwork.LinuxDataplane).ToNot(BeNil())
 		Expect(*instance.Spec.CalicoNetwork.LinuxDataplane).To(Equal(operator.LinuxDataplaneIptables))
 		Expect(*instance.Spec.CalicoNetwork.BGP).To(Equal(operator.BGPEnabled))
+		Expect(*instance.Spec.ControlPlaneReplicas).To(Equal(int32(2)))
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 	})
 
@@ -68,6 +69,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(instance.Spec.CalicoNetwork.LinuxDataplane).ToNot(BeNil())
 		Expect(*instance.Spec.CalicoNetwork.LinuxDataplane).To(Equal(operator.LinuxDataplaneIptables))
 		Expect(*instance.Spec.CalicoNetwork.BGP).To(Equal(operator.BGPEnabled))
+		Expect(*instance.Spec.ControlPlaneReplicas).To(Equal(int32(2)))
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 	})
 
@@ -78,6 +80,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		var twentySeven int32 = 27
 		var oneTwoThree int32 = 123
 		var one intstr.IntOrString = intstr.FromInt(1)
+		var replicas int32 = 3
 
 		hpEnabled := operator.HostPortsEnabled
 		disabled := operator.BGPDisabled
@@ -128,8 +131,9 @@ var _ = Describe("Defaulting logic tests", func() {
 					HostPorts:          &hpEnabled,
 					MultiInterfaceMode: &miMode,
 				},
-				NodeMetricsPort: &nodeMetricsPort,
-				FlexVolumePath:  "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
+				ControlPlaneReplicas: &replicas,
+				NodeMetricsPort:      &nodeMetricsPort,
+				FlexVolumePath:       "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
 				NodeUpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 					Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
@@ -151,6 +155,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		var false_ = false
 		var twentySeven int32 = 27
 		var one intstr.IntOrString = intstr.FromInt(1)
+		var replicas int32 = 3
 
 		disabled := operator.BGPDisabled
 		miMode := operator.MultiInterfaceModeNone
@@ -191,8 +196,9 @@ var _ = Describe("Defaulting logic tests", func() {
 					MultiInterfaceMode: &miMode,
 					HostPorts:          &hpDisabled, // Only one valid value in BPF mode.
 				},
-				NodeMetricsPort: &nodeMetricsPort,
-				FlexVolumePath:  "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
+				ControlPlaneReplicas: &replicas,
+				NodeMetricsPort:      &nodeMetricsPort,
+				FlexVolumePath:       "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/",
 				NodeUpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 					Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateDaemonSet{

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -314,6 +314,10 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 		}
 	}
 
+	if instance.Spec.ControlPlaneReplicas != nil && *instance.Spec.ControlPlaneReplicas <= 0 {
+		return fmt.Errorf("Installation spec.ControlPlaneReplicas should be greater than 0")
+	}
+
 	validComponentNames := map[operatorv1.ComponentName]struct{}{
 		operatorv1.ComponentNameKubeControllers: {},
 		operatorv1.ComponentNameNode:            {},

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -192,6 +192,26 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(validateCustomResource(instance)).To(HaveOccurred())
 	})
 
+	It("should validate ControlPlaneReplicas", func() {
+		var replicas int32
+
+		replicas = -1
+		instance.Spec.ControlPlaneReplicas = &replicas
+		Expect(validateCustomResource(instance)).To(HaveOccurred())
+
+		replicas = 0
+		instance.Spec.ControlPlaneReplicas = &replicas
+		Expect(validateCustomResource(instance)).To(HaveOccurred())
+
+		replicas = 1
+		instance.Spec.ControlPlaneReplicas = &replicas
+		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
+
+		replicas = 2
+		instance.Spec.ControlPlaneReplicas = &replicas
+		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
+	})
+
 	It("should validate HostPorts", func() {
 		instance.Spec.CalicoNetwork.HostPorts = nil
 		err := validateCustomResource(instance)

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -20,18 +20,6 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
-	operatorv1 "github.com/tigera/operator/api/v1"
-	logstoragecommon "github.com/tigera/operator/pkg/controller/logstorage/common"
-	"github.com/tigera/operator/pkg/controller/options"
-	"github.com/tigera/operator/pkg/controller/status"
-	"github.com/tigera/operator/pkg/controller/utils"
-	"github.com/tigera/operator/pkg/controller/utils/imageset"
-	"github.com/tigera/operator/pkg/dns"
-	"github.com/tigera/operator/pkg/render"
-	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-	rsecret "github.com/tigera/operator/pkg/render/common/secret"
-	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -46,6 +34,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	logstoragecommon "github.com/tigera/operator/pkg/controller/logstorage/common"
+	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/controller/utils/imageset"
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/render"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	rsecret "github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
 )
 
 var log = logf.Log.WithName("controller_logstorage")
@@ -210,6 +211,7 @@ func GetLogStorage(ctx context.Context, cli client.Client) (*operatorv1.LogStora
 	return instance, nil
 }
 
+// fillDefaults populates the default values onto an LogStorage object.
 func fillDefaults(opr *operatorv1.LogStorage) {
 	if opr.Spec.Retention == nil {
 		opr.Spec.Retention = &operatorv1.Retention{}

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -195,6 +195,7 @@ var _ = Describe("LogStorage controller", func() {
 			Context("LogStorage is nil", func() {
 				var install *operatorv1.Installation
 				BeforeEach(func() {
+					var replicas int32 = 2
 					install = &operatorv1.Installation{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
@@ -204,7 +205,8 @@ var _ = Describe("LogStorage controller", func() {
 							Computed: &operatorv1.InstallationSpec{},
 						},
 						Spec: operatorv1.InstallationSpec{
-							Variant: operatorv1.TigeraSecureEnterprise,
+							ControlPlaneReplicas: &replicas,
+							Variant:              operatorv1.TigeraSecureEnterprise,
 						},
 					}
 					Expect(cli.Create(ctx, install)).ShouldNot(HaveOccurred())
@@ -317,6 +319,7 @@ var _ = Describe("LogStorage controller", func() {
 				var mockStatus *status.MockStatus
 				var install *operatorv1.Installation
 				BeforeEach(func() {
+					var replicas int32 = 2
 					install = &operatorv1.Installation{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
@@ -326,8 +329,9 @@ var _ = Describe("LogStorage controller", func() {
 							Computed: &operatorv1.InstallationSpec{},
 						},
 						Spec: operatorv1.InstallationSpec{
-							Variant:  operatorv1.TigeraSecureEnterprise,
-							Registry: "some.registry.org/",
+							ControlPlaneReplicas: &replicas,
+							Variant:              operatorv1.TigeraSecureEnterprise,
+							Registry:             "some.registry.org/",
 						},
 					}
 					Expect(cli.Create(ctx, install)).ShouldNot(HaveOccurred())
@@ -1075,7 +1079,7 @@ var _ = Describe("LogStorage controller", func() {
 				var mockStatus *status.MockStatus
 
 				BeforeEach(func() {
-
+					var replicas int32 = 2
 					Expect(cli.Create(ctx, &operatorv1.Installation{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "default",
@@ -1085,7 +1089,8 @@ var _ = Describe("LogStorage controller", func() {
 							Computed: &operatorv1.InstallationSpec{},
 						},
 						Spec: operatorv1.InstallationSpec{
-							Variant: operatorv1.TigeraSecureEnterprise,
+							ControlPlaneReplicas: &replicas,
+							Variant:              operatorv1.TigeraSecureEnterprise,
 						},
 					})).ShouldNot(HaveOccurred())
 

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
-
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/compliance"
@@ -30,6 +28,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
+	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 
@@ -495,6 +494,14 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
+	// Set replicas to 1 for management or managed clusters.
+	// TODO Remove after MCM tigera-manager HA deployment is supported.
+	var replicas *int32 = installation.ControlPlaneReplicas
+	if managementCluster != nil || managementClusterConnection != nil {
+		var mcmReplicas int32 = 1
+		replicas = &mcmReplicas
+	}
+
 	// Render the desired objects from the CRD and create or update them.
 	component, err := render.Manager(
 		keyValidatorConfig,
@@ -512,6 +519,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		internalTrafficSecret,
 		r.clusterDomain,
 		elasticLicenseType,
+		replicas,
 	)
 	if err != nil {
 		log.Error(err, "Error rendering Manager")

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Manager controller tests", func() {
 	var scheme *runtime.Scheme
 	var instance *operatorv1.Manager
 	var ctx context.Context
+	var replicas int32
 
 	BeforeEach(func() {
 		// Create a Kubernetes client.
@@ -65,6 +66,7 @@ var _ = Describe("Manager controller tests", func() {
 		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		c = fake.NewFakeClientWithScheme(scheme)
 		ctx = context.Background()
+		replicas = 2
 	})
 
 	It("should query a default manager instance", func() {
@@ -125,8 +127,9 @@ var _ = Describe("Manager controller tests", func() {
 				&operatorv1.Installation{
 					ObjectMeta: metav1.ObjectMeta{Name: "default"},
 					Spec: operatorv1.InstallationSpec{
-						Variant:  operatorv1.TigeraSecureEnterprise,
-						Registry: "some.registry.org/",
+						ControlPlaneReplicas: &replicas,
+						Variant:              operatorv1.TigeraSecureEnterprise,
+						Registry:             "some.registry.org/",
 					},
 					Status: operatorv1.InstallationStatus{
 						Variant: operatorv1.TigeraSecureEnterprise,
@@ -326,6 +329,7 @@ var _ = Describe("Manager controller tests", func() {
 	Context("image reconciliation", func() {
 		var r ReconcileManager
 		var mockStatus *status.MockStatus
+
 		BeforeEach(func() {
 			// Create an object we can use throughout the test to do the compliance reconcile loops.
 			mockStatus = &status.MockStatus{}
@@ -362,8 +366,9 @@ var _ = Describe("Manager controller tests", func() {
 				&operatorv1.Installation{
 					ObjectMeta: metav1.ObjectMeta{Name: "default"},
 					Spec: operatorv1.InstallationSpec{
-						Variant:  operatorv1.TigeraSecureEnterprise,
-						Registry: "some.registry.org/",
+						ControlPlaneReplicas: &replicas,
+						Variant:              operatorv1.TigeraSecureEnterprise,
+						Registry:             "some.registry.org/",
 					},
 					Status: operatorv1.InstallationStatus{
 						Variant: operatorv1.TigeraSecureEnterprise,

--- a/pkg/controller/utils/merge.go
+++ b/pkg/controller/utils/merge.go
@@ -93,6 +93,11 @@ func OverrideInstallationSpec(cfg, override operatorv1.InstallationSpec) operato
 		copy(inst.ControlPlaneTolerations, override.ControlPlaneTolerations)
 	}
 
+	switch compareFields(inst.ControlPlaneReplicas, override.ControlPlaneReplicas) {
+	case BOnlySet, Different:
+		inst.ControlPlaneReplicas = override.ControlPlaneReplicas
+	}
+
 	switch compareFields(inst.NodeMetricsPort, override.NodeMetricsPort) {
 	case BOnlySet, Different:
 		inst.NodeMetricsPort = override.NodeMetricsPort

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
 	"github.com/tigera/operator/pkg/render/common/podsecuritycontext"
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 
@@ -781,7 +782,6 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 		name = "calico-apiserver"
 	}
 
-	var replicas int32 = 1
 	hostNetwork := c.hostNetwork()
 	dnsPolicy := corev1.DNSClusterFirst
 	if hostNetwork {
@@ -812,7 +812,7 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
+			Replicas: c.installation.ControlPlaneReplicas,
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},
@@ -842,6 +842,10 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 				},
 			},
 		},
+	}
+
+	if c.installation.ControlPlaneReplicas != nil && *c.installation.ControlPlaneReplicas > 1 {
+		d.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(name, rmeta.APIServerNamespace(c.installation.Variant))
 	}
 
 	if c.installation.Variant == operatorv1.TigeraSecureEnterprise {

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -21,22 +21,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tigera/operator/pkg/render/testutils"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/onsi/gomega/gstruct"
 	"github.com/openshift/library-go/pkg/crypto"
-	netv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
@@ -44,7 +41,9 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/testutils"
 	"github.com/tigera/operator/test"
 )
 
@@ -52,13 +51,16 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 	var instance *operatorv1.InstallationSpec
 	var managementCluster = &operatorv1.ManagementCluster{Spec: operatorv1.ManagementClusterSpec{Address: "example.com:1234"}}
 	var k8sServiceEp k8sapi.ServiceEndpoint
+	var replicas int32
 
 	BeforeEach(func() {
 		instance = &operatorv1.InstallationSpec{
-			Registry: "testregistry.com/",
-			Variant:  operatorv1.TigeraSecureEnterprise,
+			ControlPlaneReplicas: &replicas,
+			Registry:             "testregistry.com/",
+			Variant:              operatorv1.TigeraSecureEnterprise,
 		}
 		k8sServiceEp = k8sapi.ServiceEndpoint{}
+		replicas = 2
 	})
 
 	DescribeTable("should render an API server with default configuration", func(clusterDomain string) {
@@ -152,7 +154,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		Expect(d.Labels).To(HaveKeyWithValue("apiserver", "true"))
 		Expect(d.Labels).To(HaveKeyWithValue("k8s-app", "tigera-apiserver"))
 
-		Expect(*d.Spec.Replicas).To(BeEquivalentTo(1))
+		Expect(*d.Spec.Replicas).To(BeEquivalentTo(2))
 		Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
 		Expect(len(d.Spec.Selector.MatchLabels)).To(Equal(1))
 		Expect(d.Spec.Selector.MatchLabels).To(HaveKeyWithValue("apiserver", "true"))
@@ -718,6 +720,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		}
 		Expect((dep.(*appsv1.Deployment)).Spec.Template.Spec.Containers[0].Args).To(ConsistOf(expectedArgs))
 	})
+
 	It("should add an init container if certificate management is enabled", func() {
 		instance.CertificateManagement = &operatorv1.CertificateManagement{SignerName: "a.b/c"}
 		component, err := render.APIServer(k8sServiceEp, instance, false, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
@@ -770,6 +773,32 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		rtest.ExpectEnv(deploy.Spec.Template.Spec.InitContainers[0].Env, "SIGNER", "a.b/c")
 	})
 
+	It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {
+		var replicas int32 = 1
+		instance.ControlPlaneReplicas = &replicas
+
+		component, err := render.APIServer(k8sServiceEp, instance, false, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		resources, _ := component.Objects()
+
+		deploy, ok := rtest.GetResource(resources, "tigera-apiserver", "tigera-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(deploy.Spec.Template.Spec.Affinity).To(BeNil())
+	})
+
+	It("should render PodAffinity when ControlPlaneReplicas is greater than 1", func() {
+		var replicas int32 = 2
+		instance.ControlPlaneReplicas = &replicas
+
+		component, err := render.APIServer(k8sServiceEp, instance, false, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		resources, _ := component.Objects()
+
+		deploy, ok := rtest.GetResource(resources, "tigera-apiserver", "tigera-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-apiserver", "tigera-system")))
+	})
 })
 
 func verifyAPIService(service *apiregv1.APIService, enterprise bool, clusterDomain string) {
@@ -1036,13 +1065,16 @@ var (
 var _ = Describe("API server rendering tests (Calico)", func() {
 	var instance *operatorv1.InstallationSpec
 	var k8sServiceEp k8sapi.ServiceEndpoint
+	var replicas int32
 
 	BeforeEach(func() {
 		instance = &operatorv1.InstallationSpec{
-			Registry: "testregistry.com/",
-			Variant:  operatorv1.Calico,
+			ControlPlaneReplicas: &replicas,
+			Registry:             "testregistry.com/",
+			Variant:              operatorv1.Calico,
 		}
 		k8sServiceEp = k8sapi.ServiceEndpoint{}
+		replicas = 2
 	})
 
 	DescribeTable("should render an API server with default configuration", func(clusterDomain string) {
@@ -1112,7 +1144,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(d.Labels).To(HaveKeyWithValue("apiserver", "true"))
 		Expect(d.Labels).To(HaveKeyWithValue("k8s-app", "calico-apiserver"))
 
-		Expect(*d.Spec.Replicas).To(BeEquivalentTo(1))
+		Expect(*d.Spec.Replicas).To(BeEquivalentTo(2))
 		Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
 		Expect(len(d.Spec.Selector.MatchLabels)).To(Equal(1))
 		Expect(d.Spec.Selector.MatchLabels).To(HaveKeyWithValue("apiserver", "true"))
@@ -1289,5 +1321,32 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 
 		deployment := deploymentResource.(*appsv1.Deployment)
 		rtest.ExpectK8sServiceEpEnvVars(deployment.Spec.Template.Spec, "k8shost", "1234")
+	})
+
+	It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {
+		var replicas int32 = 1
+		instance.ControlPlaneReplicas = &replicas
+
+		component, err := render.APIServer(k8sServiceEp, instance, false, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		resources, _ := component.Objects()
+
+		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(deploy.Spec.Template.Spec.Affinity).To(BeNil())
+	})
+
+	It("should render PodAffinity when ControlPlaneReplicas is greater than 1", func() {
+		var replicas int32 = 2
+		instance.ControlPlaneReplicas = &replicas
+
+		component, err := render.APIServer(k8sServiceEp, instance, false, nil, nil, nil, nil, nil, openshift, nil, dns.DefaultClusterDomain)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		resources, _ := component.Objects()
+
+		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", "calico-apiserver")))
 	})
 })

--- a/pkg/render/common/podaffinity/pod_anti_affinity.go
+++ b/pkg/render/common/podaffinity/pod_anti_affinity.go
@@ -1,0 +1,27 @@
+package podaffinity
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewPodAntiAffinity(name, namespace string) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"k8s-app": name,
+							},
+						},
+						Namespaces:  []string{namespace},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -3,20 +3,20 @@ package render_test
 import (
 	"fmt"
 
-	rtest "github.com/tigera/operator/pkg/render/common/test"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
+	rtest "github.com/tigera/operator/pkg/render/common/test"
 )
 
 var _ = Describe("dex rendering tests", func() {
@@ -36,13 +36,14 @@ var _ = Describe("dex rendering tests", func() {
 			dexSecret      *corev1.Secret
 			idpSecret      *corev1.Secret
 			pullSecrets    []*corev1.Secret
+			replicas       int32
 		)
 
 		BeforeEach(func() {
-
 			installation = &operatorv1.InstallationSpec{
-				KubernetesProvider: operatorv1.ProviderNone,
-				Registry:           "testregistry.com/",
+				ControlPlaneReplicas: &replicas,
+				KubernetesProvider:   operatorv1.ProviderNone,
+				Registry:             "testregistry.com/",
 			}
 
 			authentication = &operatorv1.Authentication{
@@ -80,6 +81,8 @@ var _ = Describe("dex rendering tests", func() {
 					},
 					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 				}}
+
+			replicas = 2
 		})
 
 		It("should render all resources for a OIDC setup", func() {
@@ -144,6 +147,7 @@ var _ = Describe("dex rendering tests", func() {
 
 			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, tlsSecret, dexSecret, idpSecret, clusterName)
 			component := render.Dex(pullSecrets, false, &operatorv1.InstallationSpec{
+				ControlPlaneReplicas:    installation.ControlPlaneReplicas,
 				ControlPlaneTolerations: []corev1.Toleration{t},
 			}, dexCfg, clusterName, false)
 			resources, _ := component.Objects()
@@ -186,6 +190,31 @@ var _ = Describe("dex rendering tests", func() {
 				rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 			}
 			Expect(len(resources)).To(Equal(len(expectedResources)))
+		})
+
+		It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {
+			var replicas int32 = 1
+			installation.ControlPlaneReplicas = &replicas
+
+			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, tlsSecret, dexSecret, idpSecret, clusterName)
+			component := render.Dex(pullSecrets, false, installation, dexCfg, clusterName, false)
+			resources, _ := component.Objects()
+			deploy, ok := rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(deploy.Spec.Template.Spec.Affinity).To(BeNil())
+		})
+
+		It("should render PodAffinity when ControlPlaneReplicas is greater than 1", func() {
+			var replicas int32 = 2
+			installation.ControlPlaneReplicas = &replicas
+
+			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, tlsSecret, dexSecret, idpSecret, clusterName)
+			component := render.Dex(pullSecrets, false, installation, dexCfg, clusterName, false)
+			resources, _ := component.Objects()
+			deploy, ok := rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
+			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-dex", "tigera-dex")))
 		})
 	})
 })

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -44,8 +44,6 @@ const (
 	GuardianSecretName             = "tigera-managed-cluster-connection"
 )
 
-var guardianReplicas int32 = 1
-
 func Guardian(
 	url string,
 	pullSecrets []*corev1.Secret,
@@ -202,6 +200,8 @@ func (c *GuardianComponent) clusterRoleBinding() client.Object {
 }
 
 func (c *GuardianComponent) deployment() client.Object {
+	var replicas int32 = 1
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -218,7 +218,7 @@ func (c *GuardianComponent) deployment() client.Object {
 					"k8s-app": GuardianName,
 				},
 			},
-			Replicas: &guardianReplicas,
+			Replicas: &replicas,
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -37,8 +37,6 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 )
 
-var kubeControllerReplicas int32 = 1
-
 const (
 	KubeController                  = "calico-kube-controllers"
 	KubeControllerServiceAccount    = "calico-kube-controllers"
@@ -477,6 +475,8 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		podSpec = relasticsearch.PodSpecDecorate(podSpec)
 	}
 
+	var replicas int32 = 1
+
 	d := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -487,7 +487,7 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &kubeControllerReplicas,
+			Replicas: &replicas,
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
 
 	ocsv1 "github.com/openshift/api/security/v1"
 	"github.com/tigera/operator/pkg/render/common/authentication"
@@ -96,6 +97,7 @@ func Manager(
 	internalTrafficSecret *corev1.Secret,
 	clusterDomain string,
 	esLicenseType ElasticsearchLicenseType,
+	replicas *int32,
 ) (Component, error) {
 	var tlsSecrets []*corev1.Secret
 	tlsAnnotations := map[string]string{
@@ -140,6 +142,7 @@ func Manager(
 		installation:                  installation,
 		managementCluster:             managementCluster,
 		esLicenseType:                 esLicenseType,
+		replicas:                      replicas,
 	}, nil
 }
 
@@ -162,6 +165,7 @@ type managerComponent struct {
 	proxyImage                    string
 	esProxyImage                  string
 	csrInitImage                  string
+	replicas                      *int32
 }
 
 func (c *managerComponent) ResolveImages(is *operatorv1.ImageSet) error {
@@ -262,7 +266,6 @@ func (c *managerComponent) Ready() bool {
 
 // managerDeployment creates a deployment for the Tigera Secure manager component.
 func (c *managerComponent) managerDeployment() *appsv1.Deployment {
-	var replicas int32 = 1
 	annotations := make(map[string]string)
 
 	if c.complianceServerCertSecret != nil {
@@ -319,6 +322,10 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 		}),
 	}, c.esClusterConfig, c.esSecrets).(*corev1.PodTemplateSpec)
 
+	if c.replicas != nil && *c.replicas > 1 {
+		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity("tigera-manager", ManagerNamespace)
+	}
+
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -334,7 +341,7 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 					"k8s-app": "tigera-manager",
 				},
 			},
-			Replicas: &replicas,
+			Replicas: c.replicas,
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -15,23 +15,24 @@
 package render_test
 
 import (
-	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/dns"
-	"github.com/tigera/operator/pkg/render/common/authentication"
-	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-	rtest "github.com/tigera/operator/pkg/render/common/test"
-	"github.com/tigera/operator/pkg/render/testutils"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/authentication"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
+	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/testutils"
 )
 
 var _ = Describe("Tigera Secure Manager rendering tests", func() {
@@ -40,7 +41,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Value:     "",
 		ValueFrom: nil,
 	}
-	installation := &operatorv1.InstallationSpec{}
+	var replicas int32 = 2
+	installation := &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas}
 	const expectedResourcesNumber = 11
 
 	expectedDNSNames := dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, dns.DefaultClusterDomain)
@@ -397,7 +399,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			rtest.CreateCertSecret(render.ManagerTLSSecretName, rmeta.OperatorNamespace()),
 			nil, false,
 			i,
-			nil, nil, nil, "", render.ElasticsearchLicenseTypeUnknown)
+			nil, nil, nil, "", render.ElasticsearchLicenseTypeUnknown,
+			&replicas)
 		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 		resources, _ := component.Objects()
 		return rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
@@ -408,9 +411,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			ControlPlaneNodeSelector: map[string]string{
 				"foo": "bar",
 			},
+			ControlPlaneReplicas: &replicas,
 		})
 		Expect(deployment.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 	})
+
 	It("should apply controlPlaneTolerations", func() {
 		t := corev1.Toleration{
 			Key:      "foo",
@@ -419,12 +424,16 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}
 		deployment := renderManager(&operatorv1.InstallationSpec{
 			ControlPlaneTolerations: []corev1.Toleration{t},
+			ControlPlaneReplicas:    &replicas,
 		})
 		Expect(deployment.Spec.Template.Spec.Tolerations).To(ContainElements(t, rmeta.TolerateMaster, rmeta.TolerateCriticalAddonsOnly))
 	})
 
 	It("should render all resources for certificate management", func() {
-		resources := renderObjects(false, nil, &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{}}, false)
+		resources := renderObjects(false, nil, &operatorv1.InstallationSpec{
+			CertificateManagement: &operatorv1.CertificateManagement{},
+			ControlPlaneReplicas:  &replicas,
+		}, false)
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -463,13 +472,39 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerTLSSecretName))
 		Expect(deployment.Spec.Template.Spec.Volumes[0].Secret).To(BeNil())
 	})
+
+	It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {
+		var replicas int32 = 1
+		installation.ControlPlaneReplicas = &replicas
+
+		resources := renderObjects(false, nil, &operatorv1.InstallationSpec{
+			CertificateManagement: &operatorv1.CertificateManagement{},
+			ControlPlaneReplicas:  &replicas,
+		}, false)
+		deploy, ok := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(deploy.Spec.Template.Spec.Affinity).To(BeNil())
+	})
+
+	It("should render PodAffinity when ControlPlaneReplicas is greater than 1", func() {
+		var replicas int32 = 2
+		installation.ControlPlaneReplicas = &replicas
+
+		resources := renderObjects(false, nil, &operatorv1.InstallationSpec{
+			CertificateManagement: &operatorv1.CertificateManagement{},
+			ControlPlaneReplicas:  &replicas,
+		}, false)
+		deploy, ok := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-manager", render.ManagerNamespace)))
+	})
 })
 
 func renderObjects(oidc bool, managementCluster *operatorv1.ManagementCluster, installation *operatorv1.InstallationSpec, includeManagerTLSSecret bool) []client.Object {
 	var dexCfg authentication.KeyValidatorConfig
 	if oidc {
-		var authentication *operatorv1.Authentication
-		authentication = &operatorv1.Authentication{
+		authentication := &operatorv1.Authentication{
 			Spec: operatorv1.AuthenticationSpec{
 				ManagerDomain: "https://127.0.0.1",
 				OIDC:          &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
@@ -504,6 +539,7 @@ func renderObjects(oidc bool, managementCluster *operatorv1.ManagementCluster, i
 		internalTraffic,
 		dns.DefaultClusterDomain,
 		render.ElasticsearchLicenseTypeEnterpriseTrial,
+		installation.ControlPlaneReplicas,
 	)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
 	Expect(component.ResolveImages(nil)).To(BeNil())


### PR DESCRIPTION
## Description

Make the following Calico Enterprise components deployment replica
configurable via the new optional ControlPlaneReplicas field in
InstallationSpec:
* tigera-dex/tigera-dex
* tigera-elasticsearch/tigera-secure-es-gateway
* tigera-manager/tigera-manager (standalone cluster only)
* tigera-system/tigera-apiserver

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
