### PR TITLE
Setting MaxUnavailable to 1 when calculation against # of available calico node pods resolves to 0

### DIFF
--- a/pkg/controller/migration/namespace_migration.go
+++ b/pkg/controller/migration/namespace_migration.go
@@ -57,6 +57,8 @@ const (
 	typhaDeploymentName          = "calico-typha"
 	nodeDaemonSetName            = "calico-node"
 	kubeControllerDeploymentName = "calico-kube-controllers"
+
+	defaultMaxUnavailable int32 = 1
 )
 
 var (
@@ -529,7 +531,7 @@ func (m *CoreNamespaceMigration) migrateEachNode(ctx context.Context, log logr.L
 			// to come up. Also if the operator crashed we don't want to continue
 			// updating if the pods are not healthy.
 			log.V(1).Info("Waiting for new calico pods to be healthy")
-			err := m.waitUntilNodeCanBeMigrated(ctx)
+			err := m.waitUntilNodeCanBeMigrated(ctx, log)
 			if err == nil {
 				log.WithValues("node.Name", node.Name).V(1).Info("Adding label to node")
 				err = m.addNodeLabel(ctx, node.Name, nodeSelectorKey, nodeSelectorValuePost)
@@ -571,23 +573,35 @@ func (m *CoreNamespaceMigration) getNodesToMigrate() []*v1.Node {
 
 // waitUntilNodeCanBeMigrated checks the number of desired and ready pods in the kube-system and calico-system
 // daemonsets to make sure we don't simultaneously migrate more pods than allowed.
-func (m *CoreNamespaceMigration) waitUntilNodeCanBeMigrated(ctx context.Context) error {
+func (m *CoreNamespaceMigration) waitUntilNodeCanBeMigrated(ctx context.Context, log logr.Logger) error {
 	return wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		// num node desired schedule, num node ready, node max unavailable in kube-system
 		ksD, ksR, _, err := m.getNumPodsDesiredAndReady(ctx, kubeSystem, nodeDaemonSetName)
 		if err != nil {
 			return false, err
 		}
+
+		// num node desired schedule, num node ready, node max unavailable in calico-system
 		csD, csR, csMaxUnavailable, err := m.getNumPodsDesiredAndReady(ctx, common.CalicoNamespace, nodeDaemonSetName)
 		if err != nil {
 			return false, err
 		}
 
-		var maxUnavailable int32 = 1
+		var maxUnavailable int32 = defaultMaxUnavailable
 
 		if csMaxUnavailable != nil {
-			n, err := intstr.GetValueFromIntOrPercent(csMaxUnavailable, int(ksD+csD), false)
-			if err == nil {
-				maxUnavailable = int32(n)
+			numNodesMaxUnavailable, err := intstr.GetValueFromIntOrPercent(csMaxUnavailable, int(ksD+csD), false)
+			if err != nil {
+				log.Error(err, "Invalid maxUnavailable value, falling back to default of 1")
+			} else {
+				// Due to the potential rounding down of numNodesMaxUnavailable = (csMaxUnavailable %) * ksD+csD, where maxUnavailable is a percentage value,
+				// ,it may resolve to zero. Then we should default back maxUnavailable to 1 on the theory that surge might not work
+				// due to quota.
+				if numNodesMaxUnavailable < 1 {
+					log.Info("Max unavailble nodes calculation resolved to 0, defaulting back to 1 to allow upgrades to continue")
+				} else {
+					maxUnavailable = int32(numNodesMaxUnavailable)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Due to the potential rounding down of numNodesMaxUnavailable = (csMaxUnavailable %) * ksD+csD, where maxUnavailable is a percentage value, ,it may resolve to zero. Then we should default back maxUnavailable to 1 on the theory that surge might not work due to quota.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
