### PR TITLE
Do not run calico-node on AWS EKS Fargate nodes

### DIFF
--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -176,6 +176,23 @@ var _ = Describe("core handler", func() {
 				i.Spec.KubernetesProvider = operatorv1.ProviderAKS
 				Expect(handleNodeSelectors(&comps, i)).ToNot(HaveOccurred())
 			})
+			It("shouldn't error for eks fargate affinity on eks ", func() {
+				comps.node.Spec.Template.Spec.Affinity = &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{{
+								MatchExpressions: []v1.NodeSelectorRequirement{{
+									Key:      "eks.amazonaws.com/compute-type",
+									Operator: v1.NodeSelectorOpNotIn,
+									Values:   []string{"fargate"},
+								}},
+							}},
+						},
+					},
+				}
+				i.Spec.KubernetesProvider = operatorv1.ProviderEKS
+				Expect(handleNodeSelectors(&comps, i)).ToNot(HaveOccurred())
+			})
 			It("should error for other affinities on aks", func() {
 				comps.node.Spec.Template.Spec.Affinity = &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
@@ -190,6 +207,22 @@ var _ = Describe("core handler", func() {
 					},
 				}
 				i.Spec.KubernetesProvider = operatorv1.ProviderAKS
+				Expect(handleNodeSelectors(&comps, i)).To(HaveOccurred())
+			})
+			It("should error for other affinities on eks", func() {
+				comps.node.Spec.Template.Spec.Affinity = &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{{
+								MatchExpressions: []v1.NodeSelectorRequirement{{
+									Key:      "eks.amazonaws.com/compute-type",
+									Operator: v1.NodeSelectorOpExists,
+								}},
+							}},
+						},
+					},
+				}
+				i.Spec.KubernetesProvider = operatorv1.ProviderEKS
 				Expect(handleNodeSelectors(&comps, i)).To(HaveOccurred())
 			})
 		})

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -678,6 +678,20 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 				},
 			},
 		}
+	} else if c.cfg.Installation.KubernetesProvider == operatorv1.ProviderEKS {
+		affinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+						MatchExpressions: []corev1.NodeSelectorRequirement{{
+							Key:      "eks.amazonaws.com/compute-type",
+							Operator: corev1.NodeSelectorOpNotIn,
+							Values:   []string{"fargate"},
+						}},
+					}},
+				},
+			},
+		}
 	}
 
 	// Determine the name to use for the calico/node daemonset. For mixed-mode, we run the enterprise DaemonSet


### PR DESCRIPTION
## Description

Resolves https://github.com/projectcalico/calico/issues/4731

[AWS Fargate with Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) is an amazon service that allows users to run a kubernetes cluster without any standard nodes and rather use AWS Fargate (a serverless container service provided by AWS under ECS) to run the pods. These fargate nodes can only run a single pod and have many limitations as compared to normal nodes making it impossible for calico-node pods to run on them. 

The node is tainted to prevent pods like typha and kube-controllers from running there, but Calico-node tolerates all taints. And this results in many pending calico pods that can never run on those nodes.

This PR sets a node affinity to prevent calico pods from being scheduled on these fargate nodes. The PR has been implemented very similar to https://github.com/tigera/operator/pull/1048 which does the same but for AKS's virtual nodes.

```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
      - matchExpressions:
        - key: eks.amazonaws.com/compute-type
          operator: NotIn
          values:
          - fargate
```


## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
