### PR TITLE
Automated cherry pick of #1506: Don't run so many Typha instances on small clusters

### DIFF
--- a/pkg/common/autoscale.go
+++ b/pkg/common/autoscale.go
@@ -14,17 +14,40 @@
 package common
 
 // GetTyphaScaleCount will return the number of Typhas needed for the number of nodes.
+//
+// Nodes       Replicas
+//   1-2              1
+//   3-4              2
+//  <200              3
+//  >400              4
+//  >600              5
+//  >800              6
+// >1000              7
+//    .....
+// >2000              12
+//    .....
+// >3600             20
 func GetExpectedTyphaScale(nodes int) int {
 	var maxNodesPerTypha int = 200
+
 	// This gives a count of how many 200s so we need 1+ this number to get at least
 	// 1 typha for every 200 nodes.
 	typhas := (nodes / maxNodesPerTypha) + 1
+
 	// We add one more to ensure there is always 1 extra for high availability purposes.
 	typhas += 1
-	// If we don't have enough nodes to have 3 typhs then make sure there is one typha for each node.
-	if nodes <= 3 {
-		typhas = nodes
-	} else if typhas < 3 { // If typhas is less than 3 always make sure we have 3
+
+	// We have a couple special cases for small clusters. We want to ensure that we run one fewer
+	// Typha instances than there are nodes, so that there is room for rescheduling. We also want
+	// to ensure we have at least two, where possible, so that we have redundancy.
+	if nodes <= 2 {
+		// For one and two node clusters, we only need a single typha.
+		typhas = 1
+	} else if nodes <= 4 {
+		// For three and four node clusters, we can run an additional typha.
+		typhas = 2
+	} else if typhas < 3 {
+		// For clusters with more than 4 nodes, make sure we have a minimum of three for redundancy.
 		typhas = 3
 	}
 	return typhas

--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -40,18 +40,6 @@ const (
 // typhaAutoscaler periodically lists the nodes and, if needed, scales the Typha deployment up/down.
 // Number of replicas should be at least (1 typha for every 200 nodes) + 1 but the number of typhas
 // cannot exceed the number of nodes+masters.
-// Nodes       Replicas
-//     1              1
-//     2              2
-//  <200              3
-//  >400              4
-//  >600              5
-//  >800              6
-// >1000              7
-//    .....
-// >2000              12
-//    .....
-// >3600             20
 type typhaAutoscaler struct {
 	client         kubernetes.Interface
 	syncPeriod     time.Duration

--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -160,12 +160,21 @@ var _ = Describe("Test typha autoscaler ", func() {
 		ta := newTyphaAutoscaler(c, nlw, tlw, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
+		// For clusters smaller than 3 nodes we only expect 1 replica.
+		verifyTyphaReplicas(c, 1)
+
+		// For three and four node clusters, we expect 2.
+		n3 := createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux"})
+		verifyTyphaReplicas(c, 2)
+		_ = createNode(c, "node4", map[string]string{"kubernetes.io/os": "linux"})
 		verifyTyphaReplicas(c, 2)
 
-		n3 := createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux"})
+		// For > 4 nodes, we expect redundancy with 3 replicas.
+		_ = createNode(c, "node5", map[string]string{"kubernetes.io/os": "linux"})
 		verifyTyphaReplicas(c, 3)
 
-		// Verify that making a node unschedulable updates replicas.
+		// Verify that making a node unschedulable updates replicas. Should bring us back
+		// down to 4 node scale.
 		n3.Spec.Unschedulable = true
 		_, err = c.CoreV1().Nodes().Update(ctx, n3, metav1.UpdateOptions{})
 		Expect(err).To(BeNil())
@@ -190,16 +199,18 @@ var _ = Describe("Test typha autoscaler ", func() {
 		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 
-		// Create three nodes, one of which is not yet migrated
+		// Create five nodes, one of which is not yet migrated
 		createNode(c, "node1", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
 		createNode(c, "node2", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
-		createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "pre-operator"})
+		createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
+		createNode(c, "node4", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
+		createNode(c, "node5", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "pre-operator"})
 
 		// Create the autoscaler and run it
 		ta := newTyphaAutoscaler(c, nlw, tlw, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
-		// normally we'd expect to see three replicas for three nodes, but since one node is not migrated,
+		// normally we'd expect to see three replicas for five nodes, but since one node is not migrated,
 		// we should still only expect two
 		verifyTyphaReplicas(c, 2)
 	})
@@ -224,13 +235,15 @@ var _ = Describe("Test typha autoscaler ", func() {
 		// Create two nodes, one of which is a virtual-kubelet
 		createNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"})
 		createNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"})
-		createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux", "kubernetes.azure.com/cluster": "foo", "type": "virtual-kubelet"})
+		createNode(c, "node3", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(c, "node4", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(c, "node5", map[string]string{"kubernetes.io/os": "linux", "kubernetes.azure.com/cluster": "foo", "type": "virtual-kubelet"})
 
 		// Create the autoscaler and run it
 		ta := newTyphaAutoscaler(c, nlw, tlw, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
-		// normally we'd expect to see three replicas for three nodes, but since one node is a virtual-kubelet,
+		// normally we'd expect to see three replicas for five nodes, but since one node is a virtual-kubelet,
 		// we should still only expect two
 		verifyTyphaReplicas(c, 2)
 	})
@@ -240,6 +253,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 			Name:      "calico-typha",
 			Namespace: "calico-system",
 		}
+
 		// Create a typha deployment
 		var r int32 = 0
 		typha := &appsv1.Deployment{
@@ -257,8 +271,9 @@ var _ = Describe("Test typha autoscaler ", func() {
 		// Create a few nodes
 		_ = createNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"})
 		_ = createNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"})
-		_ = createNode(c, "node3", map[string]string{"kubernetes.io/os": "window"})
-		_ = createNode(c, "node4", map[string]string{"kubernetes.io/os": "window"})
+		_ = createNode(c, "node3", map[string]string{"kubernetes.io/os": "windows"})
+		_ = createNode(c, "node4", map[string]string{"kubernetes.io/os": "windows"})
+		_ = createNode(c, "node5", map[string]string{"kubernetes.io/os": "windows"})
 
 		// Create the autoscaler and run it
 		ta := newTyphaAutoscaler(c, nlw, tlw, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
@@ -286,7 +301,7 @@ func createNode(c kubernetes.Interface, name string, labels map[string]string) *
 }
 
 func verifyTyphaReplicas(c kubernetes.Interface, expectedReplicas int) {
-	Eventually(func() int32 {
+	EventuallyWithOffset(1, func() int32 {
 		typha, err := c.AppsV1().Deployments("calico-system").Get(context.Background(), "calico-typha", metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		// Just return an invalid number that will never match an expected replica count.


### PR DESCRIPTION
Cherry pick of #1506 on release-v1.24.

#1506: Don't run so many Typha instances on small clusters