### PR TITLE
Fix that sync state could be blocked when the TigeraStatus CR doesn't exist

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -145,9 +145,13 @@ func (m *statusManager) updateStatus() {
 		return
 	}
 
-	if m.removeTigeraStatus() {
+	if m.enabled != nil && !*m.enabled {
+		// This status manager is explicitly disabled, because the controller has called OnCRNotFound.
+		// Remove any TigeraStatus object that had previously been created, and skip updating the status.
+		m.removeTigeraStatus()
 		return
 	}
+	// This status manager is enabled. Perform a sync.
 
 	// Unless we've been given an explicit degraded reason we are not ready to start reporting statuses until
 	// ReadyToMonitor has been called by the owner of the status manager. This means there's no point in syncing
@@ -581,27 +585,24 @@ func (m *statusManager) isInitialized() bool {
 	return m.enabled != nil
 }
 
-// removeTigeraStatus returns true and removes the status displayed in TigeraStatus if corresponding CR not found
-func (m *statusManager) removeTigeraStatus() bool {
+// removeTigeraStatus removes the TigeraStatus object controlled by this status manager, if it exists.
+func (m *statusManager) removeTigeraStatus() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	if !m.crExists {
 		// No CR to delete, so short-circuit.
-		return true
+		return
 	}
-	if m.enabled != nil && !*m.enabled {
-		// Status manager is explicitly disabled. Delete the TigeraStatus CR if it exists.
-		ts := &operator.TigeraStatus{ObjectMeta: metav1.ObjectMeta{Name: m.component}}
-		err := m.client.Delete(context.TODO(), ts)
-		if err != nil && !errors.IsNotFound(err) {
-			log.WithValues("reason", err).Info("Failed to remove TigeraStatus", "component", m.component)
-		} else {
-			// CR no longer exists.
-			m.crExists = false
-		}
-		return true
+
+	// Status manager is explicitly disabled. Delete the TigeraStatus CR if it exists.
+	ts := &operator.TigeraStatus{ObjectMeta: metav1.ObjectMeta{Name: m.component}}
+	err := m.client.Delete(context.TODO(), ts)
+	if err != nil && !errors.IsNotFound(err) {
+		log.WithValues("reason", err).Info("Failed to remove TigeraStatus", "component", m.component)
+	} else {
+		// CR no longer exists.
+		m.crExists = false
 	}
-	return false
 }
 
 // podsFailing takes a selector and returns if any of the pods that match it are failing. Failing pods are defined

--- a/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
@@ -62,7 +62,8 @@ spec:
                   nodes:
                     description: The nodes that are aggregated into a single layer.
                     items:
-                      description: UIGraphNode contains details about a graph node.
+                      description: UIGraphNode contains details about a graph node
+                        so that the UI can render it correctly.
                       properties:
                         id:
                           description: The node ID.
@@ -93,112 +94,10 @@ spec:
                     description: Whether ports are expanded. If false, port information
                       is aggregated.
                     type: boolean
-                  expanded:
-                    description: The set of nodes that are expanded to the next level
-                      of expansion.
-                    items:
-                      description: UIGraphNode contains details about a graph node.
-                      properties:
-                        id:
-                          description: The node ID.
-                          type: string
-                        name:
-                          description: The node name.
-                          type: string
-                        namespace:
-                          description: The node namespace.
-                          type: string
-                        type:
-                          description: The node type.
-                          type: string
-                      required:
-                      - id
-                      - name
-                      - type
-                      type: object
-                    type: array
-                  focus:
-                    description: The set of nodes that are the focus of the graph.
-                      All nodes returned by the graph query will be connected to at
-                      least one of these nodes. If this is empty, then all nodes will
-                      be returned.
-                    items:
-                      description: UIGraphNode contains details about a graph node.
-                      properties:
-                        id:
-                          description: The node ID.
-                          type: string
-                        name:
-                          description: The node name.
-                          type: string
-                        namespace:
-                          description: The node namespace.
-                          type: string
-                        type:
-                          description: The node type.
-                          type: string
-                      required:
-                      - id
-                      - name
-                      - type
-                      type: object
-                    type: array
                   followConnectionDirection:
                     description: Whether or not to automatically follow directly connected
                       nodes.
                     type: boolean
-                  followedEgress:
-                    description: Followed nodes. These are nodes on the periphery
-                      of the graph that we follow further out of the scope of the
-                      graph focus. For example a Node N may have egress connections
-                      to X and Y, but neither X nor Y are displayed in the graph because
-                      they are not explicitly in focus. The service graph response
-                      will indicate that Node N has egress connections that may be
-                      followed.  If Node N is added to this "FollowedEgress" then
-                      the response will include the egress connections to X and Y.
-                    items:
-                      description: UIGraphNode contains details about a graph node.
-                      properties:
-                        id:
-                          description: The node ID.
-                          type: string
-                        name:
-                          description: The node name.
-                          type: string
-                        namespace:
-                          description: The node namespace.
-                          type: string
-                        type:
-                          description: The node type.
-                          type: string
-                      required:
-                      - id
-                      - name
-                      - type
-                      type: object
-                    type: array
-                  followedIngress:
-                    items:
-                      description: UIGraphNode contains details about a graph node.
-                      properties:
-                        id:
-                          description: The node ID.
-                          type: string
-                        name:
-                          description: The node name.
-                          type: string
-                        namespace:
-                          description: The node namespace.
-                          type: string
-                        type:
-                          description: The node type.
-                          type: string
-                      required:
-                      - id
-                      - name
-                      - type
-                      type: object
-                    type: array
                   hostAggregationSelectors:
                     description: The set of selectors used to aggregate hosts (Kubernetes
                       nodes). Nodes are aggregated based on the supplied set of selectors.
@@ -220,8 +119,10 @@ spec:
                       type: object
                     type: array
                   layers:
-                    description: The set of layer names. This references other UISettings
-                      resources.
+                    description: The set of layer names that are active in this view.  Note
+                      that layers may be defined, but it is not necessary to have
+                      each layer "active". Corresponds directly to the name of the
+                      UISettings resource that contains a layer definition.
                     items:
                       type: string
                     type: array
@@ -231,6 +132,63 @@ spec:
                       layout algorithms, or click-to-grid.  Mostly here for future
                       use.
                     type: string
+                  nodes:
+                    description: Graph node specific view data. This provides information
+                      about what is in focus, expanded, hidden, deemphasized etc.
+                      at a per-node level.
+                    items:
+                      description: UIGraphNodeView contains the view configuration
+                        for a specific graph node.
+                      properties:
+                        deemphasize:
+                          description: Whether the UI should de-emphasize the node
+                            when visible. This is just a UI directive and does not
+                            correspond to a backend parameter.
+                          type: boolean
+                        expanded:
+                          description: This node is expanded to the next level.  This
+                            node can, for example, be a layer that is expanded into
+                            its constituent parts.
+                          type: boolean
+                        followEgress:
+                          type: boolean
+                        followIngress:
+                          description: Whether the ingress/egress connections to/from
+                            this node are included in the graph.  This effectively
+                            brings more nodes into focus.
+                          type: boolean
+                        hide:
+                          description: Whether the UI should hide the node. This is
+                            just a UI directive and does not correspond to a backend
+                            parameter.
+                          type: boolean
+                        hideUnrelated:
+                          description: Whether the UI should hide unrelated nodes.
+                            This is just a UI directive and does not correspond to
+                            a backend parameter.
+                          type: boolean
+                        id:
+                          description: The node ID.
+                          type: string
+                        inFocus:
+                          description: This node is a primary focus of the graph (i.e.
+                            the graph contains this node and connected nodes).
+                          type: boolean
+                        name:
+                          description: The node name.
+                          type: string
+                        namespace:
+                          description: The node namespace.
+                          type: string
+                        type:
+                          description: The node type.
+                          type: string
+                      required:
+                      - id
+                      - name
+                      - type
+                      type: object
+                    type: array
                   positions:
                     description: Positions of graph nodes.
                     items:
@@ -260,11 +218,6 @@ spec:
                     type: boolean
                 required:
                 - expandPorts
-                - followConnectionDirection
-                - layers
-                - layoutType
-                - positions
-                - splitIngressEgress
                 type: object
             required:
             - description


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The problem here was that `removeTigeraStatus` used to gate execution of `updateStatus` if it returned `true`.

We had added code which short-circuited and returned true if `!m.crExists`, which was always hit at start of day. The `removeTigeraStatus` function itself was pretty convoluted and shouldn't have been the function deciding whether we should update the status or not anyway.

I believe the intention of the true / false return was that `updateStatus` should NOT be called if the status manager is explicitly, administratively disabled (`m.enabled != nil && !*m.enabled`). However, the short-circuit branch bypassed the enabled check and always indicated that the SM was disabled.

This PR simplifies `removeTigeraStatus` (all it does now is actually remove the tigera status) and moves the check for whether or not we should execute `updateStatus` outside of that function so that the logic is more clear. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.