### PR TITLE
Use certificatemanager for dex

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -124,20 +124,11 @@ func add(mgr manager.Manager, r *ReconcileAPIServer) error {
 		}
 	}
 
-	// Watch for certificate changes. We watch both secrets in case the user is switching between variants.
-	if err = utils.AddSecretsWatch(c, "calico-apiserver-certs", common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
-	}
-	if err = utils.AddSecretsWatch(c, "tigera-apiserver-certs", common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
-	}
-
-	if err = utils.AddSecretsWatch(c, render.PacketCaptureCertSecret, common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
-	}
-
-	if err = utils.AddSecretsWatch(c, certificatemanagement.CASecretName, common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
+	for _, secretName := range []string{"calico-apiserver-certs", "tigera-apiserver-certs", render.PacketCaptureCertSecret,
+		certificatemanagement.CASecretName, render.DexTLSSecretName} {
+		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
+			return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
+		}
 	}
 
 	if err = imageset.AddImageSetWatch(c); err != nil {

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -115,7 +115,7 @@ func add(mgr manager.Manager, c controller.Controller) error {
 			relasticsearch.PublicCertSecret, render.ElasticsearchComplianceBenchmarkerUserSecret,
 			render.ElasticsearchComplianceControllerUserSecret, render.ElasticsearchComplianceReporterUserSecret,
 			render.ElasticsearchComplianceSnapshotterUserSecret, render.ElasticsearchComplianceServerUserSecret,
-			render.ComplianceServerCertSecret, render.ManagerInternalTLSSecretName, render.DexCertSecretName, certificatemanagement.CASecretName} {
+			render.ComplianceServerCertSecret, render.ManagerInternalTLSSecretName, certificatemanagement.CASecretName} {
 			if err = utils.AddSecretsWatch(c, secretName, namespace); err != nil {
 				return fmt.Errorf("compliance-controller failed to watch the secret '%s' in '%s' namespace: %w", secretName, namespace, err)
 			}

--- a/pkg/controller/logstorage/logstorage.go
+++ b/pkg/controller/logstorage/logstorage.go
@@ -19,11 +19,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/render"
@@ -110,24 +108,6 @@ func (r *ReconcileLogStorage) createLogStorage(
 		return reconcile.Result{}, false, finalizerCleanup, nil
 	}
 
-	var dexCfg render.DexRelyingPartyConfig
-	// If the authentication CR is available and it is not configured to use the Tigera OIDC type then configure dex.
-	if authentication != nil && (authentication.Spec.OIDC == nil || authentication.Spec.OIDC.Type != operatorv1.OIDCTypeTigera) {
-		var dexCertSecret *corev1.Secret
-		dexCertSecret = &corev1.Secret{}
-		if err := r.client.Get(ctx, types.NamespacedName{Name: render.DexCertSecretName, Namespace: common.OperatorNamespace()}, dexCertSecret); err != nil {
-			r.status.SetDegraded("Failed to read dex tls secret", err.Error())
-			return reconcile.Result{}, false, finalizerCleanup, err
-		}
-
-		dexSecret := &corev1.Secret{}
-		if err := r.client.Get(ctx, types.NamespacedName{Name: render.DexObjectName, Namespace: common.OperatorNamespace()}, dexSecret); err != nil {
-			r.status.SetDegraded("Failed to read dex tls secret", err.Error())
-			return reconcile.Result{}, false, finalizerCleanup, err
-		}
-		dexCfg = render.NewDexRelyingPartyConfig(authentication, dexCertSecret, dexSecret, r.clusterDomain)
-	}
-
 	var baseURL string
 	if authentication != nil && authentication.Spec.ManagerDomain != "" {
 		baseURL = authentication.Spec.ManagerDomain
@@ -159,7 +139,6 @@ func (r *ReconcileLogStorage) createLogStorage(
 		ESService:                   esService,
 		KbService:                   kbService,
 		ClusterDomain:               r.clusterDomain,
-		DexCfg:                      dexCfg,
 		BaseURL:                     baseURL,
 		ElasticLicenseType:          esLicenseType,
 	}

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -485,7 +485,6 @@ var _ = Describe("LogStorage controller", func() {
 					})).ToNot(HaveOccurred())
 
 					Expect(cli.Create(ctx, render.CreateDexClientSecret())).ToNot(HaveOccurred())
-					Expect(cli.Create(ctx, render.CreateCertificateSecret([]byte(""), render.DexCertSecretName, common.OperatorNamespace()))).ToNot(HaveOccurred())
 
 					Expect(cli.Create(ctx, &storagev1.StorageClass{
 						ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/utils/auth.go
+++ b/pkg/controller/utils/auth.go
@@ -49,12 +49,7 @@ func GetKeyValidatorConfig(ctx context.Context, cli client.Client, authenticatio
 				return nil, err
 			}
 		} else {
-			dexTLSSecret := &corev1.Secret{}
-			if err := cli.Get(ctx, types.NamespacedName{Name: render.DexCertSecretName, Namespace: common.OperatorNamespace()}, dexTLSSecret); err != nil {
-				return nil, err
-			}
-
-			keyValidatorConfig = render.NewDexKeyValidatorConfig(authenticationCR, idpSecret, dexTLSSecret, clusterDomain)
+			keyValidatorConfig = render.NewDexKeyValidatorConfig(authenticationCR, idpSecret, clusterDomain)
 		}
 	}
 

--- a/pkg/controller/utils/auth.go
+++ b/pkg/controller/utils/auth.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (
@@ -44,6 +58,9 @@ func GetKeyValidatorConfig(ctx context.Context, cli client.Client, authenticatio
 				kvcOptions = append(kvcOptions, tigerakvc.WithGroupsPrefix(oidc.GroupsPrefix))
 			}
 
+			if rootCA, found := idpSecret.Data[render.RootCASecretField]; found {
+				kvcOptions = append(kvcOptions, tigerakvc.WithRootCA(rootCA))
+			}
 			keyValidatorConfig, err = tigerakvc.New(oidc.IssuerURL, string(idpSecret.Data["clientID"]), kvcOptions...)
 			if err != nil {
 				return nil, err

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -170,6 +170,27 @@ func (c componentHandler) CreateOrUpdateOrDelete(ctx context.Context, component 
 				if err := c.client.Create(ctx, obj); err != nil {
 					return err
 				}
+			case *v1.Secret:
+				objSecret := obj.(*v1.Secret)
+				curSecret := cur.(*v1.Secret)
+				// Secret types are immutable, we need to delete the old version if the type has changed. If the
+				// object type is unset, it will result in SecretTypeOpaque, so this difference can be excluded.
+				if objSecret.Type != curSecret.Type &&
+					!(len(objSecret.Type) == 0 && curSecret.Type == v1.SecretTypeOpaque) {
+					if err := c.client.Delete(ctx, obj); err != nil {
+						logCtx.WithValues("key", key).Info("Failed to delete secret for recreation.")
+						return err
+					}
+					obj.SetResourceVersion("")
+					if err := c.client.Create(ctx, obj); err != nil {
+						return err
+					}
+				} else {
+					if err := c.client.Update(ctx, mobj); err != nil {
+						logCtx.WithValues("key", key).Info("Failed to update object.")
+						return err
+					}
+				}
 			default:
 				if err := c.client.Update(ctx, mobj); err != nil {
 					logCtx.WithValues("key", key).Info("Failed to update object.")

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -25,6 +25,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -878,6 +879,32 @@ var _ = Describe("Component handler tests", func() {
 			},
 		},
 	)
+
+	It("allows you to replace a secret if the types change", func() {
+		// Please note that a fake client does not behave exactly as it would on K8s:
+		// - A secret without a type in a real cluster automatically becomes type Opaque
+		// - An update where the secret type changes would be rejected in a real cluster, yet the fake client accepts it.
+		// This test serves to purpose of at least verifying that an update of a secret type works without error.
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-secret"},
+			Type:       corev1.SecretTypeOpaque,
+		}
+		fc := &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs: []client.Object{
+				secret,
+			},
+		}
+		err := handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-secret"}, secret)).NotTo(HaveOccurred())
+		Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+		secret.Type = corev1.SecretTypeTLS
+		err = handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-secret"}, secret)).NotTo(HaveOccurred())
+		Expect(secret.Type).To(Equal(corev1.SecretTypeTLS))
+	})
 })
 
 // A fake component that only returns ready and always creates the "test-namespace" Namespace.

--- a/pkg/render/common/authentication/tigera/key_validator_config/key_validator_config.go
+++ b/pkg/render/common/authentication/tigera/key_validator_config/key_validator_config.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tigerakvc
 
 import (
@@ -29,6 +43,7 @@ type KeyValidatorConfig struct {
 	groupsClaim     string
 	usernamePrefix  string
 	groupsPrefix    string
+	rootCA          []byte
 }
 
 func New(issuerURL string, clientID string, options ...Option) (authentication.KeyValidatorConfig, error) {
@@ -43,7 +58,7 @@ func New(issuerURL string, clientID string, options ...Option) (authentication.K
 		option(kvc)
 	}
 
-	wellKnownConfig, err := authentication.NewWellKnownConfig(kvc.issuerURL)
+	wellKnownConfig, err := authentication.NewWellKnownConfig(kvc.issuerURL, kvc.rootCA)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/render/common/authentication/tigera/key_validator_config/key_validator_config_options.go
+++ b/pkg/render/common/authentication/tigera/key_validator_config/key_validator_config_options.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tigerakvc
 
 type Option func(*KeyValidatorConfig)
@@ -23,5 +37,11 @@ func WithUsernamePrefix(usernamePrefix string) Option {
 func WithGroupsPrefix(groupsPrefix string) Option {
 	return func(config *KeyValidatorConfig) {
 		config.groupsClaim = groupsPrefix
+	}
+}
+
+func WithRootCA(rootCA []byte) Option {
+	return func(config *KeyValidatorConfig) {
+		config.rootCA = rootCA
 	}
 }

--- a/pkg/render/common/authentication/types.go
+++ b/pkg/render/common/authentication/types.go
@@ -21,10 +21,6 @@ type KeyValidatorConfig interface {
 	RequiredAnnotations() map[string]string
 	// RequiredSecrets returns secrets that the KeyValidatorConfig implementation requires.
 	RequiredSecrets(namespace string) []*corev1.Secret
-	// RequiredVolumeMounts returns volume mounts that the KeyValidatorConfig implementation requires.
-	RequiredVolumeMounts() []corev1.VolumeMount
-	// RequiredVolumes returns volumes that the KeyValidatorConfig implementation requires.
-	RequiredVolumes() []corev1.Volume
 }
 
 func NewWellKnownConfig(issuerURL string) (*WellKnownConfig, error) {

--- a/pkg/render/common/authentication/types.go
+++ b/pkg/render/common/authentication/types.go
@@ -1,6 +1,22 @@
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package authentication
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -21,10 +37,21 @@ type KeyValidatorConfig interface {
 	RequiredAnnotations() map[string]string
 	// RequiredSecrets returns secrets that the KeyValidatorConfig implementation requires.
 	RequiredSecrets(namespace string) []*corev1.Secret
+	// RequiredVolumeMounts returns volume mounts that the KeyValidatorConfig implementation requires.
+	RequiredVolumeMounts() []corev1.VolumeMount
+	// RequiredVolumes returns volumes that the KeyValidatorConfig implementation requires.
+	RequiredVolumes() []corev1.Volume
 }
 
-func NewWellKnownConfig(issuerURL string) (*WellKnownConfig, error) {
+func NewWellKnownConfig(issuerURL string, rootCA []byte) (*WellKnownConfig, error) {
 	httpClient := http.DefaultClient
+	if len(rootCA) > 0 {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(rootCA)
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: caCertPool},
+		}
+	}
 
 	wellKnown := strings.TrimSuffix(issuerURL, "/") + "/.well-known/openid-configuration"
 	req, err := http.NewRequest("GET", wellKnown, nil)

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -745,10 +745,6 @@ func (c *complianceComponent) complianceServerVolumeMounts() []corev1.VolumeMoun
 		c.cfg.ComplianceServerCertSecret.VolumeMount(),
 	}
 
-	if c.cfg.KeyValidatorConfig != nil {
-		mounts = append(mounts, c.cfg.KeyValidatorConfig.RequiredVolumeMounts()...)
-	}
-
 	return mounts
 }
 
@@ -757,11 +753,6 @@ func (c *complianceComponent) complianceServerVolumes() []corev1.Volume {
 		c.cfg.ComplianceServerCertSecret.Volume(),
 		c.cfg.TrustedBundle.Volume(),
 	}
-
-	if c.cfg.KeyValidatorConfig != nil {
-		volumes = append(volumes, c.cfg.KeyValidatorConfig.RequiredVolumes()...)
-	}
-
 	return volumes
 }
 

--- a/pkg/render/crypto_utils.go
+++ b/pkg/render/crypto_utils.go
@@ -57,22 +57,6 @@ func VoltronTunnelSecret() *corev1.Secret {
 	}
 }
 
-func CreateDexTLSSecret(dexCommonName string) *corev1.Secret {
-	key, cert := createSelfSignedSecret(dexCommonName, []string{dexCommonName})
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DexTLSSecretName,
-			Namespace: common.OperatorNamespace(),
-		},
-		Type: corev1.SecretTypeTLS,
-		Data: map[string][]byte{
-			corev1.TLSCertKey:       []byte(cert),
-			corev1.TLSPrivateKeyKey: []byte(key),
-		},
-	}
-}
-
 // Secrets to establish a tunnel between Voltron and Guardian
 // Differs from other secrets in the way that it needs a DNS name and KeyUsage.
 func createSelfSignedSecret(cn string, altNames []string) (string, string) {

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 package render
 
 import (
@@ -21,7 +22,6 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/dns"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podaffinity"
 	"github.com/tigera/operator/pkg/render/common/podsecuritycontext"
@@ -38,20 +38,11 @@ import (
 )
 
 const (
-	// Manifest object variables
-	DexNamespace  = "tigera-dex"
-	DexObjectName = "tigera-dex"
-	DexPort       = 5556
-	// This is the secret containing just a cert that a client should mount in order to trust Dex.
-	DexCertSecretName = "tigera-dex-tls-crt"
-	// This is the secret that Dex mounts, containing a key and a cert.
+	DexNamespace     = "tigera-dex"
+	DexObjectName    = "tigera-dex"
+	DexPort          = 5556
 	DexTLSSecretName = "tigera-dex-tls"
-
-	// Constants related to Dex configurations
-	DexClientId = "tigera-manager"
-
-	// Common name to add to the Dex TLS secret.
-	DexCNPattern = "tigera-dex.tigera-dex.svc.%s"
+	DexClientId      = "tigera-manager"
 )
 
 func Dex(cfg *DexComponentConfiguration) Component {
@@ -70,6 +61,7 @@ type DexComponentConfiguration struct {
 	DexConfig     DexConfig
 	ClusterDomain string
 	DeleteDex     bool
+	TLSKeyPair    certificatemanagement.KeyPairInterface
 }
 
 type dexComponent struct {
@@ -125,7 +117,6 @@ func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, secret.ToRuntimeObjects(c.cfg.DexConfig.RequiredSecrets(common.OperatorNamespace())...)...)
 	}
 
-	objs = append(objs, c.cfg.DexConfig.CreateCertSecret())
 	objs = append(objs, secret.ToRuntimeObjects(c.cfg.DexConfig.RequiredSecrets(DexNamespace)...)...)
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(DexNamespace, c.cfg.PullSecrets...)...)...)
 
