### PR TITLE
Support for migrating a BPF cluster to operator install

### DIFF
--- a/pkg/controller/migration/convert/bpf.go
+++ b/pkg/controller/migration/convert/bpf.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"fmt"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// handleBPF is a migration handler which ensures BPF configuration is carried forward.
+func handleBPF(c *components, install *operatorv1.Installation) error {
+	felixConfiguration := &crdv1.FelixConfiguration{}
+	err := c.client.Get(ctx, types.NamespacedName{Name: "default"}, felixConfiguration)
+	if err != nil {
+		return fmt.Errorf("error reading felixconfiguration %w", err)
+	}
+	if felixConfiguration.Spec.BPFEnabled != nil && *felixConfiguration.Spec.BPFEnabled {
+		if install.Spec.CalicoNetwork == nil {
+			install.Spec.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
+		}
+
+		bpf := operatorv1.LinuxDataplaneBPF
+		install.Spec.CalicoNetwork.LinuxDataplane = &bpf
+		install.Spec.CalicoNetwork.HostPorts = nil
+	}
+	return nil
+}

--- a/pkg/controller/migration/convert/bpf.go
+++ b/pkg/controller/migration/convert/bpf.go
@@ -55,11 +55,6 @@ func copyK8sServicesEPConfigMap(c *components) error {
 	if err != nil {
 		return fmt.Errorf("Failed to create configmap %q in tigera-operator ns %s", cmName, err)
 	}
-
-	err = c.client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: cmName}})
-	if err != nil {
-		return fmt.Errorf("failed to delete configmap %q in kube-system ns %s", cmName, err)
-	}
 	return nil
 }
 

--- a/pkg/controller/migration/convert/bpf.go
+++ b/pkg/controller/migration/convert/bpf.go
@@ -36,7 +36,7 @@ func copyK8sServicesEPConfigMap(c *components) error {
 		Namespace: "kube-system",
 	}
 	if err := c.client.Get(ctx, cmNamespacedName, cm); err != nil {
-		return fmt.Errorf("Failed read to ConfigMap %q: %s", cmName, err)
+		return fmt.Errorf("failed read to configMap %q: %s", cmName, err)
 	}
 	host := cm.Data["KUBERNETES_SERVICE_HOST"]
 	port := cm.Data["KUBERNETES_SERVICE_PORT"]

--- a/pkg/controller/migration/convert/bpf.go
+++ b/pkg/controller/migration/convert/bpf.go
@@ -53,7 +53,7 @@ func copyK8sServicesEPConfigMap(c *components) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to create configmap %q in tigera-operator ns %s", cmName, err)
+		return fmt.Errorf("failed to create configmap %q in tigera-operator ns %s", cmName, err)
 	}
 	return nil
 }

