### PR TITLE
Ensure esgateway secret provided by the user do not have ownerreferences added

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -845,6 +845,168 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(secret.GetOwnerReferences()).To(HaveLen(1))
 				})
 
+				It("test that ES gateway TLS cert secret is created if not provided and has an OwnerReference on it", func() {
+
+					resources := []client.Object{
+						&storagev1.StorageClass{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: storageClassName,
+							},
+						},
+						&operatorv1.LogStorage{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "tigera-secure",
+							},
+							Spec: operatorv1.LogStorageSpec{
+								Nodes: &operatorv1.Nodes{
+									Count: int64(1),
+								},
+								StorageClassName: storageClassName,
+							},
+						},
+						&esv1.Elasticsearch{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.ElasticsearchName,
+								Namespace: render.ElasticsearchNamespace,
+							},
+							Status: esv1.ElasticsearchStatus{
+								Phase: esv1.ElasticsearchReadyPhase,
+							},
+						},
+						&kbv1.Kibana{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.KibanaName,
+								Namespace: render.KibanaNamespace,
+							},
+							Status: kbv1.KibanaStatus{
+								AssociationStatus: cmnv1.AssociationEstablished,
+							},
+						},
+						&corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
+							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
+						},
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.ElasticsearchAdminUserSecret,
+								Namespace: render.ElasticsearchNamespace,
+							},
+							Data: map[string][]byte{
+								"elastic": []byte("password"),
+							},
+						},
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.KibanaInternalCertSecret,
+								Namespace: common.OperatorNamespace(),
+							},
+						},
+					}
+
+					for _, rec := range resources {
+						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
+					}
+
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Waiting for curator secrets to become available", "").Return()
+					result, err := r.Reconcile(ctx, reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					// Expect to be waiting for Elasticsearch and Kibana to be functional
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					secret := &corev1.Secret{}
+
+					Expect(cli.Get(ctx, esCertSecretOperKey, secret)).ShouldNot(HaveOccurred())
+					Expect(secret.GetOwnerReferences()).To(HaveLen(1))
+				})
+
+				It("should not add OwnerReference to user supplied ES gateway TLS cert", func() {
+
+					resources := []client.Object{
+						&storagev1.StorageClass{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: storageClassName,
+							},
+						},
+						&operatorv1.LogStorage{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "tigera-secure",
+							},
+							Spec: operatorv1.LogStorageSpec{
+								Nodes: &operatorv1.Nodes{
+									Count: int64(1),
+								},
+								StorageClassName: storageClassName,
+							},
+						},
+						&esv1.Elasticsearch{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.ElasticsearchName,
+								Namespace: render.ElasticsearchNamespace,
+							},
+							Status: esv1.ElasticsearchStatus{
+								Phase: esv1.ElasticsearchReadyPhase,
+							},
+						},
+						&kbv1.Kibana{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.KibanaName,
+								Namespace: render.KibanaNamespace,
+							},
+							Status: kbv1.KibanaStatus{
+								AssociationStatus: cmnv1.AssociationEstablished,
+							},
+						},
+						&corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
+							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
+						},
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.ElasticsearchAdminUserSecret,
+								Namespace: render.ElasticsearchNamespace,
+							},
+							Data: map[string][]byte{
+								"elastic": []byte("password"),
+							},
+						},
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.KibanaInternalCertSecret,
+								Namespace: common.OperatorNamespace(),
+							},
+						},
+					}
+
+					testCA := test.MakeTestCA("logstorage-test")
+					dnsNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
+					kbSecret, err := secret.CreateTLSSecret(testCA,
+						render.TigeraElasticsearchCertSecret, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey,
+						rmeta.DefaultCertificateDuration, nil, dnsNames...,
+					)
+					Expect(err).ShouldNot(HaveOccurred())
+					resources = append(resources, kbSecret)
+
+					for _, rec := range resources {
+						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
+					}
+
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					mockStatus.On("SetDegraded", "Waiting for curator secrets to become available", "").Return()
+					result, err := r.Reconcile(ctx, reconcile.Request{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(result).Should(Equal(reconcile.Result{}))
+
+					secret := &corev1.Secret{}
+
+					Expect(cli.Get(ctx, esCertSecretOperKey, secret)).ShouldNot(HaveOccurred())
+					Expect(secret.GetOwnerReferences()).To(HaveLen(0))
+				})
+
 				Context("checking rendered images", func() {
 					BeforeEach(func() {
 						mockStatus.On("ClearDegraded", mock.Anything)

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/tigera/operator/pkg/common"
 	"hash/fnv"
 	"net/url"
 	"strings"
@@ -39,6 +38,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/ptr"


### PR DESCRIPTION
## Description

This change add a new test to make sure an OwnerReference is not being added to an esgateway custom secret

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