@@ -140,7 +131,6 @@ func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 	return objs, nil
 }
 
-// Method to satisfy the Component interface.
 func (c *dexComponent) Ready() bool {
 	return true
 }
@@ -196,18 +186,11 @@ func (c *dexComponent) clusterRoleBinding() client.Object {
 
 func (c *dexComponent) deployment() client.Object {
 	var initContainers []corev1.Container
-	if c.cfg.Installation.CertificateManagement != nil {
-		initContainers = append(initContainers, certificatemanagement.CreateCSRInitContainer(
-			c.cfg.Installation.CertificateManagement,
-			c.csrInitImage,
-			"tls",
-			DexObjectName,
-			corev1.TLSPrivateKeyKey,
-			corev1.TLSCertKey,
-			dns.GetServiceDNSNames(DexObjectName, DexNamespace, c.cfg.ClusterDomain),
-			DexNamespace))
+	if c.cfg.TLSKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(DexNamespace))
 	}
-
+	annotations := c.cfg.DexConfig.RequiredAnnotations()
+	annotations[c.cfg.TLSKeyPair.HashAnnotationKey()] = c.cfg.TLSKeyPair.HashAnnotationValue()
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -234,7 +217,7 @@ func (c *dexComponent) deployment() client.Object {
 					Labels: map[string]string{
 						"k8s-app": DexObjectName,
 					},
-					Annotations: c.cfg.DexConfig.RequiredAnnotations(),
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
@@ -258,11 +241,10 @@ func (c *dexComponent) deployment() client.Object {
 									ContainerPort: DexPort,
 								},
 							},
-
-							VolumeMounts: c.cfg.DexConfig.RequiredVolumeMounts(),
+							VolumeMounts: append(c.cfg.DexConfig.RequiredVolumeMounts(), c.cfg.TLSKeyPair.VolumeMount()),
 						},
 					},
