### PR TITLE
Fix manifest migration of IptablesBackend

### DIFF
--- a/pkg/controller/migration/convert/felix_vars.go
+++ b/pkg/controller/migration/convert/felix_vars.go
@@ -59,6 +59,12 @@ func handleFelixVars(c *components) error {
 			return err
 		}
 
+		// FelixConfig's default for IptablesBackend is auto and the FelixConfig does not support
+		// auto as a value so nothing to do with this case.
+		if env.Name == "FELIX_IPTABLESBACKEND" && strings.ToLower(*fval) == "auto" {
+			continue
+		}
+
 		// downcase and remove FELIX_ prefix
 		key := strings.ToLower(strings.TrimPrefix(env.Name, "FELIX_"))
 		pp, err := patchFromVal(key, *fval)


### PR DESCRIPTION
## Description

The FelixConfiguration resource field IptablesBackend does not support Auto as a valid value but the environment variable field does. Migration from a manifest install was taking the Auto from the environment variable and setting the FelixConfiguration.IptablesBackend. This PR skips setting anything if the value is Auto. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
