### PR TITLE
bundle: update operator bundle tooling and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -712,7 +712,7 @@ bundle: bundle-generate bundle-crd-clean update-bundle bundle-validate bundle-im
 
 .PHONY: bundle-crd-clean
 bundle-crd-clean:
-	git checkout -- config/crd/bases/
+	git checkout -- config/crd/bases
 
 .PHONY: bundle-validate
 bundle-validate:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,10 +60,13 @@ Before beginning, ensure that the docs at docs.projectcalico.org for the Calico 
 
 1. After the semaphore job in the releasing steps is complete, and images have been tagged and pushed, checkout the tag you released and create a new branch.
 
-1. Login to our operator project on connect.redhat.com and publish the operator image on the RH Catalog. This step needs to happen before we generate and submit the operator metadata bundle.
+1. Login to our operator project on connect.redhat.com and publish the operator image on the RH Catalog. This step needs to happen before we generate and submit the operator bundle.
 
-1. Create the operator bundle, using the tag version for VERSION and the version that the release replaces in PREV_VERSION. The versions are semver strings.
-   CHANNELS and DEFAULT_CHANNEL should be set to the release stream.
+1. Create the operator bundle using `make bundle` with the required variables `VERSION`, `PREV_VERSION`, `CHANNELS`, and `DEFAULT_CHANNEL`:
+   - **VERSION**: this release version. E.g. `1.13.1` (Note that these version strings are semver strings without the `v`.)
+   - **PREV_VERSION**: the latest published bundle version in this release stream. Navigate to the [certified operators production catalog](https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/tigera-operator) and look for the most recent version from this release branch. E.g., if this release is `v1.24.11` but the most recently published v1.24.x bundle is `v1.24.9` then you would use `VERSION=v1.24.11` and `PREV_VERSION=v1.24.9`. If this release is the first in this release branch, then there is no prior version so set `PREV_VERSION=0.0.0`.
+   - **CHANNELS** and **DEFAULT_CHANNEL**: should be set to the release branch of this operator release. E.g., if the operator release tag is `v1.23.5`, then CHANNELS and DEFAULT_CHANNEL should be `release-v1.23`.
+
    For example:
 
    ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,8 +63,8 @@ Before beginning, ensure that the docs at docs.projectcalico.org for the Calico 
 1. Login to our operator project on connect.redhat.com and publish the operator image on the RH Catalog. This step needs to happen before we generate and submit the operator bundle.
 
 1. Create the operator bundle using `make bundle` with the required variables `VERSION`, `PREV_VERSION`, `CHANNELS`, and `DEFAULT_CHANNEL`:
-   - **VERSION**: this release version. E.g. `1.13.1` (Note that these version strings are semver strings without the `v`.)
-   - **PREV_VERSION**: the latest published bundle version in this release stream. Navigate to the [certified operators production catalog](https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/tigera-operator) and look for the most recent version from this release branch. E.g., if this release is `v1.24.11` but the most recently published v1.24.x bundle is `v1.24.9` then you would use `VERSION=v1.24.11` and `PREV_VERSION=v1.24.9`. If this release is the first in this release branch, then there is no prior version so set `PREV_VERSION=0.0.0`.
+   - **VERSION**: this release version. E.g. `1.13.1` (**Note**: that these version strings are semver strings without the `v`.)
+   - **PREV_VERSION**: the latest published bundle version in this release stream. Navigate to the [certified operators production catalog](https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/tigera-operator) and look for the most recent version from this release branch. E.g., if this release is `v1.24.11` but the most recently published v1.24.x bundle is `1.24.9` then you would use `VERSION=1.24.11` and `PREV_VERSION=1.24.9`. If this release is the first in this release branch, then there is no prior version so set `PREV_VERSION=0.0.0`.
    - **CHANNELS** and **DEFAULT_CHANNEL**: should be set to the release branch of this operator release. E.g., if the operator release tag is `v1.23.5`, then CHANNELS and DEFAULT_CHANNEL should be `release-v1.23`.
 
    For example:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,7 +63,10 @@ Before beginning, ensure that the docs at docs.projectcalico.org for the Calico 
 1. Login to our operator project on connect.redhat.com and publish the operator image on the RH Catalog. This step needs to happen before we generate and submit the operator bundle.
 
 1. Create the operator bundle using `make bundle` with the required variables `VERSION`, `PREV_VERSION`, `CHANNELS`, and `DEFAULT_CHANNEL`:
