### PR TITLE
Improving teardown

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -73,6 +73,9 @@ type KubeControllersConfiguration struct {
 	ClusterDomain           string
 	MetricsPort             int
 
+	// For details on why this is needed see 'Node and Installation finalizer' in the core_controller.
+	Terminating bool
+
 	// Secrets - provided by the caller. Used to generate secrets in the destination
 	// namespace to be returned by the rendered. Expected that the calling code
 	// take care to pass the same secret on each reconcile where possible.
@@ -240,6 +243,11 @@ func (c *kubeControllersComponent) Objects() ([]client.Object, []client.Object) 
 		objectsToCreate = append(objectsToCreate, c.prometheusService())
 	} else {
 		objectsToDelete = append(objectsToDelete, c.prometheusService())
+	}
+
+	if c.cfg.Terminating {
+		objectsToDelete = append(objectsToDelete, objectsToCreate...)
+		objectsToCreate = nil
 	}
 
 	return objectsToCreate, objectsToDelete

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -35,6 +35,7 @@ func Namespaces(cfg *NamespaceConfiguration) Component {
 type NamespaceConfiguration struct {
 	Installation *operatorv1.InstallationSpec
 	PullSecrets  []*corev1.Secret
+	Terminating  bool
 }
 
 type namespaceComponent struct {
@@ -60,6 +61,10 @@ func (c *namespaceComponent) Objects() ([]client.Object, []client.Object) {
 	}
 	if len(c.cfg.PullSecrets) > 0 {
 		ns = append(ns, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.cfg.PullSecrets...)...)...)
+	}
+
+	if c.cfg.Terminating {
+		return nil, ns
 	}
 
 	return ns, nil

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -56,6 +56,7 @@ const (
 	BGPLayoutPath                     = "/etc/calico/early-networking.yaml"
 	K8sSvcEndpointConfigMapName       = "kubernetes-services-endpoint"
 	nodeTerminationGracePeriodSeconds = 5
+	NodeFinalizer                     = "tigera.io/cni-protector"
 )
 
 var (
@@ -90,6 +91,10 @@ type NodeConfiguration struct {
 	NodeAppArmorProfile     string
 	BirdTemplates           map[string]string
 	NodeReporterMetricsPort int
+	// Indicates node is being terminated, so remove most resources but
+	// leave RBAC and SA to allow any CNI plugin calls to continue to function
+	// For details on why this is needed see 'Node and Installation finalizer' in the core_controller.
+	Terminating bool
 
 	// BGPLayouts is returned by the rendering code after modifying its namespace
 	// so that it can be deployed into the cluster.
@@ -161,56 +166,67 @@ func (c *nodeComponent) SupportedOSType() rmeta.OSType {
 }
 
 func (c *nodeComponent) Objects() ([]client.Object, []client.Object) {
-	objsToCreate := []client.Object{
+	objs := []client.Object{
 		c.nodeServiceAccount(),
 		c.nodeRole(),
 		c.nodeRoleBinding(),
 	}
 
+	// These are objects to keep even when we're terminating
+	objsToKeep := []client.Object{}
+
+	if c.cfg.Terminating {
+		objsToKeep = objs
+		objs = []client.Object{}
+	}
+
 	if c.cfg.BGPLayouts != nil {
-		objsToCreate = append(objsToCreate, configmap.ToRuntimeObjects(configmap.CopyToNamespace(common.CalicoNamespace, c.cfg.BGPLayouts)...)...)
+		objs = append(objs, configmap.ToRuntimeObjects(configmap.CopyToNamespace(common.CalicoNamespace, c.cfg.BGPLayouts)...)...)
 	}
 
 	// Include secrets and config necessary for node and Typha to communicate. These are passed in to us as configuration,
 	// but need to be rendered into the correct namespace.
 	if c.cfg.TLS.CAConfigMap != nil {
-		objsToCreate = append(objsToCreate, configmap.ToRuntimeObjects(configmap.CopyToNamespace(common.CalicoNamespace, c.cfg.TLS.CAConfigMap)...)...)
+		objs = append(objs, configmap.ToRuntimeObjects(configmap.CopyToNamespace(common.CalicoNamespace, c.cfg.TLS.CAConfigMap)...)...)
 	}
 	if c.cfg.TLS.NodeSecret != nil {
-		objsToCreate = append(objsToCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.cfg.TLS.NodeSecret)...)...)
+		objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.cfg.TLS.NodeSecret)...)...)
 	}
