### PR TITLE
Add java opts back to the pod spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/tigera/api v0.0.0-20211202170222-d8128d06db71
 	go.uber.org/zap v1.19.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.22.3
 	k8s.io/apiextensions-apiserver v0.22.3

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -25,6 +25,7 @@ import (
 	cmnv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
+	"gopkg.in/inf.v0"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta "k8s.io/api/batch/v1beta1"
@@ -488,6 +489,10 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 				"memory": resource.MustParse("4Gi"),
 			},
 		},
+		Env: []corev1.EnvVar{
+			// Set to 50% of the default memory, such that resources can be divided over ES and Lucene.
+			{Name: "ES_JAVA_OPTS", Value: "-Xms2G -Xmx2G"},
+		},
 		VolumeMounts: volumeMounts,
 	}
 
@@ -503,6 +508,15 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	if es.cfg.LogStorage.Spec.Nodes != nil && es.cfg.LogStorage.Spec.Nodes.ResourceRequirements != nil {
 		userOverrides := *es.cfg.LogStorage.Spec.Nodes.ResourceRequirements
 		esContainer.Resources = overrideResourceRequirements(esContainer.Resources, userOverrides)
+
+		// Now extract the memory request value to compute the recommended heap size for ES container
+		recommendedHeapSize := memoryQuantityToJVMHeapSize(esContainer.Resources.Requests.Memory())
+		esContainer.Env = []corev1.EnvVar{
+			{
+				Name:  "ES_JAVA_OPTS",
+				Value: fmt.Sprintf("-Xms%v -Xmx%v", recommendedHeapSize, recommendedHeapSize),
+			},
+		}
 	}
 
 	// https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
@@ -757,6 +771,72 @@ func (es elasticsearchComponent) secureSettingsSecret() *corev1.Secret {
 		},
 		Data: secureSettings,
 	}
+}
+
+// Determine the recommended JVM heap size as a string (with appropriate unit suffix) based on
+// the given resource.Quantity.
+//
+// Important note: Following Elastic ECK docs, the recommendation is to set the Java heap size
+// to half the size of RAM allocated to the Pod:
+// https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html#k8s-compute-resources-elasticsearch
+//
+// Finally limit the value to 26GiB to encourage zero-based compressed oops:
+// https://www.elastic.co/blog/a-heap-of-trouble
+func memoryQuantityToJVMHeapSize(q *resource.Quantity) string {
+	// Get the Quantity's raw number with any scale factor applied (based any unit when it was parsed)
+	// e.g.
+	// "2Gi" is parsed as a Quantity with value 2147483648, scale factor 0, and returns 2147483648
+	// "2G" is parsed as a Quantity with value 2, scale factor 9, and returns 2000000000
+	// "1000" is parsed as a Quantity with value 1000, scale factor 0, and returns 1000
+	rawMemQuantity := q.AsDec()
+
+	// Use half of that for the JVM heap.
+	divisor := inf.NewDec(2, 0)
+	halvedQuantity := new(inf.Dec).QuoRound(rawMemQuantity, divisor, 0, inf.RoundFloor)
+
+	// The remaining operations below perform validation and possible modification of the
+	// Quantity number in order to conform to Java standards for JVM arguments -Xms and -Xmx
+	// (for min and max memory limits).
+	// Source: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html
+
+	// As part of JVM requirements, ensure that the memory quantity is a multiple of 1024. Round down to
+	// the nearest multiple of 1024.
+	divisor = inf.NewDec(1024, 0)
+	factor := new(inf.Dec).QuoRound(halvedQuantity, divisor, 0, inf.RoundFloor)
+	roundedToNearest := new(inf.Dec).Mul(factor, divisor)
+
+	newRawMemQuantity := roundedToNearest.UnscaledBig().Int64()
+	// Edge case: Ensure a minimum value of at least 2 Mi (megabytes); this could plausibly happen if
+	// the user mistakenly uses the wrong format (e.g. using 1Mi instead of 1Gi)
+	minLimit := inf.NewDec(2097152, 0)
+	if roundedToNearest.Cmp(minLimit) < 0 {
+		newRawMemQuantity = minLimit.UnscaledBig().Int64()
+	}
+
+	// Limit the JVM heap to 26GiB.
+	maxLimit := inf.NewDec(27917287424, 0)
+	if roundedToNearest.Cmp(maxLimit) > 0 {
+		newRawMemQuantity = maxLimit.UnscaledBig().Int64()
+	}
+
+	// Note: Because we round to the nearest multiple of 1024 above and then use BinarySI format below,
+	// we will always get a binary unit (e.g. Ki, Mi, Gi). However, depending on what the raw number is
+	// the Quantity internal formatter might not use the most intuitive unit.
+	//
+	// E.g. For a raw number 1000000000, we explicitly round to 999999488 to get to the nearest 1024 multiple.
+	// We then create a new Quantity, which will format its value to "976562Ki".
+	// One might expect Quantity to use "Mi" instead of "Ki". However, doing so would result in rounding
+	// (which Quantity does not do).
+	//
+	// Whereas a raw number 2684354560 requires no explicit rounding from us (since it's already a
+	// multiple of 1024). Then the new Quantity will format it to "2560Mi".
+	recommendedQuantity := resource.NewQuantity(newRawMemQuantity, resource.BinarySI)
+
+	// Extract the string representation with correct unit suffix. In order to translate string to a
+	// format that JVM understands, we need to remove the trailing "i" (e.g. "2Gi" becomes "2G")
+	recommendedHeapSize := strings.TrimSuffix(recommendedQuantity.String(), "i")
+
+	return recommendedHeapSize
 }
 
 // nodeSets calculates the number of NodeSets needed for the Elasticsearch cluster. Multiple NodeSets are returned only

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -182,6 +182,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Expect(limits.Memory().String()).To(Equal("4Gi"))
 				Expect(resources.Cpu().String()).To(Equal("250m"))
 				Expect(resources.Memory().String()).To(Equal("4Gi"))
