### PR TITLE
Default tigera infrastructure UISettings layer definition to line up with UI expected data

### DIFF
--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -930,9 +930,9 @@ spec:
                   routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
                 type: string
               routeTableRange:
-                description: Calico programs additional Linux route tables for various
-                  purposes.  RouteTableRange specifies the indices of the route tables
-                  that Calico should use.
+                description: Deprecated in favor of RouteTableRanges. Calico programs
+                  additional Linux route tables for various purposes. RouteTableRange
+                  specifies the indices of the route tables that Calico should use.
                 properties:
                   max:
                     type: integer
@@ -942,6 +942,21 @@ spec:
                 - max
                 - min
                 type: object
+              routeTableRanges:
+                description: Calico programs additional Linux route tables for various
+                  purposes. RouteTableRanges specifies a set of table index ranges
+                  that Calico should use. Deprecates`RouteTableRange`, overrides `RouteTableRange`.
+                items:
+                  properties:
+                    max:
+                      type: integer
+                    min:
+                      type: integer
+                  required:
+                  - max
+                  - min
+                  type: object
+                type: array
               serviceLoopPrevention:
                 description: 'When service IP advertisement is enabled, prevent routing
                   loops to service IPs that are not in use, by dropping or rejecting

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -948,9 +948,13 @@ func (c *managerComponent) clusterWideDefaultView() *v3.UISettings {
 			Group:       "cluster-settings",
 			Description: "Default",
 			View: &v3.UIGraphView{
-				Layers: []string{
-					"cluster-settings.layer.tigera-infrastructure",
-				},
+				Nodes: []v3.UIGraphNodeView{{
+					UIGraphNode: v3.UIGraphNode{
+						ID:   "layer/cluster-settings.layer.tigera-infrastructure",
+						Type: "layer",
+						Name: "cluster-settings.layer.tigera-infrastructure",
+					},
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

The UI is no longer using the Layers field in UISettings and just expects the layer to be included in the set of nodes. I forgot to make this change in the original commit and only spotted during integration testing that it was wrong.

Tested in cluster.

The UISettings data is only used by the UI.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
