### PR TITLE
Make sure registry field and documentation match

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -32,13 +32,13 @@ type InstallationSpec struct {
 	// +kubebuilder:validation:Enum=Calico;TigeraSecureEnterprise
 	Variant ProductVariant `json:"variant,omitempty"`
 
-	// Registry is the default Docker registry used for component Docker images. If specified,
-	// all images will be pulled from this registry. If not specified then the default registries
-	// will be used. A special case value, UseDefault, is supported to explicitly specify
-	// the default registries will be used.
+	// Registry is the default Docker registry used for component Docker images.
+	// If specified then the given value must end with a slash character (`/`) and all images will be pulled from this registry.
+	// If not specified then the default registries will be used. A special case value, UseDefault, is
+	// supported to explicitly specify the default registries will be used.
 	//
 	// Image format:
-	//    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+	//    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
 	//
 	// This option allows configuring the `<registry>` portion of the above format.
 	// +optional
@@ -51,7 +51,7 @@ type InstallationSpec struct {
 	// image path will be used for each image.
 	//
 	// Image format:
-	//    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+	//    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
 	//
 	// This option allows configuring the `<imagePath>` portion of the above format.
 	// +optional
@@ -64,7 +64,7 @@ type InstallationSpec struct {
 	// image prefix will be used for each image.
 	//
 	// Image format:
-	//    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+	//    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
 	//
 	// This option allows configuring the `<imagePrefix>` portion of the above format.
 	// +optional

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -403,7 +403,7 @@ spec:
                   the image path for each image. If not specified or empty, the default
                   for each image will be used. A special case value, UseDefault, is
                   supported to explicitly specify the default image path will be used
-                  for each image. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<imagePath>` portion of the
                   above format."
                 type: string
@@ -413,7 +413,7 @@ spec:
                   a prefix on each image. If not specified or empty, no prefix will
                   be used. A special case value, UseDefault, is supported to explicitly
                   specify the default image prefix will be used for each image. \n
-                  Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<imagePrefix>` portion of
                   the above format."
                 type: string
@@ -497,10 +497,11 @@ spec:
                 type: string
               registry:
                 description: "Registry is the default Docker registry used for component
-                  Docker images. If specified, all images will be pulled from this
-                  registry. If not specified then the default registries will be used.
-                  A special case value, UseDefault, is supported to explicitly specify
-                  the default registries will be used. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  Docker images. If specified then the given value must end with a
+                  slash character (`/`) and all images will be pulled from this registry.
+                  If not specified then the default registries will be used. A special
+                  case value, UseDefault, is supported to explicitly specify the default
+                  registries will be used. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<registry>` portion of the
                   above format."
                 type: string
@@ -1110,7 +1111,7 @@ spec:
                       used as the image path for each image. If not specified or empty,
                       the default for each image will be used. A special case value,
                       UseDefault, is supported to explicitly specify the default image
-                      path will be used for each image. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      path will be used for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<imagePath>` portion
                       of the above format."
                     type: string
@@ -1120,7 +1121,7 @@ spec:
                       as a prefix on each image. If not specified or empty, no prefix
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default image prefix will be used
-                      for each image. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<imagePrefix>` portion
                       of the above format."
                     type: string
@@ -1205,11 +1206,12 @@ spec:
                     type: string
                   registry:
                     description: "Registry is the default Docker registry used for
-                      component Docker images. If specified, all images will be pulled
+                      component Docker images. If specified then the given value must
+                      end with a slash character (`/`) and all images will be pulled
                       from this registry. If not specified then the default registries
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default registries will be used. \n
-                      Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<registry>` portion of
                       the above format."
                     type: string


### PR DESCRIPTION
## Description

This change updates the docstring of the installation spec registry field and related fields to make it clear that the registry, if specified, should contain a slash at the end of its value.

Manifest file updated with `make gen-files`.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