+				Expect(esContainer.Env[0].Value).To(Equal("-Xms2G -Xmx2G"))
 
 				//Check that the expected config made it's way to the Elastic CR
 				Expect(nodeSet.Config.Data).Should(Equal(map[string]interface{}{
@@ -785,8 +786,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					component := render.LogStorage(cfg)
 
 					createResources, _ := component.Objects()
-					podResource := getElasticsearch(createResources).Spec.NodeSets[0].PodTemplate.Spec.Containers[0].Resources
-					Expect(podResource).Should(Equal(res))
+					pod := getElasticsearch(createResources).Spec.NodeSets[0].PodTemplate.Spec.Containers[0]
+					Expect(pod.Resources).Should(Equal(res))
+					Expect(pod.Env[0].Value).To(Equal("-Xms1G -Xmx1G"))
 				})
 				It("sets default memory and cpu requirements in pod template", func() {
 					res := corev1.ResourceRequirements{
@@ -815,14 +817,15 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					component := render.LogStorage(cfg)
 
 					createResources, _ := component.Objects()
-					podResource := getElasticsearch(createResources).Spec.NodeSets[0].PodTemplate.Spec.Containers[0].Resources
-					Expect(podResource).Should(Equal(expectedRes))
+					pod := getElasticsearch(createResources).Spec.NodeSets[0].PodTemplate.Spec.Containers[0]
+					Expect(pod.Resources).Should(Equal(expectedRes))
+					Expect(pod.Env[0].Value).To(Equal("-Xms2G -Xmx2G"))
 				})
 				It("sets value of Limits to user's Requests when user's Limits is not set and default Limits is lesser than Requests", func() {
 					res := corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("3"),
-							"memory": resource.MustParse("2Gi"),
+							"memory": resource.MustParse("1Gi"),
 						},
 					}
 					expectedRes := corev1.ResourceRequirements{
@@ -832,7 +835,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 						Requests: corev1.ResourceList{
 							"cpu":    resource.MustParse("3"),
-							"memory": resource.MustParse("2Gi"),
+							"memory": resource.MustParse("1Gi"),
 						},
 					}
 					cfg.LogStorage.Spec.Nodes = &operatorv1.Nodes{
@@ -843,8 +846,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					component := render.LogStorage(cfg)
 
 					createResources, _ := component.Objects()
-					podResource := getElasticsearch(createResources).Spec.NodeSets[0].PodTemplate.Spec.Containers[0].Resources
-					Expect(podResource).Should(Equal(expectedRes))
+					pod := getElasticsearch(createResources).Spec.NodeSets[0].PodTemplate.Spec.Containers[0]
+					Expect(pod.Resources).Should(Equal(expectedRes))
+					Expect(pod.Env[0].Value).To(Equal("-Xms512M -Xmx512M"))
 				})
 				It("sets value of Requests to user's Limits when user's Requests is not set and default Requests is greater than Limits", func() {
 					res := corev1.ResourceRequirements{


### PR DESCRIPTION
Add JAVA_OPTS back as tt turns out that the automatic heap resolution of ES/ECK does not work as advertised.

The PR is almost verbatim the code of PR #1583 , but the resources are not one third, but half of the requested mem. This is because we no longer need to reserve memory for ML.

Further reading on the feature that did not work for us:
- https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-jvm-heap-size.html


