### PR TITLE
Order the fields in dex env

### DIFF
--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -333,25 +333,16 @@ func (d *dexConfig) RequiredEnv(string) []corev1.EnvVar {
 		{Name: dexSecretEnv, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: d.dexSecret.Name}}}},
 	}
 	if d.idpSecret != nil {
-		for key := range d.idpSecret.Data {
-			switch key {
-			case ClientIDSecretField:
-				env = append(env, corev1.EnvVar{Name: clientIDEnv, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: ClientIDSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: d.idpSecret.Name}}}})
-				break
-			case ClientSecretSecretField:
-				env = append(env, corev1.EnvVar{Name: clientSecretEnv, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: d.idpSecret.Name}}}})
-				break
-			case adminEmailSecretField:
-				env = append(env, corev1.EnvVar{Name: googleAdminEmailEnv, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: adminEmailSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: d.idpSecret.Name}}}})
-				break
-			case BindDNSecretField:
-				env = append(env, corev1.EnvVar{Name: bindDNEnv, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: BindDNSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: d.idpSecret.Name}}}})
-				break
-			case BindPWSecretField:
-				env = append(env, corev1.EnvVar{Name: bindPWEnv, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: BindPWSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: d.idpSecret.Name}}}})
-				break
+		addIfPresent := func(fieldName, envName string) {
+			if _, found := d.idpSecret.Data[fieldName]; found {
+				env = append(env, corev1.EnvVar{Name: envName, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: fieldName, LocalObjectReference: corev1.LocalObjectReference{Name: d.idpSecret.Name}}}})
 			}
 		}
+		addIfPresent(ClientIDSecretField, clientIDEnv)
+		addIfPresent(ClientSecretSecretField, clientSecretEnv)
+		addIfPresent(adminEmailSecretField, googleAdminEmailEnv)
+		addIfPresent(BindDNSecretField, bindDNEnv)
+		addIfPresent(BindPWSecretField, bindPWEnv)
 	}
 
 	return env

--- a/pkg/render/dex_config_test.go
+++ b/pkg/render/dex_config_test.go
@@ -145,7 +145,7 @@ var _ = Describe("dex config tests", func() {
 		Expect(dexConfig.Issuer()).To(Equal(fmt.Sprintf("%s/dex", domain)))
 
 		Expect(dexConfig.RequiredVolumes()).To(ConsistOf(expectedVolumes))
-		Expect(dexConfig.RequiredEnv("")).To(ConsistOf(expectedEnv))
+		Expect(dexConfig.RequiredEnv("")).To(Equal(expectedEnv))
 		Expect(dexConfig.RequiredSecrets("tigera-operator")).To(ConsistOf(tlsSecret, dexSecret, secret))
 
 	},


### PR DESCRIPTION
It turns out that the idp secret's fields are not always read in the same order. This can cause the envvars in the spec of the dex deployment to change periodically/perpetually, without any actual changes.
