### PR TITLE
Fix packet capture RBAC for default users

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1340,11 +1340,11 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 		{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"packetcaptures/files"},
-			Verbs:     []string{"get", "delete"},
+			Verbs:     []string{"get"},
 		},
 		{
 			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"packetcaptureslist"},
+			Resources: []string{"packetcaptures"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		// Additional "list" requests required to view flows.
@@ -1465,11 +1465,6 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"packetcaptures/files"},
 			Verbs:     []string{"get", "delete"},
-		},
-		{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"packetcaptureslist"},
-			Verbs:     []string{"get", "list", "watch"},
 		},
 		// Additional "list" requests that the Tigera Secure manager needs
 		{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -967,11 +967,11 @@ var (
 		{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"packetcaptures/files"},
-			Verbs:     []string{"get", "delete"},
+			Verbs:     []string{"get"},
 		},
 		{
 			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"packetcaptureslist"},
+			Resources: []string{"packetcaptures"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
@@ -1062,11 +1062,6 @@ var (
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"packetcaptures/files"},
 			Verbs:     []string{"get", "delete"},
-		},
-		{
-			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"packetcaptureslist"},
-			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
## Description

Remove packetcaptureslist resource type in RBAC config - I don;'t think it exists according to the docs and according to using service graph

Removed delete option for tigera-ui-user - so it becomes a read only user of packet captures (I agreed this with Phil)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
