### PR TITLE
Fix mcm where certificate is not accepted

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package certificatemanager
 
 import (
@@ -232,7 +246,9 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 				// We want to return nothing, so a new secret will be created to overwrite this one.
 				return nil, nil, nil
 			}
-			return nil, nil, fmt.Errorf("certificate %s was created by an older ca", secretName)
+			// We treat the certificate as a BYO secret, because this may be a certificate created by a management cluster
+			// and used inside a managed cluster. If it is not, it should get updated automatically when readCertOnly=false.
+			issuer = nil
 		}
 	}
 	return &certificatemanagement.KeyPair{

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -171,6 +171,15 @@ spec:
                   Calico policy will be bypassed. [Default: insert]'
                 type: string
               dataplaneDriver:
+                description: DataplaneDriver filename of the external dataplane driver
+                  to use.  Only used if UseInternalDataplaneDriver is set to false.
+                type: string
+              dataplaneWatchdogTimeout:
+                description: 'DataplaneWatchdogTimeout is the readiness/liveness timeout
+                  used for Felix''s (internal) dataplane driver. Increase this value
+                  if you experience spurious non-ready or non-live events when Felix
+                  is under heavy load. Decrease the value to get felix to report non-live
+                  or non-ready more quickly. [Default: 90s]'
                 type: string
               debugDisableLogDropping:
                 type: boolean
@@ -378,6 +387,8 @@ spec:
                   usage. [Default: 10s]'
                 type: string
               ipv6Support:
+                description: IPv6Support controls whether Felix enables support for
+                  IPv6 (if supported by the in-use dataplane).
                 type: boolean
               kubeNodePortRanges:
                 description: 'KubeNodePortRanges holds list of port ranges used for
@@ -580,6 +591,9 @@ spec:
                   Felix makes reports. [Default: 86400s]'
                 type: string
               useInternalDataplaneDriver:
+                description: UseInternalDataplaneDriver, if true, Felix will use its
+                  internal dataplane programming logic.  If false, it will launch
+                  an external dataplane driver and communicate with it over protobuf.
                 type: boolean
               vxlanEnabled:
                 type: boolean

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -52,9 +52,15 @@ spec:
                 type: integer
               awsSecondaryIPSupport:
                 description: 'AWSSecondaryIPSupport controls whether Felix will try
-                  to provision AWS secondary ENIs and secondary IPs for workloads
-                  that have IPs from IP pools that are configured with an AWS subnet
-                  ID. [Default: Disabled]'
+                  to provision AWS secondary ENIs for workloads that have IPs from
+                  IP pools that are configured with an AWS subnet ID.  If the field
+                  is set to "EnabledENIPerWorkload" then each workload with an AWS-backed
+                  IP will be assigned its own secondary ENI. If set to "Enabled" then
+                  each workload with an AWS-backed IP pool will be allocated a secondary
+                  IP address on a secondary ENI; this mode requires additional IP
+                  pools to be provisioned for the host to claim IPs for the primary
+                  IP of the secondary ENIs. Accepted value must be one of "Enabled",
+                  "EnabledENIPerWorkload" or "Disabled". [Default: Disabled]'
                 type: string
               awsSrcDstCheck:
                 description: 'Set source-destination-check on AWS EC2 instances. Accepted


### PR DESCRIPTION
The certificate manager checks if a certificate was issued by a different tigera-ca-private secret to sniff out if the certificate is old/outdated. Currently, If it is, then the following happens:
1 For GetOrCreateKeyPair, it will overwrite the secret with a new one.
2 For GetCertificate, it will throw an error.

The second point is problematic, because if a certificate was created by the management cluster, the cert is perfectly fine to use. Therefore, this PR removes the error.