### PR TITLE
Secure prometheus metrics endpoints

### DIFF
--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -471,7 +471,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentTigeraNode.Image,
 					components.ComponentTigeraNode.Version)))
-			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(3))
+			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(4))
 			fv := test.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver")
 			Expect(fv).ToNot(BeNil())
 			Expect(fv.Image).To(Equal(
@@ -487,6 +487,12 @@ var _ = Describe("Testing core-controller installation", func() {
 			csrinit = test.GetContainer(ds.Spec.Template.Spec.InitContainers, render.CSRInitContainerName)
 			Expect(csrinit).ToNot(BeNil())
 			Expect(csrinit.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s:%s",
+					components.ComponentCSRInitContainer.Image,
+					components.ComponentCSRInitContainer.Version)))
+			csrinit2 := test.GetContainer(ds.Spec.Template.Spec.InitContainers, fmt.Sprintf("%s-%s", render.CalicoNodeMetricsService, render.CSRInitContainerName))
+			Expect(csrinit2).ToNot(BeNil())
+			Expect(csrinit2.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentCSRInitContainer.Image,
 					components.ComponentCSRInitContainer.Version)))
@@ -564,7 +570,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentTigeraNode.Image,
 					"sha256:tigeracnxnodehash")))
-			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(3))
+			Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(4))
 			fv := test.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver")
 			Expect(fv).ToNot(BeNil())
 			Expect(fv.Image).To(Equal(
@@ -580,6 +586,12 @@ var _ = Describe("Testing core-controller installation", func() {
 			csrinit = test.GetContainer(ds.Spec.Template.Spec.InitContainers, render.CSRInitContainerName)
 			Expect(csrinit).ToNot(BeNil())
 			Expect(csrinit.Image).To(Equal(
+				fmt.Sprintf("some.registry.org/%s@%s",
+					components.ComponentCSRInitContainer.Image,
+					"sha256:calicocsrinithash")))
+			csrinit2 := test.GetContainer(ds.Spec.Template.Spec.InitContainers, fmt.Sprintf("%s-%s", render.CalicoNodeMetricsService, render.CSRInitContainerName))
+			Expect(csrinit2).ToNot(BeNil())
+			Expect(csrinit2.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentCSRInitContainer.Image,
 					"sha256:calicocsrinithash")))

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/library-go/pkg/crypto"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,6 +45,9 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	rsecret "github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/url"
 )
 
@@ -119,7 +124,8 @@ func add(mgr manager.Manager, c controller.Controller) error {
 	for _, secretName := range []string{
 		render.ElasticsearchLogCollectorUserSecret, render.ElasticsearchEksLogForwarderUserSecret,
 		relasticsearch.PublicCertSecret, render.S3FluentdSecretName, render.EksLogForwarderSecret,
-		render.SplunkFluentdTokenSecretName, render.SplunkFluentdCertificateSecretName} {
+		render.SplunkFluentdTokenSecretName, render.SplunkFluentdCertificateSecretName, monitor.PrometheusTLSSecretName,
+		render.FluentdPrometheusTLSSecretName} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("log-collector-controller failed to watch the Secret resource(%s): %v", secretName, err)
 		}
@@ -310,6 +316,57 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
+	var fluentdPrometheusTLS *corev1.Secret
+	trustedBundle, err := utils.GetPrometheusCertificateBundle(ctx, r.client, render.LogCollectorNamespace, installation.CertificateManagement)
+	if err != nil {
+		log.Error(err, "Unable to create a metrics certificate bundle")
+		r.status.SetDegraded("Unable to create a metrics certificate bundle", err.Error())
+		return reconcile.Result{}, err
+	}
+	if installation.CertificateManagement == nil {
+		fluentdPrometheusTLS, err = utils.ValidateCertPair(r.client,
+			common.OperatorNamespace(),
+			render.FluentdPrometheusTLSSecretName,
+			corev1.TLSPrivateKeyKey,
+			corev1.TLSCertKey,
+		)
+		if err != nil {
+			log.Error(err, "Invalid TLS Cert")
+			r.status.SetDegraded("Error validating TLS certificate", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		if fluentdPrometheusTLS == nil {
+			fluentdPrometheusTLS, err = rsecret.CreateTLSSecret(nil,
+				render.FluentdPrometheusTLSSecretName,
+				common.OperatorNamespace(),
+				corev1.TLSPrivateKeyKey,
+				corev1.TLSCertKey,
+				rmeta.DefaultCertificateDuration,
+				[]crypto.CertificateExtensionFunc{tls.SetServerAuth},
+				render.FluentdPrometheusTLSSecretName,
+			)
+			if err != nil {
+				log.Error(err, "Error creating TLS certificate")
+				r.status.SetDegraded("Error creating TLS certificate", err.Error())
+				return reconcile.Result{}, err
+			}
+		}
+		prometheusTLS, err := utils.GetSecret(ctx, r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
+		if prometheusTLS == nil {
+			log.Info("Prometheus secrets are not available yet, waiting until they become available")
+			r.status.SetDegraded("Prometheus secrets are not available yet, waiting until they become available", "")
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		} else if err != nil {
+			r.status.SetDegraded("Failed to get Prometheus credentials", err.Error())
+			return reconcile.Result{}, err
+		}
+		r.status.RemoveCertificateSigningRequests(common.TigeraPrometheusNamespace)
+	} else {
+		// Monitor pending CSRs for the TigeraStatus
+		r.status.AddCertificateSigningRequests(render.LogCollectorNamespace, map[string]string{"k8s-app": render.LogCollectorNamespace})
+	}
+
 	var exportLogs = utils.IsFeatureActive(license, common.ExportLogsFeature)
 	if !exportLogs && instance.Spec.AdditionalStores != nil {
 		r.status.SetDegraded("Feature is not active", "License does not support feature: export-logs")
@@ -431,9 +488,22 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		Installation:    installation,
 		ClusterDomain:   r.clusterDomain,
 		OSType:          rmeta.OSTypeLinux,
+		TLS:             fluentdPrometheusTLS,
+		TrustedBundle:   trustedBundle,
 	}
 	// Render the fluentd component for Linux
 	component := render.Fluentd(fluentdCfg)
+	components := []render.Component{component}
+	if fluentdPrometheusTLS != nil {
+		oprIssued, err := utils.IsCertOperatorIssued(fluentdPrometheusTLS.Data[corev1.TLSCertKey])
+		if err != nil {
+			reqLogger.Error(err, "failed checking certificate issuer")
+			r.status.SetDegraded("failed checking certificate issuer", err.Error())
+		}
+		if oprIssued {
+			components = append(components, render.NewPassthrough(fluentdPrometheusTLS))
+		}
+	}
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
 		reqLogger.Error(err, "Error with images from ImageSet")
@@ -441,9 +511,11 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
-		r.status.SetDegraded("Error creating / updating resource", err.Error())
-		return reconcile.Result{}, err
+	for _, comp := range components {
+		if err := handler.CreateOrUpdateOrDelete(ctx, comp, r.status); err != nil {
+			r.status.SetDegraded("Error creating / updating resource", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Render a fluentd component for Windows if the cluster has Windows nodes.

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -318,7 +318,11 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 
 	var fluentdPrometheusTLS *corev1.Secret
 	trustedBundle, err := utils.GetPrometheusCertificateBundle(ctx, r.client, render.LogCollectorNamespace, installation.CertificateManagement)
-	if err != nil {
+	if trustedBundle == nil {
+		r.status.SetDegraded("Waiting for the prometheus client secret to become available", "")
+		err = fmt.Errorf("waiting for the prometheus client secret to become available")
+		return reconcile.Result{}, nil
+	} else if err != nil {
 		log.Error(err, "Unable to create a metrics certificate bundle")
 		r.status.SetDegraded("Unable to create a metrics certificate bundle", err.Error())
 		return reconcile.Result{}, err

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -20,18 +20,20 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/mock"
-	"github.com/tigera/operator/pkg/common"
-	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/test"
 
+	"github.com/stretchr/testify/mock"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/test"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -72,6 +74,7 @@ var _ = Describe("LogCollector controller tests", func() {
 			mockStatus.On("AddDeployments", mock.Anything).Return()
 			mockStatus.On("AddStatefulSets", mock.Anything).Return()
 			mockStatus.On("AddCronJobs", mock.Anything)
+			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
 			mockStatus.On("IsAvailable").Return(true)
 			mockStatus.On("OnCRFound").Return()
 			mockStatus.On("ClearDegraded")
@@ -127,6 +130,7 @@ var _ = Describe("LogCollector controller tests", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      render.ElasticsearchEksLogForwarderUserSecret,
 					Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, rtest.CreateCertSecret(monitor.PrometheusClientTLSSecretName, common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 			// Apply the logcollector CR to the fake cluster.
 			Expect(c.Create(ctx, &operatorv1.LogCollector{

--- a/pkg/controller/logstorage/esmetrics.go
+++ b/pkg/controller/logstorage/esmetrics.go
@@ -8,13 +8,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openshift/library-go/pkg/crypto"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	rsecret "github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
+	"github.com/tigera/operator/pkg/tls"
 )
 
 func (r *ReconcileLogStorage) createEsMetrics(
@@ -25,6 +31,7 @@ func (r *ReconcileLogStorage) createEsMetrics(
 	clusterConfig *relasticsearch.ClusterConfig,
 	ctx context.Context,
 	hdler utils.ComponentHandler,
+	clusterDomain string,
 ) (reconcile.Result, bool, error) {
 	esMetricsSecret, err := utils.GetSecret(context.Background(), r.client, esmetrics.ElasticsearchMetricsSecret, common.OperatorNamespace())
 	if err != nil {
@@ -46,6 +53,45 @@ func (r *ReconcileLogStorage) createEsMetrics(
 		return reconcile.Result{}, false, nil
 	}
 
+	trustedBundle, err := utils.GetPrometheusCertificateBundle(ctx, r.client, render.ElasticsearchNamespace, install.CertificateManagement)
+	if err != nil {
+		log.Error(err, "Unable to create a metrics certificate bundle")
+		r.status.SetDegraded("Unable to create a metrics certificate bundle", err.Error())
+		return reconcile.Result{}, false, err
+	}
+	var serverTLS *corev1.Secret
+	if install.CertificateManagement == nil {
+		serverTLS, err = utils.ValidateCertPair(r.client,
+			common.OperatorNamespace(),
+			esmetrics.ElasticsearchMetricsServerTLSSecret,
+			corev1.TLSPrivateKeyKey,
+			corev1.TLSCertKey,
+		)
+		if err != nil {
+			log.Error(err, "Invalid TLS Cert")
+			r.status.SetDegraded("Error validating TLS certificate", err.Error())
+			return reconcile.Result{}, false, err
+		}
+
+		if serverTLS == nil {
+			dnsNames := dns.GetServiceDNSNames(esmetrics.ElasticsearchMetricsName, render.ElasticsearchNamespace, clusterDomain)
+			serverTLS, err = rsecret.CreateTLSSecret(nil,
+				esmetrics.ElasticsearchMetricsServerTLSSecret,
+				common.OperatorNamespace(),
+				corev1.TLSPrivateKeyKey,
+				corev1.TLSCertKey,
+				rmeta.DefaultCertificateDuration,
+				[]crypto.CertificateExtensionFunc{tls.SetServerAuth},
+				dnsNames...,
+			)
+			if err != nil {
+				log.Error(err, "Error creating TLS certificate")
+				r.status.SetDegraded("Error creating TLS certificate", err.Error())
+				return reconcile.Result{}, false, err
+			}
+		}
+	}
+
 	esMetricsCfg := &esmetrics.Config{
 		Installation:         install,
 		PullSecrets:          pullSecrets,
@@ -53,18 +99,34 @@ func (r *ReconcileLogStorage) createEsMetrics(
 		ESMetricsCredsSecret: esMetricsSecret,
 		ESCertSecret:         publicCertSecretESCopy,
 		ClusterDomain:        r.clusterDomain,
+		ServerTLS:            serverTLS,
+		TrustedBundle:        trustedBundle,
 	}
 	esMetricsComponent := esmetrics.ElasticsearchMetrics(esMetricsCfg)
+	components := []render.Component{esMetricsComponent}
+	if serverTLS != nil {
+		oprIssued, err := utils.IsCertOperatorIssued(serverTLS.Data[corev1.TLSCertKey])
+		if err != nil {
+			reqLogger.Error(err, "Error checking certificate issuer")
+			r.status.SetDegraded("Error checking certificate issuer", err.Error())
+		}
+		if oprIssued {
+			components = append(components, render.NewPassthrough(serverTLS))
+		}
+	}
+
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, esMetricsComponent); err != nil {
 		reqLogger.Error(err, "Error with images from ImageSet")
 		r.status.SetDegraded("Error with images from ImageSet", err.Error())
 		return reconcile.Result{}, false, err
 	}
 
-	if err := hdler.CreateOrUpdateOrDelete(ctx, esMetricsComponent, r.status); err != nil {
-		reqLogger.Error(err, err.Error())
-		r.status.SetDegraded("Error creating / updating resource", err.Error())
-		return reconcile.Result{}, false, err
+	for _, comp := range components {
+		if err := hdler.CreateOrUpdateOrDelete(ctx, comp, r.status); err != nil {
+			reqLogger.Error(err, err.Error())
+			r.status.SetDegraded("Error creating / updating resource", err.Error())
+			return reconcile.Result{}, false, err
+		}
 	}
 
 	return reconcile.Result{}, true, nil

--- a/pkg/controller/logstorage/esmetrics.go
+++ b/pkg/controller/logstorage/esmetrics.go
@@ -54,7 +54,11 @@ func (r *ReconcileLogStorage) createEsMetrics(
 	}
 
 	trustedBundle, err := utils.GetPrometheusCertificateBundle(ctx, r.client, render.ElasticsearchNamespace, install.CertificateManagement)
-	if err != nil {
+	if trustedBundle == nil {
+		r.status.SetDegraded("Waiting for the prometheus client secret to become available", "")
+		err = fmt.Errorf("waiting for the prometheus client secret to become available")
+		return reconcile.Result{}, false, nil
+	} else if err != nil {
 		log.Error(err, "Unable to create a metrics certificate bundle")
 		r.status.SetDegraded("Unable to create a metrics certificate bundle", err.Error())
 		return reconcile.Result{}, false, err

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -17,6 +17,7 @@ package logstorage
 import (
 	"context"
 	"fmt"
+	"github.com/tigera/operator/pkg/render/monitor"
 	"reflect"
 
 	. "github.com/onsi/ginkgo"
@@ -116,6 +117,10 @@ var _ = Describe("LogStorage controller", func() {
 
 		ctx = context.Background()
 		cli = fake.NewFakeClientWithScheme(scheme)
+		Expect(cli.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: common.OperatorNamespace(), Name: monitor.PrometheusClientTLSSecretName},
+			Data:       map[string][]byte{corev1.TLSCertKey: []byte("cert")},
+		})).ShouldNot(HaveOccurred())
 	})
 	Context("Reconcile", func() {
 		Context("Check default logstorage settings", func() {

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -19,17 +19,17 @@ import (
 	_ "embed"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
-	"github.com/tigera/operator/pkg/dns"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/openshift/library-go/pkg/crypto"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -46,9 +46,13 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rsecret "github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls"
 )
 
 var log = logf.Log.WithName("controller_monitor")
@@ -115,7 +119,18 @@ func add(mgr manager.Manager, c controller.Controller) error {
 		return fmt.Errorf("monitor-controller failed to watch ImageSet: %w", err)
 	}
 
-	if err = utils.AddSecretsWatch(c, monitor.PrometheusTLSSecretName, common.OperatorNamespace()); err != nil {
+	for _, secret := range []string{
+		monitor.PrometheusTLSSecretName,
+		render.FluentdPrometheusTLSSecretName,
+		render.NodePrometheusTLSServerSecret,
+		esmetrics.ElasticsearchMetricsServerTLSSecret,
+		render.FluentdPrometheusTLSSecretName} {
+		if err = utils.AddSecretsWatch(c, secret, common.OperatorNamespace()); err != nil {
+			return fmt.Errorf("monitor-controller failed to watch secret: %w", err)
+		}
+	}
+
+	if err = utils.AddConfigMapWatch(c, render.TyphaCAConfigMapName, common.OperatorNamespace()); err != nil {
 		return fmt.Errorf("monitor-controller failed to watch secret: %w", err)
 	}
 
@@ -200,12 +215,20 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 			return reconcile.Result{}, err
 		}
 	}
-
-	var tlsSecret *corev1.Secret
+	certBundle, err := getCertificateBundle(ctx, r.client, install.CertificateManagement)
+	if err != nil {
+		log.Error(err, "Unable to create a certificate bundle")
+		r.status.SetDegraded("Unable to create a certificate bundle", err.Error())
+		return reconcile.Result{}, err
+	}
+	var serverTLSSecret *corev1.Secret
+	var clientTLSSecret *corev1.Secret
+	operatorManagedServerTLSSecret := true
+	operatorManagedClientTLSSecret := true
 	if install.CertificateManagement == nil {
 		// Check that if the apiserver cert pair secret exists that it is valid (has key and cert fields)
 		// If it does not exist then this function still returns true
-		tlsSecret, err = utils.ValidateCertPair(r.client,
+		serverTLSSecret, err = utils.ValidateCertPair(r.client,
 			common.OperatorNamespace(),
 			monitor.PrometheusTLSSecretName,
 			corev1.TLSPrivateKeyKey,
@@ -216,17 +239,35 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 			r.status.SetDegraded("Error validating TLS certificate", err.Error())
 			return reconcile.Result{}, err
 		}
+		serverTLSSecret, operatorManagedServerTLSSecret, err = utils.EnsureCertificateSecret(
+			monitor.PrometheusTLSSecretName, serverTLSSecret, corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration,
+			dns.GetServiceDNSNames(monitor.PrometheusHTTPAPIServiceName, common.TigeraPrometheusNamespace, r.clusterDomain)...)
+		if err != nil {
+			r.status.SetDegraded(fmt.Sprintf("Error ensuring prometheus server TLS certificate %q exists and has valid DNS names", render.PrometheusTLSSecretName), err.Error())
+			return reconcile.Result{}, err
+		}
 
-		if tlsSecret == nil {
-			svcDNSNames := dns.GetServiceDNSNames(monitor.PrometheusHTTPAPIServiceName, common.TigeraPrometheusNamespace, r.clusterDomain)
-			tlsSecret, err = rsecret.CreateTLSSecret(nil,
-				monitor.PrometheusTLSSecretName,
+		clientTLSSecret, err = utils.ValidateCertPair(r.client,
+			common.OperatorNamespace(),
+			monitor.PrometheusClientTLSSecretName,
+			corev1.TLSPrivateKeyKey,
+			corev1.TLSCertKey,
+		)
+		if err != nil {
+			log.Error(err, "Invalid TLS Cert")
+			r.status.SetDegraded("Error validating TLS certificate", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		if clientTLSSecret == nil {
+			clientTLSSecret, err = rsecret.CreateTLSSecret(nil,
+				monitor.PrometheusClientTLSSecretName,
 				common.OperatorNamespace(),
 				corev1.TLSPrivateKeyKey,
 				corev1.TLSCertKey,
 				rmeta.DefaultCertificateDuration,
-				nil,
-				svcDNSNames...,
+				[]crypto.CertificateExtensionFunc{tls.SetClientAuth},
+				monitor.PrometheusClientTLSSecretName,
 			)
 			if err != nil {
 				log.Error(err, "Error creating TLS certificate")
@@ -235,10 +276,19 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 			}
 		}
 
+		operatorManagedClientTLSSecret, err = utils.IsCertOperatorIssued(clientTLSSecret.Data[corev1.TLSCertKey])
+		if err != nil {
+			log.Error(err, "Invalid TLS Cert")
+			r.status.SetDegraded("Error validating TLS certificate", err.Error())
+			return reconcile.Result{}, err
+		}
+
 		r.status.RemoveCertificateSigningRequests(common.TigeraPrometheusNamespace)
 	} else {
 		// Monitor pending CSRs for the TigeraStatus
 		r.status.AddCertificateSigningRequests(common.TigeraPrometheusNamespace, map[string]string{"k8s-app": common.TigeraPrometheusNamespace})
+		serverTLSSecret = render.CreateCertificateSecret(install.CertificateManagement.CACert, render.PrometheusTLSSecretName, common.OperatorNamespace())
+		clientTLSSecret = render.CreateCertificateSecret(install.CertificateManagement.CACert, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
 	}
 
 	// Fetch the Authentication spec. If present, we use to configure user authentication.
@@ -273,15 +323,24 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		PullSecrets:              pullSecrets,
 		AlertmanagerConfigSecret: alertmanagerConfigSecret,
 		KeyValidatorConfig:       keyValidatorConfig,
-		TLSSecret:                tlsSecret,
+		ServerTLSSecret:          serverTLSSecret,
+		ClientTLSSecret:          clientTLSSecret,
 		ClusterDomain:            r.clusterDomain,
+		TrustedCertBundle:        certBundle,
 	}
 
 	// Render prometheus component
 	components := []render.Component{
 		monitor.Monitor(monitorCfg),
-		render.NewPassthrough(tlsSecret),
 	}
+
+	if operatorManagedServerTLSSecret {
+		components = append(components, render.NewPassthrough(serverTLSSecret))
+	}
+	if operatorManagedClientTLSSecret {
+		components = append(components, render.NewPassthrough(clientTLSSecret))
+	}
+
 	if createInOperatorNamespace {
 		components = append(components, render.NewPassthrough(alertmanagerConfigSecret))
 	}
@@ -315,6 +374,45 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// getCertificateBundle creates a configmap with a bundle for mTLS with other components.
+func getCertificateBundle(ctx context.Context, cli client.Client, cm *operatorv1.CertificateManagement) (*corev1.ConfigMap, error) {
+	pem := strings.Builder{}
+	addPem := func(secretName string) error {
+		secret := &corev1.Secret{}
+		err := cli.Get(ctx, types.NamespacedName{Name: secretName, Namespace: common.OperatorNamespace()}, secret)
+		if errors.IsNotFound(err) {
+			if cm == nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		} else {
+			pem.WriteString(fmt.Sprintf("\n\n# %v\n", secretName))
+			pem.Write(secret.Data[corev1.TLSCertKey])
+		}
+		return err
+	}
+
+	for _, secret := range []string{render.NodePrometheusTLSServerSecret, render.FluentdPrometheusTLSSecretName, esmetrics.ElasticsearchMetricsServerTLSSecret} {
+		addPem(secret)
+	}
+	if cm != nil {
+		pem.WriteString("\n\n# Certificate management CA cert\n")
+		pem.Write(cm.CACert)
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.PrometheusCABundle,
+			Namespace: common.TigeraPrometheusNamespace,
+		},
+		Data: map[string]string{
+			corev1.ServiceAccountRootCAKey: pem.String(),
+		},
+	}, nil
 }
 
 //go:embed alertmanager-config.yaml

--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -111,7 +111,6 @@ var _ = Describe("Monitor controller tests", func() {
 		var (
 			am = &monitoringv1.Alertmanager{}
 			p  = &monitoringv1.Prometheus{}
-			pm = &monitoringv1.PodMonitor{}
 			pr = &monitoringv1.PrometheusRule{}
 			sm = &monitoringv1.ServiceMonitor{}
 		)
@@ -120,10 +119,10 @@ var _ = Describe("Monitor controller tests", func() {
 			// Prometheus related objects should not exist.
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeAlertmanager, Namespace: common.TigeraPrometheusNamespace}, am)).To(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodePrometheus, Namespace: common.TigeraPrometheusNamespace}, p)).To(HaveOccurred())
-			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}, pm)).To(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.TigeraPrometheusDPRate, Namespace: common.TigeraPrometheusNamespace}, pr)).To(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeMonitor, Namespace: common.TigeraPrometheusNamespace}, sm)).To(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.ElasticsearchMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).To(HaveOccurred())
+			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).To(HaveOccurred())
 		})
 
 		It("should create Prometheus related resources", func() {
@@ -133,10 +132,10 @@ var _ = Describe("Monitor controller tests", func() {
 			// Prometheus related objects should be rendered after reconciliation.
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeAlertmanager, Namespace: common.TigeraPrometheusNamespace}, am)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodePrometheus, Namespace: common.TigeraPrometheusNamespace}, p)).NotTo(HaveOccurred())
-			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}, pm)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.TigeraPrometheusDPRate, Namespace: common.TigeraPrometheusNamespace}, pr)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeMonitor, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.ElasticsearchMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
+			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
 		})
 	})
 

--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/monitor"
 )
 
@@ -100,6 +101,7 @@ var _ = Describe("Monitor controller tests", func() {
 			TypeMeta:   metav1.TypeMeta{Kind: "Monitor", APIVersion: "operator.tigera.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
 		})).NotTo(HaveOccurred())
+		Expect(cli.Create(ctx, render.CreateCertificateConfigMap("test", render.TyphaCAConfigMapName, common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 		// Mark that the watch for prometheus resources was successful
 		r.prometheusReady.MarkAsReady()

--- a/pkg/controller/monitor/prometheus.go
+++ b/pkg/controller/monitor/prometheus.go
@@ -74,6 +74,13 @@ func addServiceMonitorElasticsearchWatch(c controller.Controller) error {
 	})
 }
 
+func addServiceMonitorFluentdWatch(c controller.Controller) error {
+	return utils.AddNamespacedWatch(c, &monitoringv1.ServiceMonitor{
+		TypeMeta:   metav1.TypeMeta{Kind: monitoringv1.ServiceMonitorsKind, APIVersion: monitor.MonitoringAPIVersion},
+		ObjectMeta: metav1.ObjectMeta{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace},
+	})
+}
+
 func addWatch(c controller.Controller) error {
 	var err error
 	if err = addAlertmanagerWatch(c); err != nil {
@@ -96,8 +103,8 @@ func addWatch(c controller.Controller) error {
 		return fmt.Errorf("failed to watch ServiceMonitor elasticsearch-metrics resource: %w", err)
 	}
 
-	if err = addPodMonitorWatch(c); err != nil {
-		return fmt.Errorf("failed to watch PodMonitor resource: %w", err)
+	if err = addServiceMonitorFluentdWatch(c); err != nil {
+		return fmt.Errorf("failed to watch ServiceMonitor fluentd-metrics resource: %w", err)
 	}
 
 	if err = utils.AddSecretsWatch(c, monitor.AlertmanagerConfigSecret, common.OperatorNamespace()); err != nil {

--- a/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
@@ -86,6 +86,11 @@ spec:
                 required:
                 - nodes
                 type: object
+              user:
+                description: The user associated with these settings. This is filled
+                  in by the APIServer on a create request if the owning group is filtered
+                  by user. Cannot be modified.
+                type: string
               view:
                 description: View data. One of View, Layer or Dashboard should be
                   specified.

--- a/pkg/crds/enterprise/crd.projectcalico.org_uisettingsgroups.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_uisettingsgroups.yaml
@@ -52,6 +52,21 @@ spec:
                   and groups that can access the   storefront set of applications
                   - "user" if these settings are accessible to only a single user'
                 type: string
+              filterType:
+                description: The type of filter to use when listing and watching the
+                  UISettings associated with this group. If set to None a List/watch
+                  of UISettings in this group will return all UISettings. If set to
+                  User a list/watch of UISettings in this group will return only UISettings
+                  created by the user making the request. For settings groups that
+                  are specific to users and where multiple users may access the settings
+                  in this group we recommend setting this to "User" to avoid cluttering
+                  up the UI with settings for other users. Note this is only a filter.
+                  Full lockdown of UISettings for specific users should be handled
+                  using appropriate RBAC.
+                enum:
+                - None
+                - User
+                type: string
             required:
             - description
             type: object

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1037,7 +1037,7 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 	volumes = append(volumes,
 		corev1.Volume{
 			Name:         ProjectCalicoApiServerTLSSecretName(c.cfg.Installation.Variant),
-			VolumeSource: certificateVolumeSource(c.cfg.Installation.CertificateManagement, ProjectCalicoApiServerTLSSecretName(c.cfg.Installation.Variant)),
+			VolumeSource: CertificateVolumeSource(c.cfg.Installation.CertificateManagement, ProjectCalicoApiServerTLSSecretName(c.cfg.Installation.Variant)),
 		},
 	)
 

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -788,7 +788,7 @@ func (c *complianceComponent) complianceServerVolumeMounts() []corev1.VolumeMoun
 func (c *complianceComponent) complianceServerVolumes() []corev1.Volume {
 	defaultMode := int32(420)
 
-	serverVolumeSource := certificateVolumeSource(c.cfg.Installation.CertificateManagement, ComplianceServerCertSecret)
+	serverVolumeSource := CertificateVolumeSource(c.cfg.Installation.CertificateManagement, ComplianceServerCertSecret)
 	if c.cfg.Installation.CertificateManagement == nil {
 		serverVolumeSource.Secret.Items = []corev1.KeyToPath{
 			{

--- a/pkg/render/crypto_utils.go
+++ b/pkg/render/crypto_utils.go
@@ -153,3 +153,17 @@ func CreateCertificateSecret(caPem []byte, secretName string, namespace string) 
 		},
 	}
 }
+
+// CreateCertificateConfigMap is a convenience method for creating a configmap that contains only a ca or cert to trust.
+func CreateCertificateConfigMap(caPem string, secretName string, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			corev1.TLSCertKey: caPem,
+		},
+	}
+}

--- a/pkg/render/csr.go
+++ b/pkg/render/csr.go
@@ -142,7 +142,7 @@ func CSRClusterRoleBinding(name, namespace string) *rbacv1.ClusterRoleBinding {
 	return crb
 }
 
-func certificateVolumeSource(certificateManagement *operatorv1.CertificateManagement, secretName string) corev1.VolumeSource {
+func CertificateVolumeSource(certificateManagement *operatorv1.CertificateManagement, secretName string) corev1.VolumeSource {
 	var defaultMode int32 = 420
 	if certificateManagement != nil {
 		return corev1.VolumeSource{

--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -350,7 +350,7 @@ func (d *dexConfig) RequiredEnv(string) []corev1.EnvVar {
 
 func (d *dexConfig) RequiredVolumes() []corev1.Volume {
 
-	tlsVolumeSource := certificateVolumeSource(d.certificateManagement, DexTLSSecretName)
+	tlsVolumeSource := CertificateVolumeSource(d.certificateManagement, DexTLSSecretName)
 	defaultMode := int32(420)
 	volumes := []corev1.Volume{
 		{

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
@@ -166,6 +167,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "fluentd-node-windows", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
 			{name: render.PacketCaptureAPIRoleBinding, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
@@ -269,6 +271,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "log-collector-s3-credentials", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -336,6 +339,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-fluentd", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
@@ -432,6 +436,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "logcollector-splunk-credentials", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
 			{name: "logcollector-splunk-public-certificate", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -518,6 +523,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "logcollector-splunk-credentials", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -591,6 +597,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "fluentd-filters", ns: "tigera-fluentd", group: "", version: "v1", kind: "ConfigMap"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -631,6 +638,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "eks-log-forwarder", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "eks-log-forwarder", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "eks-log-forwarder", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -110,6 +110,7 @@ func (e *elasticsearchMetrics) Objects() (objsToCreate, objsToDelete []client.Ob
 
 func (e elasticsearchMetrics) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ElasticsearchMetricsName,
 			Namespace: render.ElasticsearchNamespace,
@@ -127,6 +128,7 @@ func (e *elasticsearchMetrics) SupportedOSType() rmeta.OSType {
 
 func (e *elasticsearchMetrics) metricsService() *corev1.Service {
 	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ElasticsearchMetricsName,
 			Namespace: render.ElasticsearchNamespace,
@@ -215,7 +217,7 @@ func (e elasticsearchMetrics) metricsDeployment() *appsv1.Deployment {
 										ReadOnly:  true,
 									},
 									{
-										Name:      e.cfg.TrustedBundle.Name,
+										Name:      render.PrometheusCABundle,
 										MountPath: "/ca",
 										ReadOnly:  true,
 									},
@@ -230,10 +232,10 @@ func (e elasticsearchMetrics) metricsDeployment() *appsv1.Deployment {
 							VolumeSource: render.CertificateVolumeSource(e.cfg.Installation.CertificateManagement, ElasticsearchMetricsServerTLSSecret),
 						},
 						{
-							Name: e.cfg.TrustedBundle.Name,
+							Name: render.PrometheusCABundle,
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{Name: e.cfg.TrustedBundle.Name},
+									LocalObjectReference: corev1.LocalObjectReference{Name: render.PrometheusCABundle},
 								},
 							},
 						},

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -15,6 +15,10 @@
 package esmetrics
 
 import (
+	"fmt"
+	"github.com/tigera/operator/pkg/dns"
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +35,9 @@ import (
 )
 
 const (
-	ElasticsearchMetricsSecret = "tigera-ee-elasticsearch-metrics-elasticsearch-access"
+	ElasticsearchMetricsSecret          = "tigera-ee-elasticsearch-metrics-elasticsearch-access"
+	ElasticsearchMetricsServerTLSSecret = "tigera-ee-elasticsearch-metrics-tls"
+	ElasticsearchMetricsName            = "tigera-elasticsearch-metrics"
 )
 
 func ElasticsearchMetrics(cfg *Config) render.Component {
@@ -47,11 +53,14 @@ type Config struct {
 	ESMetricsCredsSecret *corev1.Secret
 	ESCertSecret         *corev1.Secret
 	ClusterDomain        string
+	ServerTLS            *corev1.Secret
+	TrustedBundle        *corev1.ConfigMap
 }
 
 type elasticsearchMetrics struct {
 	cfg            *Config
 	esMetricsImage string
+	csrImage       string
 }
 
 func (e *elasticsearchMetrics) ResolveImages(is *operatorv1.ImageSet) error {
@@ -61,7 +70,23 @@ func (e *elasticsearchMetrics) ResolveImages(is *operatorv1.ImageSet) error {
 	path := e.cfg.Installation.ImagePath
 	prefix := e.cfg.Installation.ImagePrefix
 
+	var errMsgs []string
+
 	e.esMetricsImage, err = components.GetReference(components.ComponentElasticsearchMetrics, reg, path, prefix, is)
+	if err != nil {
+		errMsgs = append(errMsgs, err.Error())
+	}
+
+	if e.cfg.Installation.CertificateManagement != nil {
+		e.csrImage, err = render.ResolveCSRInitImage(e.cfg.Installation, is)
+		if err != nil {
+			errMsgs = append(errMsgs, err.Error())
+		}
+	}
+
+	if len(errMsgs) != 0 {
+		return fmt.Errorf(strings.Join(errMsgs, ","))
+	}
 
 	return err
 }
@@ -70,9 +95,26 @@ func (e *elasticsearchMetrics) Objects() (objsToCreate, objsToDelete []client.Ob
 	toCreate := secret.ToRuntimeObjects(
 		secret.CopyToNamespace(render.ElasticsearchNamespace, e.cfg.ESMetricsCredsSecret)...,
 	)
-	toCreate = append(toCreate, e.metricsService(), e.metricsDeployment())
+	toCreate = append(toCreate, e.metricsService(), e.metricsDeployment(), e.cfg.TrustedBundle, e.serviceAccount())
 
-	return toCreate, nil
+	if e.cfg.Installation.CertificateManagement == nil {
+		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(render.ElasticsearchNamespace, e.cfg.ServerTLS)...)...)
+		objsToDelete = append(objsToDelete, render.CSRClusterRoleBinding(ElasticsearchMetricsName, render.ElasticsearchNamespace))
+	} else {
+		objsToDelete = append(objsToDelete, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: ElasticsearchMetricsServerTLSSecret, Namespace: render.ElasticsearchNamespace}})
+		toCreate = append(toCreate, render.CSRClusterRoleBinding(ElasticsearchMetricsName, render.ElasticsearchNamespace))
+	}
+
+	return toCreate, objsToDelete
+}
+
+func (e elasticsearchMetrics) serviceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ElasticsearchMetricsName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+	}
 }
 
 func (e *elasticsearchMetrics) Ready() bool {
@@ -86,15 +128,15 @@ func (e *elasticsearchMetrics) SupportedOSType() rmeta.OSType {
 func (e *elasticsearchMetrics) metricsService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-elasticsearch-metrics",
+			Name:      ElasticsearchMetricsName,
 			Namespace: render.ElasticsearchNamespace,
 			Labels: map[string]string{
-				"k8s-app": "tigera-elasticsearch-metrics",
+				"k8s-app": ElasticsearchMetricsName,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"k8s-app": "tigera-elasticsearch-metrics",
+				"k8s-app": ElasticsearchMetricsName,
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -109,42 +151,92 @@ func (e *elasticsearchMetrics) metricsService() *corev1.Service {
 }
 
 func (e elasticsearchMetrics) metricsDeployment() *appsv1.Deployment {
+	var initContainers []corev1.Container
+
+	annotations := map[string]string{
+		"k8s-app":                           ElasticsearchMetricsName,
+		render.PrometheusCABundleAnnotation: rmeta.AnnotationHash(e.cfg.TrustedBundle.Data),
+	}
+	if e.cfg.Installation.CertificateManagement != nil {
+		initContainers = append(initContainers,
+			render.CreateCSRInitContainer(
+				e.cfg.Installation.CertificateManagement,
+				e.csrImage,
+				ElasticsearchMetricsServerTLSSecret,
+				ElasticsearchMetricsServerTLSSecret,
+				corev1.TLSPrivateKeyKey,
+				corev1.TLSCertKey,
+				dns.GetServiceDNSNames(ElasticsearchMetricsName, render.ElasticsearchNamespace, e.cfg.ClusterDomain),
+				render.ElasticsearchNamespace),
+		)
+	}
+
+	if e.cfg.ServerTLS != nil {
+		annotations[fmt.Sprintf("hash.operator.tigera.io/%s", e.cfg.ServerTLS.Name)] = rmeta.AnnotationHash(e.cfg.ServerTLS.Data)
+	}
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-elasticsearch-metrics",
+			Name:      ElasticsearchMetricsName,
 			Namespace: render.ElasticsearchNamespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr.Int32ToPtr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"k8s-app": "tigera-elasticsearch-metrics",
+					"k8s-app": ElasticsearchMetricsName,
 				},
 			},
 			Template: *relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"k8s-app": "tigera-elasticsearch-metrics",
-					},
+					Labels: annotations,
 				},
 				Spec: relasticsearch.PodSpecDecorate(corev1.PodSpec{
-					Tolerations:      e.cfg.Installation.ControlPlaneTolerations,
-					NodeSelector:     e.cfg.Installation.ControlPlaneNodeSelector,
-					ImagePullSecrets: secret.GetReferenceList(e.cfg.PullSecrets),
+					Tolerations:        e.cfg.Installation.ControlPlaneTolerations,
+					NodeSelector:       e.cfg.Installation.ControlPlaneNodeSelector,
+					ImagePullSecrets:   secret.GetReferenceList(e.cfg.PullSecrets),
+					ServiceAccountName: ElasticsearchMetricsName,
+					InitContainers:     initContainers,
 					Containers: []corev1.Container{
 						relasticsearch.ContainerDecorate(
 							corev1.Container{
-								Name:    "tigera-elasticsearch-metrics",
+								Name:    ElasticsearchMetricsName,
 								Image:   e.esMetricsImage,
 								Command: []string{"/bin/elasticsearch_exporter"},
 								Args: []string{"--es.uri=https://$(ELASTIC_USERNAME):$(ELASTIC_PASSWORD)@$(ELASTIC_HOST):$(ELASTIC_PORT)",
 									"--es.all", "--es.indices", "--es.indices_settings", "--es.shards", "--es.cluster_settings",
 									"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
-									"--web.telemetry-path=/metrics"},
+									"--web.telemetry-path=/metrics", "--tls.key=/tls/tls.key", "--tls.crt=/tls/tls.crt", "--ca.crt=/ca/tls.crt"},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      ElasticsearchMetricsServerTLSSecret,
+										MountPath: "/tls",
+										ReadOnly:  true,
+									},
+									{
+										Name:      e.cfg.TrustedBundle.Name,
+										MountPath: "/ca",
+										ReadOnly:  true,
+									},
+								},
 							}, render.DefaultElasticsearchClusterName, ElasticsearchMetricsSecret,
 							e.cfg.ClusterDomain, e.SupportedOSType(),
 						),
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name:         ElasticsearchMetricsServerTLSSecret,
+							VolumeSource: render.CertificateVolumeSource(e.cfg.Installation.CertificateManagement, ElasticsearchMetricsServerTLSSecret),
+						},
+						{
+							Name: e.cfg.TrustedBundle.Name,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: e.cfg.TrustedBundle.Name},
+								},
+							},
+						},
 					},
 				}),
 			}, e.cfg.ESConfig, []*corev1.Secret{e.cfg.ESMetricsCredsSecret, e.cfg.ESCertSecret}).(*corev1.PodTemplateSpec),

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -19,17 +19,15 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/tigera/operator/pkg/ptr"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _ = Describe("Elasticsearch metrics", func() {
@@ -46,136 +44,28 @@ var _ = Describe("Elasticsearch metrics", func() {
 			esConfig = relasticsearch.NewClusterConfig("cluster", 1, 1, 1)
 
 			cfg = &Config{
-				Installation:         installation,
-				PullSecrets:          []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "pullsecret", Namespace: render.ElasticsearchNamespace}}},
-				ESConfig:             esConfig,
-				ESMetricsCredsSecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-				ESCertSecret:         &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-				ClusterDomain:        "cluster.local",
+				Installation: installation,
+				PullSecrets:  []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "pullsecret", Namespace: render.ElasticsearchNamespace}}},
+				ESConfig:     esConfig,
+				ESMetricsCredsSecret: &corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
+				ESCertSecret: &corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
+				ClusterDomain: "cluster.local",
+				ServerTLS: &corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: ElasticsearchMetricsServerTLSSecret, Namespace: common.OperatorNamespace()}},
+				TrustedBundle: &corev1.ConfigMap{
+					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: render.PrometheusCABundle, Namespace: render.ElasticsearchNamespace}},
 			}
 		})
 
 		It("Successfully renders the Elasticsearch metrics resources", func() {
-			expectedResources := []client.Object{
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.TigeraElasticsearchCertSecret,
-						Namespace: render.ElasticsearchNamespace,
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tigera-elasticsearch-metrics",
-						Namespace: render.ElasticsearchNamespace,
-						Labels:    map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
-					},
-					Spec: corev1.ServiceSpec{
-						Selector: map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "metrics-port",
-								Port:       9081,
-								Protocol:   corev1.ProtocolTCP,
-								TargetPort: intstr.FromInt(9081),
-							},
-						},
-					},
-				},
-				&appsv1.Deployment{
-					TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tigera-elasticsearch-metrics",
-						Namespace: render.ElasticsearchNamespace,
-					},
-					Spec: appsv1.DeploymentSpec{
-						Replicas: ptr.Int32ToPtr(1),
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{"k8s-app": "tigera-elasticsearch-metrics"},
-								Annotations: map[string]string{
-									"hash.operator.tigera.io/elasticsearch-configmap": "ae0242f242af19c4916434cb08e8f68f8c15f61d",
-									"hash.operator.tigera.io/elasticsearch-secrets":   "9718549725e37ca6a5f12ba2405392a04d7b5521",
-								},
-							},
-							Spec: corev1.PodSpec{
-								ImagePullSecrets: []corev1.LocalObjectReference{{Name: "pullsecret"}},
-								Containers: []corev1.Container{{
-									Name:    "tigera-elasticsearch-metrics",
-									Image:   "testregistry.com/tigera/elasticsearch-metrics@testdigest",
-									Command: []string{"/bin/elasticsearch_exporter"},
-									Args: []string{"--es.uri=https://$(ELASTIC_USERNAME):$(ELASTIC_PASSWORD)@$(ELASTIC_HOST):$(ELASTIC_PORT)",
-										"--es.all", "--es.indices", "--es.indices_settings", "--es.shards", "--es.cluster_settings",
-										"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
-										"--web.telemetry-path=/metrics"},
-									Env: []corev1.EnvVar{
-										{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
-										{Name: "ELASTIC_SCHEME", Value: "https"},
-										{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
-										{Name: "ELASTIC_PORT", Value: "9200"},
-										{Name: "ELASTIC_ACCESS_MODE", Value: "serviceuser"},
-										{Name: "ELASTIC_SSL_VERIFY", Value: "true"},
-										{
-											Name: "ELASTIC_USER",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{
-													LocalObjectReference: corev1.LocalObjectReference{
-														Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
-													},
-													Key: "username",
-												},
-											},
-										},
-										{
-											Name: "ELASTIC_USERNAME",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{
-													LocalObjectReference: corev1.LocalObjectReference{
-														Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
-													},
-													Key: "username",
-												},
-											},
-										},
-										{
-											Name: "ELASTIC_PASSWORD",
-											ValueFrom: &corev1.EnvVarSource{
-												SecretKeyRef: &corev1.SecretKeySelector{
-													LocalObjectReference: corev1.LocalObjectReference{
-														Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
-													},
-													Key: "password",
-												},
-											},
-										},
-										{Name: "ELASTIC_CA", Value: "/etc/ssl/elastic/ca.pem"},
-										{Name: "ES_CA_CERT", Value: "/etc/ssl/elastic/ca.pem"},
-										{Name: "ES_CURATOR_BACKEND_CERT", Value: "/etc/ssl/elastic/ca.pem"},
-									},
-									VolumeMounts: []corev1.VolumeMount{
-										{Name: "elastic-ca-cert-volume", MountPath: "/etc/ssl/elastic/"},
-									},
-								}},
-
-								Volumes: []corev1.Volume{{
-									Name: "elastic-ca-cert-volume",
-									VolumeSource: corev1.VolumeSource{
-										Secret: &corev1.SecretVolumeSource{
-											SecretName: "tigera-secure-es-gateway-http-certs-public",
-											Items:      []corev1.KeyToPath{{Key: "tls.crt", Path: "ca.pem"}},
-										},
-									},
-								}},
-							},
-						},
-					},
-				},
-			}
 
 			component := ElasticsearchMetrics(cfg)
