### PR TITLE
Add the internal-manager-tls pem to the trusted bundle for es-proxy

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -403,6 +403,8 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 			r.status.SetDegraded(fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.ManagerInternalTLSSecretName, common.OperatorNamespace()), err.Error())
 			return reconcile.Result{}, nil
 		}
+		// Es-proxy needs to trust Voltron for cross-cluster requests.
+		trustedBundle.AddCertificates(internalTrafficSecret)
 	}
 
 	// Fetch the Authentication spec. If present, we use to configure user authentication.


### PR DESCRIPTION
Es proxy needs to trust the internal-manager-tls certificate for mcm requests.