### PR TITLE
Add watch permissions for licensekeys for kube-controllers.

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -332,7 +332,7 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 			// Needed to validate the license
 			APIGroups: []string{"crd.projectcalico.org"},
 			Resources: []string{"licensekeys"},
-			Verbs:     []string{"get"},
+			Verbs:     []string{"get", "watch"},
 		},
 		{
 			APIGroups: []string{"projectcalico.org"},


### PR DESCRIPTION
## Description
- Need to add watch and list permissions on licensekeys for crd.projectcalico.org. This prevents error spamming in kube-controllers when attempting to watch licensekeys.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
