### PR TITLE
windows: don't upgrade from Calico to Calico

### DIFF
--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1199,7 +1199,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			It("should trigger upgrade of out-of-date Calico Windows nodes", func() {
 				// Set variant to Calico and set maxUnavailable to 2.
-				cr.Spec.Variant = operator.Calico
+				cr.Spec.Variant = operator.TigeraSecureEnterprise
 				two := intstr.FromInt(2)
 				cr.Spec.NodeUpdateStrategy = appsv1.DaemonSetUpdateStrategy{
 					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
@@ -1210,10 +1210,11 @@ var _ = Describe("Testing core-controller installation", func() {
 				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				// Create two nodes that should be upgraded. The current variant
-				// is Calico and version is `components.CalicoRelease`.
+				// Create two nodes that should be upgraded to the latest Enterprise version
+				// - n1 is running Calico
+				// - n2 is running an older Enterprise version
 				n1 := test.CreateWindowsNode(cs, "windows1", operator.Calico, "v3.21.999")
-				n2 := test.CreateWindowsNode(cs, "windows2", operator.TigeraSecureEnterprise, components.ComponentTigeraWindows.Version)
+				n2 := test.CreateWindowsNode(cs, "windows2", operator.TigeraSecureEnterprise, "v3.11.999")
 
 				mockStatus.On("SetWindowsUpgradeStatus", mock.Anything, mock.Anything, mock.Anything, nil)
 

--- a/pkg/controller/installation/windows/calico_windows_upgrader.go
+++ b/pkg/controller/installation/windows/calico_windows_upgrader.go
@@ -131,6 +131,12 @@ func (w *calicoWindowsUpgrader) getNodeUpgradeStatus() (map[string]*corev1.Node,
 			return nil, nil, nil, fmt.Errorf("Node %v does not have the version annotation, it might be unhealthy or it might be running an unsupported Calico version.", node.Name)
 		}
 
+		// Don't upgrade from Calico to Calico
+		if variant == w.install.Variant && variant == operatorv1.Calico {
+			windowsLog.V(1).Info(fmt.Sprintf("Skipping upgrade of node %v from Calico to Calico", node.Name))
+			continue
+		}
+
 		if node.Labels[common.CalicoWindowsUpgradeLabel] == common.CalicoWindowsUpgradeLabelInProgress {
 			windowsLog.V(1).Info(fmt.Sprintf("Node %v has the upgrade in-progress label", node.Name))
 			inProgress[node.Name] = node


### PR DESCRIPTION
## Description

For the main upgrade use case of Calico -> Enterprise, the workflow can result in an intermediate upgrade to Calico. We can prevent that by preventing the calicoWindowsUpgrade from performing Calico -> Calico upgrades. Users wanting to upgrade from Calico -> Calico on their AKS Windows nodes would do what they currently do (upgrade their nodepool).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
