### PR TITLE
Ensure typha and node secrets provided by the user do not have ownerreferences added

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -916,8 +916,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	}
 
 	var typhaNodeTLS *render.TyphaNodeTLS
-	operatorManagedNodeSecret := true
-	operatorManagedTyphaSecret := true
+	var renderNodeAndTyphaSecrets bool
 	if instance.Spec.CertificateManagement == nil {
 		// First, attempt to load TLS secrets from the cluster, if any exist.
 		typhaNodeTLS, err = r.GetTyphaNodeTLSConfig()
@@ -935,20 +934,10 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 				r.SetDegraded("Error generating Typha/Felix secrets", err, reqLogger)
 				return reconcile.Result{}, err
 			}
-		} else {
-			operatorManagedNodeSecret, err = utils.IsCertOperatorIssued(typhaNodeTLS.NodeSecret.Data[render.TLSSecretCertName])
-			if err != nil {
-				log.Error(err, "Error checking if Felix secrets are operator managed")
-				r.SetDegraded("Error checking if Felix secrets are operator managed", err, reqLogger)
-				return reconcile.Result{}, err
-			}
-			operatorManagedTyphaSecret, err = utils.IsCertOperatorIssued(typhaNodeTLS.TyphaSecret.Data[render.TLSSecretCertName])
-			if err != nil {
-				log.Error(err, "Error checking if Typha secrets are operator managed")
-				r.SetDegraded("Error checking if Typha secrets are operator managed", err, reqLogger)
-				return reconcile.Result{}, err
-			}
+
+			renderNodeAndTyphaSecrets = true
 		}
+
 	} else {
 		// Use CSR-based certificate signing.
 		typhaNodeTLS = &render.TyphaNodeTLS{
@@ -1087,11 +1076,8 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		typhaNodeTLS.CAConfigMap,
 	}
 
-	if typhaNodeTLS.NodeSecret != nil && operatorManagedNodeSecret {
-		objs = append(objs, typhaNodeTLS.NodeSecret)
-	}
-	if typhaNodeTLS.TyphaSecret != nil && operatorManagedTyphaSecret {
-		objs = append(objs, typhaNodeTLS.TyphaSecret)
+	if renderNodeAndTyphaSecrets {
+		objs = append(objs, typhaNodeTLS.NodeSecret, typhaNodeTLS.TyphaSecret)
 	}
 	if managerInternalTLSSecret != nil {
 		objs = append(objs, managerInternalTLSSecret)


### PR DESCRIPTION
## Description

This change add a new test to make sure an OwnerReference is not being added to user provided typha-certs and node-certs secrets

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