-					Volumes: c.cfg.DexConfig.RequiredVolumes(),
+					Volumes: append(c.cfg.DexConfig.RequiredVolumes(), c.cfg.TLSKeyPair.Volume()),
 				},
 			},
 		},

--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,9 +58,7 @@ const (
 	BindPWSecretField            = "bindPW"
 
 	// OIDC well-known-config related constants.
-	jwksURI     = "https://tigera-dex.tigera-dex.svc.%s:5556/dex/keys"
-	tokenURI    = "https://tigera-dex.tigera-dex.svc.%s:5556/dex/token"
-	userInfoURI = "https://tigera-dex.tigera-dex.svc.%s:5556/dex/userinfo"
+	jwksURI = "https://tigera-dex.tigera-dex.svc.%s:5556/dex/keys"
 
 	// Env related constants.
 	googleAdminEmailEnv = "ADMIN_EMAIL"
@@ -108,6 +106,14 @@ func NewDexConfig(
 
 type DexKeyValidatorConfig struct {
 	*dexBaseCfg
+}
+
+func (d *DexKeyValidatorConfig) RequiredVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{}
+}
+
+func (d *DexKeyValidatorConfig) RequiredVolumes() []corev1.Volume {
+	return []corev1.Volume{}
 }
 
 type dexConfig struct {

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -126,29 +126,6 @@ const (
 )
 
 const (
-	keystoreInitVolumeName = "elastic-internal-secure-settings"
-	keystoreInitMountPath  = "/mnt/elastic-internal/secure-settings"
-
-	keystoreInitScript = `#!/usr/bin/env bash
-set -eux
-
-echo "Initializing keystore."
-
-# create a keystore in the default data path
-# We use they elasticsearch-keystore list to test if the keystore has been initialized.
-! /usr/share/elasticsearch/bin/elasticsearch-keystore list && /usr/share/elasticsearch/bin/elasticsearch-keystore create
-
-# add all existing secret entries into it
-for filename in  /mnt/elastic-internal/secure-settings/*; do
-	[[ -e "$filename" ]] || continue # glob does not match
-	key=$(basename "$filename")
-	echo "Adding $key to the keystore."
-	/usr/share/elasticsearch/bin/elasticsearch-keystore add-file "$key" "$filename" -f
-done
-
-echo "Keystore initialization successful."
-`
-
 	csrRootCAConfigMapName = "elasticsearch-config"
 )
 
@@ -208,7 +185,6 @@ type ElasticsearchConfiguration struct {
 	ESService                   *corev1.Service
 	KbService                   *corev1.Service
 	ClusterDomain               string
-	DexCfg                      DexRelyingPartyConfig
 	BaseURL                     string // BaseUrl is where the manager is reachable, for setting Kibana publicBaseUrl
 	ElasticLicenseType          ElasticsearchLicenseType
 }
@@ -336,12 +312,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.elasticsearchServiceAccount())
 		toCreate = append(toCreate, es.cfg.ClusterConfig.ConfigMap())
 
-		secureSettings := es.secureSettingsSecret()
-		if len(secureSettings.Data) > 0 {
-			toCreate = append(toCreate, secureSettings)
-		}
-
-		toCreate = append(toCreate, es.elasticsearchCluster(len(secureSettings.Data) > 0))
+		toCreate = append(toCreate, es.elasticsearchCluster())
 
 		// Kibana CRs
 		toCreate = append(toCreate, CreateNamespace(KibanaNamespace, es.cfg.Installation.KubernetesProvider))
@@ -391,10 +362,6 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 			CreateNamespace(ElasticsearchNamespace, es.cfg.Installation.KubernetesProvider),
 			es.elasticsearchExternalService(),
 		)
