### PR TITLE
[release-v1.24] Auto pick #1689: Upgrade ECK image to 1.8.0

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -100,7 +100,7 @@ components:
   # quay.io/tigera so all enterprise images come from the same repository and org.
   elasticsearch-operator:
     image: tigera/eck-operator
-    version: 1.7.1
+    version: 1.8.0
   prometheus:
     image: tigera/prometheus
     version: v2.17.2

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -73,7 +73,7 @@ var (
 	}
 
 	ComponentElasticsearchOperator = component{
-		Version: "1.7.1",
+		Version: "1.8.0",
 		Image:   "tigera/eck-operator",
 	}
 


### PR DESCRIPTION
Cherry pick of #1689 on release-v1.24.

#1689: Upgrade ECK image to 1.8.0