-	var objsToDelete []client.Object
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		// Include Service for exposing node metrics.
-		objsToCreate = append(objsToCreate, c.nodeMetricsService())
+		objs = append(objs, c.nodeMetricsService())
 	}
 
 	cniConfig := c.nodeCNIConfigMap()
 	if cniConfig != nil {
-		objsToCreate = append(objsToCreate, cniConfig)
+		objs = append(objs, cniConfig)
 	}
 
 	if btcm := c.birdTemplateConfigMap(); btcm != nil {
-		objsToCreate = append(objsToCreate, btcm)
+		objs = append(objs, btcm)
 	}
 
 	if c.cfg.Installation.KubernetesProvider == operatorv1.ProviderDockerEE {
-		objsToCreate = append(objsToCreate, c.clusterAdminClusterRoleBinding())
+		objs = append(objs, c.clusterAdminClusterRoleBinding())
 	}
 
 	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
-		objsToCreate = append(objsToCreate, c.nodePodSecurityPolicy())
+		objs = append(objs, c.nodePodSecurityPolicy())
 	}
 
-	objsToCreate = append(objsToCreate, c.nodeDaemonset(cniConfig))
+	objs = append(objs, c.nodeDaemonset(cniConfig))
 
 	if c.cfg.Installation.CertificateManagement != nil {
-		objsToCreate = append(objsToCreate, csrClusterRole())
-		objsToCreate = append(objsToCreate, CSRClusterRoleBinding("calico-node", common.CalicoNamespace))
+		objs = append(objs, csrClusterRole())
+		objs = append(objs, CSRClusterRoleBinding("calico-node", common.CalicoNamespace))
 	}
 
