### PR TITLE
[release-v1.24] Pick of #1810: windows: only render upgrader components on AKS

### DIFF
--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -52,7 +52,6 @@ func allCalicoComponents(
 	typhaNodeTLS *render.TyphaNodeTLS,
 	managerInternalTLSSecret *corev1.Secret,
 	bt map[string]string,
-	p operatorv1.Provider,
 	aci *operatorv1.AmazonCloudIntegration,
 	up bool,
 	nodeAppArmorProfile string,
@@ -62,7 +61,6 @@ func allCalicoComponents(
 	bgpLayout *corev1.ConfigMap,
 	logCollector *operatorv1.LogCollector,
 ) ([]render.Component, error) {
-	cr.KubernetesProvider = p
 	namespaces := render.Namespaces(cr, pullSecrets)
 
 	objs := []client.Object{}
@@ -191,7 +189,7 @@ var _ = Describe("Rendering tests", func() {
 		// - 7 typha resources (Service, SA, Role, Binding, Deployment, PodDisruptionBudget, PodSecurityPolicy)
 		// - 6 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment, PodSecurityPolicy, Service, Secret)
 		// - 1 namespace
-		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
+		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c)).To(Equal(6 + 4 + 2 + 7 + 6 + 1))
 		Expect(getAKSWindowsUpgraderComponentCount(c)).To(Equal(0))
@@ -205,7 +203,7 @@ var _ = Describe("Rendering tests", func() {
 		var nodeMetricsPort int32 = 9081
 		instance.Variant = operatorv1.TigeraSecureEnterprise
 		instance.NodeMetricsPort = &nodeMetricsPort
-		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
+		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(componentCount(c)).To(Equal((6 + 4 + 2 + 7 + 6 + 1) + 1 + 1))
 		Expect(getAKSWindowsUpgraderComponentCount(c)).To(Equal(0))
@@ -225,7 +223,7 @@ var _ = Describe("Rendering tests", func() {
 				Name: render.ManagerInternalTLSSecretName, Namespace: common.OperatorNamespace(),
 			},
 		}
-		c, err := allCalicoComponents(k8sServiceEp, instance, &operatorv1.ManagementCluster{}, nil, nil, typhaNodeTLS, internalManagerTLSSecret, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
+		c, err := allCalicoComponents(k8sServiceEp, instance, &operatorv1.ManagementCluster{}, nil, nil, typhaNodeTLS, internalManagerTLSSecret, nil, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 
 		expectedResources := []struct {
@@ -290,14 +288,15 @@ var _ = Describe("Rendering tests", func() {
 	})
 
 	It("should render windows upgrader resources for AKS", func() {
-		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderAKS, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
+		instance.KubernetesProvider = operatorv1.ProviderAKS
+		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		Expect(getAKSWindowsUpgraderComponentCount(c)).To(Equal(2))
 	})
 
 	It("should render calico with a apparmor profile if annotation is present in installation", func() {
 		apparmorProf := "foobar"
-		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, apparmorProf, dns.DefaultClusterDomain, 0, 0, nil, nil)
+		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, apparmorProf, dns.DefaultClusterDomain, 0, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		var cn *appsv1.DaemonSet
 		for _, comp := range comps {
@@ -321,7 +320,7 @@ var _ = Describe("Rendering tests", func() {
 		}
 		bgpLayout.Name = "bgp-layout"
 		bgpLayout.Namespace = common.OperatorNamespace()
-		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 0, 0, bgpLayout, nil)
+		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 0, 0, bgpLayout, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		var cm *corev1.ConfigMap
 		var ds *appsv1.DaemonSet
@@ -346,7 +345,7 @@ var _ = Describe("Rendering tests", func() {
 		testNode := func(processPath operatorv1.CollectProcessPathOption, expectedHostPID bool) {
 			var logCollector operatorv1.LogCollector
 			logCollector.Spec.CollectProcessPath = &processPath
-			comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, &logCollector)
+			comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, &logCollector)
 			Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 			var ds *appsv1.DaemonSet
 			for _, comp := range comps {
@@ -377,7 +376,7 @@ var _ = Describe("Rendering tests", func() {
 	})
 
 	It("should set node priority class to system-node-critical", func() {
-		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, nil)
+		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		var cn *appsv1.DaemonSet
 		for _, comp := range comps {
@@ -393,7 +392,7 @@ var _ = Describe("Rendering tests", func() {
 	})
 
 	It("should set typha priority class to system-cluster-critical", func() {
-		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, nil)
+		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		var cn *appsv1.Deployment
 		for _, comp := range comps {
@@ -409,7 +408,7 @@ var _ = Describe("Rendering tests", func() {
 	})
 
 	It("should set kube controllers priority class to system-cluster-critical", func() {
-		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, nil)
+		comps, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, nil, false, "", dns.DefaultClusterDomain, 0, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
 		var cn *appsv1.Deployment
 		for _, comp := range comps {

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -62,7 +62,7 @@ func allCalicoComponents(
 	bgpLayout *corev1.ConfigMap,
 	logCollector *operatorv1.LogCollector,
 ) ([]render.Component, error) {
-
+	cr.KubernetesProvider = p
 	namespaces := render.Namespaces(cr, pullSecrets)
 
 	objs := []client.Object{}
@@ -190,11 +190,11 @@ var _ = Describe("Rendering tests", func() {
 		// - 2 ConfigMap for Typha comms (1 in operator namespace and 1 in calico namespace)
 		// - 7 typha resources (Service, SA, Role, Binding, Deployment, PodDisruptionBudget, PodSecurityPolicy)
 		// - 6 kube-controllers resources (ServiceAccount, ClusterRole, Binding, Deployment, PodSecurityPolicy, Service, Secret)
-		// - 2 windows-upgrader resources (ServiceAccount, DaemonSet)
 		// - 1 namespace
 		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
-		Expect(componentCount(c)).To(Equal(6 + 4 + 2 + 7 + 6 + 2 + 1))
+		Expect(componentCount(c)).To(Equal(6 + 4 + 2 + 7 + 6 + 1))
+		Expect(getAKSWindowsUpgraderComponentCount(c)).To(Equal(0))
 	})
 
 	It("should render all resources when variant is Tigera Secure", func() {
@@ -207,7 +207,8 @@ var _ = Describe("Rendering tests", func() {
 		instance.NodeMetricsPort = &nodeMetricsPort
 		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderNone, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
-		Expect(componentCount(c)).To(Equal((6 + 4 + 2 + 7 + 6 + 2 + 1) + 1 + 1))
+		Expect(componentCount(c)).To(Equal((6 + 4 + 2 + 7 + 6 + 1) + 1 + 1))
+		Expect(getAKSWindowsUpgraderComponentCount(c)).To(Equal(0))
 	})
 
 	It("should render all resources when variant is Tigera Secure and Management Cluster", func() {
@@ -273,10 +274,6 @@ var _ = Describe("Rendering tests", func() {
 			{render.ManagerInternalTLSSecretName, common.CalicoNamespace, "", "v1", "Secret"},
 			{common.KubeControllersDeploymentName, "", "policy", "v1beta1", "PodSecurityPolicy"},
 			{"calico-kube-controllers-metrics", common.CalicoNamespace, "", "v1", "Service"},
-
-			// windows upgrader objects.
-			{common.CalicoWindowsUpgradeResourceName, common.CalicoNamespace, "", "v1", "ServiceAccount"},
-			{common.CalicoWindowsUpgradeResourceName, common.CalicoNamespace, "apps", "v1", "DaemonSet"},
 		}
 
 		var resources []client.Object
@@ -289,6 +286,13 @@ var _ = Describe("Rendering tests", func() {
 		for i, expectedRes := range expectedResources {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
+		Expect(getAKSWindowsUpgraderComponentCount(c)).To(Equal(0))
+	})
+
+	It("should render windows upgrader resources for AKS", func() {
+		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, operatorv1.ProviderAKS, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
+		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
+		Expect(getAKSWindowsUpgraderComponentCount(c)).To(Equal(2))
 	})
 
 	It("should render calico with a apparmor profile if annotation is present in installation", func() {
@@ -429,6 +433,21 @@ func componentCount(components []render.Component) int {
 		glog.Printf("Component: %s\n", reflect.TypeOf(c))
 		for i, o := range objsToCreate {
 			glog.Printf(" - %d/%d: %s/%s\n", i, len(objsToCreate), o.GetNamespace(), o.GetName())
+		}
+	}
+	return count
+}
+
+func getAKSWindowsUpgraderComponentCount(components []render.Component) int {
+	var resources []client.Object
+	for _, component := range components {
+		var toCreate, _ = component.Objects()
+		resources = append(resources, toCreate...)
+	}
+	count := 0
+	for _, r := range resources {
+		if r.GetName() == common.CalicoWindowsUpgradeResourceName {
+			count += 1
 		}
 	}
 	return count

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -68,6 +68,10 @@ func (c *windowsComponent) Objects() ([]client.Object, []client.Object) {
 		c.windowsUpgradeDaemonset(),
 	}
 
+	if c.cr.KubernetesProvider != operatorv1.ProviderAKS {
+		return nil, objs
+	}
+
 	return objs, nil
 }
 


### PR DESCRIPTION
Cherry pick of #1810 on release-v1.24.

#1810: windows: only render upgrader components on AKS