-   - **VERSION**: this release version. E.g. `1.13.1` (**Note**: that these version strings are semver strings without the `v`.)
+
+   **Note**: the version strings in `VERSION` and `PREV_VERSION` are semver strings without the v.
+
+   - **VERSION**: this release version. E.g. `1.13.1`
    - **PREV_VERSION**: the latest published bundle version in this release stream. Navigate to the [certified operators production catalog](https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/tigera-operator) and look for the most recent version from this release branch. E.g., if this release is `v1.24.11` but the most recently published v1.24.x bundle is `1.24.9` then you would use `VERSION=1.24.11` and `PREV_VERSION=1.24.9`. If this release is the first in this release branch, then there is no prior version so set `PREV_VERSION=0.0.0`.
    - **CHANNELS** and **DEFAULT_CHANNEL**: should be set to the release branch of this operator release. E.g., if the operator release tag is `v1.23.5`, then CHANNELS and DEFAULT_CHANNEL should be `release-v1.23`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,7 +51,7 @@ You should have no local changes and tests should be passing.
 
 If the release includes new Calico CRDs, add the new CRDs to `hack/gen-bundle/get-manifests.sh` and `config/manifests/bases/operator.clusterserviceversion.yaml`.
 
-## Publishing a release on RH Catalog
+## Publishing a release on the RH Catalog
 
 We currently only publish operator releases targeting Calico. If the release targets Calico, continue onto the following steps to generate the
 operator bundle for it, and publish the release on the RH Catalog.
@@ -62,7 +62,7 @@ Before beginning, ensure that the docs at docs.projectcalico.org for the Calico 
 
 1. Login to our operator project on connect.redhat.com and publish the operator image on the RH Catalog. This step needs to happen before we generate and submit the operator metadata bundle.
 
-1. Create the operator metadata bundle, using the tag version for VERSION and the version that the release replaces in PREV_VERSION. The versions are semver strings.
+1. Create the operator bundle, using the tag version for VERSION and the version that the release replaces in PREV_VERSION. The versions are semver strings.
    CHANNELS and DEFAULT_CHANNEL should be set to the release stream.
    For example:
 
@@ -72,17 +72,4 @@ Before beginning, ensure that the docs at docs.projectcalico.org for the Calico 
 
    This step will create the bundle `bundle/1.13.1`.
 
