### PR TITLE
Update kindest/node version to v1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ run-uts:
 
 ## Create a local kind dual stack cluster.
 KUBECONFIG?=./kubeconfig.yaml
-K8S_VERSION?=v1.18.6
+K8S_VERSION?=v1.21.2
 cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 	# First make sure any previous cluster is deleted
 	make cluster-destroy


### PR DESCRIPTION
## Description

This should solve `make ut` issues on failing to start control plane on
newer linux kernel, e.g., Ubuntu 21.10 with kernel 5.13.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
