### PR TITLE
Do not set or change OwnerReference of UISettings

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -17,8 +17,9 @@ package logstorage
 import (
 	"context"
 	"fmt"
-	"github.com/tigera/operator/pkg/render/monitor"
 	"reflect"
+
+	"github.com/tigera/operator/pkg/render/monitor"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -16,8 +16,9 @@ package esmetrics
 
 import (
 	"fmt"
-	"github.com/tigera/operator/pkg/dns"
 	"strings"
+
+	"github.com/tigera/operator/pkg/dns"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
## Description

UISettings are always owned by the group and so the controller should only set owner ref for the group and not any UISettings it creates.

The APIServer forces the relationship between the UISettings and the UISettingsGroup by setting the OwnerReference on the UISettings to be that of the "parent" UISettingsGroup

Operator sets owner ref on the group.  Operator deleted will daisy chain garbage collection down the associated settings for the operator owned groups.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
