### PR TITLE
Add namespaces flag to eck to prevent interference

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1195,6 +1195,7 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *appsv1.StatefulSet {
 						// Verbosity level of logs. -2=Error, -1=Warn, 0=Info, 0 and above=Debug
 						Args: []string{
 							"manager",
+							"--namespaces=tigera-elasticsearch,tigera-kibana",
 							"--log-verbosity=0",
 							"--metrics-port=0",
 							"--container-registry=" + es.cfg.Installation.Registry,

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -191,6 +191,22 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"node.ingest":                 "true",
 					"cluster.max_shards_per_node": 10000,
 				}))
+				resultECK := rtest.GetResource(createResources, render.ECKOperatorName, render.ECKOperatorNamespace,
+					"apps", "v1", "StatefulSet").(*appsv1.StatefulSet)
+				Expect(resultECK.Spec.Template.Spec.Containers[0].Args).To(ConsistOf([]string{
+					"manager",
+					"--namespaces=tigera-elasticsearch,tigera-kibana",
+					"--log-verbosity=0",
+					"--metrics-port=0",
+					"--container-registry=testregistry.com/",
+					"--max-concurrent-reconciles=3",
+					"--ca-cert-validity=8760h",
+					"--ca-cert-rotate-before=24h",
+					"--cert-validity=8760h",
+					"--cert-rotate-before=24h",
+					"--enable-webhook=false",
+					"--manage-webhook-certs=false",
+				}))
 			})
 			It("should render an elasticsearchComponent and delete the Elasticsearch and Kibana ExternalService", func() {
 				expectedCreateResources := []resourceTestObj{


### PR DESCRIPTION
This flag allows clusters to have other ECK operators (if the CRDs are compatible) in their cluster to create Elasticsearch clusters. Without the flag, they would be competing for namespaces.