### PR TITLE
[release-v1.25] Auto pick #1788: adding tesla non-cloud changes to keep consistency #1790: Add tests to check that the elasticsearch index suffix is

### DIFF
--- a/pkg/render/common/configmap/configmaps.go
+++ b/pkg/render/common/configmap/configmaps.go
@@ -22,11 +22,29 @@ func CopyToNamespace(ns string, oConfigMaps ...*v1.ConfigMap) []*v1.ConfigMap {
 // ToRuntimeObjects converts the given list of configMaps to a list of client.Objects
 func ToRuntimeObjects(configMaps ...*v1.ConfigMap) []client.Object {
 	var objs []client.Object
-	for _, secret := range configMaps {
-		if secret == nil {
+	for _, configMap := range configMaps {
+		if configMap == nil {
 			continue
 		}
-		objs = append(objs, secret)
+		objs = append(objs, configMap)
 	}
 	return objs
+}
+
+// GetEnvVarSource returns an EnvVarSource using the given configmap name and key.
+func GetEnvVarSource(cmName string, key string, optional bool) *v1.EnvVarSource {
+	var opt *bool
+	if optional {
+		r := optional
+		opt = &r
+	}
+	return &v1.EnvVarSource{
+		ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+			LocalObjectReference: v1.LocalObjectReference{
+				Name: cmName,
+			},
+			Key:      key,
+			Optional: opt,
+		},
+	}
 }

--- a/pkg/render/common/test/testing.go
+++ b/pkg/render/common/test/testing.go
@@ -151,6 +151,16 @@ func ExpectEnv(env []v1.EnvVar, key, value string) {
 	Expect(false).To(BeTrue(), fmt.Sprintf("Missing expected environment variable %s", key))
 }
 
+func ExpectVolumeMount(vms []v1.VolumeMount, name, path string) {
+	for _, vm := range vms {
+		if vm.Name == name {
+			Expect(vm.MountPath).To(Equal(path))
+			return
+		}
+	}
+	Expect(false).To(BeTrue(), fmt.Sprintf("Missing expected volume mount %s", name))
+}
+
 func CreateCertSecret(name, namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -212,8 +212,26 @@ var _ = Describe("compliance rendering tests", func() {
 			rtest.ExpectGlobalReportType(rtest.GetResource(resources, "policy-audit", "", "projectcalico.org", "v3", "GlobalReportType"), "policy-audit")
 			rtest.ExpectGlobalReportType(rtest.GetResource(resources, "cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"), "cis-benchmark")
 
-			var dpComplianceServer = rtest.GetResource(resources, "compliance-server", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			dpComplianceServer := rtest.GetResource(resources, "compliance-server", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			complianceController := rtest.GetResource(resources, "compliance-controller", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			complianceSnapshotter := rtest.GetResource(resources, "compliance-snapshotter", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			complianceBenchmarker := rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+				corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
+			))
+			Expect(complianceController.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+				corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
+			))
+			Expect(complianceSnapshotter.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+				corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
+			))
+			Expect(complianceBenchmarker.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+				corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
+			))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+				corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
+			))
 			Expect(len(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(3))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("tls"))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/code/apiserver.local.config/certificates"))

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -88,23 +88,20 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Volumes[0].VolumeSource.HostPath.Path).To(Equal("/var/log/calico"))
 		envs := ds.Spec.Template.Spec.Containers[0].Env
 
-		expectedEnvs := []corev1.EnvVar{
-			{Name: "FLUENT_UID", Value: "0"},
-			{Name: "FLOW_LOG_FILE", Value: "/var/log/calico/flowlogs/flows.log"},
-			{Name: "DNS_LOG_FILE", Value: "/var/log/calico/dnslogs/dns.log"},
-			{Name: "FLUENTD_ES_SECURE", Value: "true"},
-			{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
-			{Name: "ELASTIC_PORT", Value: "9200"},
-			{
-				Name: "NODENAME",
+		Expect(envs).Should(ContainElements(
+			corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "clusterTestName"},
+			corev1.EnvVar{Name: "FLUENT_UID", Value: "0"},
+			corev1.EnvVar{Name: "FLOW_LOG_FILE", Value: "/var/log/calico/flowlogs/flows.log"},
+			corev1.EnvVar{Name: "DNS_LOG_FILE", Value: "/var/log/calico/dnslogs/dns.log"},
+			corev1.EnvVar{Name: "FLUENTD_ES_SECURE", Value: "true"},
+			corev1.EnvVar{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
+			corev1.EnvVar{Name: "ELASTIC_PORT", Value: "9200"},
+			corev1.EnvVar{Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 				},
 			},
-		}
-		for _, expected := range expectedEnvs {
-			Expect(envs).To(ContainElement(expected))
-		}
+		))
 
 		container := ds.Spec.Template.Spec.Containers[0]
 

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -103,6 +103,13 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 
 		// Should mount ManagerTLSSecret for non-managed clusters
 		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		idji := rtest.GetResource(resources, "intrusion-detection-es-job-installer", render.IntrusionDetectionNamespace, "batch", "v1", "Job").(*batchv1.Job)
+		Expect(idc.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+			corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "clusterTestName"},
+		))
+		Expect(idji.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+			corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "clusterTestName"},
+		))
 		Expect(idc.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
 		Expect(idc.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/manager-tls"))
 		Expect(idc.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))

--- a/pkg/render/intrusiondetection/dpi/dpi_test.go
+++ b/pkg/render/intrusiondetection/dpi/dpi_test.go
@@ -201,6 +201,9 @@ var _ = Describe("DPI rendering tests", func() {
 		}
 
 		ds := rtest.GetResource(resources, dpi.DeepPacketInspectionName, dpi.DeepPacketInspectionNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(ds.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
+			corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "clusterTestName"},
+		))
 		Expect(len(ds.Spec.Template.Spec.Containers)).Should(Equal(1))
 		Expect(*ds.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu()).Should(Equal(resource.MustParse(dpi.DefaultCPURequest)))
 		Expect(*ds.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu()).Should(Equal(resource.MustParse(dpi.DefaultCPULimit)))


### PR DESCRIPTION
Cherry pick of https://github.com/tigera/operator/pull/1788 https://github.com/tigera/operator/pull/1790 (without the CRD commit) on release-v1.25.

https://github.com/tigera/operator/pull/1788: adding tesla non-cloud changes to keep consistency
https://github.com/tigera/operator/pull/1790: Add tests to check that the elasticsearch index suffix is