-
 			Expect(component.ResolveImages(&operatorv1.ImageSet{
 				Spec: operatorv1.ImageSetSpec{
 					Images: []operatorv1.Image{{
@@ -184,9 +74,177 @@ var _ = Describe("Elasticsearch metrics", func() {
 					}},
 				},
 			})).ShouldNot(HaveOccurred())
+			resources, _ := component.Objects()
 
-			createdResources, _ := component.Objects()
-			Expect(createdResources).Should(Equal(expectedResources))
+			expectedResources := []struct {
+				name    string
+				ns      string
+				group   string
+				version string
+				kind    string
+			}{
+				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, "", "v1", "Secret"},
+				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "", "v1", "Service"},
+				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "apps", "v1", "Deployment"},
+				{render.PrometheusCABundle, render.ElasticsearchNamespace, "", "v1", "ConfigMap"},
+				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "", "v1", "ServiceAccount"},
+				{ElasticsearchMetricsServerTLSSecret, render.ElasticsearchNamespace, "", "v1", "Secret"},
+			}
+			Expect(len(resources)).To(Equal(len(expectedResources)))
+			for i, expectedRes := range expectedResources {
+				rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+			}
+			deploy := rtest.GetResource(resources, ElasticsearchMetricsName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			service := rtest.GetResource(resources, ElasticsearchMetricsName, render.ElasticsearchNamespace, "", "v1", "Service").(*corev1.Service)
+			configMap := rtest.GetResource(resources, render.PrometheusCABundle, render.ElasticsearchNamespace, "", "v1", "ConfigMap").(*corev1.ConfigMap)
+			secret := rtest.GetResource(resources, ElasticsearchMetricsServerTLSSecret, render.ElasticsearchNamespace, "", "v1", "Secret").(*corev1.Secret)
+
+			expectedService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ElasticsearchMetricsName,
+					Namespace: render.ElasticsearchNamespace,
+					Labels:    map[string]string{"k8s-app": ElasticsearchMetricsName},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"k8s-app": ElasticsearchMetricsName},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "metrics-port",
+							Port:       9081,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(9081),
+						},
+					},
+				},
+			}
+			expectedDeploy := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ElasticsearchMetricsName,
+					Namespace: render.ElasticsearchNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.Int32ToPtr(1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"k8s-app": ElasticsearchMetricsName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"k8s-app": ElasticsearchMetricsName},
+							Annotations: map[string]string{
+								"hash.operator.tigera.io/elasticsearch-configmap": "ae0242f242af19c4916434cb08e8f68f8c15f61d",
+								"hash.operator.tigera.io/elasticsearch-secrets":   "9718549725e37ca6a5f12ba2405392a04d7b5521",
+							},
+						},
+						Spec: corev1.PodSpec{
+							ImagePullSecrets: []corev1.LocalObjectReference{{Name: "pullsecret"}},
+							Containers: []corev1.Container{{
+								Name:    ElasticsearchMetricsName,
+								Image:   "testregistry.com/tigera/elasticsearch-metrics@testdigest",
+								Command: []string{"/bin/elasticsearch_exporter"},
+								Args: []string{"--es.uri=https://$(ELASTIC_USERNAME):$(ELASTIC_PASSWORD)@$(ELASTIC_HOST):$(ELASTIC_PORT)",
+									"--es.all", "--es.indices", "--es.indices_settings", "--es.shards", "--es.cluster_settings",
+									"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
+									"--web.telemetry-path=/metrics", "--tls.key=/tls/tls.key", "--tls.crt=/tls/tls.crt", "--ca.crt=/ca/tls.crt"},
+								Env: []corev1.EnvVar{
+									{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
+									{Name: "ELASTIC_SCHEME", Value: "https"},
+									{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
+									{Name: "ELASTIC_PORT", Value: "9200"},
+									{Name: "ELASTIC_ACCESS_MODE", Value: "serviceuser"},
+									{Name: "ELASTIC_SSL_VERIFY", Value: "true"},
+									{
+										Name: "ELASTIC_USER",
+										ValueFrom: &corev1.EnvVarSource{
+											SecretKeyRef: &corev1.SecretKeySelector{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
+												},
+												Key: "username",
+											},
+										},
+									},
+									{
+										Name: "ELASTIC_USERNAME",
+										ValueFrom: &corev1.EnvVarSource{
+											SecretKeyRef: &corev1.SecretKeySelector{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
+												},
+												Key: "username",
+											},
+										},
+									},
+									{
+										Name: "ELASTIC_PASSWORD",
+										ValueFrom: &corev1.EnvVarSource{
+											SecretKeyRef: &corev1.SecretKeySelector{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "tigera-ee-elasticsearch-metrics-elasticsearch-access",
+												},
+												Key: "password",
+											},
+										},
+									},
+									{Name: "ELASTIC_CA", Value: "/etc/ssl/elastic/ca.pem"},
+									{Name: "ES_CA_CERT", Value: "/etc/ssl/elastic/ca.pem"},
+									{Name: "ES_CURATOR_BACKEND_CERT", Value: "/etc/ssl/elastic/ca.pem"},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      ElasticsearchMetricsServerTLSSecret,
+										MountPath: "/tls",
+										ReadOnly:  true,
+									},
+									{
+										Name:      render.PrometheusCABundle,
+										MountPath: "/ca",
+										ReadOnly:  true,
+									},
+									{Name: "elastic-ca-cert-volume", MountPath: "/etc/ssl/elastic/"},
+								},
+							}},
+							ServiceAccountName: ElasticsearchMetricsName,
+							Volumes: []corev1.Volume{
+								{
+									Name: ElasticsearchMetricsServerTLSSecret,
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{SecretName: ElasticsearchMetricsServerTLSSecret, DefaultMode: ptr.Int32ToPtr(420)}},
+								},
+								{
+									Name: render.PrometheusCABundle,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: render.PrometheusCABundle},
+										},
+									},
+								},
+								{
+									Name: "elastic-ca-cert-volume",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "tigera-secure-es-gateway-http-certs-public",
+											Items:      []corev1.KeyToPath{{Key: "tls.crt", Path: "ca.pem"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			expectedConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: render.PrometheusCABundle, Namespace: render.ElasticsearchNamespace}}
+			expectedSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: ElasticsearchMetricsServerTLSSecret, Namespace: render.ElasticsearchNamespace}}
+
+			Expect(service.Spec).To(Equal(expectedService.Spec))
+			Expect(configMap.Data).To(Equal(expectedConfigMap.Data))
+			Expect(secret.Data).To(Equal(expectedSecret.Data))
+			Expect(deploy.Annotations).To(Equal(expectedDeploy.Annotations))
+			Expect(deploy.Spec.Template.Spec.Volumes).To(Equal(expectedDeploy.Spec.Template.Spec.Volumes))
+			Expect(deploy.Spec.Template.Spec.Containers[0].VolumeMounts).To(Equal(expectedDeploy.Spec.Template.Spec.Containers[0].VolumeMounts))
+			Expect(deploy.Spec.Template.Spec.Containers[0].Args).To(Equal(expectedDeploy.Spec.Template.Spec.Containers[0].Args))
+			Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(Equal(expectedDeploy.Spec.Template.Spec.Containers[0].Env))
+			Expect(deploy.Spec.Template.Spec.Containers[0].Command).To(Equal(expectedDeploy.Spec.Template.Spec.Containers[0].Command))
 		})
 
 		It("should apply controlPlaneNodeSelector correctly", func() {
@@ -195,7 +253,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 			component := ElasticsearchMetrics(cfg)
 
 			resources, _ := component.Objects()
-			d, ok := rtest.GetResource(resources, "tigera-elasticsearch-metrics", render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			d, ok := rtest.GetResource(resources, ElasticsearchMetricsName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue())
 			Expect(d.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 		})
@@ -211,7 +269,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 			component := ElasticsearchMetrics(cfg)
 
 			resources, _ := component.Objects()
-			d, ok := rtest.GetResource(resources, "tigera-elasticsearch-metrics", render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			d, ok := rtest.GetResource(resources, ElasticsearchMetricsName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue())
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
 		})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -353,7 +353,7 @@ func (c *managerComponent) managerVolumes() []corev1.Volume {
 	if c.cfg.Installation.CertificateManagement != nil {
 		certificateManagement = c.cfg.Installation.CertificateManagement
 	}
-	tlsVolumeSource := certificateVolumeSource(certificateManagement, ManagerTLSSecretName)
+	tlsVolumeSource := CertificateVolumeSource(certificateManagement, ManagerTLSSecretName)
 	v := []corev1.Volume{
 		{
 			Name:         ManagerTLSSecretName,

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -654,6 +654,9 @@ func (mc *monitorComponent) serviceMonitorElasticsearch() *monitoringv1.ServiceM
 	}
 }
 
+// serviceMonitorFluentd creates a service monitor to make Prometheus watch Fluentd. Previously, a pod monitor was used.
+// However, the pod monitor does not have all the tls configuration options that we need, namely reading them from the
+// file system, as opposed to getting them from watching kubernetes secrets.
 func (mc *monitorComponent) serviceMonitorFluentd() *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{
 		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.ServiceMonitorsKind, APIVersion: MonitoringAPIVersion},

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -38,11 +38,11 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 )
 
 const (
-	MonitoringAPIVersion = "monitoring.coreos.com/v1"
-
+	MonitoringAPIVersion        = "monitoring.coreos.com/v1"
 	CalicoNodeAlertmanager      = "calico-node-alertmanager"
 	CalicoNodeMonitor           = "calico-node-monitor"
 	CalicoNodePrometheus        = "calico-node-prometheus"
@@ -58,6 +58,7 @@ const (
 	PrometheusDefaultPort           = 9090
 	PrometheusProxyPort             = 9095
 	PrometheusTLSSecretName         = "calico-node-prometheus-tls"
+	PrometheusClientTLSSecretName   = "calico-node-prometheus-client-tls"
 	calicoNodePrometheusServiceName = "calico-node-prometheus"
 
 	tigeraPrometheusServiceHealthEndpoint = "/health"
@@ -70,15 +71,21 @@ const (
 func Monitor(cfg *Config) render.Component {
 	var tlsSecrets []*corev1.Secret
 	var tlsHash string
+	var clientTLSHash string
 	if cfg.Installation.CertificateManagement == nil {
-		tlsSecrets = []*corev1.Secret{secret.CopyToNamespace(common.TigeraPrometheusNamespace, cfg.TLSSecret)[0]}
-		tlsHash = rmeta.AnnotationHash(cfg.TLSSecret.Data)
+		tlsSecrets = []*corev1.Secret{
+			secret.CopyToNamespace(common.TigeraPrometheusNamespace, cfg.ServerTLSSecret)[0],
+			secret.CopyToNamespace(common.TigeraPrometheusNamespace, cfg.ClientTLSSecret)[0],
+		}
+		tlsHash = rmeta.AnnotationHash(cfg.ServerTLSSecret.Data)
+		clientTLSHash = rmeta.AnnotationHash(cfg.ClientTLSSecret.Data)
 	}
 
 	return &monitorComponent{
-		cfg:        cfg,
-		tlsSecrets: tlsSecrets,
-		tlsHash:    tlsHash,
+		cfg:           cfg,
+		tlsSecrets:    tlsSecrets,
+		tlsHash:       tlsHash,
+		clientTLSHash: clientTLSHash,
 	}
 }
 
@@ -88,8 +95,10 @@ type Config struct {
 	PullSecrets              []*corev1.Secret
 	AlertmanagerConfigSecret *corev1.Secret
 	KeyValidatorConfig       authentication.KeyValidatorConfig
-	TLSSecret                *corev1.Secret
+	ServerTLSSecret          *corev1.Secret
+	ClientTLSSecret          *corev1.Secret
 	ClusterDomain            string
+	TrustedCertBundle        *corev1.ConfigMap
 }
 
 type monitorComponent struct {
@@ -100,6 +109,7 @@ type monitorComponent struct {
 	csrImage               string
 	tlsSecrets             []*corev1.Secret
 	tlsHash                string
+	clientTLSHash          string
 }
 
 func (mc *monitorComponent) ResolveImages(is *operatorv1.ImageSet) error {
@@ -145,6 +155,7 @@ func (mc *monitorComponent) SupportedOSType() rmeta.OSType {
 func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 	toCreate := []client.Object{
 		render.CreateNamespace(common.TigeraPrometheusNamespace, mc.cfg.Installation.KubernetesProvider),
+		mc.cfg.TrustedCertBundle,
 	}
 
 	// Create role and role bindings first.
@@ -156,9 +167,17 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.cfg.PullSecrets...)...)...)
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.cfg.AlertmanagerConfigSecret)...)...)
+
+	// This is to delete a service that had been released in v3.8 with a typo in the name.
+	// TODO Remove the toDelete object after we drop support for v3.8.
+	toDelete := []client.Object{
+		mc.serviceMonitorElasicsearchToDelete(),
+	}
 	if mc.cfg.Installation.CertificateManagement == nil {
 		toCreate = append(toCreate, secret.ToRuntimeObjects(mc.tlsSecrets...)...)
+		toDelete = append(toDelete, render.CSRClusterRoleBinding(prometheusServiceAccountName, common.TigeraPrometheusNamespace))
 	} else {
+		toDelete = append(toDelete, secret.ToRuntimeObjects(mc.tlsSecrets...)...)
 		toCreate = append(toCreate, render.CSRClusterRoleBinding(prometheusServiceAccountName, common.TigeraPrometheusNamespace))
 	}
 	toCreate = append(toCreate,
@@ -171,7 +190,7 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 		mc.prometheusRule(),
 		mc.serviceMonitorCalicoNode(),
 		mc.serviceMonitorElasticsearch(),
-		mc.podMonitor(),
+		mc.serviceMonitorFluentd(),
 		mc.prometheusHTTPAPIService(),
 		mc.clusterRole(),
 		mc.clusterRoleBinding(),
@@ -180,12 +199,6 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 	if mc.cfg.KeyValidatorConfig != nil {
 		toCreate = append(toCreate, secret.ToRuntimeObjects(mc.cfg.KeyValidatorConfig.RequiredSecrets(common.TigeraPrometheusNamespace)...)...)
 		toCreate = append(toCreate, configmap.ToRuntimeObjects(mc.cfg.KeyValidatorConfig.RequiredConfigMaps(common.TigeraPrometheusNamespace)...)...)
-	}
-
-	// This is to delete a service that had been released in v3.8 with a typo in the name.
-	// TODO Remove the toDelete object after we drop support for v3.8.
-	toDelete := []client.Object{
-		mc.serviceMonitorElasicsearchToDelete(),
 	}
 
 	return toCreate, toDelete
@@ -281,14 +294,20 @@ func (mc *monitorComponent) alertmanagerService() *corev1.Service {
 }
 
 func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
-	certVolume := corev1.Volume{
-		Name: PrometheusTLSSecretName,
-	}
-
 	var initContainers []corev1.Container
 	if mc.cfg.Installation.CertificateManagement != nil {
 		svcDNSNames := dns.GetServiceDNSNames(PrometheusHTTPAPIServiceName, common.TigeraPrometheusNamespace, mc.cfg.ClusterDomain)
-
+		clientInit := render.CreateCSRInitContainer(
+			mc.cfg.Installation.CertificateManagement,
+			mc.csrImage,
+			PrometheusClientTLSSecretName,
+			PrometheusHTTPAPIServiceName,
+			corev1.TLSPrivateKeyKey,
+			corev1.TLSCertKey,
+			[]string{PrometheusClientTLSSecretName},
+			common.TigeraPrometheusNamespace)
+		// Make sure the names are not identical for the two init containers.
+		clientInit.Name = fmt.Sprintf("%s-%s", PrometheusClientTLSSecretName, clientInit.Name)
 		initContainers = append(initContainers, render.CreateCSRInitContainer(
 			mc.cfg.Installation.CertificateManagement,
 			mc.csrImage,
@@ -297,18 +316,27 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 			corev1.TLSPrivateKeyKey,
 			corev1.TLSCertKey,
 			svcDNSNames,
-			common.TigeraPrometheusNamespace))
+			common.TigeraPrometheusNamespace),
+			clientInit)
 
-		certVolume.VolumeSource = corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}
-	} else {
-		certVolume.VolumeSource = corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: PrometheusTLSSecretName,
-			},
-		}
 	}
 	volumes := []corev1.Volume{
-		certVolume,
+		{
+			Name:         PrometheusTLSSecretName,
+			VolumeSource: render.CertificateVolumeSource(mc.cfg.Installation.CertificateManagement, PrometheusTLSSecretName),
+		},
+		{
+			Name:         PrometheusClientTLSSecretName,
+			VolumeSource: render.CertificateVolumeSource(mc.cfg.Installation.CertificateManagement, PrometheusClientTLSSecretName),
+		},
+		{
+			Name: mc.cfg.TrustedCertBundle.Name,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: mc.cfg.TrustedCertBundle.Name},
+				},
+			},
+		},
 	}
 	env := []corev1.EnvVar{
 		{
@@ -321,8 +349,18 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 		},
 		{
 			// No other way to annotate this pod.
-			Name:  "TLS_SECRET_HASH_ANNOTATION",
+			Name:  "TLS_SERVER_SECRET_HASH_ANNOTATION",
 			Value: mc.tlsHash,
+		},
+		{
+			// No other way to annotate this pod.
+			Name:  "TLS_CLIENT_SECRET_HASH_ANNOTATION",
+			Value: mc.clientTLSHash,
+		},
+		{
+			// No other way to annotate this pod.
+			Name:  "TLS_CA_BUNDLE_HASH_ANNOTATION",
+			Value: rmeta.AnnotationHash(mc.cfg.TrustedCertBundle.Data),
 		},
 	}
 
