### PR TITLE
[release-v1.22] Auto pick #1572: Add control plane tolerations to prometheus api

### DIFF
--- a/pkg/render/prometheus_api.go
+++ b/pkg/render/prometheus_api.go
@@ -225,7 +225,7 @@ func (p *tigeraPrometheusAPIComponent) deployment(prometheusServiceListenPort in
 					HostNetwork:      podHostNetworked,
 					ImagePullSecrets: secret.GetReferenceList(p.pullSecrets),
 					NodeSelector:     p.installation.ControlPlaneNodeSelector,
-					Tolerations:      []corev1.Toleration{rmeta.TolerateMaster},
+					Tolerations:      append(p.installation.ControlPlaneTolerations, rmeta.TolerateMaster),
 					Containers: []corev1.Container{
 						p.tigeraPrometheusAPIContainers(prometheusServiceListenPort),
 					},


### PR DESCRIPTION
Cherry pick of #1572 on release-v1.22.

#1572: Add control plane tolerations to prometheus api