### PR TITLE
Install UISettings and UISettingsGroup as part of manager after api server is installed

### DIFF
--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -118,10 +118,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 
 		var err error
@@ -321,10 +317,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 
 		component, err := render.APIServer(cfg)
@@ -378,10 +370,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 
 		component, err := render.APIServer(cfg)
@@ -456,10 +444,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 
 		cfg.Installation.ControlPlaneNodeSelector = map[string]string{"nodeName": "control01"}
@@ -525,10 +509,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 
 		component, err := render.APIServer(cfg)
@@ -697,10 +677,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -790,10 +766,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -856,10 +828,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 
 		i := 0

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	}
 	var replicas int32 = 2
 	installation := &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas}
-	const expectedResourcesNumber = 11
+	const expectedResourcesNumber = 15
 
 	expectedDNSNames := dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, dns.DefaultClusterDomain)
 	expectedDNSNames = append(expectedDNSNames, "localhost")
@@ -64,6 +64,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
+			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 			{name: render.ManagerTLSSecretName, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
@@ -248,6 +252,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "tigera-manager-role", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-manager-binding", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
+			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 			{name: "manager-tls", ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
 			{name: render.VoltronTunnelSecretName, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
 			{name: render.ManagerInternalTLSSecretName, ns: "tigera-manager", group: "", version: "v1", kind: "Secret"},
@@ -467,6 +475,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "cluster-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+			{name: "user-settings", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+			{name: "cluster-settings.layer.tigera-infrastructure", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
+			{name: "cluster-settings.view.default", ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: render.ComplianceServerCertSecret, ns: render.ManagerNamespace, group: "", version: "v1", kind: "Secret"},


### PR DESCRIPTION


## Description
Order of installs was incorrect.  v3 UISetings and UISettingsGroups need to be installed *after* the APIserver.  Installing as part of manager since they are UI components.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
