### PR TITLE
Add rights for packet capture to update status

### DIFF
--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -187,6 +187,11 @@ func (pc *packetCaptureApiComponent) clusterRole() client.Object {
 			Resources: []string{"packetcaptures"},
 			Verbs:     []string{"get"},
 		},
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"packetcaptures/status"},
+			Verbs:     []string{"update"},
+		},
 	}
 
 	return &rbacv1.ClusterRole{

--- a/pkg/render/packetcapture_api_test.go
+++ b/pkg/render/packetcapture_api_test.go
@@ -309,6 +309,11 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 				Resources: []string{"packetcaptures"},
 				Verbs:     []string{"get"},
 			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"packetcaptures/status"},
+				Verbs:     []string{"update"},
+			},
 		}))
 		clusterRoleBinding := rtest.GetResource(resources, render.PacketCaptureClusterRoleBindingName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
 		Expect(clusterRoleBinding.RoleRef.Name).To(Equal(render.PacketCaptureClusterRoleName))


### PR DESCRIPTION
## Description

Update rights for packet capture API to update the status of a packet capture resource.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
