### PR TITLE
updating envoy config to have NodePort listener

### DIFF
--- a/pkg/render/applicationlayer/envoy-config.yaml
+++ b/pkg/render/applicationlayer/envoy-config.yaml
@@ -1,6 +1,6 @@
 static_resources:
   listeners:
-    - name: inbound
+    - name: services
       transparent: true
       address:
         socket_address:
@@ -16,7 +16,7 @@ static_resources:
         - name: envoy.filters.listener.original_src
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.listener.original_src.v3.OriginalSrc
-      filter_chains:
+      filter_chains: &filter_chains
         - filter_chain_match:
             transport_protocol: tls
           filters:
@@ -166,6 +166,24 @@ static_resources:
                         downstream_local_address : "%DOWNSTREAM_LOCAL_ADDRESS%"
                         domain: "%REQ(HOST?:AUTHORITY)%"
                         upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+    - name: nodeports
+      transparent: true
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 16002 # must be services port + 1
+      listener_filters:
+        - name: envoy.filters.listener.tls_inspector
+          typed_config: {}
+        - name: envoy.filters.listener.http_inspector
+          typed_config: {}
+        - name: envoy.filters.listener.original_dst
+          typed_config: {}
+        - name: envoy.filters.listener.original_src
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.original_src.v3.OriginalSrc
+            mark: 0x4000 # must be the same as the mark resulting from kube-proxy's masq bit
+      filter_chains: *filter_chains
   clusters:
     - name: original_dst_cluster
       type: ORIGINAL_DST


### PR DESCRIPTION
## Description

The `envoy-config.yaml` is missing the listener for NodePorts. This is causing the l7 annotated NodePorts to fail. This patch fixes that. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
