### PR TITLE
Don't append slash to UseDefault for Installation spec.Registry

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tigera/operator/pkg/active"
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/installation/windows"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration"
@@ -395,8 +396,8 @@ func mergeAndFillDefaults(i *operator.Installation, o *configv1.Network, kubeadm
 // fillDefaults populates the default values onto an Installation object.
 func fillDefaults(instance *operator.Installation) error {
 	// Populate the instance with defaults for any fields not provided by the user.
-	if len(instance.Spec.Registry) != 0 && !strings.HasSuffix(instance.Spec.Registry, "/") {
-		// Make sure registry always ends with a slash.
+	if len(instance.Spec.Registry) != 0 && instance.Spec.Registry != components.UseDefault && !strings.HasSuffix(instance.Spec.Registry, "/") {
+		// Make sure registry, except for the special case "UseDefault", always ends with a slash.
 		instance.Spec.Registry = fmt.Sprintf("%s/", instance.Spec.Registry)
 	}
 

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	operator "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
 )
 
@@ -277,6 +278,13 @@ var _ = Describe("Defaulting logic tests", func() {
 		err := fillDefaults(instance)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(instance.Spec.Registry).To(Equal("test-reg/"))
+		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
+
+		// But "UseDefault" should not be modified.
+		instance.Spec.Registry = components.UseDefault
+		err = fillDefaults(instance)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instance.Spec.Registry).To(Equal(components.UseDefault))
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Description

The installation API's `spec.Registry` allows us to specify the special value `UseDefault`. But our defaulting logic appends a slash to that default value. This PR fixes the defaulting so we leave `UseDefault` alone so code in the `components` package that relies on `UseDefault` works as expected.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
