### PR TITLE
Automated cherry pick of #1795: Remove <v3.12 pod monitor

### DIFF
--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -201,6 +201,9 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, configmap.ToRuntimeObjects(mc.cfg.KeyValidatorConfig.RequiredConfigMaps(common.TigeraPrometheusNamespace)...)...)
 	}
 
+	// Remove the pod monitor that existed prior to v3.12.
+	toDelete = append(toDelete, &monitoringv1.PodMonitor{ObjectMeta: metav1.ObjectMeta{Name: FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}})
+
 	return toCreate, toDelete
 }
 


### PR DESCRIPTION
Cherry pick of #1795 on release-v1.25.

#1795: Remove <v3.12 pod monitor