### PR TITLE
Ensure manager-tls secret provided by the user do not have ownerreference added

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -533,13 +533,13 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 	components = append(components, component)
 
-	for _, component := range components {
-		if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
-			log.Error(err, "Error with images from ImageSet")
-			r.status.SetDegraded("Error with images from ImageSet", err.Error())
-			return reconcile.Result{}, err
-		}
+	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
+		log.Error(err, "Error with images from ImageSet")
+		r.status.SetDegraded("Error with images from ImageSet", err.Error())
+		return reconcile.Result{}, err
+	}
 
+	for _, component := range components {
 		if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
 			r.status.SetDegraded("Error creating / updating resource", err.Error())
 			return reconcile.Result{}, err

--- a/pkg/controller/utils/certs.go
+++ b/pkg/controller/utils/certs.go
@@ -74,12 +74,10 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 		)
 	}
 
-	issuer, err := GetCertificateIssuer(secret.Data[certName])
+	operatorManaged, err := IsCertOperatorIssued(secret.Data[certName])
 	if err != nil {
 		return nil, err
 	}
-
-	operatorManaged := IsOperatorIssued(issuer)
 
 	// For user provided certs, skip checking whether they have the right DNS
 	// names.
@@ -105,6 +103,16 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 // IsOperatorIssued checks if the cert secret is issued operator.
 func IsOperatorIssued(issuer string) bool {
 	return operatorIssuedCertRegexp.MatchString(issuer)
+}
+
+func IsCertOperatorIssued(certPem []byte) (bool, error) {
+
+	issuer, err := GetCertificateIssuer(certPem)
+	if err != nil {
+		return false, err
+	}
+
+	return IsOperatorIssued(issuer), nil
 }
 
 // GetCertificateIssuer returns the issuer of a PEM block.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -88,7 +88,9 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 	}
 	var tlsAnnotation string
 	if cfg.Installation.CertificateManagement == nil {
-		tlsSecrets = append(tlsSecrets, cfg.TLSKeyPair)
+		if cfg.OperatorManagedTLSKeyPair {
+			tlsSecrets = append(tlsSecrets, cfg.TLSKeyPair)
+		}
 		tlsSecrets = append(tlsSecrets, secret.CopyToNamespace(ManagerNamespace, cfg.TLSKeyPair)...)
 		tlsAnnotation = rmeta.AnnotationHash(cfg.TLSKeyPair.Data)
 	}
@@ -135,6 +137,7 @@ type ManagerConfiguration struct {
 	ClusterDomain                 string
 	ESLicenseType                 ElasticsearchLicenseType
 	Replicas                      *int32
+	OperatorManagedTLSKeyPair     bool
 }
 
 type managerComponent struct {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -88,9 +88,6 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 	}
 	var tlsAnnotation string
 	if cfg.Installation.CertificateManagement == nil {
-		if cfg.OperatorManagedTLSKeyPair {
-			tlsSecrets = append(tlsSecrets, cfg.TLSKeyPair)
-		}
 		tlsSecrets = append(tlsSecrets, secret.CopyToNamespace(ManagerNamespace, cfg.TLSKeyPair)...)
 		tlsAnnotation = rmeta.AnnotationHash(cfg.TLSKeyPair.Data)
 	}
@@ -137,7 +134,6 @@ type ManagerConfiguration struct {
 	ClusterDomain                 string
 	ESLicenseType                 ElasticsearchLicenseType
 	Replicas                      *int32
-	OperatorManagedTLSKeyPair     bool
 }
 
 type managerComponent struct {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -550,6 +550,7 @@ func renderObjects(oidc bool, managementCluster *operatorv1.ManagementCluster, i
 		ClusterDomain:                 dns.DefaultClusterDomain,
 		ESLicenseType:                 render.ElasticsearchLicenseTypeEnterpriseTrial,
 		Replicas:                      installation.ControlPlaneReplicas,
+		OperatorManagedTLSKeyPair:     includeManagerTLSSecret,
 	}
 	component, err := render.Manager(cfg)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)


### PR DESCRIPTION
## Description

This change is a bug fix to prevent an OwnerReference being added to an user provided manager-tls secret
This change introduce a new manager controller test to validate this bug fix

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
