### PR TITLE
Retry when Typha autoscaler reads zero nodes from indexer

### DIFF
--- a/pkg/common/autoscale.go
+++ b/pkg/common/autoscale.go
@@ -21,7 +21,7 @@ func GetExpectedTyphaScale(nodes int) int {
 	typhas := (nodes / maxNodesPerTypha) + 1
 	// We add one more to ensure there is always 1 extra for high availability purposes.
 	typhas += 1
-	// If we don't have enough nodes to have 3 typhs then make sure there is one typha for each node.
+	// If we don't have enough nodes to have 3 typhas then make sure there is one typha for each node.
 	if nodes <= 3 {
 		typhas = nodes
 	} else if typhas < 3 { // If typhas is less than 3 always make sure we have 3

--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -172,6 +172,16 @@ var _ = Describe("Test typha autoscaler ", func() {
 		verifyTyphaReplicas(c, 2)
 	})
 
+	It("should return error if there's no schedulable nodes", func() {
+		ta := newTyphaAutoscaler(c, nlw, tlw, statusManager)
+		ta.start(ctx)
+
+		Eventually(func() error {
+			_, _, err := ta.getNodeCounts()
+			return err
+		}, 5*time.Second).Should(HaveOccurred(), "number of schedulable nodes is zero")
+	})
+
 	It("should ignore non-migrated nodes in its count", func() {
 		typhaMeta := metav1.ObjectMeta{
 			Name:      "calico-typha",


### PR DESCRIPTION
## Description

When the Typha autoscaler reads zero nodes from the indexer, it will
retry node indexer `List()` again until the schedulable nodes are
greater than zero.

We notice an issue in a cluster where kube apiserver performance is
degraded due to malfunctioning nodes/routers. The Operator will scale
Typha up/down which causes churns to the cluster.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
