### PR TITLE
Fix windows upgrader test

### DIFF
--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1153,7 +1153,12 @@ var _ = Describe("Testing core-controller installation", func() {
 					return test.AssertNodesHadUpgradeTriggered(cs, n1, n2)
 				}, 10*time.Second).Should(BeNil())
 
+				Eventually(func() bool {
+					return mockStatus.WasCalled("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+				}, 5*time.Second).Should(BeTrue())
+
 				mockStatus.AssertExpectations(GinkgoT())
+
 				Consistently(func() error {
 					return test.AssertNodesHadUpgradeTriggered(cs, n1, n2)
 				}, 10*time.Second).Should(BeNil())

--- a/pkg/controller/status/mock.go
+++ b/pkg/controller/status/mock.go
@@ -91,3 +91,15 @@ func (m *MockStatus) IsProgressing() bool {
 func (m *MockStatus) IsDegraded() bool {
 	return m.Called().Bool(0)
 }
+
+func (m *MockStatus) WasCalled(method string, arguments ...interface{}) bool {
+	for _, call := range m.Calls {
+		if call.Method == method {
+			_, diffCount := call.Arguments.Diff(arguments)
+			if diffCount == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION


## Description

In some tests we trigger a node upgrade node then wait until the
node has been patched before calling mockStatus.AssertExpectations.
But it's possible that by the time we call AssertExpectations, the
windows upgrader has not yet called SetWindowsUpgradeStatus.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
