### PR TITLE
Automated cherry pick of #1506: Don't run so many Typha instances on small clusters

### DIFF
--- a/pkg/common/autoscale.go
+++ b/pkg/common/autoscale.go
@@ -14,17 +14,40 @@
 package common
 
 // GetTyphaScaleCount will return the number of Typhas needed for the number of nodes.
+//
+// Nodes       Replicas
+//   1-2              1
+//   3-4              2
+//  <200              3
+//  >400              4
+//  >600              5
+//  >800              6
+// >1000              7
+//    .....
+// >2000              12
+//    .....
+// >3600             20
 func GetExpectedTyphaScale(nodes int) int {
 	var maxNodesPerTypha int = 200
+
 	// This gives a count of how many 200s so we need 1+ this number to get at least
 	// 1 typha for every 200 nodes.
 	typhas := (nodes / maxNodesPerTypha) + 1
+
 	// We add one more to ensure there is always 1 extra for high availability purposes.
 	typhas += 1
-	// If we don't have enough nodes to have 3 typhs then make sure there is one typha for each node.
-	if nodes <= 3 {
-		typhas = nodes
-	} else if typhas < 3 { // If typhas is less than 3 always make sure we have 3
+
+	// We have a couple special cases for small clusters. We want to ensure that we run one fewer
+	// Typha instances than there are nodes, so that there is room for rescheduling. We also want
+	// to ensure we have at least two, where possible, so that we have redundancy.
+	if nodes <= 2 {
+		// For one and two node clusters, we only need a single typha.
+		typhas = 1
+	} else if nodes <= 4 {
+		// For three and four node clusters, we can run an additional typha.
+		typhas = 2
+	} else if typhas < 3 {
+		// For clusters with more than 4 nodes, make sure we have a minimum of three for redundancy.
 		typhas = 3
 	}
 	return typhas

--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -40,18 +40,6 @@ const (
 // typhaAutoscaler periodically lists the nodes and, if needed, scales the Typha deployment up/down.
 // Number of replicas should be at least (1 typha for every 200 nodes) + 1 but the number of typhas
 // cannot exceed the number of nodes+masters.
-// Nodes       Replicas
-//     1              1
-//     2              2
-//  <200              3
-//  >400              4
-//  >600              5
-//  >800              6
-// >1000              7
-//    .....
-// >2000              12
-//    .....
-// >3600             20
 type typhaAutoscaler struct {
 	client            kubernetes.Interface
 	syncPeriod        time.Duration


### PR DESCRIPTION
Cherry pick of #1506 on release-v1.24.

#1506: Don't run so many Typha instances on small clusters

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

After some experience in the wild, we believe we don't need so many replicas on small clusters. This is largely because:
- during rolling update Typha will restart very quickly. 
- Running additional Typhas on very small clusters has additional resource impact 
- Running numTyphas == numNodes can also result in scheduling deadlocks during cluster scaling events, when the cluster autoscaler cannot find a suitable node to reschedule typha (since only one instance can run per node). 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.