### PR TITLE
logr.Logger.Info requires extra parameters string keys for extra parameters

### DIFF
--- a/pkg/controller/monitor/prometheus.go
+++ b/pkg/controller/monitor/prometheus.go
@@ -158,11 +158,11 @@ func waitToAddPrometheusWatch(c controller.Controller, client kubernetes.Interfa
 
 	for {
 		if err := requiresPrometheusResources(client); err != nil {
-			log.Info("%v. monitor-controller will retry.", err)
+			log.Info("%v. monitor-controller will retry.", "reason", err)
 		} else {
 			// watch for prometheus resource changes
 			if err := addWatch(c); err != nil {
-				log.Info("%v. monitor-controller will retry.", err)
+				log.Info("%v. monitor-controller will retry.", "reason", err)
 			} else {
 				readyFlag.MarkAsReady()
 				return nil


### PR DESCRIPTION
Some `logr.Logger.Info` calls are missing a required key for the parameter `err`, resulting in the following logger error:
```
{
  "level":"dpanic",
  "ts":<redacted>,
  "logger":"controller_monitor",
  "msg":"odd number of arguments passed as key-value pairs for logging",
  "ignored key":"the server could not find the requested resource",
  "stacktrace":"github.com/go-logr/zapr.handleFields\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:100\ngithub.com/go-logr/zapr.(*zapLogger).Info\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:127\ngithub.com/tigera/operator/pkg/controller/monitor.waitToAddPrometheusWatch\n\t/go/src/github.com/tigera/operator/pkg/controller/monitor/prometheus.go:161"
}
```
This change fix add a `reason` key to the `err` parameter to fix the logger error.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
