### PR TITLE
[release-v1.22] Auto pick #1536: Allow ARCHES to be overwritten #1550: Remove "duplicate" image-all target (use images-all instead)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: fmt vet ut
 # The target architecture is select by setting the ARCH variable.
 # When ARCH is undefined it is set to the detected host architecture.
 # When ARCH differs from the host architecture a crossbuild will be performed.
-ARCHES=$(patsubst build/Dockerfile.%,%,$(wildcard build/Dockerfile.*))
+ARCHES ?= $(patsubst build/Dockerfile.%,%,$(wildcard build/Dockerfile.*))
 
 # BUILDARCH is the host architecture
 # ARCH is the target architecture


### PR DESCRIPTION
Cherry pick of #1536 #1550 on release-v1.22.

#1536: Allow ARCHES to be overwritten
#1550: Remove "duplicate" image-all target (use images-all instead)