### PR TITLE
cherrypick: Wait for node and typha informer to sync in Typha autoscaler start

### DIFF
--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -129,7 +129,7 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 		// Start the informers and wait for them to sync.
 		go t.nodeInformer.Run(ctx.Done())
 		go t.typhaInformer.Run(ctx.Done())
-		for !t.nodeInformer.HasSynced() && !t.typhaInformer.HasSynced() {
+		for !t.nodeInformer.HasSynced() || !t.typhaInformer.HasSynced() {
 			time.Sleep(100 * time.Millisecond)
 		}
 


### PR DESCRIPTION
## Description

Fix wait condition in Typha autoscaler `start()` when waiting for
both node and Typha informers to sync.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
