### PR TITLE
windows upgrader followup

### DIFF
--- a/pkg/common/windows.go
+++ b/pkg/common/windows.go
@@ -30,13 +30,14 @@ var (
 )
 
 const (
-	CalicoWindowsUpgradeResourceName    = "calico-windows-upgrade"
-	CalicoWindowsUpgradeVolumePath      = `c:\CalicoUpgrade`
-	CalicoWindowsUpgradeLabel           = "projectcalico.org/windows-upgrade"
-	CalicoWindowsUpgradeLabelInProgress = "in-progress"
-	CalicoVersionAnnotation             = "projectcalico.org/version"
-	CalicoVariantAnnotation             = "projectcalico.org/variant"
-	CalicoWindowsUpgradeTaintKey        = "projectcalico.org/windows-upgrade"
+	CalicoWindowsUpgradeResourceName          = "calico-windows-upgrade"
+	CalicoWindowsUpgradeVolumePath            = `c:\CalicoUpgrade`
+	CalicoWindowsUpgradeLabel                 = "projectcalico.org/windows-upgrade"
+	CalicoWindowsUpgradeLabelInProgress       = "in-progress"
+	CalicoVersionAnnotation                   = "projectcalico.org/version"
+	CalicoVariantAnnotation                   = "projectcalico.org/variant"
+	CalicoWindowsUpgradeTaintKey              = "projectcalico.org/windows-upgrade"
+	CalicoWindowsNodeUpgradeStatusErrorReason = "Error getting Calico for Windows nodes upgrade status"
 )
 
 // GetNodeVariantAndVersion gets the node's variant and version annotation

--- a/pkg/common/windows.go
+++ b/pkg/common/windows.go
@@ -37,7 +37,7 @@ const (
 	CalicoVersionAnnotation                   = "projectcalico.org/version"
 	CalicoVariantAnnotation                   = "projectcalico.org/variant"
 	CalicoWindowsUpgradeTaintKey              = "projectcalico.org/windows-upgrade"
-	CalicoWindowsNodeUpgradeStatusErrorReason = "Error getting Calico for Windows nodes upgrade status"
+	CalicoWindowsNodeUpgradeStatusErrorReason = "Error processing Calico for Windows upgrades"
 )
 
 // GetNodeVariantAndVersion gets the node's variant and version annotation

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1234,6 +1234,12 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		reqLogger.V(1).Info("Unable to determine MTU - no explicit config, and /var/lib/calico is not mounted")
 	}
 
