### PR TITLE
Add resource quota to components

### DIFF
--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -929,5 +929,20 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(*fc.Spec.RouteTableRange).To(Equal(crdv1.RouteTableRange{Min: 65, Max: 99}))
 			Expect(fc.Spec.LogSeverityScreen).To(Equal("Error"))
 		})
+		It("should Reconcile with GKE and create a resource quota", func() {
+			cr.Spec.KubernetesProvider = operator.ProviderGKE
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			rq := corev1.ResourceQuota{
+				TypeMeta: metav1.TypeMeta{Kind: "ResourceQuota", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-critical-pods",
+					Namespace: common.CalicoNamespace,
+				},
+			}
+			Expect(test.GetResource(c, &rq)).To(BeNil())
+		})
 	})
 })

--- a/pkg/render/common/resourcequota/resourcequota.go
+++ b/pkg/render/common/resourcequota/resourcequota.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package resourcequota
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	CalicoCriticalResourceQuotaName = "calico-critical-pods"
+	TigeraCriticalResourceQuotaName = "tigera-critical-pods"
+)
+
+// ResourceQuotaForPriorityClassScope creates a ResourceQuota in a specified namespace and
+// selects the priority classes provides. This allows pods with the specified pods to be scheduled
+// This doesn't guarantee that a pod will be scheduled as Kubernetes will also check to ensure
+// that other resource quota constraints in the namespace are satisfied.
+func ResourceQuotaForPriorityClassScope(name, namespace string, priorityClasses []string) *corev1.ResourceQuota {
+	return &corev1.ResourceQuota{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ResourceQuota",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			ScopeSelector: &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{
+					{
+						ScopeName: corev1.ResourceQuotaScopePriorityClass,
+						Operator:  corev1.ScopeSelectorOpIn,
+						Values:    priorityClasses,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -33,6 +33,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
+	"github.com/tigera/operator/pkg/render/common/resourcequota"
 	"github.com/tigera/operator/pkg/render/common/secret"
 )
 
@@ -234,6 +235,14 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 			LogCollectorNamespace,
 			c.installation.KubernetesProvider))
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.pullSecrets...)...)...)
+
+	if c.installation.KubernetesProvider == operatorv1.ProviderGKE {
+		// We do this only for GKE as other providers don't (yet?)
+		// automatically add resource quota that constrains whether
+		// components that are marked cluster or node critical
+		// can be scheduled.
+		objs = append(objs, c.fluentdResourceQuota())
+	}
 	if c.s3Credential != nil {
 		objs = append(objs, c.s3CredentialSecret())
 	}
@@ -274,6 +283,11 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 
 func (c *fluentdComponent) Ready() bool {
 	return true
+}
+
+func (c *fluentdComponent) fluentdResourceQuota() *corev1.ResourceQuota {
+	criticalPriorityClasses := []string{NodePriorityClassName}
+	return resourcequota.ResourceQuotaForPriorityClassScope(resourcequota.TigeraCriticalResourceQuotaName, LogCollectorNamespace, criticalPriorityClasses)
 }
 
 func (c *fluentdComponent) s3CredentialSecret() *corev1.Secret {

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -145,6 +145,17 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}))
 	})
 