@@ -330,6 +368,16 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 		{
 			Name:      PrometheusTLSSecretName,
 			MountPath: "/tls",
+			ReadOnly:  true,
+		},
+		{
+			Name:      PrometheusClientTLSSecretName,
+			MountPath: "/client-tls",
+			ReadOnly:  true,
+		},
+		{
+			Name:      mc.cfg.TrustedCertBundle.Name,
+			MountPath: fmt.Sprintf("/%s", mc.cfg.TrustedCertBundle.Name),
 			ReadOnly:  true,
 		},
 	}
@@ -351,6 +399,7 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 			ImagePullSecrets:   secret.GetReferenceList(mc.cfg.PullSecrets),
 			ServiceAccountName: prometheusServiceAccountName,
 			Volumes:            volumes,
+			VolumeMounts:       volumeMounts,
 			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
@@ -504,29 +553,6 @@ func (mc *monitorComponent) prometheusHTTPAPIService() *corev1.Service {
 	}
 }
 
-func (mc *monitorComponent) podMonitor() *monitoringv1.PodMonitor {
-	return &monitoringv1.PodMonitor{
-		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.PodMonitorsKind, APIVersion: MonitoringAPIVersion},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      FluentdMetrics,
-			Namespace: common.TigeraPrometheusNamespace,
-			Labels:    map[string]string{"team": "network-operators"},
-		},
-		Spec: monitoringv1.PodMonitorSpec{
-			Selector:          metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "fluentd-node"}},
-			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{"tigera-fluentd"}},
-			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
-				{
-					HonorLabels:   true,
-					Interval:      "5s",
-					Port:          "metrics-port",
-					ScrapeTimeout: "5s",
-				},
-			},
-		},
-	}
-}
-
 func (mc *monitorComponent) prometheusRule() *monitoringv1.PrometheusRule {
 	return &monitoringv1.PrometheusRule{
 		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.PrometheusRuleKind, APIVersion: MonitoringAPIVersion},
@@ -576,14 +602,29 @@ func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMoni
 					Interval:      "5s",
 					Port:          "calico-metrics-port",
 					ScrapeTimeout: "5s",
+					Scheme:        "https",
+					TLSConfig:     mc.tlsConfig(render.CalicoNodeMetricsService),
 				},
 				{
 					HonorLabels:   true,
 					Interval:      "5s",
 					Port:          "calico-bgp-metrics-port",
 					ScrapeTimeout: "5s",
+					Scheme:        "https",
+					TLSConfig:     mc.tlsConfig(render.CalicoNodeMetricsService),
 				},
 			},
