### PR TITLE
removing validation for LogIntervalSeconds

### DIFF
--- a/api/v1/applicationlayer_types.go
+++ b/api/v1/applicationlayer_types.go
@@ -43,7 +43,6 @@ type LogCollectionSpec struct {
 	// Interval in seconds for sending L7 log information for processing.
 	// +optional
 	// Default: 5 sec
-	// +kubebuilder:validation:Minimum:=1
 	LogIntervalSeconds *int64 `json:"logIntervalSeconds,omitempty"`
 
 	// Maximum number of unique L7 logs that are sent LogIntervalSeconds.

--- a/pkg/crds/operator/operator.tigera.io_applicationlayers.yaml
+++ b/pkg/crds/operator/operator.tigera.io_applicationlayers.yaml
@@ -46,7 +46,6 @@ spec:
                     description: 'Interval in seconds for sending L7 log information
                       for processing. Default: 5 sec'
                     format: int64
-                    minimum: 1
                     type: integer
                   logRequestsPerInterval:
                     description: 'Maximum number of unique L7 logs that are sent LogIntervalSeconds.


### PR DESCRIPTION
## Description

When using validations (minimum, maximum) helm v2 is expecting it to be a `float64`, so the current CRD fails. To fix this I am removing the validation. We are expected to keep this back on after we drop support for helm v2.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