+	It("should render with a resource quota for provider GKE", func() {
+		installation.KubernetesProvider = operatorv1.ProviderGKE
+
+		// Should render the correct resources.
+		component := render.Fluentd(instance, nil, esConfigMap, s3Creds, splkCreds, filters, eksConfig, nil, installation, dns.DefaultClusterDomain, rmeta.OSTypeLinux)
+		resources, _ := component.Objects()
+
+		// Should render resource quota
+		Expect(rtest.GetResource(resources, "tigera-critical-pods", "tigera-fluentd", "", "v1", "ResourceQuota")).ToNot(BeNil())
+	})
+
 	It("should render for Windows nodes", func() {
 		expectedResources := []struct {
 			name    string

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -40,7 +40,6 @@ import (
 	"github.com/tigera/operator/pkg/render/common/configmap"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
-	"github.com/tigera/operator/pkg/render/common/resourcequota"
 	"github.com/tigera/operator/pkg/render/common/secret"
 )
 
@@ -168,14 +167,6 @@ func (c *nodeComponent) Objects() ([]client.Object, []client.Object) {
 		c.nodeRoleBinding(),
 	}
 
-	if c.cfg.Installation.KubernetesProvider == operatorv1.ProviderGKE {
-		// We do this only for GKE as other providers don't (yet?)
-		// automatically add resource quota that constrains whether
-		// Calico components that are marked cluster or node critical
-		// can be scheduled.
-		objsToCreate = append(objsToCreate, c.calicoResourceQuota())
-	}
-
 	if c.cfg.BGPLayouts != nil {
 		objsToCreate = append(objsToCreate, configmap.ToRuntimeObjects(configmap.CopyToNamespace(common.CalicoNamespace, c.cfg.BGPLayouts)...)...)
 	}
@@ -224,11 +215,6 @@ func (c *nodeComponent) Objects() ([]client.Object, []client.Object) {
 
 func (c *nodeComponent) Ready() bool {
 	return true
-}
-
-func (c *nodeComponent) calicoResourceQuota() *corev1.ResourceQuota {
-	criticalPriorityClasses := []string{NodePriorityClassName, ClusterPriorityClassName}
-	return resourcequota.ResourceQuotaForPriorityClassScope(resourcequota.CalicoCriticalResourceQuotaName, common.CalicoNamespace, criticalPriorityClasses)
 }
 
 // nodeServiceAccount creates the node's service account.

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1894,24 +1894,6 @@ var _ = Describe("Node rendering tests", func() {
 				SubPath:   "template-1.yaml",
 			}))
 	})
-
-	Describe("GKE", func() {
-		It("should render a resource quota resource", func() {
-			// Override the installation with one configured for GKE.
-			gkeInstallation := &operatorv1.InstallationSpec{
-				KubernetesProvider: operatorv1.ProviderGKE,
-				CNI:                &operatorv1.CNISpec{Type: operatorv1.PluginGKE},
-			}
-			cfg.Installation = gkeInstallation
-
-			component := render.Node(&cfg)
-			Expect(component.ResolveImages(nil)).To(BeNil())
-			resources, _ := component.Objects()
-
-			// Should render resource quota
-			Expect(rtest.GetResource(resources, "calico-critical-pods", "calico-system", "", "v1", "ResourceQuota")).ToNot(BeNil())
-		})
-	})
 	Describe("AKS", func() {
 		It("should avoid virtual nodes", func() {
 			defaultInstance.KubernetesProvider = operatorv1.ProviderAKS

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1895,6 +1895,23 @@ var _ = Describe("Node rendering tests", func() {
 			}))
 	})
 
+	Describe("GKE", func() {
+		It("should render a resource quota resource", func() {
+			// Override the installation with one configured for GKE.
+			gkeInstallation := &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				CNI:                &operatorv1.CNISpec{Type: operatorv1.PluginGKE},
+			}
+			cfg.Installation = gkeInstallation
+
+			component := render.Node(&cfg)
+			Expect(component.ResolveImages(nil)).To(BeNil())
+			resources, _ := component.Objects()
+
+			// Should render resource quota
+			Expect(rtest.GetResource(resources, "calico-critical-pods", "calico-system", "", "v1", "ResourceQuota")).ToNot(BeNil())
+		})
+	})
 	Describe("AKS", func() {
 		It("should avoid virtual nodes", func() {
 			defaultInstance.KubernetesProvider = operatorv1.ProviderAKS


### PR DESCRIPTION
## Description

In GKE, resource quotas are set up in a way that pods with priority classes `system-node-critical` and `system-cluster-critical` are only schedulable if they are in the `kube-system` namespace. This PR adds resource quota for the `calico-system` and `tigera-fluentd` namespace, when deployed in GKE, which should unblock this.

A few things to note:
- I've only done this for GKE. I am not sure what impact this will have for other providers and wanted to minimize this.
- Rather than adding resource quotas from respective controllers and having resource quota as it's own component, it seemed to fit better being rendered in respective components and can be easily rendered in the right namespace.
- I didn't switch fluentd priority class to the earlier calico-priority mostly because I can't yet pick the right way to manage different priority classes. Should there be a single priority class for each component or should we pick a few priorities based on what each component does and assign things that way. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