+	// Check whether the calicoWindowsUpgrader is degraded. If so, requeue
+	// a reconcile.
+	if r.calicoWindowsUpgrader.IsDegraded() {
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
 	// We have successfully reconciled the Calico installation.
 	if instance.Spec.KubernetesProvider == operator.ProviderOpenShift {
 		openshiftConfig := &configv1.Network{}

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1112,6 +1112,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 		Context("calicoWindowsUpgrader", func() {
 			BeforeEach(func() {
+				// calicoWindowsUpgrader only upgrades nodes on AKS.
 				cr.Spec.KubernetesProvider = operator.ProviderAKS
 			})
 

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -704,7 +704,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("AddCertificateSigningRequests", mock.Anything)
 			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
 			mockStatus.On("ReadyToMonitor")
-			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 
 			// Create the indexer and informer shared by the typhaAutoscaler and
 			// calicoWindowsUpgrader.
@@ -1124,7 +1124,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				// Create node with current Enterprise version.
 				n1 := test.CreateWindowsNode(cs, "windows1", cr.Spec.Variant, components.EnterpriseRelease)
 
-				mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{"windows1"})
+				mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{"windows1"}, nil)
 
 				// Node is up to date and should not have changed.
 				Consistently(func() error {
@@ -1150,7 +1150,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				n1 := test.CreateWindowsNode(cs, "windows1", operator.Calico, "v3.21.999")
 				n2 := test.CreateWindowsNode(cs, "windows2", operator.TigeraSecureEnterprise, components.EnterpriseRelease)
 
-				mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+				mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 
 				// Ensure that outdated nodes have the new label and taint.
 				Eventually(func() error {
@@ -1158,7 +1158,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				}, 10*time.Second).Should(BeNil())
 
 				Eventually(func() bool {
-					return mockStatus.WasCalled("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+					return mockStatus.WasCalled("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 				}, 5*time.Second).Should(BeTrue())
 
 				mockStatus.AssertExpectations(GinkgoT())

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1111,6 +1111,10 @@ var _ = Describe("Testing core-controller installation", func() {
 		})
 
 		Context("calicoWindowsUpgrader", func() {
+			BeforeEach(func() {
+				cr.Spec.KubernetesProvider = operator.ProviderAKS
+			})
+
 			It("should do nothing if node is up to date", func() {
 				cr.Spec.Variant = operator.TigeraSecureEnterprise
 				Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1123,7 +1123,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Create node with current Enterprise version.
-				n1 := test.CreateWindowsNode(cs, "windows1", cr.Spec.Variant, components.EnterpriseRelease)
+				n1 := test.CreateWindowsNode(cs, "windows1", cr.Spec.Variant, components.ComponentTigeraWindows.Version)
 
 				mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{"windows1"}, nil)
 
@@ -1149,7 +1149,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				// Create two nodes that should be upgraded. The current variant
 				// is Calico and version is `components.CalicoRelease`.
 				n1 := test.CreateWindowsNode(cs, "windows1", operator.Calico, "v3.21.999")
-				n2 := test.CreateWindowsNode(cs, "windows2", operator.TigeraSecureEnterprise, components.EnterpriseRelease)
+				n2 := test.CreateWindowsNode(cs, "windows2", operator.TigeraSecureEnterprise, components.ComponentTigeraWindows.Version)
 
 				mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 

--- a/pkg/controller/installation/windows/calico_windows_upgrader.go
+++ b/pkg/controller/installation/windows/calico_windows_upgrader.go
@@ -164,10 +164,16 @@ func (w *calicoWindowsUpgrader) isUpgradeFromCalicoToEnterprise(node *corev1.Nod
 }
 
 func (w *calicoWindowsUpgrader) getExpectedVersion() string {
+	// Use the component's version rather than top-level version values
+	// `EnterpriseRelease` or `CalicoRelease` since for dev releases we use
+	// a custom versions YAML file with an aggregate release name.
+	//
+	// For release versions, the windows upgrade component version will be equal
+	// to the top-level version.
 	if w.install.Variant == operatorv1.TigeraSecureEnterprise {
-		return components.EnterpriseRelease
+		return components.ComponentTigeraWindows.Version
 	}
-	return components.CalicoRelease
+	return components.ComponentWindows.Version
 }
 
 func sortedSliceFromMap(m map[string]*corev1.Node) []string {

--- a/pkg/controller/installation/windows/calico_windows_upgrader.go
+++ b/pkg/controller/installation/windows/calico_windows_upgrader.go
@@ -301,21 +301,14 @@ func patchNodeToStartUpgrade(ctx context.Context, client kubernetes.Interface, n
 			upgradeLabelExists = true
 		}
 
-		// If either the taint or label are missing, patch the node.
-		if !taintExists || !upgradeLabelExists {
-			windowsLog.V(1).Info(fmt.Sprintf("Taint or upgrade label missing for node %v. taintExists: %v, labelExists: %v", nodeName, taintExists, upgradeLabelExists))
+		patches := []objPatch{}
+
+		if !taintExists {
+			windowsLog.V(1).Info(fmt.Sprintf("Taint missing for node %v", nodeName))
 			newTaints := node.DeepCopy().Spec.Taints
 			newTaints = append(newTaints, *common.CalicoWindowsUpgradingTaint)
 
-			// With JSONPatch '/' must be escaped as '~1' http://jsonpatch.com/
-			labelKey := strings.Replace(common.CalicoWindowsUpgradeLabel, "/", "~1", -1)
-
 			p := []objPatch{
-				{
-					Op:    "add",
-					Path:  fmt.Sprintf("/metadata/labels/%s", labelKey),
-					Value: common.CalicoWindowsUpgradeLabelInProgress,
-				},
 				// Test that the taints didn't change. If this test fails the entire
 				// patch fails.
 				{
@@ -330,13 +323,29 @@ func patchNodeToStartUpgrade(ctx context.Context, client kubernetes.Interface, n
 					Value: newTaints,
 				},
 			}
+			patches = append(patches, p...)
 
-			patchBytes, err := json.Marshal(p)
-			if err != nil {
-				return false, err
+		}
+
+		if !upgradeLabelExists {
+			windowsLog.V(1).Info(fmt.Sprintf("Upgrade label missing for node %v", nodeName))
+			// With JSONPatch '/' must be escaped as '~1' http://jsonpatch.com/
+			labelKey := strings.Replace(common.CalicoWindowsUpgradeLabel, "/", "~1", -1)
+
+			p := objPatch{
+				Op:    "add",
+				Path:  fmt.Sprintf("/metadata/labels/%s", labelKey),
+				Value: common.CalicoWindowsUpgradeLabelInProgress,
 			}
+			patches = append(patches, p)
+		}
 
-			_, err = client.CoreV1().Nodes().Patch(ctx, node.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+		// If either the taint or label do not exist, patch the node to add them.
+		if len(patches) > 0 {
+			windowsLog.V(1).Info(fmt.Sprintf("Patching node %v to add upgrade taint and/or label", nodeName))
+
+			err = patchNode(ctx, client, nodeName, patches...)
+
 			if err == nil {
 				return true, nil
 			}
@@ -381,18 +390,11 @@ func patchNodeToCompleteUpgrade(ctx context.Context, client kubernetes.Interface
 			upgradeLabelExists = true
 		}
 
-		// If either the taint or label exist, patch the node to remove them.
-		if taintExists || upgradeLabelExists {
-			windowsLog.V(1).Info(fmt.Sprintf("Taint or upgrade label exists for node %v. taintExists: %v, labelExists: %v", nodeName, taintExists, upgradeLabelExists))
-			// With JSONPatch '/' must be escaped as '~1' http://jsonpatch.com/
-			labelKey := strings.Replace(common.CalicoWindowsUpgradeLabel, "/", "~1", -1)
+		patches := []objPatch{}
 
+		if taintExists {
+			windowsLog.V(1).Info(fmt.Sprintf("Upgrade taint exists for node %v", nodeName))
 			p := []objPatch{
-				// Remove the upgrade label.
-				{
-					Op:   "remove",
-					Path: fmt.Sprintf("/metadata/labels/%s", labelKey),
-				},
 				// Test that the taint to remove didn't change. If this test fails the entire
 				// patch fails.
 				{
@@ -406,8 +408,27 @@ func patchNodeToCompleteUpgrade(ctx context.Context, client kubernetes.Interface
 					Path: fmt.Sprintf("/spec/taints/%d", taintIndex),
 				},
 			}
+			patches = append(patches, p...)
+		}
 
-			err = patchNode(ctx, client, nodeName, p...)
+		if upgradeLabelExists {
+			windowsLog.V(1).Info(fmt.Sprintf("Upgrade label exists for node %v", nodeName))
+			// With JSONPatch '/' must be escaped as '~1' http://jsonpatch.com/
+			labelKey := strings.Replace(common.CalicoWindowsUpgradeLabel, "/", "~1", -1)
+
+			p := objPatch{
+				// Remove the upgrade label.
+				Op:   "remove",
+				Path: fmt.Sprintf("/metadata/labels/%s", labelKey),
+			}
+			patches = append(patches, p)
+		}
+
+		// If either the taint or label exist, patch the node to remove them.
+		if len(patches) > 0 {
+			windowsLog.V(1).Info(fmt.Sprintf("Patching node %v to remove upgrade taint and/or label", nodeName))
+
+			err = patchNode(ctx, client, nodeName, patches...)
 
 			if err == nil {
 				return true, nil

--- a/pkg/controller/installation/windows/calico_windows_upgrader.go
+++ b/pkg/controller/installation/windows/calico_windows_upgrader.go
@@ -60,6 +60,7 @@ type calicoWindowsUpgrader struct {
 	syncPeriod        time.Duration
 	installChan       chan *operatorv1.InstallationSpec
 	install           *operatorv1.InstallationSpec
+	isRunning         bool
 }
 
 type calicoWindowsUpgraderOption func(*calicoWindowsUpgrader)
@@ -91,6 +92,10 @@ func NewCalicoWindowsUpgrader(cs kubernetes.Interface, c client.Client, indexInf
 
 // UpdateConfig updates the calicoWindowsUpgrader's installation config.
 func (w *calicoWindowsUpgrader) UpdateConfig(install *operatorv1.InstallationSpec) {
+	if !w.isRunning {
+		windowsLog.V(1).Info("windows upgrader is not running, skipping config update")
+		return
+	}
 	w.installChan <- install
 }
 
@@ -252,7 +257,17 @@ func (w *calicoWindowsUpgrader) finishUpgrade(ctx context.Context, node *corev1.
 
 // Start begins running the calicoWindowsUpgrader.
 func (w *calicoWindowsUpgrader) Start(ctx context.Context) {
+	// Set calicoWindowsUpgrader running status so it can determine whether it
+	// should receive install config updates. Do this here instead of inside
+	// the new goroutine so there are no race issues if we call w.UpdateConfig right after w.Start.
+	w.isRunning = true
+
 	go func() {
+		// Make sure we update the running status when we exit.
+		defer func() {
+			w.isRunning = false
+		}()
+
 		for !w.nodeIndexInformer.HasSynced() {
 			time.Sleep(100 * time.Millisecond)
 		}
@@ -267,6 +282,10 @@ func (w *calicoWindowsUpgrader) Start(ctx context.Context) {
 			case install := <-w.installChan:
 				w.install = install
 			case <-ticker.C:
+				if w.install.KubernetesProvider != operatorv1.ProviderAKS {
+					windowsLog.Info("windows upgrader only runs on AKS. Stopping main loop")
+					return
+				}
 				w.updateWindowsNodes()
 			case <-ctx.Done():
 				windowsLog.Info("Stopping main loop")

--- a/pkg/controller/installation/windows/calico_windows_upgrader_test.go
+++ b/pkg/controller/installation/windows/calico_windows_upgrader_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		n2 := test.CreateNode(cs, "node2", map[string]string{"kubernetes.io/os": "linux"},
 			map[string]string{common.CalicoVersionAnnotation: "v2.0.0", common.CalicoVariantAnnotation: string(operator.TigeraSecureEnterprise)})
 
-		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{})
+		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{}, nil)
 		c.UpdateConfig(cr)
 
 		Consistently(func() error {
@@ -135,13 +135,13 @@ var _ = Describe("Calico windows upgrader", func() {
 		}, 10*time.Second, 100*time.Millisecond).Should(BeNil())
 
 		// Wait until SetWindowsUpgradeStatus has been called.
-		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{}, []string{})
+		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{}, []string{}, nil)
 		mockStatus.AssertExpectations(GinkgoT())
 	})
 
 	It("should upgrade outdated nodes", func() {
 		// Only node n2 should be upgraded.
-		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{"node2"}, []string{"node3"})
+		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{"node2"}, []string{"node3"}, nil)
 
 		n1 := test.CreateNode(cs, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
 		n2 := test.CreateWindowsNode(cs, "node2", operator.Calico, "v3.21.999")
@@ -165,11 +165,11 @@ var _ = Describe("Calico windows upgrader", func() {
 		}, 5*time.Second).Should(BeNil())
 
 		// Wait until SetWindowsUpgradeStatus has been called.
-		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{"node2"}, []string{"node3"})
+		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{"node2"}, []string{"node3"}, nil)
 		mockStatus.AssertExpectations(GinkgoT())
 
 		// Last arg will contain both node 2 and node 3, in some order.
-		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, mock.Anything)
+		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, mock.Anything, nil)
 
 		// Set the latest Calico Windows variant and version like the node service would.
 		setNodeVariantAndVersion(cs, nodeIndexInformer, n2, operator.Calico, components.CalicoRelease)
@@ -181,7 +181,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		}, 5*time.Second).Should(BeNil())
 
 		// Wait until SetWindowsUpgradeStatus has been called.
-		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{}, mock.Anything)
+		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{}, mock.Anything, nil)
 		mockStatus.AssertExpectations(GinkgoT())
 	})
 
@@ -193,7 +193,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		// variant.
 		n1 := test.CreateWindowsNode(cs, "node1", operator.TigeraSecureEnterprise, "v3.11.0")
 
-		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{"node1"}, []string{})
+		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{"node1"}, []string{}, nil)
 
 		c.Start(ctx)
 		c.UpdateConfig(cr)
@@ -204,13 +204,13 @@ var _ = Describe("Calico windows upgrader", func() {
 		}, 5*time.Second).Should(BeNil())
 
 		// Wait until SetWindowsUpgradeStatus has been called.
-		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{"node1"}, []string{})
+		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{"node1"}, []string{}, nil)
 		mockStatus.AssertExpectations(GinkgoT())
 
 		// Set the latest Calico Windows version like the node service would. This will trigger a reconcile.
 		// Ensure that when calicoWindowsUpgrader runs again, the node taint and
 		// label are removed.
-		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{"node1"})
+		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{"node1"}, nil)
 
 		setNodeVariantAndVersion(cs, nodeIndexInformer, n1, operator.Calico, components.CalicoRelease)
 
@@ -219,7 +219,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		}, 5*time.Second).Should(BeNil())
 
 		// Wait until SetWindowsUpgradeStatus has been called.
-		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{}, []string{"node1"})
+		waitForSetWindowsUpgradeStatusCalled(mockStatus, []string{}, []string{}, []string{"node1"}, nil)
 		mockStatus.AssertExpectations(GinkgoT())
 	})
 
