### PR TITLE
Fix cert-management for ECK and PCAP

### DIFF
--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -347,10 +347,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				}
 				compareInitContainer(initContainers[0], "elastic-internal-init-os-settings", []corev1.VolumeMount{})
 				compareInitContainer(initContainers[1], "elastic-internal-init-filesystem", []corev1.VolumeMount{
-					{Name: "elastic-internal-transport-certificates-secret", MountPath: "/mnt/elastic-internal/transport-certificates"},
 					{Name: "elastic-internal-transport-certificates", MountPath: "/csr"},
-					{Name: "elastic-internal-elasticsearch-config-local", MountPath: "/mnt/elastic-internal/elasticsearch-config-local"},
-					{Name: "elastic-internal-elasticsearch-bin-local", MountPath: "/mnt/elastic-internal/elasticsearch-bin-local"},
 				})
 				compareInitContainer(initContainers[2], "key-cert-elastic", []corev1.VolumeMount{
 					{Name: "elastic-internal-http-certificates", MountPath: render.CSRCMountPath},

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -275,8 +275,8 @@ func (pc *packetCaptureApiComponent) initContainers() []corev1.Container {
 			pc.csrInitImage,
 			PacketCaptureCertSecret,
 			PacketCaptureServiceName,
-			APIServerSecretKeyName,
-			APIServerSecretCertName,
+			corev1.TLSPrivateKeyKey,
+			corev1.TLSCertKey,
 			dns.GetServiceDNSNames(PacketCaptureServiceName, PacketCaptureNamespace, pc.clusterDomain),
 			PacketCaptureNamespace))
 	}


### PR DESCRIPTION
I have noticed that Certificate Management was out of date ever since ECK was updated to a newer version. The way certificates are created and mounted has changed since then. This PR addresses that issues.

Also a bug was spotted with PCAP.