### PR TITLE
Remove authenticationreviews

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1345,16 +1345,6 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			},
 			Verbs: []string{"get", "watch", "list"},
 		},
-		// A POST to AuthenticationReviews can be compared with a POST to the TokenReviews endpoint.
-		// This api is added to circumvent a bug in the k8s-apiserver that is present in k8s
-		// versions up to v1.18 (kubernetes/pull/87612) when oidc audiences are enabled.
-		//
-		// Also include AuthorizationReviews that the UI uses to determine what features it can enable.
-		{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews", "authorizationreviews"},
-			Verbs:     []string{"create"},
-		},
 	}
 
 	// Privileges for lma.tigera.io have no effect on managed clusters.
@@ -1479,16 +1469,6 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 				"globalthreatfeeds/status",
 			},
 			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
-		},
-		// A POST to AuthenticationReviews can be compared with a POST to the TokenReviews endpoint.
-		// This api is added to circumvent a bug in the k8s-apiserver that is present in k8s
-		// versions up to v1.18 (kubernetes/pull/87612) when oidc audiences are enabled.
-		//
-		// Also include AuthorizationReviews that the UI uses to determine what features it can enable.
-		{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews", "authorizationreviews"},
-			Verbs:     []string{"create"},
 		},
 	}
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -990,11 +990,6 @@ var (
 			Verbs: []string{"get", "watch", "list"},
 		},
 		{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews", "authorizationreviews"},
-			Verbs:     []string{"create"},
-		},
-		{
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
@@ -1087,11 +1082,6 @@ var (
 				"globalthreatfeeds/status",
 			},
 			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
-		},
-		{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews", "authorizationreviews"},
-			Verbs:     []string{"create"},
 		},
 		{
 			APIGroups: []string{"lma.tigera.io"},

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -596,8 +596,8 @@ func (c *complianceComponent) complianceServerClusterRole() *rbacv1.ClusterRole 
 		// Requests on behalf of the compliance-server will be sent to Voltron, where an authentication review will take
 		// place with its bearer token.
 		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews"},
+			APIGroups: []string{"authentication.k8s.io"},
+			Resources: []string{"tokenreviews"},
 			Verbs:     []string{"create"},
 		})
 	}

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -238,8 +238,8 @@ var _ = Describe("compliance rendering tests", func() {
 					Verbs:     []string{"create"},
 				},
 				{
-					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"authenticationreviews"},
+					APIGroups: []string{"authentication.k8s.io"},
+					Resources: []string{"tokenreviews"},
 					Verbs:     []string{"create"},
 				},
 				{

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -162,15 +162,6 @@ func (c *GuardianComponent) clusterRole() client.Object {
 				Resources: []string{"users", "groups", "serviceaccounts"},
 				Verbs:     []string{"impersonate"},
 			},
-			{
-				// Guardian forwards its token when sending the request to other services
-				// PacketCapture will authenticate the token from the request and check if impersonation is allowed
-				// AuthenticationReview API can authenticate a bearer token from the request if the token can create
-				// authenticationreviews
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"authenticationreviews"},
-				Verbs:     []string{"create"},
-			},
 		},
 	}
 }

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -299,8 +299,8 @@ func (c *intrusionDetectionComponent) intrusionDetectionClusterRole() *rbacv1.Cl
 				Verbs:     []string{"watch", "list", "get"},
 			},
 			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"authenticationreviews"},
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
 				Verbs:     []string{"create"},
 			},
 		}

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -117,8 +117,8 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		}))
 
 		Expect(clusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews"},
+			APIGroups: []string{"authentication.k8s.io"},
+			Resources: []string{"tokenreviews"},
 			Verbs:     []string{"create"},
 		}))
 	})

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -351,17 +351,6 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 		},
 	}
 
-	if cfg.ManagementCluster != nil {
-		// For cross-cluster requests an authentication review will be done for authenticating the kube-controllers.
-		// Requests on behalf of the kube-controllers will be sent to Voltron, where an authentication review will
-		// take place with its bearer token.
-		rules = append(rules, rbacv1.PolicyRule{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews"},
-			Verbs:     []string{"create"},
-		})
-	}
-
 	if cfg.ManagementClusterConnection != nil {
 		rules = append(rules,
 			rbacv1.PolicyRule{

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -401,7 +401,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(20))
+		Expect(len(clusterRole.Rules)).To(Equal(19))
 	})
 
 	It("should include a ControlPlaneNodeSelector when specified", func() {

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -335,16 +335,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
 
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
-
-		// Management clusters also have a role for authenticationreviews.
-		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(19))
-		Expect(clusterRole.Rules).To(ContainElement(
-			rbacv1.PolicyRule{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"authenticationreviews"},
-				Verbs:     []string{"create"},
-			}))
 	})
 
 	It("should render all es-calico-kube-controllers resources for a default configuration using TigeraSecureEnterprise and ClusterType is Management", func() {
@@ -410,15 +400,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
-		// Management clusters also have a role for authenticationreviews.
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(len(clusterRole.Rules)).To(Equal(20))
-		Expect(clusterRole.Rules).To(ContainElement(
-			rbacv1.PolicyRule{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"authenticationreviews"},
-				Verbs:     []string{"create"},
-			}))
 	})
 
 	It("should include a ControlPlaneNodeSelector when specified", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -693,6 +693,12 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 				Verbs:     []string{"create"},
 			},
 			{
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			},
+
+			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"networksets",
@@ -767,17 +773,6 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 				Verbs:     []string{"list", "get", "watch", "update"},
 			},
 		)
-	}
-
-	if managementCluster {
-		// For cross-cluster requests an authentication review will be done for authenticating the tigera-manager.
-		// Requests on behalf of the tigera-manager will be sent to Voltron, where an authentication review will
-		// take place with its bearer token.
-		cr.Rules = append(cr.Rules, rbacv1.PolicyRule{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews"},
-			Verbs:     []string{"create"},
-		})
 	}
 
 	if !openshift {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -384,8 +384,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				Verbs:     []string{"list", "get", "watch", "update"},
 			},
 			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"authenticationreviews"},
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
 				Verbs:     []string{"create"},
 			},
 			{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -140,6 +140,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				Verbs:     []string{"create"},
 			},
 			{
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			},
+			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"networksets",

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -174,8 +174,8 @@ func (pc *packetCaptureApiComponent) clusterRole() client.Object {
 			Verbs:     []string{"create"},
 		},
 		{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"authenticationreviews"},
+			APIGroups: []string{"authentication.k8s.io"},
+			Resources: []string{"tokenreviews"},
 			Verbs:     []string{"create"},
 		},
 		{

--- a/pkg/render/packetcapture_api_test.go
+++ b/pkg/render/packetcapture_api_test.go
@@ -299,8 +299,8 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 				Verbs:     []string{"create"},
 			},
 			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"authenticationreviews"},
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
 				Verbs:     []string{"create"},
 			},
 			{


### PR DESCRIPTION
AuthenticationReviews was always meant to be temporary, due to a bug in k8s that only affected us when OIDC was used in combination with special k8s-apiserver flags. This is no longer applicable, and thus, we can remove the use of this api in favor of TokenReviews, which is native to k8s.

Sometimes we replace authentication reviews and sometimes we remove the permissions. The reason for this is:
- Authentication Reviews are always based on the bearer token present in a request from UI to a backend server. This forces us to add the permission to tigera-ui-user/tigera-network-admin.
- Whereas Token Reviews can be done on behalf of other users (When impersonation is used). In most cases Voltron impersonates a user and therefore Voltron needs TokenReviews access.

