### PR TITLE
Change the order of es-gateway and es-kube-controllers creation

### DIFF
--- a/pkg/controller/logstorage/eskubecontrollers.go
+++ b/pkg/controller/logstorage/eskubecontrollers.go
@@ -46,6 +46,10 @@ func (r *ReconcileLogStorage) createEsKubeControllers(
 		log.Error(err, err.Error())
 		r.status.SetDegraded("Failed to get Elasticsearch pub cert secret used by kube controllers", err.Error())
 		return reconcile.Result{}, false, err
+	} else if kubeControllerEsPublicCertSecret == nil {
+		reqLogger.Info("Waiting for Elasticsearch pub cert secret to be available")
+		r.status.SetDegraded("Waiting for Elasticsearch pub cert secret to be available", "")
+		return reconcile.Result{}, false, nil
 	}
 
 	kubeControllersUserSecret, err := utils.GetSecret(ctx, r.client, kubecontrollers.ElasticsearchKubeControllersUserSecret, common.OperatorNamespace())

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -450,19 +450,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	if managementClusterConnection == nil {
-		result, proceed, err = r.createEsKubeControllers(
-			install,
-			hdler,
-			reqLogger,
-			managementCluster,
-			authentication,
-			esLicenseType,
-			ctx,
-		)
-		if err != nil || !proceed {
-			return result, err
-		}
-
 		result, proceed, err = r.createEsGateway(
 			install,
 			variant,
@@ -470,6 +457,19 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			esAdminUserSecret,
 			hdler,
 			reqLogger,
+			ctx,
+		)
+		if err != nil || !proceed {
+			return result, err
+		}
+
+		result, proceed, err = r.createEsKubeControllers(
+			install,
+			hdler,
+			reqLogger,
+			managementCluster,
+			authentication,
+			esLicenseType,
 			ctx,
 		)
 		if err != nil || !proceed {


### PR DESCRIPTION
## Description
Create es-gateway first so that es-kube-controllers does not encounter any issues waiting for the tigera-secure-es-gateway-http-certs-public secret to be available.