### PR TITLE
Generate operator bundles using v1 crds only and include fututure OCP versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -608,13 +608,6 @@ BUNDLE_DEPLOY_DIR ?= build/_output/bundle/$(VERSION)/deploy
 .PHONY: bundle
 bundle: bundle-generate bundle-crd-clean update-bundle bundle-validate bundle-image
 
-# Set CRD_OPTIONS to generate v1beta1 crds. This is required for RH
-# certification. We need apiextensions.k8s.io/v1beta1 crds until we
-# stop supporting OCP 4.5 or RH Connect supports v1 crds.
-.PHONY: bundle-crd-options
-bundle-crd-options:
-	$(eval CRD_OPTIONS = crd:crdVersions=v1beta1,trivialVersions=true)
-
 .PHONY: bundle-crd-clean
 bundle-crd-clean:
 	git checkout -- config/crd/bases/
@@ -635,7 +628,7 @@ endif
 	$(CONTAINERIZED) "hack/gen-bundle/get-manifests.sh"
 
 .PHONY: bundle-generate
-bundle-generate: bundle-crd-options manifests $(KUSTOMIZE) $(OPERATOR_SDK_BARE) bundle-manifests
+bundle-generate: manifests $(KUSTOMIZE) $(OPERATOR_SDK_BARE) bundle-manifests
 	$(KUSTOMIZE) build config/manifests \
 	| $(OPERATOR_SDK_BARE) generate bundle \
 		--crds-dir $(BUNDLE_CRD_DIR) \

--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -65,7 +65,7 @@ sed -i 's/\(operators\.operatorframework\.\io\.bundle\.package\.v1\)=operator/\1
 
 # Add in required labels
 cat <<EOF >> bundle.Dockerfile
-LABEL com.redhat.openshift.versions="v4.5-v4.7"
+LABEL com.redhat.openshift.versions="v4.5"
 LABEL com.redhat.delivery.backport=true
 LABEL com.redhat.delivery.operator.bundle=true
 EOF


### PR DESCRIPTION
## Description

This PR removes the workaround where we generated v1beta1 crds for our operator bundles for certification. It also updates the OCP versions for which the bundles are created. Our operator should be published for all future OCP versions now.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
