### PR TITLE
Ensure apiserver and packetcapture secrets provided by the user do not have ownerreferences added

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -25,9 +25,13 @@ import (
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/test"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -47,6 +51,7 @@ var _ = Describe("apiserver controller tests", func() {
 		scheme     *runtime.Scheme
 		ctx        context.Context
 		mockStatus *status.MockStatus
+		variant    operatorv1.ProductVariant
 	)
 
 	BeforeEach(func() {
@@ -72,30 +77,12 @@ var _ = Describe("apiserver controller tests", func() {
 		mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
 		mockStatus.On("ReadyToMonitor")
 
-		var replicas int32 = 2
-		Expect(cli.Create(ctx, &operatorv1.Installation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "default",
-			},
-			Status: operatorv1.InstallationStatus{
-				Variant:  operatorv1.TigeraSecureEnterprise,
-				Computed: &operatorv1.InstallationSpec{},
-			},
-			Spec: operatorv1.InstallationSpec{
-				ControlPlaneReplicas:  &replicas,
-				Variant:               operatorv1.TigeraSecureEnterprise,
-				Registry:              "some.registry.org/",
-				CertificateManagement: &operatorv1.CertificateManagement{},
-			},
-		})).To(BeNil())
-		// Apply prerequisites for the basic reconcile to succeed.
-		Expect(cli.Create(ctx, &operatorv1.APIServer{
-			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
-		})).ToNot(HaveOccurred())
+		variant = operatorv1.TigeraSecureEnterprise
 	})
 
 	Context("verify reconciliation", func() {
 		It("should use builtin images", func() {
+			setUpApiServerInstallation(cli, ctx, variant, &operatorv1.CertificateManagement{})
 
 			r := ReconcileAPIServer{
 				client:          cli,
@@ -168,6 +155,8 @@ var _ = Describe("apiserver controller tests", func() {
 			Expect(pcSecret).NotTo(BeNil())
 		})
 		It("should use images from imageset", func() {
+			setUpApiServerInstallation(cli, ctx, variant, &operatorv1.CertificateManagement{})
+
 			Expect(cli.Create(ctx, &operatorv1.ImageSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "enterprise-" + components.EnterpriseRelease},
 				Spec: operatorv1.ImageSetSpec{
@@ -248,5 +237,90 @@ var _ = Describe("apiserver controller tests", func() {
 			Expect(test.GetResource(cli, &pcSecret)).To(BeNil())
 			Expect(pcSecret).NotTo(BeNil())
 		})
+
+		It("should not add OwnerReference to user-supplied apiserver and packetcapture TLS cert secrets", func() {
+			setUpApiServerInstallation(cli, ctx, variant, nil)
+
+			secretName := render.ApiServerTLSSecretName(variant)
+
+			testCA := test.MakeTestCA("apiserver-test")
+			apiSecret, err := secret.CreateTLSSecret(testCA,
+				secretName, common.OperatorNamespace(), render.APIServerSecretKeyName, render.APIServerSecretCertName,
+				rmeta.DefaultCertificateDuration, nil, "tigera-api", "tigera-system", dns.DefaultClusterDomain,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(cli.Create(ctx, apiSecret)).ShouldNot(HaveOccurred())
+
+			packetCaptureSecret, err := secret.CreateTLSSecret(testCA,
+				render.PacketCaptureCertSecret, common.OperatorNamespace(), v1.TLSPrivateKeyKey, v1.TLSCertKey,
+				rmeta.DefaultCertificateDuration, nil, dns.GetServiceDNSNames(render.PacketCaptureServiceName, render.PacketCaptureNamespace, dns.DefaultClusterDomain)...,
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(cli.Create(ctx, packetCaptureSecret)).ShouldNot(HaveOccurred())
+
+			r := ReconcileAPIServer{
+				client:   cli,
+				scheme:   scheme,
+				provider: operatorv1.ProviderNone,
+				status:   mockStatus,
+			}
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: secretName}, apiSecret)).ShouldNot(HaveOccurred())
+			Expect(apiSecret.GetOwnerReferences()).To(HaveLen(0))
+
+			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: render.PacketCaptureCertSecret}, packetCaptureSecret)).ShouldNot(HaveOccurred())
+			Expect(packetCaptureSecret.GetOwnerReferences()).To(HaveLen(0))
+		})
+
+		It("should add OwnerReference apiserver and packetcapture TLS cert operator managed secrets", func() {
+			setUpApiServerInstallation(cli, ctx, variant, nil)
+
+			secretName := "calico-apiserver-certs"
+			if variant == operatorv1.TigeraSecureEnterprise {
+				secretName = "tigera-apiserver-certs"
+			}
+
+			r := ReconcileAPIServer{
+				client:   cli,
+				scheme:   scheme,
+				provider: operatorv1.ProviderNone,
+				status:   mockStatus,
+			}
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			secret := &v1.Secret{}
+			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: secretName}, secret)).ShouldNot(HaveOccurred())
+			Expect(secret.GetOwnerReferences()).To(HaveLen(1))
+
+			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: render.PacketCaptureCertSecret}, secret)).ShouldNot(HaveOccurred())
+			Expect(secret.GetOwnerReferences()).To(HaveLen(1))
+		})
 	})
 })
