### PR TITLE
Make es admin username configurable for kube-controllers secret

### DIFF
--- a/pkg/controller/logstorage/common/common.go
+++ b/pkg/controller/logstorage/common/common.go
@@ -37,7 +37,7 @@ const (
 // are generated and stored in the user secret, a hashed version of the credentials is stored in the tigera-elasticsearch namespace for ES Gateway to retrieve and use to compare
 // the gateway credentials, and a secret containing real admin level credentials is created and stored in the tigera-elasticsearch namespace to be swapped in once
 // ES Gateway has confirmed that the gateway credentials match.
-func CreateKubeControllersSecrets(ctx context.Context, esAdminUserSecret *corev1.Secret, cli client.Client) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
+func CreateKubeControllersSecrets(ctx context.Context, esAdminUserSecret *corev1.Secret, esAdminUserName string, cli client.Client) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
 	kubeControllersGatewaySecret, err := utils.GetSecret(ctx, cli, kubecontrollers.ElasticsearchKubeControllersUserSecret, rmeta.OperatorNamespace())
 	if err != nil {
 		return nil, nil, nil, err
@@ -94,8 +94,8 @@ func CreateKubeControllersSecrets(ctx context.Context, esAdminUserSecret *corev1
 				},
 			},
 			Data: map[string][]byte{
-				"username": []byte("elastic"),
-				"password": esAdminUserSecret.Data["elastic"],
+				"username": []byte(esAdminUserName),
+				"password": esAdminUserSecret.Data[esAdminUserName],
 			},
 		}
 	}

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -67,22 +67,24 @@ func EsGateway(c *Config) render.Component {
 
 	secrets = append(secrets, c.KubeControllersUserSecrets...)
 	return &esGateway{
-		installation:   c.Installation,
-		pullSecrets:    c.PullSecrets,
-		secrets:        secrets,
-		tlsAnnotations: tlsAnnotations,
-		clusterDomain:  c.ClusterDomain,
+		installation:    c.Installation,
+		pullSecrets:     c.PullSecrets,
+		secrets:         secrets,
+		tlsAnnotations:  tlsAnnotations,
+		clusterDomain:   c.ClusterDomain,
+		esAdminUserName: c.EsAdminUserName,
 	}
 }
 
 type esGateway struct {
-	installation   *operatorv1.InstallationSpec
-	pullSecrets    []*corev1.Secret
-	secrets        []*corev1.Secret
-	tlsAnnotations map[string]string
-	clusterDomain  string
-	csrImage       string
-	esGatewayImage string
+	installation    *operatorv1.InstallationSpec
+	pullSecrets     []*corev1.Secret
+	secrets         []*corev1.Secret
+	tlsAnnotations  map[string]string
+	clusterDomain   string
+	csrImage        string
+	esGatewayImage  string
+	esAdminUserName string
 }
 
 type Config struct {
@@ -93,6 +95,7 @@ type Config struct {
 	KibanaInternalCertSecret   *corev1.Secret
 	EsInternalCertSecret       *corev1.Secret
 	ClusterDomain              string
+	EsAdminUserName            string
 }
 
 func (e *esGateway) ResolveImages(is *operatorv1.ImageSet) error {
@@ -188,13 +191,13 @@ func (e esGateway) esGatewayDeployment() *appsv1.Deployment {
 		{Name: "ES_GATEWAY_KIBANA_ENDPOINT", Value: KibanaHTTPSEndpoint},
 		{Name: "ES_GATEWAY_HTTPS_CERT", Value: "/certs/https/tls.crt"},
 		{Name: "ES_GATEWAY_HTTPS_KEY", Value: "/certs/https/tls.key"},
-		{Name: "ES_GATEWAY_ELASTIC_USERNAME", Value: "elastic"},
+		{Name: "ES_GATEWAY_ELASTIC_USERNAME", Value: e.esAdminUserName},
 		{Name: "ES_GATEWAY_ELASTIC_PASSWORD", ValueFrom: &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: render.ElasticsearchAdminUserSecret,
 				},
-				Key: "elastic",
+				Key: e.esAdminUserName,
 			},
 		}},
 	}

--- a/pkg/render/logstorage/esgateway/esgateway_test.go
+++ b/pkg/render/logstorage/esgateway/esgateway_test.go
@@ -87,7 +87,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 				},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: rmeta.OperatorNamespace()}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
-				clusterDomain,
+				clusterDomain, "elastic",
 			})
 
 			createResources, _ := component.Objects()
@@ -128,7 +128,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 				},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: rmeta.OperatorNamespace()}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
-				clusterDomain,
+				clusterDomain, "elastic",
 			})
 
 			createResources, _ := component.Objects()


### PR DESCRIPTION
## Description
The current assumption is that the `tigera-secure-es-elastic-user` secret contains an entry in the format `elastic: <password>` where `elastic` is the username of the admin level user. In the downstream Cloud Operator, specifically in the multi-tenant scenario, this username will not be `elastic` and will instead be `tigera-mgmt`. This change makes the username configurable for the kube-controllers Elasticsearch user secret, ensuring minimal conflicts downstream.