-	}
-
-	if es.supportsOIDC() {
-		toCreate = append(toCreate, secret.ToRuntimeObjects(es.cfg.DexCfg.RequiredSecrets(ElasticsearchNamespace)...)...)
 	}
 
 	if es.cfg.Installation.CertificateManagement != nil {
@@ -465,9 +432,6 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	// https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-jvm-heap-size.html#k8s-jvm-heap-size
 
 	var volumeMounts []corev1.VolumeMount
-	if es.supportsOIDC() {
-		volumeMounts = append(volumeMounts, es.cfg.DexCfg.RequiredVolumeMounts()...)
-	}
 
 	esContainer := corev1.Container{
 		Name: "elasticsearch",
@@ -545,29 +509,8 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	annotations := map[string]string{
 		ElasticsearchTLSHashAnnotation: rmeta.SecretsAnnotationHash(es.cfg.ElasticsearchSecrets...),
 	}
-	if es.supportsOIDC() {
-		initKeystore := corev1.Container{
-			Name:  "elastic-internal-init-keystore",
-			Image: es.esImage,
-			SecurityContext: &corev1.SecurityContext{
-				Privileged: ptr.BoolToPtr(false),
-			},
-			Command: []string{"/usr/bin/env", "bash", "-c", keystoreInitScript},
-			VolumeMounts: []corev1.VolumeMount{{
-				Name:      keystoreInitVolumeName,
-				MountPath: keystoreInitMountPath,
-				ReadOnly:  true,
-			}},
-		}
-		initContainers = append(initContainers, initKeystore)
-		annotations = es.cfg.DexCfg.RequiredAnnotations()
-	}
 
 	var volumes []corev1.Volume
-
-	if es.supportsOIDC() {
-		volumes = es.cfg.DexCfg.RequiredVolumes()
-	}
 
 	var autoMountToken bool
 	if es.cfg.Installation.CertificateManagement != nil {
@@ -728,7 +671,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 }
 
 // render the Elasticsearch CR that the ECK operator uses to create elasticsearch cluster
-func (es elasticsearchComponent) elasticsearchCluster(secureSettings bool) *esv1.Elasticsearch {
+func (es elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 	elasticsearch := &esv1.Elasticsearch{
 		TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch", APIVersion: "elasticsearch.k8s.elastic.co/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -752,29 +695,7 @@ func (es elasticsearchComponent) elasticsearchCluster(secureSettings bool) *esv1
 		},
 	}
 
-	if secureSettings {
-		elasticsearch.Spec.SecureSettings = []cmnv1.SecretSource{{
-			SecretName: ElasticsearchSecureSettingsSecretName,
-		}}
-	}
-
 	return elasticsearch
-}
-
-func (es elasticsearchComponent) secureSettingsSecret() *corev1.Secret {
-	secureSettings := make(map[string][]byte)
-
-	if es.supportsOIDC() {
-		secureSettings["xpack.security.authc.realms.oidc.oidc1.rp.client_secret"] = es.cfg.DexCfg.ClientSecret()
-	}
-
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ElasticsearchSecureSettingsSecretName,
-			Namespace: ElasticsearchNamespace,
-		},
-		Data: secureSettings,
-	}
 }
 
 // Determine the recommended JVM heap size as a string (with appropriate unit suffix) based on
