### PR TITLE
Create tigera-dpi namespace irrespective of DPI resource

### DIFF
--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -84,26 +84,45 @@ func (d *dpiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 }
 
 func (d *dpiComponent) Objects() (objsToCreate, objsToDelete []client.Object) {
-	var toDelete []client.Object
-	var toCreate []client.Object
+	var commonObjs []client.Object
+
+	nsObj := []client.Object{render.CreateNamespace(DeepPacketInspectionNamespace, d.cfg.Installation.KubernetesProvider)}
 
 	if d.cfg.HasNoDPIResource || d.cfg.HasNoLicense {
-		toDelete = append(toDelete, d.dpiNamespace())
-		return nil, toDelete
+		// create empty secrets and configMap when resource needs to be deleted.
+		commonObjs = append(commonObjs, &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: render.NodeTLSSecretName, Namespace: DeepPacketInspectionNamespace}})
+		commonObjs = append(commonObjs, &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: render.TyphaTLSSecretName, Namespace: DeepPacketInspectionNamespace}})
+		commonObjs = append(commonObjs, &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: DeepPacketInspectionNamespace}})
+		commonObjs = append(commonObjs, &corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: render.TyphaCAConfigMapName, Namespace: DeepPacketInspectionNamespace}})
+	} else {
+		commonObjs = append(commonObjs, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.NodeTLSSecret)...)...)
+		commonObjs = append(commonObjs, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.TyphaTLSSecret)...)...)
+		commonObjs = append(commonObjs, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.ESSecrets...)...)...)
+		commonObjs = append(commonObjs, configmap.ToRuntimeObjects(configmap.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.TyphaCAConfigMap)...)...)
 	}
 
-	toCreate = append(toCreate, render.CreateNamespace(DeepPacketInspectionNamespace, d.cfg.Installation.KubernetesProvider))
-	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.NodeTLSSecret)...)...)
-	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.TyphaTLSSecret)...)...)
-	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.ESSecrets...)...)...)
-	toCreate = append(toCreate, configmap.ToRuntimeObjects(configmap.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.TyphaCAConfigMap)...)...)
-	toCreate = append(toCreate,
+	commonObjs = append(commonObjs,
 		d.dpiServiceAccount(),
 		d.dpiClusterRole(),
 		d.dpiClusterRoleBinding(),
 		d.dpiDaemonset(),
 	)
-	return toCreate, nil
+
+	if d.cfg.HasNoLicense {
+		return nil, append(nsObj, commonObjs...)
+	}
+	if d.cfg.HasNoDPIResource {
+		return nsObj, commonObjs
+	}
+	return append(nsObj, commonObjs...), nil
 }
 
 func (d *dpiComponent) Ready() bool {
@@ -366,6 +385,9 @@ func (d *dpiComponent) dpiNamespace() *corev1.Namespace {
 }
 
 func (d *dpiComponent) dpiAnnotations() map[string]string {
+	if d.cfg.HasNoDPIResource || d.cfg.HasNoLicense {
+		return nil
+	}
 	return map[string]string{
 		render.TyphaCAHashAnnotation:   rmeta.AnnotationHash(d.cfg.TyphaCAConfigMap.Data),
 		render.NodeCertHashAnnotation:  rmeta.AnnotationHash(d.cfg.NodeTLSSecret.Data),

--- a/pkg/render/intrusiondetection/dpi/dpi_test.go
+++ b/pkg/render/intrusiondetection/dpi/dpi_test.go
@@ -263,7 +263,7 @@ var _ = Describe("DPI rendering tests", func() {
 		validateDPIComponents(resources, true)
 	})
 
-	It("Should delete resources for deep packet inspection if there is no valid product license", func() {
+	It("should delete resources for deep packet inspection if there is no valid product license", func() {
 		component := dpi.DPI(&dpi.DPIConfig{
 			IntrusionDetection: ids,
 			Installation:       &operatorv1.InstallationSpec{Registry: "testregistry.com/"},
@@ -282,6 +282,14 @@ var _ = Describe("DPI rendering tests", func() {
 		createResources, deleteResource := component.Objects()
 		expectedResources := []resourceTestObj{
 			{name: dpi.DeepPacketInspectionNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.NodeTLSSecretName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.TyphaTLSSecretName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: relasticsearch.PublicCertSecret, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.TyphaCAConfigMapName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "ConfigMap"},
+			{name: dpi.DeepPacketInspectionName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+			{name: dpi.DeepPacketInspectionName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: dpi.DeepPacketInspectionName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: dpi.DeepPacketInspectionName, ns: dpi.DeepPacketInspectionNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
 		Expect(len(deleteResource)).To(Equal(len(expectedResources)))
@@ -292,7 +300,7 @@ var _ = Describe("DPI rendering tests", func() {
 		}
 	})
 
-	It("Should delete resources for deep packet inspection if TLS configs are not set", func() {
+	It("should delete resources for deep packet inspection if there is no DPI resource", func() {
 		component := dpi.DPI(&dpi.DPIConfig{
 			IntrusionDetection: ids,
 			Installation:       &operatorv1.InstallationSpec{Registry: "testregistry.com/"},
@@ -309,14 +317,26 @@ var _ = Describe("DPI rendering tests", func() {
 		})
 		createResources, deleteResource := component.Objects()
 		expectedResources := []resourceTestObj{
+			{name: render.NodeTLSSecretName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.TyphaTLSSecretName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: relasticsearch.PublicCertSecret, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "Secret"},
+			{name: render.TyphaCAConfigMapName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "ConfigMap"},
+			{name: dpi.DeepPacketInspectionName, ns: dpi.DeepPacketInspectionNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+			{name: dpi.DeepPacketInspectionName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: dpi.DeepPacketInspectionName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: dpi.DeepPacketInspectionName, ns: dpi.DeepPacketInspectionNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
+		}
+		expectedCreateResources := []resourceTestObj{
 			{name: dpi.DeepPacketInspectionNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
 		}
-
 		Expect(len(deleteResource)).To(Equal(len(expectedResources)))
-		Expect(len(createResources)).To(Equal(0))
+		Expect(len(createResources)).To(Equal(len(expectedCreateResources)))
 
 		for i, expectedRes := range expectedResources {
 			rtest.ExpectResource(deleteResource[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+		}
+		for i, expectedRes := range expectedCreateResources {
+			rtest.ExpectResource(createResources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 	})
 })


### PR DESCRIPTION
## Description

Issue: Applying network policies fails during CaliEnt install as tigera-dpi namespace doesn't exist unit DeepPacketInspection resource is created.

This PR is to create a tigera-dpi namespace without depending on DeepPacketInspection resource.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
