### PR TITLE
Update kube-controllers RBAC

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -171,6 +171,15 @@ spec:
                   Calico policy will be bypassed. [Default: insert]'
                 type: string
               dataplaneDriver:
+                description: DataplaneDriver filename of the external dataplane driver
+                  to use.  Only used if UseInternalDataplaneDriver is set to false.
+                type: string
+              dataplaneWatchdogTimeout:
+                description: 'DataplaneWatchdogTimeout is the readiness/liveness timeout
+                  used for Felix''s (internal) dataplane driver. Increase this value
+                  if you experience spurious non-ready or non-live events when Felix
+                  is under heavy load. Decrease the value to get felix to report non-live
+                  or non-ready more quickly. [Default: 90s]'
                 type: string
               debugDisableLogDropping:
                 type: boolean
@@ -378,6 +387,8 @@ spec:
                   usage. [Default: 10s]'
                 type: string
               ipv6Support:
+                description: IPv6Support controls whether Felix enables support for
+                  IPv6 (if supported by the in-use dataplane).
                 type: boolean
               kubeNodePortRanges:
                 description: 'KubeNodePortRanges holds list of port ranges used for
@@ -580,6 +591,9 @@ spec:
                   Felix makes reports. [Default: 86400s]'
                 type: string
               useInternalDataplaneDriver:
+                description: UseInternalDataplaneDriver, if true, Felix will use its
+                  internal dataplane programming logic.  If false, it will launch
+                  an external dataplane driver and communicate with it over protobuf.
                 type: boolean
               vxlanEnabled:
                 type: boolean

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -52,9 +52,15 @@ spec:
                 type: integer
               awsSecondaryIPSupport:
                 description: 'AWSSecondaryIPSupport controls whether Felix will try
-                  to provision AWS secondary ENIs and secondary IPs for workloads
-                  that have IPs from IP pools that are configured with an AWS subnet
-                  ID. [Default: Disabled]'
+                  to provision AWS secondary ENIs for workloads that have IPs from
+                  IP pools that are configured with an AWS subnet ID.  If the field
+                  is set to "EnabledENIPerWorkload" then each workload with an AWS-backed
+                  IP will be assigned its own secondary ENI. If set to "Enabled" then
+                  each workload with an AWS-backed IP pool will be allocated a secondary
+                  IP address on a secondary ENI; this mode requires additional IP
+                  pools to be provisioned for the host to claim IPs for the primary
+                  IP of the secondary ENIs. Accepted value must be one of "Enabled",
+                  "EnabledENIPerWorkload" or "Disabled". [Default: Disabled]'
                 type: string
               awsSrcDstCheck:
                 description: 'Set source-destination-check on AWS EC2 instances. Accepted

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -271,15 +271,21 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration, kubeContr
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
-			// IPAM resources are manipulated when nodes are deleted.
+			// IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
 			APIGroups: []string{"crd.projectcalico.org"},
-			Resources: []string{"ippools", "ipreservations"},
+			Resources: []string{"ipreservations"},
 			Verbs:     []string{"list"},
 		},
 		{
 			APIGroups: []string{"crd.projectcalico.org"},
 			Resources: []string{"blockaffinities", "ipamblocks", "ipamhandles", "networksets"},
 			Verbs:     []string{"get", "list", "create", "update", "delete", "watch"},
+		},
+		{
+			// Pools are watched to maintain a mapping of blocks to IP pools.
+			APIGroups: []string{"crd.projectcalico.org"},
+			Resources: []string{"ippools"},
+			Verbs:     []string{"list", "watch"},
 		},
 		{
 			// Needs access to update clusterinformations.

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -224,7 +224,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(18))
+		Expect(len(clusterRole.Rules)).To(Equal(19))
 	})
 
 	It("should render all es-calico-kube-controllers resources for a default configuration (standalone) using TigeraSecureEnterprise when logstorage and secrets exist", func() {
@@ -288,7 +288,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[1].Secret.SecretName).To(Equal(relasticsearch.PublicCertSecret))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(19))
+		Expect(len(clusterRole.Rules)).To(Equal(20))
 	})
 
 	It("should render all calico-kube-controllers resources for a default configuration using TigeraSecureEnterprise and ClusterType is Management", func() {
@@ -410,7 +410,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(19))
+		Expect(len(clusterRole.Rules)).To(Equal(20))
 	})
 
 	It("should include a ControlPlaneNodeSelector when specified", func() {


### PR DESCRIPTION
## Description
Updates the RBAC for kube-controllers to match upcoming changes in calico public, tracked in [#5706](https://github.com/projectcalico/calico/pull/5706). 

Also updates CRDs generated when running tests locally.

## For PR author
- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers
A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
