### PR TITLE
WIP: GKE resource quotas handling and tweak priority classes

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1025,8 +1025,14 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	operatorComponent := render.NewPassthrough(objs)
 	components = append(components, operatorComponent)
 
+	// Render priority classes.
+	components = append(components, render.PriorityClassDefinitions())
+
 	// Render namespaces for Calico.
 	components = append(components, render.Namespaces(&instance.Spec, pullSecrets))
+
+	// Render resources quotas.
+	components = append(components, render.ResourceQuotas())
 
 	// If we're on OpenShift on AWS render a Job (and needed resources) to
 	// setup the security groups we need for IPIP, BGP, and Typha communication.

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -262,7 +262,7 @@ func (c *amazonCloudIntegrationComponent) deployment() *appsv1.Deployment {
 			},
 		},
 	}
-	SetClusterCriticalPod(&d.Spec.Template)
+	setCalicoCriticalPod(&d.Spec.Template)
 
 	return d
 }

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -453,7 +453,7 @@ func (c *fluentdComponent) daemonset() *appsv1.DaemonSet {
 		},
 	}
 
-	setNodeCriticalPod(&(ds.Spec.Template))
+	setCalicoCriticalPod(&(ds.Spec.Template))
 	return ds
 }
 

--- a/pkg/render/priority_class.go
+++ b/pkg/render/priority_class.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2019, 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	schedv1 "k8s.io/api/scheduling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operator "github.com/tigera/operator/api/v1"
+)
+
+const (
+	CalicoPriorityClassName  = "calico-priority"
+	NodePriorityClassName    = "system-node-critical"
+	ClusterPriorityClassName = "system-cluster-critical"
+)
+
+func setNodeCriticalPod(t *corev1.PodTemplateSpec) {
+	t.Spec.PriorityClassName = NodePriorityClassName
+}
+
+func SetClusterCriticalPod(t *corev1.PodTemplateSpec) {
+	t.Spec.PriorityClassName = ClusterPriorityClassName
+}
+
+func setCalicoCriticalPod(t *v1.PodTemplateSpec) {
+	t.Spec.PriorityClassName = CalicoPriorityClassName
+}
+
+func PriorityClassDefinitions() Component {
+	return &priorityClassComponent{}
+}
+
+type priorityClassComponent struct {
+}
+
+func (c *priorityClassComponent) ResolveImages(is *operator.ImageSet) error {
+	// No images to resolve
+	return nil
+}
+
+func (c *priorityClassComponent) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeAny
+}
+
+func (c *priorityClassComponent) Objects() ([]client.Object, []client.Object) {
+	return []client.Object{c.calicoPriority()}, nil
+}
+
+func (c *priorityClassComponent) Ready() bool {
+	return true
+}
+
+func (c *priorityClassComponent) calicoPriority() *schedv1.PriorityClass {
+	return &schedv1.PriorityClass{
+		TypeMeta: metav1.TypeMeta{Kind: "PriorityClass", APIVersion: "scheduling.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: PriorityClassName,
+		},
+		// The highest value setable in a priority class by a user is 1000000000.
+		Value:         1000000000,
+		GlobalDefault: false,
+		Description:   "Priority class for Calico resources that should have a high priority",
+	}
+}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,16 +16,13 @@ package render
 
 import (
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (
-	CommonName               = "common-name"
-	URISAN                   = "uri-san"
-	TyphaCommonName          = "typha-server"
-	FelixCommonName          = "typha-client"
-	NodePriorityClassName    = "system-node-critical"
-	ClusterPriorityClassName = "system-cluster-critical"
+	CommonName      = "common-name"
+	URISAN          = "uri-san"
+	TyphaCommonName = "typha-server"
+	FelixCommonName = "typha-client"
 )
 
 // A Renderer is capable of generating components to be installed on the cluster.
@@ -35,12 +32,4 @@ type Renderer interface {
 
 func SetTestLogger(l logr.Logger) {
 	log = l
-}
-
-func setNodeCriticalPod(t *corev1.PodTemplateSpec) {
-	t.Spec.PriorityClassName = NodePriorityClassName
-}
-
-func SetClusterCriticalPod(t *corev1.PodTemplateSpec) {
-	t.Spec.PriorityClassName = ClusterPriorityClassName
 }

--- a/pkg/render/resourcequota.go
+++ b/pkg/render/resourcequota.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package render
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+)
+
+const (
+	CalicoCriticalResourceQuotaName        = "calico-critical-pods"
+	CalicoClusterCriticalResourceQuotaName = "calico-cluster-critical-pods"
+	CalicoNodeCriticalResourceQuotaName    = "calico-node-critical-pods"
+)
+
+func ResourceQuotas() Component {
+	return &resourceQuotaComponent{}
+}
+
+type resourceQuotaComponent struct {
+}
+
+func (c *resourceQuotaComponent) ResolveImages(is *operatorv1.ImageSet) error {
+	// No images on a resource quota.
+	return nil
+}
+
+func (c *resourceQuotaComponent) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeAny
+}
+
+func (c *resourceQuotaComponent) Objects() ([]client.Object, []client.Object) {
+	criticalPriorityClasses := []string{NodePriorityClassName, ClusterPriorityClassName}
+	rs := []client.Object{
+		resourceQuotaForPriorityClass(CalicoCriticalResourceQuotaName, common.CalicoNamespace, criticalPriorityClasses),
+	}
+
+	return rs, nil
+}
+
+func (c *resourceQuotaComponent) Ready() bool {
+	return true
+}
+
+// resourceQuotaForPriorityClass creates a ResourceQuota in a specified namespace and
+// selects the priority classes provides. This allows pods with the specified pods to be scheduled
+// This doesn't guarantee that a pod will be scheduled as Kubernetes will also check to ensure
+// that other resource quota constraints in the namespace are satisfied.
+func resourceQuotaForPriorityClassScope(name, namespace string, priorityClasses []string) *corev1.ResourceQuota {
+	return &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			ScopeSelector: corev1.ScopeSelector{
+				MatchExpressions: corev1.ScopedResourceSelectorRequirement{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOpIn,
+					Values:    priorityClasses,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description

This is still very WIP but opening to get an early opinion. 

A few changes proposed in this PR:
- In GKE, resource quotas are set up in a way that pods with priority classes `system-node-critical` and `system-cluster-critical` are only schedulable if they are in the `kube-system` namespace. This PR adds resource quota for the `calico-system` namespace which should unblock this.
- Re-introduce the calico-priority priority class so that fluentd will continue having the older behavior. I am not sure if this should be considered just adding priority class for fluentd is correct or should this be present for other Enterprise components.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