+		},
+	}
+}
+
+func (mc *monitorComponent) tlsConfig(serverName string) *monitoringv1.TLSConfig {
+	return &monitoringv1.TLSConfig{
+		KeyFile:  fmt.Sprintf("/client-tls/%s", corev1.TLSPrivateKeyKey),
+		CertFile: fmt.Sprintf("/client-tls/%s", corev1.TLSCertKey),
+		CAFile:   fmt.Sprintf("/%s/%s", mc.cfg.TrustedCertBundle.Name, corev1.ServiceAccountRootCAKey),
+		SafeTLSConfig: monitoringv1.SafeTLSConfig{
+			ServerName: serverName,
 		},
 	}
 }
@@ -605,6 +646,33 @@ func (mc *monitorComponent) serviceMonitorElasticsearch() *monitoringv1.ServiceM
 					Interval:      "5s",
 					Port:          "metrics-port",
 					ScrapeTimeout: "5s",
+					Scheme:        "https",
+					TLSConfig:     mc.tlsConfig(esmetrics.ElasticsearchMetricsName),
+				},
+			},
+		},
+	}
+}
+
+func (mc *monitorComponent) serviceMonitorFluentd() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.ServiceMonitorsKind, APIVersion: MonitoringAPIVersion},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.FluentdMetricsService,
+			Namespace: common.TigeraPrometheusNamespace,
+			Labels:    map[string]string{"team": "network-operators"},
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector:          metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "fluentd-node"}},
+			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{render.LogCollectorNamespace}},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					HonorLabels:   true,
+					Interval:      "5s",
+					Port:          render.FluentdMetricsPort,
+					ScrapeTimeout: "5s",
+					Scheme:        "https",
+					TLSConfig:     mc.tlsConfig(render.FluentdPrometheusTLSSecretName),
 				},
 			},
 		},

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -56,7 +56,7 @@ var _ = Describe("monitor rendering tests", func() {
 			PullSecrets: []*corev1.Secret{
 				{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 			},
-			TLSSecret: &corev1.Secret{
+			ServerTLSSecret: &corev1.Secret{
 				TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{Name: monitor.PrometheusTLSSecretName, Namespace: common.OperatorNamespace()}},
 			AlertmanagerConfigSecret: defaultAlertmanagerConfigSecret,
@@ -336,7 +336,7 @@ var _ = Describe("monitor rendering tests", func() {
 			},
 			dns.DefaultClusterDomain)
 		cfg.KeyValidatorConfig = dexCfg
-		cfg.TLSSecret = &corev1.Secret{
+		cfg.ServerTLSSecret = &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      monitor.PrometheusTLSSecretName,

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -59,6 +59,12 @@ var _ = Describe("monitor rendering tests", func() {
 			ServerTLSSecret: &corev1.Secret{
 				TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{Name: monitor.PrometheusTLSSecretName, Namespace: common.OperatorNamespace()}},
+			ClientTLSSecret: &corev1.Secret{
+				TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: monitor.PrometheusClientTLSSecretName, Namespace: common.OperatorNamespace()}},
+			TrustedCertBundle: &corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: render.PrometheusCABundle, Namespace: common.TigeraPrometheusNamespace}},
 			AlertmanagerConfigSecret: defaultAlertmanagerConfigSecret,
 			ClusterDomain:            "example.org",
 		}
@@ -78,11 +84,13 @@ var _ = Describe("monitor rendering tests", func() {
 			kind    string
 		}{
 			{"tigera-prometheus", "", "", "v1", "Namespace"},
+			{render.PrometheusCABundle, common.TigeraPrometheusNamespace, "", "v1", "ConfigMap"},
 			{"tigera-prometheus-role", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
 			{"tigera-prometheus-role-binding", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
 			{"alertmanager-calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Secret"},
 			{monitor.PrometheusTLSSecretName, common.TigeraPrometheusNamespace, "", "v1", "Secret"},
+			{monitor.PrometheusClientTLSSecretName, common.TigeraPrometheusNamespace, "", "v1", "Secret"},
 			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Service"},
 			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
 			{"prometheus", common.TigeraPrometheusNamespace, "", "v1", "ServiceAccount"},
@@ -92,7 +100,7 @@ var _ = Describe("monitor rendering tests", func() {
 			{"tigera-prometheus-dp-rate", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusRuleKind},
 			{"calico-node-monitor", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"elasticsearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
-			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PodMonitorsKind},
+			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
 			{name: monitor.TigeraPrometheusObjectName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: monitor.TigeraPrometheusObjectName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -105,7 +113,7 @@ var _ = Describe("monitor rendering tests", func() {
 			rtest.ExpectResource(obj, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 
-		Expect(toDelete).To(HaveLen(1))
+		Expect(toDelete).To(HaveLen(2))
 
 		obj := toDelete[0]
 		rtest.ExpectResource(obj, "elasticearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind)
@@ -215,19 +223,19 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(prometheusServiceObj.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(9095)))
 
 		// PodMonitor
-		podmonitorObj, ok := rtest.GetResource(toCreate, monitor.FluentdMetrics, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PodMonitorsKind).(*monitoringv1.PodMonitor)
+		servicemonitorObj, ok := rtest.GetResource(toCreate, monitor.FluentdMetrics, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
 		Expect(ok).To(BeTrue())
-		Expect(podmonitorObj.ObjectMeta.Labels).To(HaveLen(1))
-		Expect(podmonitorObj.ObjectMeta.Labels["team"]).To(Equal("network-operators"))
-		Expect(podmonitorObj.Spec.Selector.MatchLabels).To(HaveLen(1))
-		Expect(podmonitorObj.Spec.Selector.MatchLabels["k8s-app"]).To(Equal("fluentd-node"))
-		Expect(podmonitorObj.Spec.NamespaceSelector.MatchNames).To(HaveLen(1))
-		Expect(podmonitorObj.Spec.NamespaceSelector.MatchNames[0]).To(Equal("tigera-fluentd"))
-		Expect(podmonitorObj.Spec.PodMetricsEndpoints).To(HaveLen(1))
-		Expect(podmonitorObj.Spec.PodMetricsEndpoints[0].HonorLabels).To(BeTrue())
-		Expect(podmonitorObj.Spec.PodMetricsEndpoints[0].Interval).To(Equal("5s"))
-		Expect(podmonitorObj.Spec.PodMetricsEndpoints[0].Port).To(Equal("metrics-port"))
-		Expect(podmonitorObj.Spec.PodMetricsEndpoints[0].ScrapeTimeout).To(Equal("5s"))
+		Expect(servicemonitorObj.ObjectMeta.Labels).To(HaveLen(1))
+		Expect(servicemonitorObj.ObjectMeta.Labels["team"]).To(Equal("network-operators"))
+		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(1))
+		Expect(servicemonitorObj.Spec.Selector.MatchLabels["k8s-app"]).To(Equal("fluentd-node"))
+		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames).To(HaveLen(1))
+		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames[0]).To(Equal("tigera-fluentd"))
+		Expect(servicemonitorObj.Spec.Endpoints).To(HaveLen(1))
+		Expect(servicemonitorObj.Spec.Endpoints[0].HonorLabels).To(BeTrue())
+		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(Equal("5s"))
+		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("fluentd-metrics-port"))
+		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(Equal("5s"))
 
 		// PrometheusRule
 		prometheusruleObj, ok := rtest.GetResource(toCreate, monitor.TigeraPrometheusDPRate, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusRuleKind).(*monitoringv1.PrometheusRule)
@@ -245,7 +253,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(prometheusruleObj.Spec.Groups[0].Rules[0].Annotations["description"]).To(Equal("{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}."))
 
 		// ServiceMonitor
-		servicemonitorObj, ok := rtest.GetResource(toCreate, monitor.CalicoNodeMonitor, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
+		servicemonitorObj, ok = rtest.GetResource(toCreate, monitor.CalicoNodeMonitor, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
 		Expect(ok).To(BeTrue())
 		Expect(servicemonitorObj.ObjectMeta.Labels).To(HaveLen(1))
 		Expect(servicemonitorObj.ObjectMeta.Labels["team"]).To(Equal("network-operators"))
@@ -362,11 +370,13 @@ var _ = Describe("monitor rendering tests", func() {
 			kind    string
 		}{
 			{"tigera-prometheus", "", "", "v1", "Namespace"},
+			{render.PrometheusCABundle, common.TigeraPrometheusNamespace, "", "v1", "ConfigMap"},
 			{"tigera-prometheus-role", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
 			{"tigera-prometheus-role-binding", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
 			{"alertmanager-calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Secret"},
 			{monitor.PrometheusTLSSecretName, common.TigeraPrometheusNamespace, "", "v1", "Secret"},
+			{monitor.PrometheusClientTLSSecretName, common.TigeraPrometheusNamespace, "", "v1", "Secret"},
 			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Service"},
 			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
 			{"prometheus", common.TigeraPrometheusNamespace, "", "v1", "ServiceAccount"},
@@ -376,7 +386,7 @@ var _ = Describe("monitor rendering tests", func() {
 			{"tigera-prometheus-dp-rate", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusRuleKind},
 			{"calico-node-monitor", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"elasticsearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
-			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PodMonitorsKind},
+			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
 			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
 			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
@@ -390,7 +400,7 @@ var _ = Describe("monitor rendering tests", func() {
 			rtest.ExpectResource(obj, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 
-		Expect(toDelete).To(HaveLen(1))
+		Expect(toDelete).To(HaveLen(2))
 
 		// Prometheus
 		prometheusObj, ok := rtest.GetResource(toCreate, monitor.CalicoNodePrometheus, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind).(*monitoringv1.Prometheus)
@@ -411,8 +421,18 @@ var _ = Describe("monitor rendering tests", func() {
 				ValueFrom: nil,
 			},
 			{
-				Name:      "TLS_SECRET_HASH_ANNOTATION",
+				Name:      "TLS_SERVER_SECRET_HASH_ANNOTATION",
 				Value:     "f09a0e0667b55a79c84a46b17ff28e4683cd072f",
+				ValueFrom: nil,
+			},
+			{
+				Name:      "TLS_CLIENT_SECRET_HASH_ANNOTATION",
+				Value:     "0e6ae3fec848d64b4647532abed2256acca56b85",
+				ValueFrom: nil,
+			},
+			{
+				Name:      "TLS_CA_BUNDLE_HASH_ANNOTATION",
+				Value:     "0e6ae3fec848d64b4647532abed2256acca56b85",
 				ValueFrom: nil,
 			},
 			{

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -57,6 +57,12 @@ const (
 	K8sSvcEndpointConfigMapName       = "kubernetes-services-endpoint"
 	nodeTerminationGracePeriodSeconds = 5
 	NodeFinalizer                     = "tigera.io/cni-protector"
+
+	CalicoNodeMetricsService          = "calico-node-metrics"
+	NodePrometheusTLSServerSecret     = "calico-node-prometheus-server-tls"
+	NodePrometheusTLSServerAnnotation = "hash.operator.tigera.io/calico-node-prometheus-server-tls"
+	PrometheusCABundle                = "tigera-prometheus-metrics-ca-bundle"
+	PrometheusCABundleAnnotation      = "hash.operator.tigera.io/tigera-prometheus-metrics-ca-bundle"
 )
 
 var (
@@ -94,7 +100,9 @@ type NodeConfiguration struct {
 	// Indicates node is being terminated, so remove most resources but
 	// leave RBAC and SA to allow any CNI plugin calls to continue to function
 	// For details on why this is needed see 'Node and Installation finalizer' in the core_controller.
-	Terminating bool
+	Terminating               bool
+	PrometheusServerTLS       *corev1.Secret
+	PrometheusMetricsCABundle *corev1.ConfigMap
 
 	// BGPLayouts is returned by the rendering code after modifying its namespace
 	// so that it can be deployed into the cluster.
@@ -222,11 +230,21 @@ func (c *nodeComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, CSRClusterRoleBinding("calico-node", common.CalicoNamespace))
 	}
 
+	var objsToDelete []client.Object
+	if c.cfg.PrometheusServerTLS != nil {
+		objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.cfg.PrometheusServerTLS)...)...)
+	} else {
+		objsToDelete = append(objsToDelete, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: NodePrometheusTLSServerSecret, Namespace: common.CalicoNamespace}})
+	}
+
+	if c.cfg.PrometheusMetricsCABundle != nil {
+		objs = append(objs, c.cfg.PrometheusMetricsCABundle)
+	}
 	if c.cfg.Terminating {
-		return objsToKeep, objs
+		return objsToKeep, append(objs, objsToDelete...)
 
 	}
-	return objs, nil
+	return objs, objsToDelete
 }
 
 func (c *nodeComponent) Ready() bool {
@@ -660,6 +678,12 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 	if len(c.cfg.BirdTemplates) != 0 {
 		annotations[birdTemplateHashAnnotation] = rmeta.AnnotationHash(c.cfg.BirdTemplates)
 	}
+	if c.cfg.PrometheusServerTLS != nil {
+		annotations[NodePrometheusTLSServerAnnotation] = rmeta.AnnotationHash(c.cfg.PrometheusServerTLS.Data)
+	}
+	if c.cfg.PrometheusMetricsCABundle != nil {
+		annotations[PrometheusCABundleAnnotation] = rmeta.AnnotationHash(c.cfg.PrometheusMetricsCABundle.Data)
+	}
 
 	annotations[TyphaCAHashAnnotation] = rmeta.AnnotationHash(c.cfg.TLS.CAConfigMap.Data)
 	if c.cfg.Installation.CertificateManagement == nil {
@@ -674,6 +698,19 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 			TLSSecretCertName,
 			dns.GetServiceDNSNames(common.NodeDaemonSetName, common.CalicoNamespace, c.cfg.ClusterDomain),
 			CSRLabelCalicoSystem))
+		if c.cfg.PrometheusMetricsCABundle != nil { // If this bundle is present, it means we want to create a mTLS certificate.
+			prometheusInit := CreateCSRInitContainer(
+				c.cfg.Installation.CertificateManagement,
+				c.certSignReqImage,
+				NodePrometheusTLSServerSecret,
+				NodePrometheusTLSServerSecret,
+				corev1.TLSPrivateKeyKey,
+				corev1.TLSCertKey,
+				dns.GetServiceDNSNames(CalicoNodeMetricsService, common.CalicoNamespace, c.cfg.ClusterDomain),
+				CSRLabelCalicoSystem)
+			prometheusInit.Name = fmt.Sprintf("%s-%s", CalicoNodeMetricsService, prometheusInit.Name)
+			initContainers = append(initContainers, prometheusInit)
+		}
 	}
 
 	if cniCfgMap != nil {
@@ -828,7 +865,7 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 		},
 		{
 			Name:         "felix-certs",
-			VolumeSource: certificateVolumeSource(c.cfg.Installation.CertificateManagement, NodeTLSSecretName),
+			VolumeSource: CertificateVolumeSource(c.cfg.Installation.CertificateManagement, NodeTLSSecretName),
 		},
 	}
 
@@ -914,6 +951,19 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 						},
 					},
 				},
+			})
+	}
+	if c.cfg.PrometheusMetricsCABundle != nil {
+		volumes = append(volumes,
+			corev1.Volume{Name: c.cfg.PrometheusMetricsCABundle.Name,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: c.cfg.PrometheusMetricsCABundle.Name},
+					},
+				},
+			},
+			corev1.Volume{Name: NodePrometheusTLSServerSecret,
+				VolumeSource: CertificateVolumeSource(c.cfg.Installation.CertificateManagement, NodePrometheusTLSServerSecret),
 			})
 	}
 
@@ -1151,7 +1201,20 @@ func (c *nodeComponent) nodeVolumeMounts() []corev1.VolumeMount {
 				SubPath:   BGPLayoutConfigMapKey,
 			})
 	}
-
+	if c.cfg.PrometheusMetricsCABundle != nil {
+		nodeVolumeMounts = append(nodeVolumeMounts,
+			corev1.VolumeMount{
+				Name:      c.cfg.PrometheusMetricsCABundle.Name,
+				MountPath: fmt.Sprintf("/%s", c.cfg.PrometheusMetricsCABundle.Name),
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      NodePrometheusTLSServerSecret,
+				MountPath: fmt.Sprintf("/%s", NodePrometheusTLSServerSecret),
+				ReadOnly:  true,
+			},
+		)
+	}
 	return nodeVolumeMounts
 }
 
@@ -1430,6 +1493,13 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 			extraNodeEnv = append(extraNodeEnv, corev1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cfg.Installation.CalicoNetwork.MultiInterfaceMode.Value()})
 		}
 
+		if c.cfg.PrometheusMetricsCABundle != nil {
+			extraNodeEnv = append(extraNodeEnv,
+				corev1.EnvVar{Name: "FELIX_PROMETHEUSREPORTERCERTFILE", Value: fmt.Sprintf("/%s/%s", NodePrometheusTLSServerSecret, corev1.TLSCertKey)},
+				corev1.EnvVar{Name: "FELIX_PROMETHEUSREPORTERKEYFILE", Value: fmt.Sprintf("/%s/%s", NodePrometheusTLSServerSecret, corev1.TLSPrivateKeyKey)},
+				corev1.EnvVar{Name: "FELIX_PROMETHEUSREPORTERCAFILE", Value: fmt.Sprintf("/%s/%s", c.cfg.PrometheusMetricsCABundle.Name, corev1.TLSCertKey)},
+			)
+		}
 		nodeEnv = append(nodeEnv, extraNodeEnv...)
 	}
 
@@ -1559,7 +1629,7 @@ func (c *nodeComponent) nodeMetricsService() *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "calico-node-metrics",
+			Name:      CalicoNodeMetricsService,
 			Namespace: common.CalicoNamespace,
 			Labels:    map[string]string{"k8s-app": "calico-node"},
 		},

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -322,7 +322,7 @@ func (pc *packetCaptureApiComponent) healthProbe() *corev1.Probe {
 func (pc *packetCaptureApiComponent) volumes() []corev1.Volume {
 	var volumes = []corev1.Volume{{
 		Name:         PacketCaptureCertSecret,
-		VolumeSource: certificateVolumeSource(pc.cfg.Installation.CertificateManagement, PacketCaptureCertSecret),
+		VolumeSource: CertificateVolumeSource(pc.cfg.Installation.CertificateManagement, PacketCaptureCertSecret),
 	}}
 
 	if pc.cfg.KeyValidatorConfig != nil {

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -460,7 +460,7 @@ func (c *typhaComponent) volumes() []corev1.Volume {
 		},
 		{
 			Name:         "typha-certs",
-			VolumeSource: certificateVolumeSource(c.cfg.Installation.CertificateManagement, TyphaTLSSecretName),
+			VolumeSource: CertificateVolumeSource(c.cfg.Installation.CertificateManagement, TyphaTLSSecretName),
 		},
 	}
 


### PR DESCRIPTION
Add mTLS to metrics endspoints that are enabled by default for enterprise:
- Now a total of 4 metrics that are secured: fluentd, node & bgp, elasticsearch metrics.
- Added service for fluentd, so we can use a service monitor; pod monitors are not compatible with certificate management
- Is dependent on new elasticsearch-metrics image, which now requires mTLS
- All the servers will trust the prometheus TLS secret, as well as the CA in case of certificate management.
- Calico Node will also trust itself, so the health probe can make a call to itself

Some other  considerations that are made while working on this feature:
- An extra key-cert pair has been created for each client and/or server participating in the mTLS.
- Each server has to trust "calico-node-prometheus-client-tls", which is the secret that prometheus mounts. Our prometheus deployment unfortunately has the confusing name calico-node-prometheus, which at this point in time it not very specific any longer.
- The reason we do not re-use existing TLS secrets is because the certificate usages are not valid for the new mTLS scenario's. This would cause disruptions for all users upgrading to this version.

cherry-pick is here: https://github.com/tigera/operator/pull/1758