### PR TITLE
add extra hostpath volume for benchmarker for GKE

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -1058,6 +1058,16 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 		},
 	}
 
+	// benchmarker needs an extra host path volume mount for GKE for CIS benchmarks
+	if c.cfg.Installation.KubernetesProvider == operatorv1.ProviderGKE {
+		volMounts = append(volMounts, corev1.VolumeMount{Name: "home-kubernetes", MountPath: "/home/kubernetes", ReadOnly: true})
+
+		vols = append(vols, corev1.Volume{
+			Name:         "home-kubernetes",
+			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/home/kubernetes"}},
+		})
+	}
+
 	podTemplate := relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "compliance-benchmarker",

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -436,4 +436,60 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(csrInitContainer.Name).To(Equal(render.CSRInitContainerName))
 		})
 	})
+
+	Context("Render Benchmarker", func() {
+
+		It("should render benchmarker properly for non GKE environments", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
+			component, err := render.Compliance(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			resources, _ := component.Objects()
+
+			var dsBenchMarker = rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+			volumeMounts := dsBenchMarker.Spec.Template.Spec.Containers[0].VolumeMounts
+
+			Expect(len(volumeMounts)).To(Equal(6))
+
+			Expect(volumeMounts[0].Name).To(Equal("var-lib-etcd"))
+			Expect(volumeMounts[0].MountPath).To(Equal("/var/lib/etcd"))
+			Expect(volumeMounts[1].Name).To(Equal("var-lib-kubelet"))
+			Expect(volumeMounts[1].MountPath).To(Equal("/var/lib/kubelet"))
+			Expect(volumeMounts[2].Name).To(Equal("etc-systemd"))
+			Expect(volumeMounts[2].MountPath).To(Equal("/etc/systemd"))
+			Expect(volumeMounts[3].Name).To(Equal("etc-kubernetes"))
+			Expect(volumeMounts[3].MountPath).To(Equal("/etc/kubernetes"))
+			Expect(volumeMounts[4].Name).To(Equal("usr-bin"))
+			Expect(volumeMounts[4].MountPath).To(Equal("/usr/local/bin"))
+			Expect(volumeMounts[5].Name).To(Equal("elastic-ca-cert-volume"))
+			Expect(volumeMounts[5].MountPath).To(Equal("/etc/ssl/elastic/"))
+		})
+
+		It("should render benchmarker properly for GKE environments", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+			component, err := render.Compliance(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			resources, _ := component.Objects()
+
+			var dsBenchMarker = rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+			volumeMounts := dsBenchMarker.Spec.Template.Spec.Containers[0].VolumeMounts
+
+			Expect(len(volumeMounts)).To(Equal(7))
+
+			Expect(volumeMounts[0].Name).To(Equal("var-lib-etcd"))
+			Expect(volumeMounts[0].MountPath).To(Equal("/var/lib/etcd"))
+			Expect(volumeMounts[1].Name).To(Equal("var-lib-kubelet"))
+			Expect(volumeMounts[1].MountPath).To(Equal("/var/lib/kubelet"))
+			Expect(volumeMounts[2].Name).To(Equal("etc-systemd"))
+			Expect(volumeMounts[2].MountPath).To(Equal("/etc/systemd"))
+			Expect(volumeMounts[3].Name).To(Equal("etc-kubernetes"))
+			Expect(volumeMounts[3].MountPath).To(Equal("/etc/kubernetes"))
+			Expect(volumeMounts[4].Name).To(Equal("usr-bin"))
+			Expect(volumeMounts[4].MountPath).To(Equal("/usr/local/bin"))
+			Expect(volumeMounts[5].Name).To(Equal("home-kubernetes"))
+			Expect(volumeMounts[5].MountPath).To(Equal("/home/kubernetes"))
+			Expect(volumeMounts[6].Name).To(Equal("elastic-ca-cert-volume"))
+			Expect(volumeMounts[6].MountPath).To(Equal("/etc/ssl/elastic/"))
+		})
+	})
+
 })


### PR DESCRIPTION
## Description

Compliance benchmarker needs an additional `hostpath: "/home/kubernetes"` to pass some of the tests for GKE. This PR adds the volume to the benchmarker daemonset. 


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
