### PR TITLE
Add init container that logs SELinux context

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -879,9 +879,15 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 						// The Image is not populated for the container so no need to get and check it
 						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
+						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(2))
 						initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 						Expect(initset).ToNot(BeNil())
+						Expect(initset.Image).To(Equal(
+							fmt.Sprintf("some.registry.org/%s:%s",
+								components.ComponentElasticsearch.Image,
+								components.ComponentElasticsearch.Version)))
+						initlogctx := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-log-selinux-context")
+						Expect(initlogctx).ToNot(BeNil())
 						Expect(initset.Image).To(Equal(
 							fmt.Sprintf("some.registry.org/%s:%s",
 								components.ComponentElasticsearch.Image,
@@ -1004,10 +1010,16 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 						// The Image is not populated for the container so no need to get and check it
 						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
+						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(2))
 						initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 						Expect(initset).ToNot(BeNil())
 						Expect(initset.Image).To(Equal(
+							fmt.Sprintf("some.registry.org/%s@%s",
+								components.ComponentElasticsearch.Image,
+								"sha256:elasticsearchhash")))
+						initlogctx := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-log-selinux-context")
+						Expect(initlogctx).ToNot(BeNil())
+						Expect(initlogctx.Image).To(Equal(
 							fmt.Sprintf("some.registry.org/%s@%s",
 								components.ComponentElasticsearch.Image,
 								"sha256:elasticsearchhash")))

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -185,8 +185,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 				// Verify that an initContainer is added
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(len(initContainers)).To(Equal(1))
+				Expect(len(initContainers)).To(Equal(2))
 				Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
+				Expect(initContainers[1].Name).To(Equal("elastic-internal-init-log-selinux-context"))
 
 				// Verify that the default container limits/requests are set.
 				esContainer := resultES.Spec.NodeSets[0].PodTemplate.Spec.Containers[0]
@@ -348,7 +349,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
 
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(initContainers).To(HaveLen(4))
+				Expect(initContainers).To(HaveLen(5))
 				compareInitContainer := func(ic corev1.Container, expectedName string, expectedVolumes []corev1.VolumeMount) {
 					Expect(ic.Name).To(Equal(expectedName))
 					Expect(ic.VolumeMounts).To(HaveLen(len(expectedVolumes)))
@@ -370,6 +371,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				compareInitContainer(initContainers[3], "key-cert-elastic-transport", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: render.CSRCMountPath},
 				})
+				compareInitContainer(initContainers[4], "elastic-internal-init-log-selinux-context", []corev1.VolumeMount{})
 			})
 
 		})
@@ -626,9 +628,10 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 			// Verify that there are 2 init containers for OIDC
 			initContainers := elasticsearch.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-			Expect(len(initContainers)).To(Equal(2))
+			Expect(len(initContainers)).To(Equal(3))
 			Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
 			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-keystore"))
+			Expect(initContainers[2].Name).To(Equal("elastic-internal-init-log-selinux-context"))
 		})
 
 		It("should not configures OIDC for Kibana when elasticsearch basic license is used", func() {
@@ -673,8 +676,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			}))
 
 			initContainers := elasticsearch.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-			Expect(len(initContainers)).To(Equal(1))
+			Expect(len(initContainers)).To(Equal(2))
 			Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
+			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-log-selinux-context"))
 		})
 
 		Context("ECKOperator memory requests/limits", func() {


### PR DESCRIPTION
## Description

Add an init container that logs SELinux context of the Elasticsearch directory. This is a workaround a k8s bug where in some circumstances the main container is not started after init containers. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