@@ -946,24 +867,6 @@ func (es elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentVo
 		"node.data":                   "true",
 		"node.ingest":                 "true",
 		"cluster.max_shards_per_node": 10000,
-	}
-	if es.supportsOIDC() {
-		config["xpack.security.authc.realms.oidc.oidc1"] = map[string]interface{}{
-			"order":                       1,
-			"rp.client_id":                DexClientId,
-			"op.jwkset_path":              es.cfg.DexCfg.JWKSURI(),
-			"op.userinfo_endpoint":        es.cfg.DexCfg.UserInfoURI(),
-			"op.token_endpoint":           es.cfg.DexCfg.TokenURI(),
-			"claims.principal":            es.cfg.DexCfg.UsernameClaim(),
-			"claims.groups":               DefaultGroupsClaim,
-			"rp.response_type":            "code",
-			"rp.requested_scopes":         []string{"openid", "email", "profile", "groups", "offline_access"},
-			"rp.redirect_uri":             fmt.Sprintf("%s/tigera-kibana/api/security/oidc/callback", es.cfg.DexCfg.BaseURL()),
-			"rp.post_logout_redirect_uri": fmt.Sprintf("%s/tigera-kibana/logged_out", es.cfg.DexCfg.BaseURL()),
-			"op.issuer":                   es.cfg.DexCfg.Issuer(),
-			"op.authorization_endpoint":   fmt.Sprintf("%s/dex/auth", es.cfg.DexCfg.BaseURL()),
-			"ssl.certificate_authorities": []string{"/usr/share/elasticsearch/config/dex/tls-dex.crt"},
-		}
 	}
 
 	if es.cfg.Installation.CertificateManagement != nil {
@@ -1273,12 +1176,6 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 			"enabled":        true,
 			"licenseEdition": "enterpriseEdition",
 		},
