### PR TITLE
Automated cherry pick of #1863: Bump go-build to 0.65.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ endif
 
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=v0.65
+GO_BUILD_VER?=v0.65.1
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(ARCH)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./api -name '*.go')


### PR DESCRIPTION
Cherry pick of #1863 on release-v1.26.

#1863: Bump go-build to 0.65.1