### PR TITLE
Fix broken release script

### DIFF
--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -18,7 +18,7 @@ fi
 
 # Skip releasing if the image already exists. No guarantee that a tagged build will only be run once. We want the build to
 # pass in the case where the image exists.
-if ! make release-check-image-exists; then
+if ! make release-check-image-exists VERSION=${tag}; then
 	echo "Image tag already exists, no need to release"
 	exit 0
 fi


### PR DESCRIPTION

## Description

Failed job on master had this output:
```
make[1]: Leaving directory '/home/semaphore/operator'
if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then
  make maybe-build-release;
fi
./hack/maybe-build-release.sh
make[1]: Entering directory '/home/semaphore/operator'
Makefile:435: *** VERSION is undefined - run using make release VERSION=vX.Y.Z.  Stop.
make[1]: Leaving directory '/home/semaphore/operator'
Image tag already exists, no need to release
export SEMAPHORE_JOB_RESULT=passed
```

This change adds the missing version to the failing make target.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