-	}
-
-	if es.supportsOIDC() {
-		config["xpack.security.authc.providers"] = []string{"oidc", "basic"}
-		config["xpack.security.authc.oidc.realm"] = "oidc1"
-		config["server.xsrf.whitelist"] = []string{"/api/security/oidc/initiate_login"}
 	}
 
 	var initContainers []corev1.Container
@@ -1610,12 +1507,6 @@ func (es elasticsearchComponent) kibanaPodSecurityPolicy() *policyv1beta1.PodSec
 	psp := podsecuritypolicy.NewBasePolicy()
 	psp.GetObjectMeta().SetName("tigera-kibana")
 	return psp
-}
-
-func (es *elasticsearchComponent) supportsOIDC() bool {
-	return (es.cfg.ElasticLicenseType == ElasticsearchLicenseTypeEnterpriseTrial ||
-		es.cfg.ElasticLicenseType == ElasticsearchLicenseTypeEnterprise) &&
-		es.cfg.DexCfg != nil
 }
 
 func (es elasticsearchComponent) oidcUserRole() client.Object {

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -470,58 +470,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			Expect(nodeSelectors["k2"]).To(Equal("v2"))
 		})
 
-		It("Configures OIDC for Kibana when the OIDC configuration is provided", func() {
-			cfg.DexCfg = render.NewDexRelyingPartyConfig(&operatorv1.Authentication{
-				Spec: operatorv1.AuthenticationSpec{
-					ManagerDomain: "https://example.com",
-					OIDC: &operatorv1.AuthenticationOIDC{
-						IssuerURL:       "https://example.com",
-						UsernameClaim:   "email",
-						GroupsClaim:     "group",
-						RequestedScopes: []string{"scope"},
-					},
-				},
-			}, render.CreateDexTLSSecret("cn"), render.CreateDexClientSecret(), "cluster.local")
-
-			component := render.LogStorage(cfg)
-
-			createResources, _ := component.Objects()
-			securitySecret := rtest.GetResource(createResources, render.ElasticsearchSecureSettingsSecretName, render.ElasticsearchNamespace, "", "", "")
-
-			Expect(securitySecret).ShouldNot(BeNil())
-			Expect(securitySecret.(*corev1.Secret).Data["xpack.security.authc.realms.oidc.oidc1.rp.client_secret"]).Should(HaveLen(24))
-			elasticsearch := getElasticsearch(createResources)
-			Expect(elasticsearch.Spec.NodeSets[0].Config.Data).Should(Equal(map[string]interface{}{
-				"cluster.max_shards_per_node": 10000,
-				"xpack.security.authc.realms.oidc.oidc1": map[string]interface{}{
-					"rp.client_id":                "tigera-manager",
-					"rp.requested_scopes":         []string{"openid", "email", "profile", "groups", "offline_access"},
-					"op.jwkset_path":              "https://tigera-dex.tigera-dex.svc.cluster.local:5556/dex/keys",
-					"op.userinfo_endpoint":        "https://tigera-dex.tigera-dex.svc.cluster.local:5556/dex/userinfo",
-					"claims.principal":            "email",
-					"order":                       1,
-					"rp.response_type":            "code",
-					"rp.redirect_uri":             "https://example.com/tigera-kibana/api/security/oidc/callback",
-					"op.issuer":                   "https://example.com/dex",
-					"op.authorization_endpoint":   "https://example.com/dex/auth",
-					"op.token_endpoint":           "https://tigera-dex.tigera-dex.svc.cluster.local:5556/dex/token",
-					"rp.post_logout_redirect_uri": "https://example.com/tigera-kibana/logged_out",
-					"claims.groups":               "groups",
-					"ssl.certificate_authorities": []string{"/usr/share/elasticsearch/config/dex/tls-dex.crt"},
-				},
-				"node.master": "true",
-				"node.data":   "true",
-				"node.ingest": "true",
-			}))
-
-			// Verify that there are 2 init containers for OIDC
-			initContainers := elasticsearch.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-			Expect(len(initContainers)).To(Equal(3))
-			Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
-			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-keystore"))
-			Expect(initContainers[2].Name).To(Equal("elastic-internal-init-log-selinux-context"))
-		})
-
 		It("should configures Kibana publicBaseUrl when BaseURL is specified", func() {
 			cfg.ElasticLicenseType = render.ElasticsearchLicenseTypeBasic
 			cfg.BaseURL = "https://test.domain.com"
@@ -534,39 +482,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			kibana := kb.(*kbv1.Kibana)
 			x := kibana.Spec.Config.Data["server"].(map[string]interface{})
 			Expect(x["publicBaseUrl"]).To(Equal("https://test.domain.com/tigera-kibana"))
-		})
-
-		It("should not configures OIDC for Kibana when elasticsearch basic license is used", func() {
-			cfg.DexCfg = render.NewDexRelyingPartyConfig(&operatorv1.Authentication{
-				Spec: operatorv1.AuthenticationSpec{
-					ManagerDomain: "https://example.com",
-					OIDC: &operatorv1.AuthenticationOIDC{
-						IssuerURL:       "https://example.com",
-						UsernameClaim:   "email",
-						GroupsClaim:     "group",
-						RequestedScopes: []string{"scope"},
-					},
-				},
-			}, render.CreateDexTLSSecret("cn"), render.CreateDexClientSecret(), "svc.cluster.local")
-			cfg.ElasticLicenseType = render.ElasticsearchLicenseTypeBasic
-
-			component := render.LogStorage(cfg)
-
-			createResources, _ := component.Objects()
-			securitySecret := rtest.GetResource(createResources, render.ElasticsearchSecureSettingsSecretName, render.ElasticsearchNamespace, "", "", "")
-			Expect(securitySecret).Should(BeNil())
-			elasticsearch := getElasticsearch(createResources)
-			Expect(elasticsearch.Spec.NodeSets[0].Config.Data).Should(Equal(map[string]interface{}{
-				"cluster.max_shards_per_node": 10000,
-				"node.master":                 "true",
-				"node.data":                   "true",
-				"node.ingest":                 "true",
-			}))
-
-			initContainers := elasticsearch.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-			Expect(len(initContainers)).To(Equal(2))
-			Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
-			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-log-selinux-context"))
 		})
 
 		Context("ECKOperator memory requests/limits", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -265,9 +265,6 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 
 // managerVolumes returns the volumes for the Tigera Secure manager component.
 func (c *managerComponent) managerVolumeMounts() []corev1.VolumeMount {
-	if c.cfg.KeyValidatorConfig != nil {
-		return c.cfg.KeyValidatorConfig.RequiredVolumeMounts()
-	}
 	return []corev1.VolumeMount{}
 }
 
@@ -290,9 +287,6 @@ func (c *managerComponent) managerVolumes() []corev1.Volume {
 			c.cfg.InternalTrafficSecret.Volume(),
 			c.cfg.TunnelSecret.Volume(),
 		)
-	}
-	if c.cfg.KeyValidatorConfig != nil {
-		v = append(v, c.cfg.KeyValidatorConfig.RequiredVolumes()...)
 	}
 
 	return v
