### PR TITLE
Get internal elasticsearch secret from proper namespace

### DIFF
--- a/pkg/controller/logstorage/esgateway.go
+++ b/pkg/controller/logstorage/esgateway.go
@@ -35,15 +35,23 @@ func (r *ReconcileLogStorage) createEsGateway(
 
 	kibanaInternalCertSecret, err := utils.GetSecret(ctx, r.client, render.KibanaInternalCertSecret, common.OperatorNamespace())
 	if err != nil {
+		reqLogger.Error(err, "failed to get Kibana tls certificate secret")
+		r.status.SetDegraded("Failed to get Kibana tls certificate secret", err.Error())
+		return reconcile.Result{}, false, err
+	} else if kibanaInternalCertSecret == nil {
 		reqLogger.Error(err, err.Error())
 		r.status.SetDegraded("Waiting for internal Kibana tls certificate secret to be available", "")
 		return reconcile.Result{}, false, nil
 	}
 
-	esInternalCertSecret, err := utils.GetSecret(ctx, r.client, relasticsearch.InternalCertSecret, common.OperatorNamespace())
+	esInternalCertSecret, err := utils.GetSecret(ctx, r.client, relasticsearch.InternalCertSecret, render.ElasticsearchNamespace)
 	if err != nil {
+		reqLogger.Error(err, "failed to get Elasticsearch tls certificate secret")
+		r.status.SetDegraded("Failed to get Elasticsearch tls certificate secret", err.Error())
+		return reconcile.Result{}, false, err
+	} else if esInternalCertSecret == nil {
 		reqLogger.Error(err, err.Error())
-		r.status.SetDegraded("Waiting for internal Kibana tls certificate secret to be available", "")
+		r.status.SetDegraded("Waiting for internal Elasticsearch tls certificate secret to be available", "")
 		return reconcile.Result{}, false, nil
 	}
 


### PR DESCRIPTION
The internal es secret is no longer in the operator namespace since other components don't use it (they use the gateway secret). The only secret that needs it now is the gateway.

This also fixes a bug where we're not checking if the kibana or elasticsearch internal secrets are nil, meaning they don't exist (because GetSecret returns a nil secret with no error if the secret doesn't exist).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