-	return objsToCreate, objsToDelete
+	if c.cfg.Terminating {
+		return objsToKeep, objs
+
+	}
+	return objs, nil
 }
 
 func (c *nodeComponent) Ready() bool {
@@ -219,22 +235,33 @@ func (c *nodeComponent) Ready() bool {
 
 // nodeServiceAccount creates the node's service account.
 func (c *nodeComponent) nodeServiceAccount() *corev1.ServiceAccount {
+	finalizer := []string{}
+	if !c.cfg.Terminating {
+		finalizer = []string{NodeFinalizer}
+	}
+
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "calico-node",
-			Namespace: common.CalicoNamespace,
+			Name:       "calico-node",
+			Namespace:  common.CalicoNamespace,
+			Finalizers: finalizer,
 		},
 	}
 }
 
 // nodeRoleBinding creates a clusterrolebinding giving the node service account the required permissions to operate.
 func (c *nodeComponent) nodeRoleBinding() *rbacv1.ClusterRoleBinding {
+	finalizer := []string{}
+	if !c.cfg.Terminating {
+		finalizer = []string{NodeFinalizer}
+	}
 	crb := &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "calico-node",
-			Labels: map[string]string{},
+			Name:       "calico-node",
+			Labels:     map[string]string{},
+			Finalizers: finalizer,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -257,11 +284,16 @@ func (c *nodeComponent) nodeRoleBinding() *rbacv1.ClusterRoleBinding {
 
 // nodeRole creates the clusterrole containing policy rules that allow the node daemonset to operate normally.
 func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
+	finalizer := []string{}
+	if !c.cfg.Terminating {
+		finalizer = []string{NodeFinalizer}
+	}
 	role := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "calico-node",
-			Labels: map[string]string{},
+			Name:       "calico-node",
+			Labels:     map[string]string{},
+			Finalizers: finalizer,
 		},
 
 		Rules: []rbacv1.PolicyRule{

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -113,8 +113,11 @@ func allCalicoComponents(
 		ClusterDomain:               clusterDomain,
 		MetricsPort:                 kubeControllersMetricsPort,
 	}
+	winCfg := &render.WindowsConfig{
+		Installation: cr,
+	}
 
-	return []render.Component{namespaces, secretsAndConfigMaps, render.Typha(typhaCfg), render.Node(nodeCfg), kubecontrollers.NewCalicoKubeControllers(kcCfg), render.Windows(cr)}, nil
+	return []render.Component{namespaces, secretsAndConfigMaps, render.Typha(typhaCfg), render.Node(nodeCfg), kubecontrollers.NewCalicoKubeControllers(kcCfg), render.Windows(winCfg)}, nil
 }
 
 var _ = Describe("Rendering tests", func() {

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Mainline component function tests", func() {
 	var mgr manager.Manager
 	var shutdownContext context.Context
 	var cancel context.CancelFunc
+	var operatorDone chan struct{}
 	BeforeEach(func() {
 		c, shutdownContext, cancel, mgr = setupManager(ManageCRDsDisable)
 		verifyCRDsExist(c)
@@ -86,6 +87,21 @@ var _ = Describe("Mainline component function tests", func() {
 	})
 
 	AfterEach(func() {
+		defer func() {
+			cancel()
+			Eventually(func() error {
+				select {
+				case <-operatorDone:
+					return nil
+				default:
+					return fmt.Errorf("operator did not shutdown")
+				}
+			}, 60*time.Second).Should(BeNil())
+		}()
+		removeInstallResourceCR(c, "default", context.Background())
+
+		waitForProductTeardown(c)
+
 		// Clean up Calico data that might be left behind.
 		Eventually(func() error {
 			cs := kubernetes.NewForConfigOrDie(mgr.GetConfig())
@@ -110,49 +126,12 @@ var _ = Describe("Mainline component function tests", func() {
 			return nil
 		}, 30*time.Second).Should(BeNil())
 
-		// Validate the calico-system namespace is deleted using an unstructured type. This hits the API server
-		// directly instead of using the client cache. This should help with flaky tests.
-		Eventually(func() error {
-			u := &unstructured.Unstructured{}
-			u.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Namespace",
-			})
-
-			k := client.ObjectKey{Name: "calico-system"}
-			err := c.Get(context.Background(), k, u)
-			return err
-		}, 240*time.Second).ShouldNot(BeNil())
 		mgr = nil
 	})
 
 	Describe("Installing CRD", func() {
-		AfterEach(func() {
-			// Delete any CRD that might have been created by the test.
-			instance := &operator.Installation{
-				TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
-				ObjectMeta: metav1.ObjectMeta{Name: "default"},
-			}
-			err := c.Get(context.Background(), client.ObjectKey{Name: "default"}, instance)
-			Expect(err).NotTo(HaveOccurred())
-			err = c.Delete(context.Background(), instance)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 		It("Should install resources for a CRD", func() {
-			done := installResourceCRD(c, mgr, shutdownContext, nil)
-			defer func() {
-				cancel()
-				Eventually(func() error {
-					select {
-					case <-done:
-						return nil
-					default:
-						return fmt.Errorf("operator did not shutdown")
-					}
-				}, 60*time.Second).Should(BeNil())
-			}()
+			operatorDone = installResourceCRD(c, mgr, shutdownContext, nil)
 			verifyCalicoHasDeployed(c)
 
 			instance := &operator.Installation{
@@ -196,18 +175,7 @@ var _ = Describe("Mainline component function tests", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
 			}
 
-			done := installResourceCRD(c, mgr, shutdownContext, nil)
-			defer func() {
-				cancel()
-				Eventually(func() error {
-					select {
-					case <-done:
-						return nil
-					default:
-						return fmt.Errorf("operator did not shutdown")
-					}
-				}, 60*time.Second).Should(BeNil())
-			}()
+			operatorDone = installResourceCRD(c, mgr, shutdownContext, nil)
 			verifyCalicoHasDeployed(c)
 
 			By("Deleting CR after its tigera status becomes available")
@@ -233,13 +201,7 @@ var _ = Describe("Mainline component function tests with ignored resource", func
 		verifyCRDsExist(c)
 	})
 	AfterEach(func() {
-		instance := &operator.Installation{
-			TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
-			ObjectMeta: metav1.ObjectMeta{Name: "not-default"},
-			Spec:       operator.InstallationSpec{},
-		}
-		err := c.Delete(context.Background(), instance)
-		Expect(err).NotTo(HaveOccurred())
+		removeInstallResourceCR(c, "not-default", context.Background())
 	})
 
 	It("Should ignore a CRD resource not named 'default'", func() {
@@ -308,7 +270,8 @@ func setupManager(manageCRDs bool) (client.Client, context.Context, context.Canc
 	Expect(err).NotTo(HaveOccurred())
 	// Create a manager to use in the tests.
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace: "",
+		Namespace:          "",
+		MetricsBindAddress: "0",
 		// Upgrade notes fro v0.14.0 (https://sdk.operatorframework.io/docs/upgrading-sdk-version/version-upgrade-guide/#v014x)
 		// say to replace restmapper but the NewDynamicRestMapper did not satisfy the
 		// MapperProvider interface
@@ -348,6 +311,21 @@ func installResourceCRD(c client.Client, mgr manager.Manager, ctx context.Contex
 
 	By("Running the operator")
 	return RunOperator(mgr, ctx)
+}
+
+func removeInstallResourceCR(c client.Client, name string, ctx context.Context) {
+	// Delete any CRD that might have been created by the test.
+	instance := &operator.Installation{
+		TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	err := c.Get(ctx, client.ObjectKey{Name: name}, instance)
+	if err != nil && kerror.IsNotFound(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred())
+	err = c.Delete(ctx, instance)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func verifyCalicoHasDeployed(c client.Client) {
@@ -418,4 +396,55 @@ func verifyCRDsExist(c client.Client) {
 		}
 		return nil
 	}, 10*time.Second).Should(BeNil())
+}
+
+func waitForProductTeardown(c client.Client) {
+	// Validate the calico-system namespace is deleted using an unstructured type. This hits the API server
+	// directly instead of using the client cache. This should help with flaky tests.
+	Eventually(func() error {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Namespace",
+		})
+
+		k := client.ObjectKey{Name: "calico-system"}
+		err := c.Get(context.Background(), k, u)
+		if err == nil {
+			return fmt.Errorf("Calico namespace still exists")
+		}
+		if !kerror.IsNotFound(err) {
+			return err
+		}
+		u = &unstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "rbac.authorization.k8s.io",
+			Version: "v1",
+			Kind:    "ClusterRoleBinding",
+		})
+		k = client.ObjectKey{Name: "calico-node"}
+		err = c.Get(context.Background(), k, u)
+		if err == nil {
+			return fmt.Errorf("Node CRB still exists")
+		}
+		if !kerror.IsNotFound(err) {
+			return err
+		}
+		u = &unstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "operator.tigera.io",
+			Version: "v1",
+			Kind:    "Installation",
+		})
+		k = client.ObjectKey{Name: "default"}
+		err = c.Get(context.Background(), k, u)
+		if err == nil {
+			return fmt.Errorf("default Installation still exists")
+		}
+		if !kerror.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}, 240*time.Second).Should(BeNil())
 }


### PR DESCRIPTION
The CI tests have been flakey recently, these changes add some
finalizers to some Calico resources to ensure the CNI plugin can
function long enough to tear down kube-controllers.

There are associated test changes that adjust he FV tests to allow
operator to teardown and remove the finalizers so everything from
a test can be cleaned up correctly.

## Description

The changes add a finalizer to the Installation resource and to the Calico node ServiceAccount, ClusterRole, and ClusterRoleBinding. The finalizers allow the operator to know when the Installation resource is being torn down so then it can wait for kube-controllers to be removed before allowing the ServiceAccount, ClusterRole, and ClusterRoleBinding from being removed. This allows the CNI plugin to tear down the networking for kube-controllers which allows the pod to be removed.


A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
