### PR TITLE
Disable WireguardHostToHost encryption for AKS/EKS with Calico CNI (#…

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1337,11 +1337,15 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 			// We also need to configure a non-default trusted DNS server, since there's no kube-dns.
 			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"})
 		}
-	// For AKS and EKS/CalicoCNI, we must explicitly ask felix to add host IP's to wireguard ifaces
+	// For AKS/AzureVNET and EKS/VPCCNI, we must explicitly ask felix to add host IP's to wireguard ifaces
 	case operatorv1.ProviderAKS:
-		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
+		if c.cfg.Installation.CNI.Type == operatorv1.PluginAzureVNET {
+			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
+		}
 	case operatorv1.ProviderEKS:
-		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
+		if c.cfg.Installation.CNI.Type == operatorv1.PluginAmazonVPC {
+			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"})
+		}
 	}
 
 	switch c.cfg.Installation.CNI.Type {

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1037,7 +1037,6 @@ var _ = Describe("Node rendering tests", func() {
 					Optional: &optional,
 				},
 			}},
-			{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		// Expect the SECURITY_GROUP env variables to not be set
@@ -1485,7 +1484,6 @@ var _ = Describe("Node rendering tests", func() {
 					Optional: &optional,
 				},
 			}},
-			{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 		// Expect the SECURITY_GROUP env variables to not be set


### PR DESCRIPTION
Disable WireguardHostToHost encryption for AKS/EKS with Calico CNI (#1905)

(cherry picked from commit 491a8ce838504ecb42181e4a2f6308569c0bba71)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