@@ -326,7 +326,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		_ = test.CreateWindowsNode(cs, "node5", operator.Calico, "v3.21.999")
 
 		// We won't know which nodes will end up being added for upgrade.
-		mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+		mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 
 		c.Start(ctx)
 		c.UpdateConfig(cr)
@@ -354,7 +354,7 @@ var _ = Describe("Calico windows upgrader", func() {
 			_ = test.CreateWindowsNode(cs, "node1", operator.Calico, "v3.21.999")
 			_ = test.CreateWindowsNode(cs, "node2", operator.Calico, "v3.21.999")
 			_ = test.CreateWindowsNode(cs, "node3", operator.Calico, "v3.21.999")
-			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 
 			c.Start(ctx)
 			c.UpdateConfig(cr)
@@ -385,7 +385,7 @@ var _ = Describe("Calico windows upgrader", func() {
 			_ = test.CreateWindowsNode(cs, "node2", operator.TigeraSecureEnterprise, "v3.11.0")
 			_ = test.CreateWindowsNode(cs, "node3", operator.TigeraSecureEnterprise, "v3.11.0")
 
-			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 
 			c.Start(ctx)
 			c.UpdateConfig(cr)
@@ -418,7 +418,7 @@ var _ = Describe("Calico windows upgrader", func() {
 			_ = test.CreateWindowsNode(cs, "node2", operator.TigeraSecureEnterprise, "old")
 			_ = test.CreateWindowsNode(cs, "node3", operator.TigeraSecureEnterprise, "old")
 
-			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 
 			cr.Variant = operator.TigeraSecureEnterprise
 			c.Start(ctx)
@@ -452,7 +452,7 @@ var _ = Describe("Calico windows upgrader", func() {
 			_ = test.CreateWindowsNode(cs, "node2", operator.Calico, "v3.21.999")
 			_ = test.CreateWindowsNode(cs, "node3", operator.Calico, "v3.21.999")
 
-			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything)
+			mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 
 			cr.Variant = operator.TigeraSecureEnterprise
 			c.Start(ctx)

--- a/pkg/controller/installation/windows/calico_windows_upgrader_test.go
+++ b/pkg/controller/installation/windows/calico_windows_upgrader_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Calico windows upgrader", func() {
 
 		n1 := test.CreateNode(cs, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
 		n2 := test.CreateWindowsNode(cs, "node2", operator.Calico, "v3.21.999")
-		n3 := test.CreateWindowsNode(cs, "node3", operator.Calico, components.CalicoRelease)
+		n3 := test.CreateWindowsNode(cs, "node3", operator.Calico, components.ComponentWindows.Version)
 
 		c.UpdateConfig(cr)
 
@@ -145,7 +145,7 @@ var _ = Describe("Calico windows upgrader", func() {
 
 		n1 := test.CreateNode(cs, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
 		n2 := test.CreateWindowsNode(cs, "node2", operator.Calico, "v3.21.999")
-		n3 := test.CreateWindowsNode(cs, "node3", operator.Calico, components.CalicoRelease)
+		n3 := test.CreateWindowsNode(cs, "node3", operator.Calico, components.ComponentWindows.Version)
 
 		c.Start(ctx)
 		c.UpdateConfig(cr)
@@ -172,7 +172,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, mock.Anything, nil)
 
 		// Set the latest Calico Windows variant and version like the node service would.
-		setNodeVariantAndVersion(cs, nodeIndexInformer, n2, operator.Calico, components.CalicoRelease)
+		setNodeVariantAndVersion(cs, nodeIndexInformer, n2, operator.Calico, components.ComponentWindows.Version)
 
 		// Ensure that when calicoWindowsUpgrader runs again, the node taint and
 		// label are removed.
@@ -212,7 +212,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		// label are removed.
 		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{"node1"}, nil)
 
-		setNodeVariantAndVersion(cs, nodeIndexInformer, n1, operator.Calico, components.CalicoRelease)
+		setNodeVariantAndVersion(cs, nodeIndexInformer, n1, operator.Calico, components.ComponentWindows.Version)
 
 		Eventually(func() error {
 			return assertNodesFinishedUpgrade(cs, n1)
@@ -263,7 +263,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		// Ensure that when calicoWindowsUpgrader runs again, the node taint and
 		// label are removed.
 		mockStatus.On("SetWindowsUpgradeStatus", []string{}, []string{}, []string{"node1"}, nil)
-		setNodeVariantAndVersion(cs, nodeIndexInformer, n1, operator.Calico, components.CalicoRelease)
+		setNodeVariantAndVersion(cs, nodeIndexInformer, n1, operator.Calico, components.ComponentWindows.Version)
 
 		Eventually(func() error {
 			return assertNodesFinishedUpgrade(cs, n1)
@@ -299,7 +299,7 @@ var _ = Describe("Calico windows upgrader", func() {
 		Expect(err).To(BeNil())
 
 		// Set the latest Calico Windows variant and version like the node service would.
-		setNodeVariantAndVersion(cs, nodeIndexInformer, n1, operator.Calico, components.CalicoRelease)
+		setNodeVariantAndVersion(cs, nodeIndexInformer, n1, operator.Calico, components.ComponentWindows.Version)
 
 		// Ensure that when calicoWindowsUpgrader runs again, the node taint and
 		// label are removed.

--- a/pkg/controller/status/mock.go
+++ b/pkg/controller/status/mock.go
@@ -68,8 +68,8 @@ func (m *MockStatus) RemoveCertificateSigningRequests(label string) {
 	m.Called(label)
 }
 
-func (m *MockStatus) SetWindowsUpgradeStatus(pending, inProgress, completed []string) {
-	m.Called(pending, inProgress, completed)
+func (m *MockStatus) SetWindowsUpgradeStatus(pending, inProgress, completed []string, err error) {
+	m.Called(pending, inProgress, completed, err)
 }
 
 func (m *MockStatus) SetDegraded(reason, msg string) {

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -69,7 +69,7 @@ type StatusManager interface {
 	RemoveStatefulSets(sss ...types.NamespacedName)
 	RemoveCronJobs(cjs ...types.NamespacedName)
 	RemoveCertificateSigningRequests(name string)
-	SetWindowsUpgradeStatus(pending, inProgress, completed []string)
+	SetWindowsUpgradeStatus(pending, inProgress, completed []string, err error)
 	SetDegraded(reason, msg string)
 	ClearDegraded()
 	IsAvailable() bool
@@ -307,12 +307,28 @@ func (w *windowsNodeUpgrades) progressingReason() string {
 
 // SetWindowsUpgradeStatus tells the status manager to monitor the upgrade
 // status of the given Windows node upgrades.
-func (m *statusManager) SetWindowsUpgradeStatus(pending, inProgress, completed []string) {
+func (m *statusManager) SetWindowsUpgradeStatus(pending, inProgress, completed []string, err error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
+	if err != nil {
+		m.degraded = true
+		m.explicitDegradedReason = common.CalicoWindowsNodeUpgradeStatusErrorReason
+		m.explicitDegradedMsg = err.Error()
+		return
+	}
+
 	m.windowsNodeUpgrades.nodesPending = pending
 	m.windowsNodeUpgrades.nodesInProgress = inProgress
 	m.windowsNodeUpgrades.nodesCompleted = completed
+
+	// If the degraded reason is set by this function then clear it since there
+	// was no error.
+	if m.explicitDegradedReason == common.CalicoWindowsNodeUpgradeStatusErrorReason {
+		m.degraded = false
+		m.explicitDegradedReason = ""
+		m.explicitDegradedMsg = ""
+	}
 }
 
 // RemoveDaemonsets tells the status manager to stop monitoring the health of the given daemonsets

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -95,6 +95,8 @@ type statusManager struct {
 	degraded               bool
 	explicitDegradedMsg    string
 	explicitDegradedReason string
+	// Track degraded state set by calicoWindowsUpgrader.
+	windowsUpgradeDegradedReason string
 
 	// Keep track of currently calculated status.
 	progressing []string
@@ -312,23 +314,14 @@ func (m *statusManager) SetWindowsUpgradeStatus(pending, inProgress, completed [
 	defer m.lock.Unlock()
 
 	if err != nil {
-		m.degraded = true
-		m.explicitDegradedReason = common.CalicoWindowsNodeUpgradeStatusErrorReason
-		m.explicitDegradedMsg = err.Error()
+		m.windowsUpgradeDegradedReason = err.Error()
 		return
 	}
 
 	m.windowsNodeUpgrades.nodesPending = pending
 	m.windowsNodeUpgrades.nodesInProgress = inProgress
 	m.windowsNodeUpgrades.nodesCompleted = completed
-
-	// If the degraded reason is set by this function then clear it since there
-	// was no error.
-	if m.explicitDegradedReason == common.CalicoWindowsNodeUpgradeStatusErrorReason {
-		m.degraded = false
-		m.explicitDegradedReason = ""
-		m.explicitDegradedMsg = ""
-	}
+	m.windowsUpgradeDegradedReason = ""
 }
 
 // RemoveDaemonsets tells the status manager to stop monitoring the health of the given daemonsets
@@ -390,6 +383,7 @@ func (m *statusManager) ClearDegraded() {
 	m.degraded = false
 	m.explicitDegradedReason = ""
 	m.explicitDegradedMsg = ""
+	m.windowsUpgradeDegradedReason = ""
 }
 
 // IsAvailable returns true if the component is available and false otherwise.
@@ -432,7 +426,9 @@ func (m *statusManager) IsDegraded() bool {
 
 	// Controllers can explicitly set us degraded, which can be set even before we tell the status manager that it
 	// should start monitoring resources.
-	if m.degraded {
+	// windowsUpgradeDegradedReason indicates an error has occurred with the
+	// Calico Windows upgrade.
+	if m.degraded || m.windowsUpgradeDegradedReason != "" {
 		return true
 	}
 
@@ -776,6 +772,9 @@ func (m *statusManager) degradedReason() string {
 	reasons := []string{}
 	if m.explicitDegradedReason != "" {
 		reasons = append(reasons, m.explicitDegradedReason)
+	}
+	if m.windowsUpgradeDegradedReason != "" {
+		reasons = append(reasons, m.windowsUpgradeDegradedReason)
 	}
 	if len(m.failing) != 0 {
 		reasons = append(reasons, "Some pods are failing")

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -433,25 +433,25 @@ var _ = Describe("Status reporting tests", func() {
 				sm.ReadyToMonitor()
 			})
 			It("should report the windows node upgrade status", func() {
-				sm.SetWindowsUpgradeStatus([]string{"n1", "n2", "n3"}, []string{}, []string{})
+				sm.SetWindowsUpgradeStatus([]string{"n1", "n2", "n3"}, []string{}, []string{}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal("Waiting for Calico for Windows to be upgraded: 0/3 nodes have been upgraded, 0 in-progress"))
 
-				sm.SetWindowsUpgradeStatus([]string{"n2", "n3"}, []string{"n1"}, []string{})
+				sm.SetWindowsUpgradeStatus([]string{"n2", "n3"}, []string{"n1"}, []string{}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal("Waiting for Calico for Windows to be upgraded: 0/3 nodes have been upgraded, 1 in-progress"))
 
-				sm.SetWindowsUpgradeStatus([]string{"n3"}, []string{"n1", "n2"}, []string{})
+				sm.SetWindowsUpgradeStatus([]string{"n3"}, []string{"n1", "n2"}, []string{}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal("Waiting for Calico for Windows to be upgraded: 0/3 nodes have been upgraded, 2 in-progress"))
 
-				sm.SetWindowsUpgradeStatus([]string{"n3"}, []string{"n2"}, []string{"n1"})
+				sm.SetWindowsUpgradeStatus([]string{"n3"}, []string{"n2"}, []string{"n1"}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal("Waiting for Calico for Windows to be upgraded: 1/3 nodes have been upgraded, 1 in-progress"))
 
-				sm.SetWindowsUpgradeStatus([]string{"n3"}, []string{}, []string{"n1", "n2"})
+				sm.SetWindowsUpgradeStatus([]string{"n3"}, []string{}, []string{"n1", "n2"}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal("Waiting for Calico for Windows to be upgraded: 2/3 nodes have been upgraded, 0 in-progress"))
 
-				sm.SetWindowsUpgradeStatus([]string{}, []string{"n3"}, []string{"n1", "n2"})
+				sm.SetWindowsUpgradeStatus([]string{}, []string{"n3"}, []string{"n1", "n2"}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal("Waiting for Calico for Windows to be upgraded: 2/3 nodes have been upgraded, 1 in-progress"))
 
-				sm.SetWindowsUpgradeStatus([]string{}, []string{}, []string{"n1", "n2", "n3"})
+				sm.SetWindowsUpgradeStatus([]string{}, []string{}, []string{"n1", "n2", "n3"}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal(""))
 			})
 		})

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -428,10 +429,32 @@ var _ = Describe("Status reporting tests", func() {
 					{ObjectMeta: metav1.ObjectMeta{Name: "csr2", Labels: labels}},
 				}, false, true),
 		)
-		Context("windowsNodeUpgrades", func() {
+		Context("Windows upgrade", func() {
 			BeforeEach(func() {
 				sm.ReadyToMonitor()
 			})
+			It("should be able to set and clear its own degraded status", func() {
+				sm.ClearDegraded()
+
+				// Calling SetWindowsUpgradeStatus with an error should result
+				// in a degraded status.
+				sm.SetWindowsUpgradeStatus(nil, nil, nil, fmt.Errorf("an error"))
+				Expect(sm.IsDegraded()).To(Equal(true))
+
+				// calicoWindowsUpgrader sets status indicating a successful
+				// run.
+				sm.SetWindowsUpgradeStatus([]string{"n1", "n2", "n3"}, []string{}, []string{}, nil)
+				Expect(sm.IsDegraded()).To(Equal(false))
+			})
+
+			It("should be able to clear degraded", func() {
+				sm.SetWindowsUpgradeStatus(nil, nil, nil, fmt.Errorf("an error"))
+				Expect(sm.IsDegraded()).To(Equal(true))
+
+				sm.ClearDegraded()
+				Expect(sm.IsDegraded()).To(Equal(false))
+			})
+
 			It("should report the windows node upgrade status", func() {
 				sm.SetWindowsUpgradeStatus([]string{"n1", "n2", "n3"}, []string{}, []string{}, nil)
 				Expect(sm.windowsNodeUpgrades.progressingReason()).To(Equal("Waiting for Calico for Windows to be upgraded: 0/3 nodes have been upgraded, 0 in-progress"))


### PR DESCRIPTION
## Description

This PR addresses some issues with the calico windows upgrader:
- Fix node patching that can result in a panic
- Ensure the upgrader only runs on AKS
- Fix status handling when windows upgrader fails to get node upgrade status

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