+
+func setUpApiServerInstallation(cli client.Client, ctx context.Context, variant operatorv1.ProductVariant, certificateManagement *operatorv1.CertificateManagement) {
+
+	replicas := int32(2)
+	Expect(cli.Create(ctx, &operatorv1.Installation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Status: operatorv1.InstallationStatus{
+			Variant:  variant,
+			Computed: &operatorv1.InstallationSpec{},
+		},
+		Spec: operatorv1.InstallationSpec{
+			ControlPlaneReplicas:  &replicas,
+			Variant:               variant,
+			Registry:              "some.registry.org/",
+			CertificateManagement: certificateManagement,
+		},
+	})).To(BeNil())
+	// Apply prerequisites for the basic reconcile to succeed.
+	Expect(cli.Create(ctx, &operatorv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+	})).ToNot(HaveOccurred())
+}

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -241,7 +241,7 @@ var _ = Describe("apiserver controller tests", func() {
 		It("should not add OwnerReference to user-supplied apiserver and packetcapture TLS cert secrets", func() {
 			setUpApiServerInstallation(cli, ctx, variant, nil)
 
-			secretName := render.ApiServerTLSSecretName(variant)
+			secretName := render.ProjectCalicoApiServerTLSSecretName(variant)
 
 			testCA := test.MakeTestCA("apiserver-test")
 			apiSecret, err := secret.CreateTLSSecret(testCA,

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/dns"
@@ -51,14 +50,14 @@ const (
 
 // The following functions are helpers for determining resource names based on
 // the configured product variant.
-func apiServerTLSSecretName(v operatorv1.ProductVariant) string {
+func ApiServerTLSSecretName(v operatorv1.ProductVariant) string {
 	if v == operatorv1.Calico {
 		return "calico-apiserver-certs"
 	}
 	return "tigera-apiserver-certs"
 }
 
-func apiserverServiceName(v operatorv1.ProductVariant) string {
+func ApiserverServiceName(v operatorv1.ProductVariant) string {
 	if v == operatorv1.Calico {
 		return "calico-api"
 	}
@@ -85,29 +84,13 @@ func APIServer(cfg *APIServerConfiguration) (Component, error) {
 	tlsHashAnnotations := make(map[string]string)
 
 	if cfg.Installation.CertificateManagement == nil {
-		svcDNSNames := dns.GetServiceDNSNames(apiserverServiceName(cfg.Installation.Variant), rmeta.APIServerNamespace(cfg.Installation.Variant), cfg.ClusterDomain)
-		if cfg.TLSKeyPair == nil {
-			var err error
-			cfg.TLSKeyPair, err = secret.CreateTLSSecret(nil,
-				apiServerTLSSecretName(cfg.Installation.Variant),
-				common.OperatorNamespace(),
-				APIServerSecretKeyName,
-				APIServerSecretCertName,
-				rmeta.DefaultCertificateDuration,
-				nil,
-				svcDNSNames...,
-			)
-			if err != nil {
-				return nil, err
-			}
-			// We only need to add the TLSKeyPair if we created it, otherwise
-			// it already exists.
-			tlsSecrets = []*corev1.Secret{cfg.TLSKeyPair}
+		if cfg.TLSKeyPairAnnotationHash {
 			tlsHashAnnotations[TlsSecretHashAnnotation] = rmeta.AnnotationHash(cfg.TLSKeyPair.Data)
 		}
+
 		copy := cfg.TLSKeyPair.DeepCopy()
 		copy.ObjectMeta = metav1.ObjectMeta{
-			Name:      apiServerTLSSecretName(cfg.Installation.Variant),
+			Name:      ApiServerTLSSecretName(cfg.Installation.Variant),
 			Namespace: rmeta.APIServerNamespace(cfg.Installation.Variant),
 		}
 		tlsSecrets = append(tlsSecrets, copy)
@@ -142,6 +125,7 @@ type APIServerConfiguration struct {
 	Openshift                   bool
 	TunnelCASecret              *corev1.Secret
 	ClusterDomain               string
+	TLSKeyPairAnnotationHash    bool
 }
 
 type apiServerComponent struct {
@@ -238,7 +222,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	// Add in certificates for API server TLS.
 	if c.cfg.Installation.CertificateManagement == nil {
 		namespacedObjects = append(namespacedObjects, c.getTLSObjects()...)
-		globalObjects = append(globalObjects, c.apiServiceRegistration(c.tlsSecrets[0].Data[APIServerSecretCertName]))
+		globalObjects = append(globalObjects, c.apiServiceRegistration(c.cfg.TLSKeyPair.Data[APIServerSecretCertName]))
 	} else {
 		namespacedObjects = append(namespacedObjects, c.apiServiceRegistration(c.cfg.Installation.CertificateManagement.CACert))
 		globalObjects = append(globalObjects, CSRClusterRoleBinding(csrRolebindingName(c.cfg.Installation.Variant), rmeta.APIServerNamespace(c.cfg.Installation.Variant)))
@@ -315,7 +299,7 @@ func (c *apiServerComponent) apiServiceRegistration(cert []byte) *apiregv1.APISe
 			VersionPriority:      200,
 			GroupPriorityMinimum: 1500,
 			Service: &apiregv1.ServiceReference{
-				Name:      apiserverServiceName(c.cfg.Installation.Variant),
+				Name:      ApiserverServiceName(c.cfg.Installation.Variant),
 				Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
 			},
 			Version:  "v3",
@@ -735,7 +719,7 @@ func (c *apiServerComponent) apiServerService() *corev1.Service {
 	s := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      apiserverServiceName(c.cfg.Installation.Variant),
+			Name:      ApiserverServiceName(c.cfg.Installation.Variant),
 			Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
 		},
 		Spec: corev1.ServiceSpec{
@@ -790,10 +774,10 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 		initContainers = append(initContainers, CreateCSRInitContainer(
 			c.cfg.Installation.CertificateManagement,
 			c.certSignReqImage,
-			apiServerTLSSecretName(c.cfg.Installation.Variant), TLSSecretCertName,
+			ApiServerTLSSecretName(c.cfg.Installation.Variant), TLSSecretCertName,
 			APIServerSecretKeyName,
 			APIServerSecretCertName,
-			dns.GetServiceDNSNames(apiserverServiceName(c.cfg.Installation.Variant), rmeta.APIServerNamespace(c.cfg.Installation.Variant), c.cfg.ClusterDomain),
+			dns.GetServiceDNSNames(ApiserverServiceName(c.cfg.Installation.Variant), rmeta.APIServerNamespace(c.cfg.Installation.Variant), c.cfg.ClusterDomain),
 			rmeta.APIServerNamespace(c.cfg.Installation.Variant)))
 	}
 
@@ -874,7 +858,7 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 	}
 
 	volumeMounts = append(volumeMounts,
-		corev1.VolumeMount{Name: apiServerTLSSecretName(c.cfg.Installation.Variant), MountPath: "/code/apiserver.local.config/certificates"},
+		corev1.VolumeMount{Name: ApiServerTLSSecretName(c.cfg.Installation.Variant), MountPath: "/code/apiserver.local.config/certificates"},
 	)
 
 	if c.cfg.ManagementCluster != nil {
@@ -1053,8 +1037,8 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 
 	volumes = append(volumes,
 		corev1.Volume{
-			Name:         apiServerTLSSecretName(c.cfg.Installation.Variant),
-			VolumeSource: certificateVolumeSource(c.cfg.Installation.CertificateManagement, apiServerTLSSecretName(c.cfg.Installation.Variant)),
+			Name:         ApiServerTLSSecretName(c.cfg.Installation.Variant),
+			VolumeSource: certificateVolumeSource(c.cfg.Installation.CertificateManagement, ApiServerTLSSecretName(c.cfg.Installation.Variant)),
 		},
 	)
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podaffinity"
+	"github.com/tigera/operator/pkg/render/common/secret"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/testutils"
 	"github.com/tigera/operator/test"
@@ -60,12 +61,26 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Registry:             "testregistry.com/",
 			Variant:              operatorv1.TigeraSecureEnterprise,
 		}
+
+		tlsKeyPair, err := secret.CreateTLSSecret(nil,
+			render.ApiServerTLSSecretName(instance.Variant),
+			common.OperatorNamespace(),
+			render.APIServerSecretKeyName,
+			render.APIServerSecretCertName,
+			rmeta.DefaultCertificateDuration,
+			nil,
+			dns.GetServiceDNSNames(render.ApiserverServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), dns.DefaultClusterDomain)...,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
 		replicas = 2
 		cfg = &render.APIServerConfiguration{
-			K8SServiceEndpoint: k8sapi.ServiceEndpoint{},
-			Installation:       instance,
-			Openshift:          openshift,
-			ClusterDomain:      dns.DefaultClusterDomain,
+			K8SServiceEndpoint:       k8sapi.ServiceEndpoint{},
+			Installation:             instance,
+			TLSKeyPair:               tlsKeyPair,
+			TLSKeyPairAnnotationHash: true,
+			Openshift:                openshift,
+			ClusterDomain:            dns.DefaultClusterDomain,
 		}
 	})
 
@@ -92,7 +107,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
@@ -104,6 +118,18 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 		}
+
+		var err error
+		cfg.TLSKeyPair, err = secret.CreateTLSSecret(nil,
+			render.ApiServerTLSSecretName(cfg.Installation.Variant),
+			common.OperatorNamespace(),
+			render.APIServerSecretKeyName,
+			render.APIServerSecretCertName,
+			rmeta.DefaultCertificateDuration,
+			nil,
+			dns.GetServiceDNSNames(render.ApiserverServiceName(cfg.Installation.Variant), rmeta.APIServerNamespace(cfg.Installation.Variant), clusterDomain)...,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// APIServer(registry string, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool
 		cfg.ClusterDomain = clusterDomain
@@ -144,10 +170,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
 
 		expectedDNSNames := dns.GetServiceDNSNames("tigera-api", "tigera-system", clusterDomain)
-		operatorCert, ok := rtest.GetResource(resources, "tigera-apiserver-certs", "tigera-operator", "", "v1", "Secret").(*corev1.Secret)
-		Expect(ok).To(BeTrue(), "Expected v1.Secret")
-		test.VerifyCert(operatorCert, "apiserver.key", "apiserver.crt", expectedDNSNames...)
-
 		tigeraCert, ok := rtest.GetResource(resources, "tigera-apiserver-certs", "tigera-system", "", "v1", "Secret").(*corev1.Secret)
 		Expect(ok).To(BeTrue(), "Expected v1.Secret")
 		test.VerifyCert(tigeraCert, "apiserver.key", "apiserver.crt", expectedDNSNames...)
@@ -282,7 +304,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
@@ -334,7 +355,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
@@ -393,7 +413,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
@@ -457,7 +476,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
@@ -622,7 +640,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: common.OperatorNamespace(), group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
@@ -711,7 +728,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "tigera-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-apiserver-certs", ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-system", group: "", version: "v1", kind: "Secret"},
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
@@ -1100,12 +1116,26 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Registry:             "testregistry.com/",
 			Variant:              operatorv1.Calico,
 		}
+
+		tlsKeyPair, err := secret.CreateTLSSecret(nil,
+			render.ApiServerTLSSecretName(instance.Variant),
+			common.OperatorNamespace(),
+			render.APIServerSecretKeyName,
+			render.APIServerSecretCertName,
+			rmeta.DefaultCertificateDuration,
+			nil,
+			dns.GetServiceDNSNames(render.ApiserverServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), dns.DefaultClusterDomain)...,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
 		replicas = 2
 		cfg = &render.APIServerConfiguration{
-			K8SServiceEndpoint: k8sapi.ServiceEndpoint{},
-			Installation:       instance,
-			Openshift:          openshift,
-			ClusterDomain:      dns.DefaultClusterDomain,
+			K8SServiceEndpoint:       k8sapi.ServiceEndpoint{},
+			Installation:             instance,
+			TLSKeyPair:               tlsKeyPair,
+			TLSKeyPairAnnotationHash: true,
+			Openshift:                openshift,
+			ClusterDomain:            dns.DefaultClusterDomain,
 		}
 	})
 
@@ -1125,7 +1155,6 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			{name: "calico-extension-apiserver-auth-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "calico-apiserver-delegate-auth", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "calico-apiserver-auth-reader", ns: "kube-system", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
-			{name: "calico-apiserver-certs", ns: "tigera-operator", group: "", version: "v1", kind: "Secret"},
 			{name: "calico-apiserver-certs", ns: "calico-apiserver", group: "", version: "v1", kind: "Secret"},
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "calico-apiserver", ns: "calico-apiserver", group: "apps", version: "v1", kind: "Deployment"},
@@ -1134,6 +1163,18 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			{name: "calico-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "allow-apiserver", ns: "calico-apiserver", group: "networking.k8s.io", version: "v1", kind: "NetworkPolicy"},
 		}
+
+		var err error
+		cfg.TLSKeyPair, err = secret.CreateTLSSecret(nil,
+			render.ApiServerTLSSecretName(cfg.Installation.Variant),
+			common.OperatorNamespace(),
+			render.APIServerSecretKeyName,
+			render.APIServerSecretCertName,
+			rmeta.DefaultCertificateDuration,
+			nil,
+			dns.GetServiceDNSNames(render.ApiserverServiceName(cfg.Installation.Variant), rmeta.APIServerNamespace(cfg.Installation.Variant), clusterDomain)...,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		// APIServer(registry string, tlsKeyPair *corev1.Secret, pullSecrets []*corev1.Secret, openshift bool
 		cfg.ClusterDomain = clusterDomain
@@ -1158,10 +1199,6 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
 
 		expectedDNSNames := dns.GetServiceDNSNames("calico-api", "calico-apiserver", clusterDomain)
-		operatorCert, ok := rtest.GetResource(resources, "calico-apiserver-certs", "tigera-operator", "", "v1", "Secret").(*corev1.Secret)
-		Expect(ok).To(BeTrue(), "Expected v1.Secret")
-		test.VerifyCert(operatorCert, "apiserver.key", "apiserver.crt", expectedDNSNames...)
-
 		tigeraCert, ok := rtest.GetResource(resources, "calico-apiserver-certs", "calico-apiserver", "", "v1", "Secret").(*corev1.Secret)
 		Expect(ok).To(BeTrue(), "Expected v1.Secret")
 		test.VerifyCert(tigeraCert, "apiserver.key", "apiserver.crt", expectedDNSNames...)
@@ -1243,7 +1280,6 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-extension-apiserver-auth-access"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-delegate-auth"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}},
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-auth-reader", Namespace: "kube-system"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-certs", Namespace: "tigera-operator"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-certs", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}},
 			&apiregv1.APIService{ObjectMeta: metav1.ObjectMeta{Name: "v3.projectcalico.org"}, TypeMeta: metav1.TypeMeta{APIVersion: "apiregistration.k8s.io/v1", Kind: "APIService"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}},

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -63,24 +63,23 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		}
 
 		tlsKeyPair, err := secret.CreateTLSSecret(nil,
-			render.ApiServerTLSSecretName(instance.Variant),
+			render.ProjectCalicoApiServerTLSSecretName(instance.Variant),
 			common.OperatorNamespace(),
 			render.APIServerSecretKeyName,
 			render.APIServerSecretCertName,
 			rmeta.DefaultCertificateDuration,
 			nil,
-			dns.GetServiceDNSNames(render.ApiserverServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), dns.DefaultClusterDomain)...,
+			dns.GetServiceDNSNames(render.ProjectCalicoApiServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), dns.DefaultClusterDomain)...,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		replicas = 2
 		cfg = &render.APIServerConfiguration{
-			K8SServiceEndpoint:       k8sapi.ServiceEndpoint{},
-			Installation:             instance,
-			TLSKeyPair:               tlsKeyPair,
-			TLSKeyPairAnnotationHash: true,
-			Openshift:                openshift,
-			ClusterDomain:            dns.DefaultClusterDomain,
+			K8SServiceEndpoint: k8sapi.ServiceEndpoint{},
+			Installation:       instance,
+			TLSKeyPair:         tlsKeyPair,
+			Openshift:          openshift,
+			ClusterDomain:      dns.DefaultClusterDomain,
 		}
 	})
 
@@ -121,13 +120,13 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 
 		var err error
 		cfg.TLSKeyPair, err = secret.CreateTLSSecret(nil,
-			render.ApiServerTLSSecretName(cfg.Installation.Variant),
+			render.ProjectCalicoApiServerTLSSecretName(cfg.Installation.Variant),
 			common.OperatorNamespace(),
 			render.APIServerSecretKeyName,
 			render.APIServerSecretCertName,
 			rmeta.DefaultCertificateDuration,
 			nil,
-			dns.GetServiceDNSNames(render.ApiserverServiceName(cfg.Installation.Variant), rmeta.APIServerNamespace(cfg.Installation.Variant), clusterDomain)...,
+			dns.GetServiceDNSNames(render.ProjectCalicoApiServerServiceName(cfg.Installation.Variant), rmeta.APIServerNamespace(cfg.Installation.Variant), clusterDomain)...,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -1118,24 +1117,23 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		}
 
 		tlsKeyPair, err := secret.CreateTLSSecret(nil,
-			render.ApiServerTLSSecretName(instance.Variant),
+			render.ProjectCalicoApiServerTLSSecretName(instance.Variant),
 			common.OperatorNamespace(),
 			render.APIServerSecretKeyName,
 			render.APIServerSecretCertName,
 			rmeta.DefaultCertificateDuration,
 			nil,
-			dns.GetServiceDNSNames(render.ApiserverServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), dns.DefaultClusterDomain)...,
+			dns.GetServiceDNSNames(render.ProjectCalicoApiServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), dns.DefaultClusterDomain)...,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		replicas = 2
 		cfg = &render.APIServerConfiguration{
-			K8SServiceEndpoint:       k8sapi.ServiceEndpoint{},
-			Installation:             instance,
-			TLSKeyPair:               tlsKeyPair,
-			TLSKeyPairAnnotationHash: true,
-			Openshift:                openshift,
-			ClusterDomain:            dns.DefaultClusterDomain,
+			K8SServiceEndpoint: k8sapi.ServiceEndpoint{},
+			Installation:       instance,
+			TLSKeyPair:         tlsKeyPair,
+			Openshift:          openshift,
+			ClusterDomain:      dns.DefaultClusterDomain,
 		}
 	})
 
@@ -1166,13 +1164,13 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 
 		var err error
 		cfg.TLSKeyPair, err = secret.CreateTLSSecret(nil,
-			render.ApiServerTLSSecretName(cfg.Installation.Variant),
+			render.ProjectCalicoApiServerTLSSecretName(cfg.Installation.Variant),
 			common.OperatorNamespace(),
 			render.APIServerSecretKeyName,
 			render.APIServerSecretCertName,
 			rmeta.DefaultCertificateDuration,
 			nil,
-			dns.GetServiceDNSNames(render.ApiserverServiceName(cfg.Installation.Variant), rmeta.APIServerNamespace(cfg.Installation.Variant), clusterDomain)...,
+			dns.GetServiceDNSNames(render.ProjectCalicoApiServerServiceName(cfg.Installation.Variant), rmeta.APIServerNamespace(cfg.Installation.Variant), clusterDomain)...,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
## Description

This change add a new test to make sure an OwnerReference is not being added to user provided tigera-apiserver-certs and tigera-packetcapture-server-tls secrets

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
