### PR TITLE
Automated cherry pick of #1795: Remove <v1.25 pod monitor

### DIFF
--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -201,6 +201,9 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, configmap.ToRuntimeObjects(mc.cfg.KeyValidatorConfig.RequiredConfigMaps(common.TigeraPrometheusNamespace)...)...)
 	}
 
+	// Remove the pod monitor that existed prior to v1.25.
+	toDelete = append(toDelete, &monitoringv1.PodMonitor{ObjectMeta: metav1.ObjectMeta{Name: FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}})
+
 	return toCreate, toDelete
 }
 

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -113,7 +113,7 @@ var _ = Describe("monitor rendering tests", func() {
 			rtest.ExpectResource(obj, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 
-		Expect(toDelete).To(HaveLen(2))
+		Expect(toDelete).To(HaveLen(3))
 
 		obj := toDelete[0]
 		rtest.ExpectResource(obj, "elasticearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind)
@@ -400,7 +400,7 @@ var _ = Describe("monitor rendering tests", func() {
 			rtest.ExpectResource(obj, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 
-		Expect(toDelete).To(HaveLen(2))
+		Expect(toDelete).To(HaveLen(3))
 
 		// Prometheus
 		prometheusObj, ok := rtest.GetResource(toCreate, monitor.CalicoNodePrometheus, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind).(*monitoringv1.Prometheus)


### PR DESCRIPTION
Cherry pick of #1795 on release-v1.25.

#1795: Remove <v1.25 pod monitor