### PR TITLE
Fix that control-plane tolerations were not applied to Typha pods

### DIFF
--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -388,6 +388,12 @@ func (c *typhaComponent) typhaDeployment() *appsv1.Deployment {
 		annotations["prometheus.io/port"] = fmt.Sprintf("%d", *c.cfg.Installation.TyphaMetricsPort)
 	}
 
+	// Allow tolerations to be overwritten by the end-user.
+	tolerations := rmeta.TolerateAll
+	if len(c.cfg.Installation.ControlPlaneTolerations) != 0 {
+		tolerations = c.cfg.Installation.ControlPlaneTolerations
+	}
+
 	d := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -417,7 +423,7 @@ func (c *typhaComponent) typhaDeployment() *appsv1.Deployment {
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					Tolerations:                   rmeta.TolerateAll,
+					Tolerations:                   tolerations,
 					Affinity:                      c.affinity(),
 					ImagePullSecrets:              c.cfg.Installation.ImagePullSecrets,
 					ServiceAccountName:            TyphaServiceAccountName,


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

According to the API definition, `ControlPlaneTolerations` apply to all
pods deployed by the operator with the exception of daemonsets, which
means they should apply to Typha as well.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.