-1. Login to our operator bundle project on connect.redhat.com
-
-1. Tag and push the operator bundle image to connect.redhat.com
-   ```
-   docker login -u unused scan.connect.redhat.com # Use the registry key found on our operator bundle project page at connect.redhat.com
-   docker tag tigera-operator-bundle:1.13.1 scan.connect.redhat.com/<project_id>/operator:1.13.1 # Replace the <project_id> with the PID found on our operator bundle project page at connect.redhat.com
-   docker push !$
-   ```
-
-3. Add the new bundle in `bundle/`, push the branch, submit a PR, and get it reviewed.
-
-4. Wait until the operator bundle has passed validation tests on our operator bundle project page at connect.redhat.com. Once that has
-   happened, publish the new bundle in the UI, and merge the operator PR.
-
+1. Publish the generated operator bundle following the [Operator Certification CI Pipeline instructions](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md). Bundles are no longer committed in this repository as they are committed in [redhat-openshift-ecosystem/certified-operators](https://github.com/redhat-openshift-ecosystem/certified-operators).

--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -63,9 +63,12 @@ yq write -i ${CSV} --style double 'metadata.annotations[olm.skipRange]' \<${VERS
 #
 sed -i 's/\(operators\.operatorframework\.\io\.bundle\.package\.v1\)=operator/\1=tigera-operator/' bundle.Dockerfile
 
+# Supported OpenShift versions. Specify min version.
+openshiftVersions=v4.6
+
 # Add in required labels
 cat <<EOF >> bundle.Dockerfile
-LABEL com.redhat.openshift.versions="v4.5"
+LABEL com.redhat.openshift.versions="${openshiftVersions}"
 LABEL com.redhat.delivery.backport=true
 LABEL com.redhat.delivery.operator.bundle=true
 EOF
@@ -104,3 +107,8 @@ sed -i 's/.*operators\.operatorframework\.io\.test.*//' bundle/${VERSION}/metada
 
 # Remove unneeded empty lines
 sed -i '/^$/d' bundle/${VERSION}/metadata/annotations.yaml
+
+# Add required com.redhat.openshift.versions
+cat <<EOF >> bundle/${VERSION}/metadata/annotations.yaml
+  com.redhat.openshift.versions: ${openshiftVersions}
+EOF

--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -58,6 +58,15 @@ fi
 # dot in the key "olm.skipRange".
 yq write -i ${CSV} --style double 'metadata.annotations[olm.skipRange]' \<${VERSION}
 
+# Add required 'relatedImages' to CSV
+# E.g.
+#
+#   relatedImages:
+#     - name: tigera-operator
+#       image: quay.io/tigera/operator@sha256:b4e3eeccfd3d5a931c07f31c244b272e058ccabd2d8155ccc3ff52ed78855e69
+yq write -i ${CSV} spec.relatedImages[0].name tigera-operator
+yq write -i ${CSV} spec.relatedImages[0].image ${OPERATOR_IMAGE_DIGEST}
+
 #
 # Now start updates to the bundle dockerfile. First update the package name.
 #

--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -39,7 +39,7 @@ mv bundle/{metadata,manifests} bundle/${VERSION}
 #
 # Update the CSV. Set the operator image container image and creation timestamp annotations.
 #
-yq write -i ${CSV} metadata.annotations.containerImage ${OPERATOR_IMAGE}
+yq write -i ${CSV} metadata.annotations.containerImage ${OPERATOR_IMAGE_DIGEST}
 TIMESTAMP=$(echo ${OPERATOR_IMAGE_INSPECT} | jq -r .[0].Created)
 yq write -i ${CSV} metadata.annotations.createdAt ${TIMESTAMP}
 

--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -90,6 +90,9 @@ EOF
 # validation fails
 yq delete -i ${CSV} spec.install.spec.permissions
 
+# Rename CSV to "tigera-operator".
+mv bundle/${VERSION}/manifests/operator.clusterserviceversion.yaml bundle/${VERSION}/manifests/tigera-operator.clusterserviceversion.yaml
+
 # Remove unneeded empty lines
 sed -i '/^$/d' bundle.Dockerfile
 

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -28,20 +28,3 @@ make release VERSION=${tag}
 
 echo "Publish release ${tag}"
 make release-publish-images VERSION=${tag}
-
-echo "Tagging and pushing operator images to RedHat Connect for certification..."
-
-docker login -u unused scan.connect.redhat.com --password-stdin <<< ${OPERATOR_RH_REGISTRY_KEY}
-redhatImage=scan.connect.redhat.com/$OPERATOR_RH_PROJECTID/operator:${tag}
-
-# Pushes to scan.connect.redhat.com fail if the image exists already.
-# If it already exists, skip tagging and pushing.
-if ! docker pull $redhatImage 2>/dev/null; then
-	echo "Tagging and pushing operator image..."
-	quayImage=quay.io/tigera/operator:${tag}
-	docker pull $quayImage
-	docker tag $quayImage $redhatImage
-	docker push $redhatImage
-else
-	echo "operator image exists on scan.connect.redhat.com, skipping tagging/pushing"
-fi


### PR DESCRIPTION
## Description

This PR fixes the operator bundle tooling and docs that are used to publish operator releases on RedHat's operator catalog. These fixes are needed for the latest updates to the certification pipeline referenced in the updated releasing doc.

This PR also removes the long broken release image push to RedHat. That method no longer works, and the [API](https://catalog.redhat.com/api/containers/v1/ui/#/Certification%20projects%20requests/pyxis.rest.legacy.cert_project_scan_request.create_certification_scan_request) to trigger image scans is going to be removed soon. Image scans will need to be done manually for now.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