--- a/pkg/controller/migration/convert/bpf_test.go
+++ b/pkg/controller/migration/convert/bpf_test.go
@@ -83,9 +83,6 @@ var _ = Describe("convert bpf config", func() {
 		err, data := getEndPointCM(&comps, common.OperatorNamespace())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data).To(Equal(cmData))
-		err, data = getEndPointCM(&comps, "kube-system")
-		Expect(err).To(HaveOccurred())
-		Expect(data).To(BeNil())
 	})
 
 	It("converts bpfenabled felixconfig set to false", func() {
@@ -127,9 +124,6 @@ var _ = Describe("convert bpf config", func() {
 		err, data := getEndPointCM(&comps, common.OperatorNamespace())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(data).To(Equal(cmData))
-		err, data = getEndPointCM(&comps, "kube-system")
-		Expect(err).To(HaveOccurred())
-		Expect(data).To(BeNil())
 	})
 
 	It("converts bpfenabled env var set to false", func() {

--- a/pkg/controller/migration/convert/bpf_test.go
+++ b/pkg/controller/migration/convert/bpf_test.go
@@ -20,12 +20,42 @@ import (
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var cmName = render.K8sSvcEndpointConfigMapName
+var cmData = map[string]string{"KUBERNETES_SERVICE_HOST": "1.1.1.1",
+	"KUBERNETES_SERVICE_PORT": "1234"}
+
+var endPointCM = &corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      cmName,
+		Namespace: "kube-system",
+	},
+	Data: cmData,
+}
+
+func getEndPointCM(c *components, ns string) (error, map[string]string) {
+	cm := &corev1.ConfigMap{}
+	cmNamespacedName := types.NamespacedName{
+		Name:      cmName,
+		Namespace: ns,
+	}
+	err := c.client.Get(ctx, cmNamespacedName, cm)
+	if err != nil {
+		return err, nil
+	}
+	return nil, cm.Data
+}
 
 var _ = Describe("convert bpf config", func() {
 	var (
@@ -45,32 +75,47 @@ var _ = Describe("convert bpf config", func() {
 		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
 		bpfEnabled := true
 		f.Spec.BPFEnabled = &bpfEnabled
-		comps.client = fake.NewFakeClientWithScheme(scheme, f)
+		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM, f)
 		err := handleBPF(&comps, i)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(*i.Spec.CalicoNetwork.LinuxDataplane).To(BeEquivalentTo(operatorv1.LinuxDataplaneBPF))
 		Expect(i.Spec.CalicoNetwork.HostPorts).To(BeNil())
+		err, data := getEndPointCM(&comps, common.OperatorNamespace())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(cmData))
+		err, data = getEndPointCM(&comps, "kube-system")
+		Expect(err).To(HaveOccurred())
+		Expect(data).To(BeNil())
 	})
 
 	It("converts bpfenabled felixconfig set to false", func() {
 		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
 		bpfEnabled := false
 		f.Spec.BPFEnabled = &bpfEnabled
-		comps.client = fake.NewFakeClientWithScheme(scheme, f)
+		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM, f)
 		err := handleBPF(&comps, i)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(i.Spec.CalicoNetwork).To(BeNil())
+		err, data := getEndPointCM(&comps, "kube-system")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(cmData))
+		err, data = getEndPointCM(&comps, common.OperatorNamespace())
+		Expect(err).To(HaveOccurred())
+		Expect(data).To(BeNil())
 	})
 
 	It("check with no felixconfig", func() {
 		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
-		comps.client = fake.NewFakeClientWithScheme(scheme)
+		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM)
 		err := handleBPF(&comps, i)
 		Expect(err).To(HaveOccurred())
+		err, data := getEndPointCM(&comps, "kube-system")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(cmData))
 	})
 
 	It("converts bpfenabled env var set to true", func() {
-		comps.client = fake.NewFakeClientWithScheme(scheme, f)
+		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM, f)
 		comps.node.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{
 			Name:  "FELIX_BPFENABLED",
 			Value: "true",
@@ -79,16 +124,38 @@ var _ = Describe("convert bpf config", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(*i.Spec.CalicoNetwork.LinuxDataplane).To(BeEquivalentTo(operatorv1.LinuxDataplaneBPF))
 		Expect(i.Spec.CalicoNetwork.HostPorts).To(BeNil())
+		err, data := getEndPointCM(&comps, common.OperatorNamespace())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(cmData))
+		err, data = getEndPointCM(&comps, "kube-system")
+		Expect(err).To(HaveOccurred())
+		Expect(data).To(BeNil())
 	})
 
 	It("converts bpfenabled env var set to false", func() {
-		comps.client = fake.NewFakeClientWithScheme(scheme, f)
+		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM, f)
 		comps.node.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{
 			Name:  "FELIX_BPFENABLED",
 			Value: "false",
 		}}
 		err := handleBPF(&comps, i)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(i.Spec.CalicoNetwork).To(BeNil())
+		err, data := getEndPointCM(&comps, "kube-system")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(cmData))
+		err, data = getEndPointCM(&comps, common.OperatorNamespace())
+		Expect(err).To(HaveOccurred())
+		Expect(data).To(BeNil())
+	})
+
+	It("returns error when configmap is not present", func() {
+		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
+		bpfEnabled := true
+		f.Spec.BPFEnabled = &bpfEnabled
+		comps.client = fake.NewFakeClientWithScheme(scheme, f)
+		err := handleBPF(&comps, i)
+		Expect(err).To(HaveOccurred())
 		Expect(i.Spec.CalicoNetwork).To(BeNil())
 	})
 })

