### PR TITLE
Fix enabling/disabling compliance flag for Voltron

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -443,21 +443,22 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	managerCfg := &render.ManagerConfiguration{
-		KeyValidatorConfig:    keyValidatorConfig,
-		ESSecrets:             esSecrets,
-		KibanaSecrets:         []*corev1.Secret{kibanaPublicCertSecret},
-		TrustedCertBundle:     trustedBundle,
-		ESClusterConfig:       esClusterConfig,
-		TLSKeyPair:            tlsSecret,
-		PullSecrets:           pullSecrets,
-		Openshift:             r.provider == operatorv1.ProviderOpenShift,
-		Installation:          installation,
-		ManagementCluster:     managementCluster,
-		TunnelSecret:          tunnelSecret,
-		InternalTrafficSecret: internalTrafficSecret,
-		ClusterDomain:         r.clusterDomain,
-		ESLicenseType:         elasticLicenseType,
-		Replicas:              replicas,
+		KeyValidatorConfig:      keyValidatorConfig,
+		ESSecrets:               esSecrets,
+		KibanaSecrets:           []*corev1.Secret{kibanaPublicCertSecret},
+		TrustedCertBundle:       trustedBundle,
+		ESClusterConfig:         esClusterConfig,
+		TLSKeyPair:              tlsSecret,
+		PullSecrets:             pullSecrets,
+		Openshift:               r.provider == operatorv1.ProviderOpenShift,
+		Installation:            installation,
+		ManagementCluster:       managementCluster,
+		TunnelSecret:            tunnelSecret,
+		InternalTrafficSecret:   internalTrafficSecret,
+		ClusterDomain:           r.clusterDomain,
+		ESLicenseType:           elasticLicenseType,
+		Replicas:                replicas,
+		ComplianceFeatureActive: installCompliance,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,21 +104,22 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 
 // ManagerConfiguration contains all the config information needed to render the component.
 type ManagerConfiguration struct {
-	KeyValidatorConfig    authentication.KeyValidatorConfig
-	ESSecrets             []*corev1.Secret
-	KibanaSecrets         []*corev1.Secret
-	TrustedCertBundle     certificatemanagement.TrustedBundle
-	ESClusterConfig       *relasticsearch.ClusterConfig
-	TLSKeyPair            certificatemanagement.KeyPairInterface
-	PullSecrets           []*corev1.Secret
-	Openshift             bool
-	Installation          *operatorv1.InstallationSpec
-	ManagementCluster     *operatorv1.ManagementCluster
-	TunnelSecret          certificatemanagement.KeyPairInterface
-	InternalTrafficSecret certificatemanagement.KeyPairInterface
-	ClusterDomain         string
-	ESLicenseType         ElasticsearchLicenseType
-	Replicas              *int32
+	KeyValidatorConfig      authentication.KeyValidatorConfig
+	ESSecrets               []*corev1.Secret
+	KibanaSecrets           []*corev1.Secret
+	TrustedCertBundle       certificatemanagement.TrustedBundle
+	ESClusterConfig         *relasticsearch.ClusterConfig
+	TLSKeyPair              certificatemanagement.KeyPairInterface
+	PullSecrets             []*corev1.Secret
+	Openshift               bool
+	Installation            *operatorv1.InstallationSpec
+	ManagementCluster       *operatorv1.ManagementCluster
+	TunnelSecret            certificatemanagement.KeyPairInterface
+	InternalTrafficSecret   certificatemanagement.KeyPairInterface
+	ClusterDomain           string
+	ESLicenseType           ElasticsearchLicenseType
+	Replicas                *int32
+	ComplianceFeatureActive bool
 }
 
 type managerComponent struct {
@@ -427,14 +428,11 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
 		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"},
+		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: fmt.Sprintf("%v", c.cfg.ComplianceFeatureActive)},
 	}
 
 	if c.cfg.KeyValidatorConfig != nil {
 		env = append(env, c.cfg.KeyValidatorConfig.RequiredEnv("VOLTRON_")...)
-	}
-
-	if _, ok := c.cfg.TrustedCertBundle.HashAnnotations()[complianceServerTLSHashAnnotation]; !ok {
-		env = append(env, corev1.EnvVar{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: "false"})
 	}
 
 	return corev1.Container{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	expectedDNSNames = append(expectedDNSNames, "localhost")
 
 	It("should render all resources for a default configuration", func() {
-		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation})
+		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, complianceFeatureActive: true})
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -112,6 +112,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(voltron.VolumeMounts[2].Name).To(Equal(certificatemanagement.TrustedCertConfigMapName))
 		Expect(voltron.VolumeMounts[2].MountPath).To(Equal(certificatemanagement.TrustedCertVolumeMountPath))
 