@@ -419,6 +413,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		{Name: "VOLTRON_PACKET_CAPTURE_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
 		{Name: "VOLTRON_PROMETHEUS_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
 		{Name: "VOLTRON_COMPLIANCE_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
+		{Name: "VOLTRON_DEX_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
 		{Name: "VOLTRON_HTTPS_KEY", Value: keyPath},
 		{Name: "VOLTRON_HTTPS_CERT", Value: certPath},
 		{Name: "VOLTRON_TUNNEL_KEY", Value: tunnelKeyPath},
@@ -457,10 +452,6 @@ func (c *managerComponent) volumeMountsForProxyManager() []corev1.VolumeMount {
 		mounts = append(mounts, c.cfg.TunnelSecret.VolumeMount())
 	}
 
-	if c.cfg.KeyValidatorConfig != nil {
-		mounts = append(mounts, c.cfg.KeyValidatorConfig.RequiredVolumeMounts()...)
-	}
-
 	return mounts
 }
 
@@ -479,7 +470,6 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 
 	if c.cfg.KeyValidatorConfig != nil {
 		env = append(env, c.cfg.KeyValidatorConfig.RequiredEnv("")...)
-		volumeMounts = append(volumeMounts, c.cfg.KeyValidatorConfig.RequiredVolumeMounts()...)
 	}
 
 	return corev1.Container{

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -265,6 +265,11 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 
 // managerVolumes returns the volumes for the Tigera Secure manager component.
 func (c *managerComponent) managerVolumeMounts() []corev1.VolumeMount {
+	if c.cfg.KeyValidatorConfig != nil {
+		trustedVolumeMount := c.cfg.TrustedCertBundle.VolumeMount()
+		trustedVolumeMount.MountPath = "/etc/ssl/certs/"
+		return []corev1.VolumeMount{trustedVolumeMount}
+	}
 	return []corev1.VolumeMount{}
 }
 

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -268,7 +268,7 @@ func (c *managerComponent) managerVolumeMounts() []corev1.VolumeMount {
 	if c.cfg.KeyValidatorConfig != nil {
 		trustedVolumeMount := c.cfg.TrustedCertBundle.VolumeMount()
 		trustedVolumeMount.MountPath = "/etc/ssl/certs/"
-		return []corev1.VolumeMount{trustedVolumeMount}
+		return append(c.cfg.KeyValidatorConfig.RequiredVolumeMounts(), trustedVolumeMount)
 	}
 	return []corev1.VolumeMount{}
 }
@@ -292,6 +292,9 @@ func (c *managerComponent) managerVolumes() []corev1.Volume {
 			c.cfg.InternalTrafficSecret.Volume(),
 			c.cfg.TunnelSecret.Volume(),
 		)
+	}
+	if c.cfg.KeyValidatorConfig != nil {
+		v = append(v, c.cfg.KeyValidatorConfig.RequiredVolumes()...)
 	}
 
 	return v

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -245,12 +245,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		// Should render the correct resource based on test case.
 		resources := renderObjects(renderConfig{oidc: true, managementCluster: nil, installation: installation})
-		Expect(len(resources)).To(Equal(expectedResourcesNumber + 1)) //Extra tls secret was added.
+		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 		d := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
-		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(5))
+		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(4))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
-		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(2))
+		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
 	})
 
 	It("should render multicluster settings properly", func() {
@@ -569,7 +569,7 @@ func renderObjects(roc renderConfig) []client.Object {
 				ManagerDomain: "https://127.0.0.1",
 				OIDC:          &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
 
-		dexCfg = render.NewDexKeyValidatorConfig(authentication, nil, render.CreateDexTLSSecret("cn"), dns.DefaultClusterDomain)
+		dexCfg = render.NewDexKeyValidatorConfig(authentication, nil, dns.DefaultClusterDomain)
 	}
 
 	var tunnelSecret certificatemanagement.KeyPairInterface

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -250,7 +250,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		// tigera-manager volumes/volumeMounts checks.
 		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(4))
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(oidcEnvVar))
-		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
+		Expect(len(d.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(2))
 	})
 
 	It("should render multicluster settings properly", func() {

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -317,9 +317,7 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 	}
 
 	if mc.cfg.KeyValidatorConfig != nil {
-		volumeMounts = append(volumeMounts, mc.cfg.KeyValidatorConfig.RequiredVolumeMounts()...)
 		env = append(env, mc.cfg.KeyValidatorConfig.RequiredEnv("")...)
-		volumes = append(volumes, mc.cfg.KeyValidatorConfig.RequiredVolumes()...)
 	}
 
 	return &monitoringv1.Prometheus{

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -340,18 +340,6 @@ var _ = Describe("monitor rendering tests", func() {
 
 		dexCfg := render.NewDexKeyValidatorConfig(authentication,
 			nil,
-			&corev1.Secret{
-				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.DexTLSSecretName,
-					Namespace: common.OperatorNamespace(),
-				},
-				Type: corev1.SecretTypeTLS,
-				Data: map[string][]byte{
-					corev1.TLSCertKey:       []byte("cert"),
-					corev1.TLSPrivateKeyKey: []byte("key"),
-				},
-			},
 			dns.DefaultClusterDomain)
 		cfg.KeyValidatorConfig = dexCfg
 		cfg.ServerTLSSecret = prometheusKeyPair
@@ -386,7 +374,6 @@ var _ = Describe("monitor rendering tests", func() {
 			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
 			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
 			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
-			{name: "tigera-dex-tls", ns: common.TigeraPrometheusNamespace, group: "", version: "v1", kind: "Secret"},
 		}
 
 		Expect(len(toCreate)).To(Equal(len(expectedResources)))


### PR DESCRIPTION
Dex config currently wraps and renders secrets. With the recent introduction of the certificate manager, we can now refactor this code. Other changes:
- The dex tls secret was mounted for key validators, which is unnecessary. They do offline bearer token validation.
- Kibana no longer needs to support OIDC, we have moved away from this functionality a number of releases ago. (I believe EEv3.7?)
- This means that the relying party config is no longer used and is removed in this PR.