--- a/pkg/controller/migration/convert/bpf_test.go
+++ b/pkg/controller/migration/convert/bpf_test.go
@@ -32,17 +32,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var cmName = render.K8sSvcEndpointConfigMapName
-var cmData = map[string]string{"KUBERNETES_SERVICE_HOST": "1.1.1.1",
-	"KUBERNETES_SERVICE_PORT": "1234"}
-
-var endPointCM = &corev1.ConfigMap{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      cmName,
-		Namespace: "kube-system",
-	},
-	Data: cmData,
-}
+var (
+	cmName = render.K8sSvcEndpointConfigMapName
+	cmData = map[string]string{"KUBERNETES_SERVICE_HOST": "1.1.1.1",
+		"KUBERNETES_SERVICE_PORT": "1234"}
+	endPointCM = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: "kube-system",
+		},
+		Data: cmData,
+	}
+)
 
 func getEndPointCM(c *components, ns string) (error, map[string]string) {
 	cm := &corev1.ConfigMap{}
@@ -69,10 +70,10 @@ var _ = Describe("convert bpf config", func() {
 		comps = emptyComponents()
 		i = &operatorv1.Installation{}
 		f = emptyFelixConfig()
+		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
 	})
 
 	It("converts bpfenabled felixconfig set to true", func() {
-		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
 		bpfEnabled := true
 		f.Spec.BPFEnabled = &bpfEnabled
 		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM, f)
@@ -86,7 +87,6 @@ var _ = Describe("convert bpf config", func() {
 	})
 
 	It("converts bpfenabled felixconfig set to false", func() {
-		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
 		bpfEnabled := false
 		f.Spec.BPFEnabled = &bpfEnabled
 		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM, f)
@@ -102,7 +102,6 @@ var _ = Describe("convert bpf config", func() {
 	})
 
 	It("check with no felixconfig", func() {
-		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
 		comps.client = fake.NewFakeClientWithScheme(scheme, endPointCM)
 		err := handleBPF(&comps, i)
 		Expect(err).To(HaveOccurred())
@@ -144,7 +143,6 @@ var _ = Describe("convert bpf config", func() {
 	})
 
 	It("returns error when configmap is not present", func() {
-		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
 		bpfEnabled := true
 		f.Spec.BPFEnabled = &bpfEnabled
 		comps.client = fake.NewFakeClientWithScheme(scheme, f)

--- a/pkg/controller/migration/convert/bpf_test.go
+++ b/pkg/controller/migration/convert/bpf_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+	kscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("convert bpf config", func() {
+	var (
+		comps  = emptyComponents()
+		i      = &operatorv1.Installation{}
+		f      = &crdv1.FelixConfiguration{}
+		scheme = kscheme.Scheme
+	)
+
+	BeforeEach(func() {
+		comps = emptyComponents()
+		i = &operatorv1.Installation{}
+		f = emptyFelixConfig()
+	})
+
+	It("converts bpfenabled felixconfig set to true", func() {
+		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
+		bpfEnabled := true
+		f.Spec.BPFEnabled = &bpfEnabled
+		comps.client = fake.NewFakeClientWithScheme(scheme, f)
+		err := handleBPF(&comps, i)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*i.Spec.CalicoNetwork.LinuxDataplane).To(BeEquivalentTo(operatorv1.LinuxDataplaneBPF))
+		Expect(i.Spec.CalicoNetwork.HostPorts).To(BeNil())
+	})
+
+	It("converts bpfenabled felixconfig set to false", func() {
+		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
+		bpfEnabled := false
+		f.Spec.BPFEnabled = &bpfEnabled
+		comps.client = fake.NewFakeClientWithScheme(scheme, f)
+		err := handleBPF(&comps, i)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(i.Spec.CalicoNetwork).To(BeNil())
+	})
+
+	It("check with no felixconfig", func() {
+		Expect(apis.AddToScheme(scheme)).ToNot(HaveOccurred())
+		comps.client = fake.NewFakeClientWithScheme(scheme)
+		err := handleBPF(&comps, i)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/controller/migration/convert/handler.go
+++ b/pkg/controller/migration/convert/handler.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019,2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package convert
 
 import operatorv1 "github.com/tigera/operator/api/v1"
@@ -25,4 +39,5 @@ var handlers = []handler{
 	handleNonCalicoCNI,
 	handleMTU,
 	handleIPPools,
+	handleBPF,
 }

--- a/pkg/controller/migration/namespace_migration.go
+++ b/pkg/controller/migration/namespace_migration.go
@@ -58,6 +58,8 @@ const (
 	nodeDaemonSetName            = "calico-node"
 	kubeControllerDeploymentName = "calico-kube-controllers"
 
+	k8sServicesEndpointConfigMap = "kubernetes-services-endpoint"
+
 	defaultMaxUnavailable int32 = 1
 )
 
@@ -248,6 +250,11 @@ func (m *CoreNamespaceMigration) Run(ctx context.Context, log logr.Logger) error
 	if err := m.deleteKubeSystemTypha(ctx); err != nil {
 		return fmt.Errorf("failed to delete kube-system typha Deployment: %s", err.Error())
 	}
+	log.V(1).Info("kube-system typha deployment deleted")
+	if err := m.deleteKubeSystemServiceEndPointCm(ctx); err != nil {
+		return fmt.Errorf("failed to delete kube-system k8sServicesEndpoint ConfigMap: %s", err.Error())
+	}
+	log.V(1).Info("kube-system services endpoint configmap deleted")
 	log.Info("Namespace migration complete")
 
 	return nil
@@ -354,6 +361,16 @@ func (m *CoreNamespaceMigration) CleanupMigration(ctx context.Context) error {
 	close(m.stopCh)
 
 	m.migrationComplete = true
+	return nil
+}
+
+// deleteKubeSystemServiceEndPointCm deletes the kubernetes-services-endpoint configmap
+// in the kube-system namespace
+func (m *CoreNamespaceMigration) deleteKubeSystemServiceEndPointCm(ctx context.Context) error {
+	err := m.client.CoreV1().ConfigMaps(kubeSystem).Delete(ctx, k8sServicesEndpointConfigMap, metav1.DeleteOptions{})
+	if err != nil && !apierrs.IsNotFound(err) {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/controller/migration/namespace_migration.go
+++ b/pkg/controller/migration/namespace_migration.go
@@ -251,10 +251,9 @@ func (m *CoreNamespaceMigration) Run(ctx context.Context, log logr.Logger) error
 		return fmt.Errorf("failed to delete kube-system typha Deployment: %s", err.Error())
 	}
 	log.V(1).Info("kube-system typha deployment deleted")
-	if err := m.deleteKubeSystemServiceEndPointCm(ctx); err != nil {
+	if err := m.deleteKubeSystemServiceEndPointConfigMap(ctx, log); err != nil {
 		return fmt.Errorf("failed to delete kube-system k8sServicesEndpoint ConfigMap: %s", err.Error())
 	}
-	log.V(1).Info("kube-system services endpoint configmap deleted")
 	log.Info("Namespace migration complete")
 
 	return nil
@@ -364,12 +363,16 @@ func (m *CoreNamespaceMigration) CleanupMigration(ctx context.Context) error {
 	return nil
 }
 
-// deleteKubeSystemServiceEndPointCm deletes the kubernetes-services-endpoint configmap
+// deleteKubeSystemServiceEndPointConfigMap deletes the kubernetes-services-endpoint configmap
 // in the kube-system namespace
-func (m *CoreNamespaceMigration) deleteKubeSystemServiceEndPointCm(ctx context.Context) error {
+func (m *CoreNamespaceMigration) deleteKubeSystemServiceEndPointConfigMap(ctx context.Context, log logr.Logger) error {
 	err := m.client.CoreV1().ConfigMaps(kubeSystem).Delete(ctx, k8sServicesEndpointConfigMap, metav1.DeleteOptions{})
-	if err != nil && !apierrs.IsNotFound(err) {
-		return err
+	if err != nil {
+		if !apierrs.IsNotFound(err) {
+			return err
+		}
+	} else {
+		log.V(1).Info("kube-system services endpoint configmap deleted")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

This PR adds support for migrating a BPF cluster from manifest install to operator based install.
Felix configuration is read and dataplane is set to BPF in the installation spec of the operator. 
## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