+		Expect(voltron.Env).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: "true"}))
+
 		Expect(len(deployment.Spec.Template.Spec.Volumes)).To(Equal(4))
 		Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerTLSSecretName))
 		Expect(deployment.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerTLSSecretName))
@@ -121,6 +123,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Volumes[2].Secret.SecretName).To(Equal(relasticsearch.PublicCertSecret))
 		Expect(deployment.Spec.Template.Spec.Volumes[3].Name).To(Equal("elastic-ca-cert-volume"))
 		Expect(deployment.Spec.Template.Spec.Volumes[3].Secret.SecretName).To(Equal(relasticsearch.PublicCertSecret))
+	})
+
+	It("should not proxy compliance if the feature is not active", func() {
+		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, complianceFeatureActive: false})
+		voltron := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment).Spec.Template.Spec.Containers[2]
+		Expect(voltron.Env).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: "false"}))
 	})
 
 	It("should ensure cnx policy recommendation support is always set to true", func() {
@@ -547,9 +555,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 })
 
 type renderConfig struct {
-	oidc              bool
-	managementCluster *operatorv1.ManagementCluster
-	installation      *operatorv1.InstallationSpec
+	oidc                    bool
+	managementCluster       *operatorv1.ManagementCluster
+	installation            *operatorv1.InstallationSpec
+	complianceFeatureActive bool
 }
 
 func renderObjects(roc renderConfig) []client.Object {
@@ -583,17 +592,18 @@ func renderObjects(roc renderConfig) []client.Object {
 
 	esConfigMap := relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
 	cfg := &render.ManagerConfiguration{
-		KeyValidatorConfig:    dexCfg,
-		TrustedCertBundle:     bundle,
-		ESClusterConfig:       esConfigMap,
-		TLSKeyPair:            managerTLS,
-		Installation:          roc.installation,
-		ManagementCluster:     roc.managementCluster,
-		TunnelSecret:          tunnelSecret,
-		InternalTrafficSecret: internalTraffic,
-		ClusterDomain:         dns.DefaultClusterDomain,
-		ESLicenseType:         render.ElasticsearchLicenseTypeEnterpriseTrial,
-		Replicas:              roc.installation.ControlPlaneReplicas,
+		KeyValidatorConfig:      dexCfg,
+		TrustedCertBundle:       bundle,
+		ESClusterConfig:         esConfigMap,
+		TLSKeyPair:              managerTLS,
+		Installation:            roc.installation,
+		ManagementCluster:       roc.managementCluster,
+		TunnelSecret:            tunnelSecret,
+		InternalTrafficSecret:   internalTraffic,
+		ClusterDomain:           dns.DefaultClusterDomain,
+		ESLicenseType:           render.ElasticsearchLicenseTypeEnterpriseTrial,
+		Replicas:                roc.installation.ControlPlaneReplicas,
+		ComplianceFeatureActive: roc.complianceFeatureActive,
 	}
 	component, err := render.Manager(cfg)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)


### PR DESCRIPTION
Based on most situations the flag to was incorrectly set to enable compliance forwarding in Voltron.