### PR TITLE
Add rights for SV to query k8s resources

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -737,7 +737,12 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events"},
+				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
+				Verbs:     []string{"list"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"replicasets", "statefulsets", "daemonsets"},
 				Verbs:     []string{"list"},
 			},
 			// When a request is made in the manager UI, they are proxied through the Voltron backend server. If the

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -186,7 +186,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events"},
+				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
+				Verbs:     []string{"list"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"replicasets", "statefulsets", "daemonsets"},
 				Verbs:     []string{"list"},
 			},
 			{
@@ -363,7 +368,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events"},
+				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
+				Verbs:     []string{"list"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"replicasets", "statefulsets", "daemonsets"},
 				Verbs:     []string{"list"},
 			},
 			{


### PR DESCRIPTION
## Description

Add "LIST" rights to tigera-manager to for services, replica sets, stateful sets and daemon sets in order to enhance the response with packet capture selectors.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
