### PR TITLE
Automated cherry pick of #1538: Add init container that logs SELinux context

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -933,9 +933,15 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 						// The Image is not populated for the container so no need to get and check it
 						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
+						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(2))
 						initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 						Expect(initset).ToNot(BeNil())
+						Expect(initset.Image).To(Equal(
+							fmt.Sprintf("some.registry.org/%s:%s",
+								components.ComponentElasticsearch.Image,
+								components.ComponentElasticsearch.Version)))
+						initlogctx := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-log-selinux-context")
+						Expect(initlogctx).ToNot(BeNil())
 						Expect(initset.Image).To(Equal(
 							fmt.Sprintf("some.registry.org/%s:%s",
 								components.ComponentElasticsearch.Image,
@@ -1070,10 +1076,16 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 						// The Image is not populated for the container so no need to get and check it
 						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
+						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(2))
 						initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 						Expect(initset).ToNot(BeNil())
 						Expect(initset.Image).To(Equal(
+							fmt.Sprintf("some.registry.org/%s@%s",
+								components.ComponentElasticsearch.Image,
+								"sha256:elasticsearchhash")))
+						initlogctx := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-log-selinux-context")
+						Expect(initlogctx).ToNot(BeNil())
+						Expect(initlogctx.Image).To(Equal(
 							fmt.Sprintf("some.registry.org/%s@%s",
 								components.ComponentElasticsearch.Image,
 								"sha256:elasticsearchhash")))

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -570,6 +570,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	}
 
 	initContainers := []corev1.Container{initOSSettingsContainer}
+
 	annotations := map[string]string{
 		ElasticsearchTLSHashAnnotation: rmeta.SecretsAnnotationHash(es.elasticsearchSecrets...),
 	}
@@ -712,6 +713,47 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			corev1.VolumeMount{MountPath: "/usr/share/elasticsearch/config/node-transport-cert", Name: csrVolumeNameTransport, ReadOnly: false},
 		)
 	}
+
+	// Init container that logs the SELinux context of the `/usr/share/elasticsearch` folder.
+	// This init container is added as a workaround for a bug where Elasticsearch fails to starts when
+	// under some scenarios Kuberentes starts the main container before all the init containers have
+	// completed, SELinux is also enabled on the node, and Kubernetes/kubelet is using the Docker runtime.
+	//
+	// When SELinux is enabled, SELinux policy only allows a container to read a file/folder when their
+	// SELinux labels match or when the mounts are configured to be shared among mutliple containers (the
+	// latter isn't used by Kubernetes). These SELinux labels are managed by the container runtime.
+	// This assignement of SELinux labels and relabelling of files/folders happen when the container is started.
+	// The container runtime also assigns the same SELinux labels to containers created within the same sandbox.
+	// The exception to this SELinux label assignement being when a container is privileged, the Docker runtime
+	// mounts the container's files/folders with a different SELinux label than the one used for the sandbox.
+	//
+	// In Kubernetes, pods are created within the same sandbox. This ensures that files/folders can be shared by
+	// containers running in the same pod. Kubernetes also explicitly requests relabelling of SELinux labels so
+	// that any mounted file/folder gets the right SELinux labels.
+	//
+	// The bug manifests on a SELinux enabled node, when the main container starts before the privileged container
+	// is complete. The main Elasticsearch container fails to read/write files on the shared volume mounts because
+	// the privileged container is the last init container to start and it uses different SELinux labels
+	// than the rest of the containers in the shared (pod) sandbox.
+	//
+	// Adding this additional init container after the privileged init container ensures that the volume mounts
+	// always get the correct SELinux labels and guarantees the labels will be correct for the main container.
+
+	initLogContextContainer := corev1.Container{
+		Name: "elastic-internal-init-log-selinux-context",
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: ptr.BoolToPtr(false),
+		},
+		Image: es.esImage,
+		Command: []string{
+			"/bin/sh",
+		},
+		Args: []string{
+			"-c",
+			"ls -ldZ /usr/share/elasticsearch",
+		},
+	}
+	initContainers = append(initContainers, initLogContextContainer)
 
 	// default to controlPlaneNodeSelector unless DataNodeSelector is set
 	nodeSels := es.installation.ControlPlaneNodeSelector

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -187,8 +187,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 				// Verify that an initContainer is added
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(len(initContainers)).To(Equal(1))
+				Expect(len(initContainers)).To(Equal(2))
 				Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
+				Expect(initContainers[1].Name).To(Equal("elastic-internal-init-log-selinux-context"))
 
 				// Verify that the default container limits/requests are set.
 				esContainer := resultES.Spec.NodeSets[0].PodTemplate.Spec.Containers[0]
@@ -354,7 +355,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
 
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(initContainers).To(HaveLen(4))
+				Expect(initContainers).To(HaveLen(5))
 				compareInitContainer := func(ic corev1.Container, expectedName string, expectedVolumes []corev1.VolumeMount) {
 					Expect(ic.Name).To(Equal(expectedName))
 					Expect(ic.VolumeMounts).To(HaveLen(len(expectedVolumes)))
@@ -376,6 +377,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				compareInitContainer(initContainers[3], "key-cert-elastic-transport", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: render.CSRCMountPath},
 				})
+				compareInitContainer(initContainers[4], "elastic-internal-init-log-selinux-context", []corev1.VolumeMount{})
 			})
 
 		})
@@ -634,9 +636,10 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 			// Verify that there are 2 init containers for OIDC
 			initContainers := elasticsearch.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-			Expect(len(initContainers)).To(Equal(2))
+			Expect(len(initContainers)).To(Equal(3))
 			Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
 			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-keystore"))
+			Expect(initContainers[2].Name).To(Equal("elastic-internal-init-log-selinux-context"))
 		})
 
 		It("should not configures OIDC for Kibana when elasticsearch basic license is used", func() {
@@ -681,8 +684,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			}))
 
 			initContainers := elasticsearch.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-			Expect(len(initContainers)).To(Equal(1))
+			Expect(len(initContainers)).To(Equal(2))
 			Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
+			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-log-selinux-context"))
 		})
 
 		Context("ECKOperator memory requests/limits", func() {


### PR DESCRIPTION
Cherry pick of #1538 on release-v1.21.

#1538: Add init container that logs SELinux context