### PR TITLE
Certificatemanager controller

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"github.com/go-logr/logr"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,12 +44,9 @@ type InstallationReconciler struct {
 //}
 
 func (r *InstallationReconciler) SetupWithManager(mgr ctrl.Manager, opts options.AddOptions) error {
-	return installation.Add(mgr, opts)
-	//if err != nil {
-	//	return err
-	//}
+	if err := certificatemanager.Add(mgr, opts); err != nil {
+		return err
+	}
 
-	//return ctrl.NewControllerManagedBy(mgr).
-	//	For(&operatorv1.Installation{}).
-	//	Complete(r)
+	return installation.Add(mgr, opts)
 }

--- a/pkg/controller/certificatemanager/certificatemanager_controller.go
+++ b/pkg/controller/certificatemanager/certificatemanager_controller.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificatemanager
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	operator "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const controllerName = "certificatemanager_controller"
+
+// Add creates a new certificate manager Controller and adds it to the Manager.
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	return add(mgr, newReconciler(mgr, opts))
+}
+
+// newReconciler returns a new reconcile.Reconciler that will ensure that a tigera-ca-private secret is created in the
+// tigera-operator namespace if necessary.
+func newReconciler(mgr manager.Manager, opts options.AddOptions) *ReconcileCertificateManager {
+	statusManager := status.New(mgr.GetClient(), "ca-certificate", opts.KubernetesVersion)
+	statusManager.Run(opts.ShutdownContext)
+	return &ReconcileCertificateManager{
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		watches:       make(map[runtime.Object]struct{}),
+		status:        statusManager,
+		clusterDomain: opts.ClusterDomain,
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r *ReconcileCertificateManager) error {
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", controllerName, err)
+	}
+
+	err = c.Watch(&source.Kind{Type: &operator.Installation{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("%s failed to watch installation resource: %w", controllerName, err)
+	}
+
+	if err = utils.AddSecretsWatch(c, certificatemanagement.CASecretName, common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, certificatemanagement.CASecretName, err)
+	}
+	return nil
+}
+
+// ReconcileCertificateManager will ensure that a tigera-ca-private secret is created in the
+// tigera-operator namespace if necessary.
+type ReconcileCertificateManager struct {
+	client        client.Client
+	scheme        *runtime.Scheme
+	watches       map[runtime.Object]struct{}
+	status        status.StatusManager
+	clusterDomain string
+}
+
+func (r *ReconcileCertificateManager) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	installation := &operator.Installation{}
+	if err := r.client.Get(ctx, utils.DefaultInstanceKey, installation); err != nil {
+		if errors.IsNotFound(err) {
+			log.Error(err, "Installation config not found")
+			r.status.OnCRNotFound()
+			return reconcile.Result{}, nil
+		}
+		log.Error(err, "An error occurred when querying the Installation resource")
+		return reconcile.Result{}, err
+	}
+	r.status.OnCRFound()
+
+	certificateManager, err := Create(r.client, &installation.Spec, r.clusterDomain)
+	if err != nil {
+		log.Error(err, "unable to create the Tigera CA")
+		r.status.SetDegraded("Unable to create the Tigera CA", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	component := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
+		Namespace:       common.OperatorNamespace(),
+		ServiceAccounts: []string{},
+		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+			// this controller is responsible for rendering the tigera-ca-private secret.
+			rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
+		},
+	})
+
+	hdl := utils.NewComponentHandler(log, r.client, r.scheme, installation)
+	if err := hdl.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
+		r.status.SetDegraded("Error creating / updating resource", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	r.status.ClearDegraded()
+
+	r.status.ReadyToMonitor()
+
+	if !r.status.IsAvailable() {
+		// Schedule a kick to check again in the near future. Hopefully by then things will be available.
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/certificatemanager/certificatemanager_controller_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_controller_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificatemanager
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/tls"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Certificate manager controller tests", func() {
+	var c client.Client
+	var scheme *runtime.Scheme
+	var installation *operatorv1.Installation
+	var ctx context.Context
+	var r ReconcileCertificateManager
+	var mockStatus *status.MockStatus
+	var certificateManagement *operatorv1.CertificateManagement
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+		mockStatus = &status.MockStatus{}
+		mockStatus.On("OnCRFound").Return()
+		mockStatus.On("ClearDegraded").Return()
+		mockStatus.On("ReadyToMonitor").Return()
+		mockStatus.On("IsAvailable").Return(true)
+		c = fake.NewClientBuilder().WithScheme(scheme).Build()
+		r = ReconcileCertificateManager{
+			client: c,
+			scheme: scheme,
+			status: mockStatus,
+		}
+		installation = &operatorv1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+		ca, err := tls.MakeCA(rmeta.DefaultOperatorCASignerName())
+		Expect(err).NotTo(HaveOccurred())
+		cert, _, _ := ca.Config.GetPEMBytes() // create a valid pem block
+		certificateManagement = &operatorv1.CertificateManagement{CACert: cert}
+	})
+
+	It("should not render anything if no installation is present", func() {
+		mockStatus.On("OnCRNotFound").Return()
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		secret, err := utils.GetSecret(ctx, c, certificatemanagement.CASecretName, common.OperatorNamespace())
+		Expect(secret).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should render the CA if installation is present", func() {
+		Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		secret, err := utils.GetSecret(ctx, c, certificatemanagement.CASecretName, common.OperatorNamespace())
+		Expect(secret).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not render anything if certificate management is used", func() {
+		installation.Spec.CertificateManagement = certificateManagement
+		Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		secret, err := utils.GetSecret(ctx, c, certificatemanagement.CASecretName, common.OperatorNamespace())
+		Expect(secret).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -954,7 +954,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	var managerInternalTLSSecret certificatemanagement.KeyPairInterface
 	if instance.Spec.Variant == operator.TigeraSecureEnterprise && managementCluster != nil {
 		dnsNames := append(dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain), render.ManagerServiceIP)
-		managerInternalTLSSecret, err = certificateManager.GetOrCreateKeyPair(r.client, render.ManagerInternalTLSSecretName, common.CalicoNamespace, dnsNames)
+		managerInternalTLSSecret, err = certificateManager.GetOrCreateKeyPair(r.client, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), dnsNames)
 		if err != nil {
 			r.status.SetDegraded(fmt.Sprintf("Error ensuring internal manager TLS certificate %q exists and has valid DNS names", render.ManagerInternalTLSSecretName), err.Error())
 			return reconcile.Result{}, err
@@ -1200,8 +1200,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			Namespace:       common.CalicoNamespace,
 			ServiceAccounts: []string{render.CalicoNodeObjectName, render.TyphaServiceAccountName},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
-				// this controller is responsible for rendering the tigera-ca-private secret.
-				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
 				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
 				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, true, true),

--- a/pkg/render/certificatemanagement/certificatemanagement.go
+++ b/pkg/render/certificatemanagement/certificatemanagement.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package certificatemanagement
 
 import (


### PR DESCRIPTION
Although not common to reproduce, I found a way where there is a conflict in the code with the new certificate code:
- The tigera-ca-private is created by core_controller, but only if everything is ok.
- Things are not always ok. For instance, when you have an invalid prometheus tls secret.
- If the tigera-ca-private secret is not yet existent a new one is created in memory.
These  conditions make that prometheus keeps reconciling and changing, because  the core_controller does not complete successfully.

To solve this a new controller was added that creates the tigera-ca-private secret.


---UPDATE---
I turned this into a draft. Some elements that are currently missing:
- Controllers should wait for this controller to be status=ready
- CreateCertificatemanager(...) should be broken down into two methods: one for creating the secret and one for using the existing secret. 