### PR TITLE
Ensure kibana secrets provided by the user do not have ownerreferences added

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -346,7 +346,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			if packetCaptureCertSecret == nil {
 				renderSecret = true
 			}
-			packetCaptureCertSecret, err = utils.EnsureCertificateSecret(
+			packetCaptureCertSecret, _, err = utils.EnsureCertificateSecret(
 				render.PacketCaptureCertSecret, packetCaptureCertSecret, v1.TLSPrivateKeyKey, v1.TLSCertKey, rmeta.DefaultCertificateDuration, dns.GetServiceDNSNames(render.PacketCaptureServiceName, render.PacketCaptureNamespace, r.clusterDomain)...,
 			)
 			if err != nil {

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -323,7 +323,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		// operator, the cert is recreated and returned. If the invalid cert is supplied by
 		// the user, set the component degraded.
 
-		complianceServerCertSecret, err = utils.EnsureCertificateSecret(
+		complianceServerCertSecret, _, err = utils.EnsureCertificateSecret(
 			render.ComplianceServerCertSecret, complianceServerCertSecret, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, dns.GetServiceDNSNames(render.ComplianceServiceName, render.ComplianceNamespace, r.clusterDomain)...,
 		)
 		if err != nil {

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -905,7 +905,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		svcDNSNames = append(svcDNSNames, render.ManagerServiceIP)
 		certDur := 825 * 24 * time.Hour // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
 
-		managerInternalTLSSecret, err = utils.EnsureCertificateSecret(
+		managerInternalTLSSecret, _, err = utils.EnsureCertificateSecret(
 			render.ManagerInternalTLSSecretName, managerInternalTLSSecret, render.ManagerInternalSecretKeyName, render.ManagerInternalSecretCertName, certDur, svcDNSNames...,
 		)
 

--- a/pkg/controller/logstorage/common/common.go
+++ b/pkg/controller/logstorage/common/common.go
@@ -124,7 +124,7 @@ func GetESGatewayCertificateSecrets(ctx context.Context, instl *operatorv1.Insta
 	}
 
 	// Ensure that cert is valid.
-	oprKeyCert, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, oprKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
+	oprKeyCert, _, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchCertSecret, oprKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/controller/logstorage/eskubecontrollers.go
+++ b/pkg/controller/logstorage/eskubecontrollers.go
@@ -81,7 +81,7 @@ func (r *ReconcileLogStorage) createEsKubeControllers(
 		svcDNSNames = append(svcDNSNames, render.ManagerServiceIP)
 		certDur := 825 * 24 * time.Hour // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
 
-		managerInternalTLSSecret, err = utils.EnsureCertificateSecret(
+		managerInternalTLSSecret, _, err = utils.EnsureCertificateSecret(
 			render.ManagerInternalTLSSecretName, managerInternalTLSSecret, render.ManagerInternalSecretKeyName, render.ManagerInternalSecretCertName, certDur, svcDNSNames...,
 		)
 

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -559,7 +559,7 @@ func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Con
 	}
 
 	// Ensure that cert is valid.
-	esKeyCert, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchInternalCertSecret, esKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
+	esKeyCert, _, err = utils.EnsureCertificateSecret(render.TigeraElasticsearchInternalCertSecret, esKeyCert, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -599,62 +599,59 @@ func (r *ReconcileLogStorage) getElasticsearchCertificateSecrets(ctx context.Con
 	return esKeyCert, certSecret, err
 }
 
-func (r *ReconcileLogStorage) kibanaInternalSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) ([]*corev1.Secret, error) {
+// kibanaInternalSecrets Get the operator kibana secret and kibana's public secret if it has valid DNS names
+// The first returned value (*corev1.Secret) is the kibana TLS certificate secret in the operator namespace
+// The second returned value (bool) is true if the kibana TLS certificate secret in the operator namespace is managed
+// by the operator (it could be user-supplied prior to 3.9)
+// The third returned value (*corev1.Secret) is the kibana public TLS certificate secret in the kibana namespace (this secret is created by ECK)
+// The fourth returned value (error) is nil if both secrets exists and are valid, if not an error is returned
+func (r *ReconcileLogStorage) kibanaInternalSecrets(ctx context.Context, instl *operatorv1.InstallationSpec) (*corev1.Secret, bool, *corev1.Secret, error) {
 
-	var secrets []*corev1.Secret
 	svcDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
+	operatorManaged := false
 
 	// Get the secret - might be nil
 	secret, err := utils.GetSecret(ctx, r.client, render.TigeraKibanaCertSecret, common.OperatorNamespace())
 	if err != nil {
-		return nil, err
+		return nil, operatorManaged, nil, err
 	}
 
 	// Ensure that cert is valid.
-	secret, err = utils.EnsureCertificateSecret(render.TigeraKibanaCertSecret, secret, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
+	secret, operatorManaged, err = utils.EnsureCertificateSecret(render.TigeraKibanaCertSecret, secret, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, svcDNSNames...)
 	if err != nil {
-		return nil, err
+		return nil, operatorManaged, nil, err
 	}
 
 	if instl.CertificateManagement != nil {
-		return []*corev1.Secret{
-			secret,
-			rsecret.CopyToNamespace(render.KibanaNamespace, secret)[0],
-			render.CreateCertificateSecret(instl.CertificateManagement.CACert, relasticsearch.InternalCertSecret, render.KibanaNamespace),
-			render.CreateCertificateSecret(instl.CertificateManagement.CACert, render.KibanaInternalCertSecret, common.OperatorNamespace()),
-		}, nil
+		return secret, operatorManaged, nil, nil
 	}
-
-	secrets = append(secrets, secret, rsecret.CopyToNamespace(render.KibanaNamespace, secret)[0])
 
 	// Get the pub secret - might be nil
 	internalSecret, err := utils.GetSecret(ctx, r.client, render.KibanaInternalCertSecret, render.KibanaNamespace)
 	if err != nil {
-		return nil, err
+		return nil, operatorManaged, nil, err
 	}
 
 	if internalSecret == nil {
 		log.Info(fmt.Sprintf("Internal cert secret %q not found yet", render.KibanaInternalCertSecret))
-		return secrets, nil
+		return secret, operatorManaged, nil, nil
 	}
 
 	issuer, err := utils.GetCertificateIssuer(secret.Data[corev1.TLSCertKey])
 	if err != nil {
-		return nil, err
+		return nil, operatorManaged, nil, err
 	}
 
 	if utils.IsOperatorIssued(issuer) {
 		err = utils.SecretHasExpectedDNSNames(internalSecret, corev1.TLSCertKey, svcDNSNames)
 		if err == utils.ErrInvalidCertDNSNames {
 			if err := logstoragecommon.DeleteInvalidECKManagedPublicCertSecret(ctx, internalSecret, r.client, log); err != nil {
-				return nil, err
+				return nil, operatorManaged, nil, err
 			}
 		}
 	}
-	// If the cert was not deleted, copy the valid cert to operator namespace.
-	secrets = append(secrets, rsecret.CopyToNamespace(common.OperatorNamespace(), internalSecret)...)
 
-	return secrets, nil
+	return secret, operatorManaged, internalSecret, nil
 }
 
 func (r *ReconcileLogStorage) getElasticsearch(ctx context.Context) (*esv1.Elasticsearch, error) {

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -769,6 +769,82 @@ var _ = Describe("LogStorage controller", func() {
 					mockStatus.AssertExpectations(GinkgoT())
 				})
 
+				It("test that LogStorage creates a kibana TLS cert secret if not provided and add an OwnerReference to it", func() {
+					Expect(cli.Create(ctx, &storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &operatorv1.LogStorage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "tigera-secure",
+						},
+						Spec: operatorv1.LogStorageSpec{
+							StorageClassName: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
+					result, err := r.Reconcile(ctx, reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					// Expect to be waiting for Elasticsearch and Kibana to be functional
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					secret := &corev1.Secret{}
+
+					Expect(cli.Get(ctx, kbCertSecretOperKey, secret)).ShouldNot(HaveOccurred())
+					Expect(secret.GetOwnerReferences()).To(HaveLen(1))
+
+					Expect(cli.Get(ctx, kbCertSecretKey, secret)).ShouldNot(HaveOccurred())
+					Expect(secret.GetOwnerReferences()).To(HaveLen(1))
+				})
+
+				It("should not add OwnerReference to user supplied kibana TLS cert", func() {
+					Expect(cli.Create(ctx, &storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &operatorv1.LogStorage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "tigera-secure",
+						},
+						Spec: operatorv1.LogStorageSpec{
+							StorageClassName: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					testCA := test.MakeTestCA("logstorage-test")
+					kbSecret, err := secret.CreateTLSSecret(testCA,
+						render.TigeraKibanaCertSecret, common.OperatorNamespace(), "tls.key", "tls.crt",
+						rmeta.DefaultCertificateDuration, nil, "tigera-secure-kb-http.tigera-elasticsearch.svc",
+					)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(cli.Create(ctx, kbSecret)).ShouldNot(HaveOccurred())
+
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
+					result, err := r.Reconcile(ctx, reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					// Expect to be waiting for Elasticsearch and Kibana to be functional
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					secret := &corev1.Secret{}
+
+					Expect(cli.Get(ctx, kbCertSecretOperKey, secret)).ShouldNot(HaveOccurred())
+					Expect(secret.GetOwnerReferences()).To(HaveLen(0))
+
+					Expect(cli.Get(ctx, kbCertSecretKey, secret)).ShouldNot(HaveOccurred())
+					Expect(secret.GetOwnerReferences()).To(HaveLen(1))
+				})
+
 				Context("checking rendered images", func() {
 					BeforeEach(func() {
 						mockStatus.On("ClearDegraded", mock.Anything)
@@ -1308,7 +1384,6 @@ func setUpLogStorageComponents(cli client.Client, ctx context.Context, storageCl
 		Kibana:                      &kbv1.Kibana{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaName, Namespace: render.KibanaNamespace}},
 		ClusterConfig:               relasticsearch.NewClusterConfig("cluster", 1, 1, 1),
 		ElasticsearchSecrets:        toSecrets(createESSecrets()),
-		KibanaSecrets:               toSecrets(createKibanaSecrets()),
 		PullSecrets: []*corev1.Secret{
 			{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 		},
@@ -1399,12 +1474,9 @@ func createKibanaSecrets() []client.Object {
 	)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	kbOperNsSecret := secret.CopyToNamespace(render.KibanaNamespace, kbSecret)[0]
-
 	kbPublicSecret := createPubSecret(render.KibanaPublicCertSecret, render.KibanaNamespace, kbSecret.Data["tls.crt"], "tls.crt")
 	return []client.Object{
 		kbSecret,
-		kbOperNsSecret,
 		kbPublicSecret,
 	}
 }

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -275,41 +275,35 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 
 	// If the manager TLS secret exists, check whether it is managed by the
 	// operator.
-	certOperatorManaged := true
-	if tlsSecret != nil {
-		certOperatorManaged, err = utils.IsCertOperatorIssued(tlsSecret.Data[render.ManagerInternalSecretCertName])
+	var operatorManagedCertSecret bool
+	if installation.CertificateManagement == nil {
+		// We use EnsureCertificateSecret to ensure a secret exists, creating one if one is not passed in.
+		// It also ensures the secret passed has the proper DNS names if the secret is operator managed.
+
+		svcDNSNames := dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain)
+		svcDNSNames = append(svcDNSNames, "localhost")
+		certDur := 825 * 24 * time.Hour // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
+		tlsSecret, operatorManagedCertSecret, err = utils.EnsureCertificateSecret(
+			render.ManagerTLSSecretName, tlsSecret, render.ManagerSecretKeyName, render.ManagerSecretCertName, certDur, svcDNSNames...,
+		)
+
+		if err != nil {
+			r.status.SetDegraded(fmt.Sprintf("Error ensuring manager TLS certificate %q exists and has valid DNS names", render.ManagerTLSSecretName), err.Error())
+			return reconcile.Result{}, err
+		}
+
+	} else if tlsSecret != nil {
+		operatorManagedCertSecret, err = utils.IsCertOperatorIssued(tlsSecret.Data[render.ManagerInternalSecretCertName])
 		if err != nil {
 			r.status.SetDegraded(fmt.Sprintf("Error checking if manager TLS certificate is operator managed"), err.Error())
 			return reconcile.Result{}, err
 		}
-	}
 
-	if installation.CertificateManagement == nil {
-		// If the secret does not exist, then create one.
-		// If the secret exists but is operator managed, then check that it has the
-		// right DNS names and update it if necessary.
-		if tlsSecret == nil || certOperatorManaged {
-			// Create the cert if it doesn't exist. If the cert exists, check that the cert
-			// has the expected DNS names. If the cert doesn't exist, the cert is recreated and returned.
-			// Note that validation of DNS names is not required for a user-provided manager TLS secret.
-			svcDNSNames := dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain)
-			svcDNSNames = append(svcDNSNames, "localhost")
-			certDur := 825 * 24 * time.Hour // 825days*24hours: Create cert with a max expiration that macOS 10.15 will accept
-			tlsSecret, err = utils.EnsureCertificateSecret(
-				render.ManagerTLSSecretName, tlsSecret, render.ManagerSecretKeyName, render.ManagerSecretCertName, certDur, svcDNSNames...,
-			)
-
-			if err != nil {
-				r.status.SetDegraded(fmt.Sprintf("Error ensuring manager TLS certificate %q exists and has valid DNS names", render.ManagerTLSSecretName), err.Error())
-				return reconcile.Result{}, err
-			}
+		if !operatorManagedCertSecret {
+			err := fmt.Errorf("user provided secret %s/%s is not supported when certificate management is enabled", render.ManagerNamespace, render.ManagerTLSSecretName)
+			r.status.SetDegraded("Invalid certificate configuration", err.Error())
+			return reconcile.Result{}, err
 		}
-	} else if !certOperatorManaged {
-		err := fmt.Errorf("user provided secret %s/%s is not supported when certificate management is enabled", render.ManagerNamespace, render.ManagerTLSSecretName)
-		r.status.SetDegraded("Invalid certificate configuration", err.Error())
-		return reconcile.Result{}, err
-	} else {
-		tlsSecret = nil
 	}
 
 	var installCompliance = utils.IsFeatureActive(license, common.ComplianceFeature)
@@ -502,7 +496,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	var components []render.Component
-	if tlsSecret != nil && certOperatorManaged {
+	if tlsSecret != nil && operatorManagedCertSecret {
 		components = append(components, render.NewPassthrough([]client.Object{tlsSecret}))
 	}
 
@@ -544,7 +538,6 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		r.status.SetDegraded("Error rendering Manager", err.Error())
 		return reconcile.Result{}, err
 	}
-	components = append(components, component)
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
 		log.Error(err, "Error with images from ImageSet")
@@ -552,6 +545,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
+	components = append(components, component)
 	for _, component := range components {
 		if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
 			r.status.SetDegraded("Error creating / updating resource", err.Error())

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -37,7 +37,6 @@ import (
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	rsecret "github.com/tigera/operator/pkg/render/common/secret"
-	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/test"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -216,10 +215,8 @@ var _ = Describe("Manager controller tests", func() {
 
 		It("should render a new manager cert if existing cert has invalid DNS names and the cert is operator managed", func() {
 			// Create a manager cert managed by the operator.
-			ca, err := tls.MakeCA(rmeta.DefaultOperatorCASignerName())
-			Expect(err).ShouldNot(HaveOccurred())
 			oldCert, err := secret.CreateTLSSecret(
-				ca, render.ManagerTLSSecretName, common.OperatorNamespace(), render.ManagerSecretKeyName,
+				nil, render.ManagerTLSSecretName, common.OperatorNamespace(), render.ManagerSecretKeyName,
 				render.ManagerSecretCertName, rmeta.DefaultCertificateDuration, nil, "tigera-manager.tigera-manager.svc")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(c.Create(ctx, oldCert)).NotTo(HaveOccurred())

--- a/pkg/controller/utils/certs.go
+++ b/pkg/controller/utils/certs.go
@@ -55,34 +55,35 @@ func GetSecret(ctx context.Context, client client.Client, name string, ns string
 }
 
 // EnsureCertificateSecret ensures that the certificate in the
-// secret has the expected DNS names. If no secret is provided, a new
-// secret is created and returned. If the secret does have the
-// right DNS names then the secret is returned.
-// If the cert in the secret has invalid DNS names and the secret is operator
-// managed, then a new secret is created and returned. Otherwise,
-// if the secret is user-supplied, an error is returned.
-func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName string, certName string, certDuration time.Duration, svcDNSNames ...string) (*corev1.Secret, error) {
+// secret has the expected DNS names. If no secret is provided, a new secret is created.
+// The first returned value (*corev1.Secret) is the validated or created Secret to use.
+// The second returned value (bool) is true if the Secret returned is managed by the operator or false if the secret is user-supplied.
+// The third returned value (error) is nil if the Secret pass in is valid or was created successfully. If there was a
+// problem creating the certificate or the Secret has invalid DNS names and the secret is not operator managed, an error is returned.
+func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName string, certName string, certDuration time.Duration, svcDNSNames ...string) (*corev1.Secret, bool, error) {
 	var err error
 
 	// Create the secret if it doesn't exist.
 	if secret == nil {
 		certsLogger.Info(fmt.Sprintf("cert %q doesn't exist, creating it", secretName))
 
-		return rsecret.CreateTLSSecret(nil,
+		secret, err = rsecret.CreateTLSSecret(nil,
 			secretName, common.OperatorNamespace(), keyName, certName,
 			certDuration, nil, svcDNSNames...,
 		)
+
+		return secret, true, err
 	}
 
 	operatorManaged, err := IsCertOperatorIssued(secret.Data[certName])
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// For user provided certs, skip checking whether they have the right DNS
 	// names.
 	if !operatorManaged {
-		return secret, err
+		return secret, operatorManaged, err
 	}
 
 	err = SecretHasExpectedDNSNames(secret, certName, svcDNSNames)
@@ -91,13 +92,13 @@ func EnsureCertificateSecret(secretName string, secret *corev1.Secret, keyName s
 		// replace the invalid one since it's managed by the operator.
 		certsLogger.Info(fmt.Sprintf("operator-managed cert %q has wrong DNS names, recreating it", secretName))
 
-		return rsecret.CreateTLSSecret(nil,
+		secret, err = rsecret.CreateTLSSecret(nil,
 			secretName, common.OperatorNamespace(), keyName, certName,
 			rmeta.DefaultCertificateDuration, nil, svcDNSNames...,
 		)
 	}
 
-	return secret, err
+	return secret, operatorManaged, err
 }
 
 // IsOperatorIssued checks if the cert secret is issued operator.
@@ -139,7 +140,7 @@ func parseCertificate(certBytes []byte) (*x509.Certificate, error) {
 	return cert, nil
 }
 
-// Check that the cert in the secret has the expected DNS names.
+// SecretHasExpectedDNSNames Check that the cert in the secret has the expected DNS names.
 func SecretHasExpectedDNSNames(secret *corev1.Secret, certKeyName string, expectedDNSNames []string) error {
 	cert, err := parseCertificate(secret.Data[certKeyName])
 	if err != nil {

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/tigera/operator/pkg/common"
 	"hash/fnv"
 	"net/url"
 	"strings"
@@ -160,8 +161,27 @@ var log = logf.Log.WithName("render")
 
 // Elasticsearch renders the
 func LogStorage(cfg *ElasticsearchConfiguration) Component {
+
+	var kibanaSecrets []*corev1.Secret
+
+	if cfg.KibanaCertSecret != nil {
+
+		kibanaSecrets = append(kibanaSecrets, secret.CopyToNamespace(KibanaNamespace, cfg.KibanaCertSecret)...)
+
+		if cfg.Installation.CertificateManagement != nil {
+
+			kibanaSecrets = append(kibanaSecrets,
+				CreateCertificateSecret(cfg.Installation.CertificateManagement.CACert, relasticsearch.InternalCertSecret, KibanaNamespace),
+				CreateCertificateSecret(cfg.Installation.CertificateManagement.CACert, KibanaInternalCertSecret, common.OperatorNamespace()))
+		} else if cfg.KibanaInternalCertSecret != nil {
+			//copy the valid cert to operator namespace.
+			kibanaSecrets = append(kibanaSecrets, secret.CopyToNamespace(common.OperatorNamespace(), cfg.KibanaInternalCertSecret)...)
+		}
+	}
+
 	return &elasticsearchComponent{
-		cfg: cfg,
+		cfg:           cfg,
+		kibanaSecrets: kibanaSecrets,
 	}
 }
 
@@ -175,7 +195,8 @@ type ElasticsearchConfiguration struct {
 	Kibana                      *kbv1.Kibana
 	ClusterConfig               *relasticsearch.ClusterConfig
 	ElasticsearchSecrets        []*corev1.Secret
-	KibanaSecrets               []*corev1.Secret
+	KibanaCertSecret            *corev1.Secret
+	KibanaInternalCertSecret    *corev1.Secret
 	PullSecrets                 []*corev1.Secret
 	Provider                    operatorv1.Provider
 	CuratorSecrets              []*corev1.Secret
@@ -188,6 +209,7 @@ type ElasticsearchConfiguration struct {
 
 type elasticsearchComponent struct {
 	cfg             *ElasticsearchConfiguration
+	kibanaSecrets   []*corev1.Secret
 	esImage         string
 	esOperatorImage string
 	kibanaImage     string
@@ -323,8 +345,8 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 			toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(KibanaNamespace, es.cfg.PullSecrets...)...)...)
 		}
 
-		if len(es.cfg.KibanaSecrets) > 0 {
-			toCreate = append(toCreate, secret.ToRuntimeObjects(es.cfg.KibanaSecrets...)...)
+		if len(es.kibanaSecrets) > 0 {
+			toCreate = append(toCreate, secret.ToRuntimeObjects(es.kibanaSecrets...)...)
 		}
 
 		toCreate = append(toCreate, es.kibanaCR())
@@ -1235,7 +1257,7 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: KibanaNamespace,
 					Annotations: map[string]string{
-						KibanaTLSAnnotationHash: rmeta.SecretsAnnotationHash(es.cfg.KibanaSecrets...),
+						KibanaTLSAnnotationHash: rmeta.SecretsAnnotationHash(es.kibanaSecrets...),
 					},
 					Labels: map[string]string{
 						"name":    KibanaName,

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -94,10 +94,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
 					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.ElasticsearchNamespace}},
 				},
-				KibanaSecrets: []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: render.KibanaNamespace}},
-				},
+				KibanaCertSecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}},
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
@@ -148,7 +145,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
-					{render.TigeraKibanaCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.KibanaName, render.KibanaNamespace, &kbv1.Kibana{}, nil},
 					{render.EsManagerRole, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
@@ -218,7 +214,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
-					{render.TigeraKibanaCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.KibanaName, render.KibanaNamespace, &kbv1.Kibana{}, nil},
 					{render.EsManagerRole, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
@@ -280,8 +275,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
-					{render.TigeraKibanaCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
+					{relasticsearch.InternalCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
+					{render.KibanaInternalCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.KibanaName, render.KibanaNamespace, &kbv1.Kibana{}, nil},
 					{render.EsManagerRole, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
 					{render.EsManagerRoleBinding, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
@@ -350,7 +346,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
-					{render.TigeraKibanaCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.KibanaPublicCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.KibanaName, render.KibanaNamespace, &kbv1.Kibana{}, nil},
@@ -370,11 +365,8 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.ElasticsearchNamespace}},
 					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
 				}
-				cfg.KibanaSecrets = []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: render.KibanaNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: common.OperatorNamespace()}},
-				}
+				cfg.KibanaCertSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}}
+				cfg.KibanaInternalCertSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}}
 				cfg.CuratorSecrets = []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: common.OperatorNamespace()}},
 					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
@@ -671,10 +663,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
 					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.ElasticsearchNamespace}},
 				},
-				KibanaSecrets: []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: render.KibanaNamespace}},
-				},
+				KibanaCertSecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}},
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
@@ -1167,11 +1156,8 @@ var deleteLogStorageTests = func(managementCluster *operatorv1.ManagementCluster
 					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.ElasticsearchNamespace}},
 					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: render.ElasticsearchNamespace}},
 				},
-				KibanaSecrets: []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: render.KibanaNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}},
-				},
+				KibanaCertSecret:         &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}},
+				KibanaInternalCertSecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}},
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},


### PR DESCRIPTION
## Description

This change is a bug fix to prevent an OwnerReference being added to an user provided kibana tls secret
This change introduce a new logstorage controller test to validate this bug fix

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
