### PR TITLE
Read ServiceAccount name from environment

### DIFF
--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestRender(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../report/common_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/common Suite", []Reporter{junitReporter})
+}

--- a/pkg/common/operator_serviceaccount.go
+++ b/pkg/common/operator_serviceaccount.go
@@ -21,31 +21,32 @@ import (
 	"github.com/cloudflare/cfssl/log"
 )
 
-var namespace = ""
+var serviceAccount = ""
 
 func init() {
-	v, ok := os.LookupEnv("OPERATOR_NAMESPACE")
-	if ok {
-		namespace = v
-		return
-	}
-	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	if err != nil {
-		log.Errorf("Failed to read namespace file: %v", err)
-	} else {
-		namespace = string(body)
-		return
-	}
-
-	namespace = "tigera-operator"
+	serviceAccount = getServiceAccount()
 }
 
-// OperatorNamespace returns the namespace the operator is running in.
+// OperatorServiceAccount returns the ServiceAccount name the operator is running in.
 // The value returned is based on the following priority (these are evaluated at startup):
-//   If the OPERATOR_NAMESPACE environment variable is non-empty then that is return.
+//   If the OPERATOR_SERVICEACCOUNT environment variable is non-empty then that is return.
 //   If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
 //   then the contents is returned.
 //   The default "tigera-operator" is returned.
-func OperatorNamespace() string {
-	return namespace
+func OperatorServiceAccount() string {
+	return serviceAccount
+}
+
+func getServiceAccount() string {
+	v, ok := os.LookupEnv("OPERATOR_SERVICEACCOUNT")
+	if ok {
+		return v
+	}
+	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		log.Info("Failed to read serviceaccount/namespace file")
+	} else {
+		return string(body)
+	}
+	return "tigera-operator"
 }

--- a/pkg/common/operator_serviceaccount_test.go
+++ b/pkg/common/operator_serviceaccount_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Operator ServiceAccount name tests", func() {
+	It("should read service account name from the environment variable", func() {
+		Expect(os.Setenv("OPERATOR_SERVICEACCOUNT", "tigera-operator-env-var")).NotTo(HaveOccurred())
+		Expect(getServiceAccount()).To(Equal("tigera-operator-env-var"))
+		Expect(os.Unsetenv("OPERATOR_SERVICEACCOUNT")).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -672,7 +672,7 @@ func (mc *monitorComponent) roleBinding() *rbacv1.RoleBinding {
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "tigera-operator",
+				Name:      common.OperatorServiceAccount(),
 				Namespace: common.OperatorNamespace(),
 			},
 		},


### PR DESCRIPTION
## Description

Read Tigera Operator ServiceAccount name in the following order:
1. Environment variable `OPERATOR_SERVICEACCOUNT`.
2. Pod file: `/var/run/secrets/kubernetes.io/serviceaccount/namespace`.
3. Use default name `tigera-operator`.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:



- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
