### PR TITLE
Add UISettingsGroup and UISettings to accessible CRD set

### DIFF
--- a/deploy/crds/enterprise/02-crd-uisettings.yaml
+++ b/deploy/crds/enterprise/02-crd-uisettings.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: uisettings.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: UISettings
+    plural: uisettings
+    singular: uisettings

--- a/deploy/crds/enterprise/02-crd-uisettingsgroup.yaml
+++ b/deploy/crds/enterprise/02-crd-uisettingsgroup.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: uisettingsgroups.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: UISettingsGroup
+    plural: uisettingsgroups
+    singular: uisettingsgroup

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1164,6 +1164,8 @@ func (c *apiServerComponent) tigeraCustomResourcesClusterRole() *rbacv1.ClusterR
 				"packetcaptures",
 				"deeppacketinspections",
 				"deeppacketinspections/status",
+				"uisettingsgroups",
+				"uisettings",
 			},
 			Verbs: []string{
 				"get",


### PR DESCRIPTION
## Description

New UISettings and UISettingsGroup CRDs need to be added to the APIServer set of backend resources.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
