### PR TITLE
Update IPv6 migration for VXLAN

### DIFF
--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -208,8 +208,8 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 				return fmt.Errorf("ipPool.CIDR(%s) is invalid: %s", v6pool.CIDR, err)
 			}
 
-			if v6pool.Encapsulation != operatorv1.EncapsulationNone {
-				return fmt.Errorf("Encapsulation is not supported by IPv6 pools, but it is set for %s", v6pool.CIDR)
+			if v6pool.Encapsulation == operatorv1.EncapsulationIPIP || v6pool.Encapsulation == operatorv1.EncapsulationIPIPCrossSubnet {
+				return fmt.Errorf("IPIP encapsulation is not supported by IPv6 pools, but it is set for %s", v6pool.CIDR)
 			}
 
 			if bpfDataplane {

--- a/pkg/controller/migration/convert/core.go
+++ b/pkg/controller/migration/convert/core.go
@@ -185,6 +185,7 @@ func handleCore(c *components, install *operatorv1.Installation) error {
 	c.node.ignoreEnv("calico-node", "CALICO_IPV4POOL_IPIP")
 	c.node.ignoreEnv("calico-node", "CALICO_IPV4POOL_VXLAN")
 	c.node.ignoreEnv("calico-node", "CALICO_IPV6POOL_CIDR")
+	c.node.ignoreEnv("calico-node", "CALICO_IPV6POOL_VXLAN")
 	c.node.ignoreEnv("calico-node", "FELIX_LOGSEVERITYSCREEN")
 	c.node.ignoreEnv("calico-node", "FELIX_HEALTHENABLED")
 	c.node.ignoreEnv("calico-node", "FELIX_USAGEREPORTINGENABLED")

--- a/pkg/controller/migration/convert/network.go
+++ b/pkg/controller/migration/convert/network.go
@@ -159,13 +159,28 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 		}
 	}
 
-	// If IPv6 only, check that CALICO_ROUTER_ID, if defined, is set to `hash`.
+	// If IPv6 only and bird backend is used, check that CALICO_ROUTER_ID, if defined, is set to `hash`.
 	// Custom router ID values are only used for manual calico-node deployments and not
 	// applicable to calico-node running as a daemonset.
 	// In IPv6-only mode, calico-node will be rendered with CALICO_ROUTER_ID="hash".
 	if ip6 != nil && *ip6 == "autodetect" && ip != nil && *ip == "none" {
-		if err := c.node.assertEnv(ctx, c.client, containerCalicoNode, "CALICO_ROUTER_ID", "hash"); err != nil {
-			return err
+		if install.Spec.CalicoNetwork.BGP != nil && *install.Spec.CalicoNetwork.BGP == operatorv1.BGPEnabled {
+			if err := c.node.assertEnv(ctx, c.client, containerCalicoNode, "CALICO_ROUTER_ID", "hash"); err != nil {
+				return err
+			}
+		} else {
+			// IPv6-only clusters with BGP disabled should not have CALICO_ROUTER_ID set.
+			routerID, err := c.node.getEnv(ctx, c.client, containerCalicoNode, "CALICO_ROUTER_ID")
+			if err != nil {
+				return err
+			}
+			if routerID != nil {
+				return ErrIncompatibleCluster{
+					err:       "CNI config indicates an IPv6-only VXLAN cluster but CALICO_ROUTER_ID is only used for BGP-enabled clusters",
+					component: ComponentCNIConfig,
+					fix:       "remove the CALICO_ROUTER_ID env var",
+				}
+			}
 		}
 	}
 

--- a/pkg/controller/migration/convert/network_test.go
+++ b/pkg/controller/migration/convert/network_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Convert network tests", func() {
 
 			v6pool.Spec.IPIPMode = crdv1.IPIPModeNever
 			v6pool.Spec.VXLANMode = crdv1.VXLANModeAlways
-			c := fake.NewFakeClientWithScheme(scheme, v6pool, ds, emptyKubeControllerSpec(), emptyFelixConfig())
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(v6pool, ds, emptyKubeControllerSpec(), emptyFelixConfig()).Build()
 			cfg, err := Convert(ctx, c)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())
@@ -456,7 +456,7 @@ var _ = Describe("Convert network tests", func() {
 			v4pool.Spec.VXLANMode = crdv1.VXLANModeAlways
 			v6pool.Spec.IPIPMode = crdv1.IPIPModeNever
 			v6pool.Spec.VXLANMode = crdv1.VXLANModeAlways
-			c := fake.NewFakeClientWithScheme(scheme, v4pool, v6pool, ds, emptyKubeControllerSpec(), emptyFelixConfig())
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(v4pool, v6pool, ds, emptyKubeControllerSpec(), emptyFelixConfig()).Build()
 			cfg, err := Convert(ctx, c)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())

--- a/pkg/controller/migration/convert/network_test.go
+++ b/pkg/controller/migration/convert/network_test.go
@@ -62,7 +62,6 @@ var _ = Describe("Convert network tests", func() {
 		v6pool.Name = "test-ipv6-pool"
 		v6pool.Spec = crdv1.IPPoolSpec{
 			CIDR:        "2001:db8::1/120",
-			IPIPMode:    crdv1.IPIPModeAlways,
 			NATOutgoing: true,
 		}
 	})
@@ -392,6 +391,84 @@ var _ = Describe("Convert network tests", func() {
 			// Run test but with only v6 pool
 			ipv6Only := fake.NewClientBuilder().WithScheme(scheme).WithObjects(v6pool, ds, emptyKubeControllerSpec(), emptyFelixConfig()).Build()
 			runTest(ipv6Only)
+		})
+		It("migrate IPv6-only config with VXLAN", func() {
+			// This is the minimal dual stack config as outlined in our docs.
+			ds := emptyNodeSpec()
+			ds.Spec.Template.Spec.InitContainers[0].Env = []corev1.EnvVar{{
+				Name:  "CNI_NETWORK_CONFIG",
+				Value: `{"type": "calico", "name": "k8s-pod-network", "ipam": {"type": "calico-ipam", "assign_ipv4":"false", "assign_ipv6":"true"}}`,
+			}}
+			ds.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{
+				Name:  "CALICO_NETWORKING_BACKEND",
+				Value: "vxlan",
+			}}
+
+			ds.Spec.Template.Spec.Containers[0].Env = append(ds.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{
+					Name:  "IP6",
+					Value: "autodetect",
+				},
+				corev1.EnvVar{
+					Name:  "FELIX_IPV6SUPPORT",
+					Value: "true",
+				},
+			)
+
+			v6pool.Spec.IPIPMode = crdv1.IPIPModeNever
+			v6pool.Spec.VXLANMode = crdv1.VXLANModeAlways
+			c := fake.NewFakeClientWithScheme(scheme, v6pool, ds, emptyKubeControllerSpec(), emptyFelixConfig())
+			cfg, err := Convert(ctx, c)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).ToNot(BeNil())
+			Expect(cfg.Spec.CNI.Type).To(Equal(operatorv1.PluginCalico))
+			Expect(cfg.Spec.CNI.IPAM.Type).To(Equal(operatorv1.IPAMPluginCalico))
+			Expect(*cfg.Spec.CalicoNetwork.BGP).To(Equal(operatorv1.BGPDisabled))
+
+			expectedV6pool, err := convertPool(*v6pool)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Spec.CalicoNetwork.IPPools).To(ContainElements(expectedV6pool))
+		})
+		It("migrate dual stack config with VXLAN", func() {
+			// This is the minimal dual stack config as outlined in our docs.
+			ds := emptyNodeSpec()
+			ds.Spec.Template.Spec.InitContainers[0].Env = []corev1.EnvVar{{
+				Name:  "CNI_NETWORK_CONFIG",
+				Value: `{"type": "calico", "name": "k8s-pod-network", "ipam": {"type": "calico-ipam", "assign_ipv4":"true", "assign_ipv6":"true"}}`,
+			}}
+			ds.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{
+				Name:  "CALICO_NETWORKING_BACKEND",
+				Value: "vxlan",
+			}}
+
+			ds.Spec.Template.Spec.Containers[0].Env = append(ds.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{
+					Name:  "IP6",
+					Value: "autodetect",
+				},
+				corev1.EnvVar{
+					Name:  "FELIX_IPV6SUPPORT",
+					Value: "true",
+				},
+			)
+
+			v4pool.Spec.IPIPMode = crdv1.IPIPModeNever
+			v4pool.Spec.VXLANMode = crdv1.VXLANModeAlways
+			v6pool.Spec.IPIPMode = crdv1.IPIPModeNever
+			v6pool.Spec.VXLANMode = crdv1.VXLANModeAlways
+			c := fake.NewFakeClientWithScheme(scheme, v4pool, v6pool, ds, emptyKubeControllerSpec(), emptyFelixConfig())
+			cfg, err := Convert(ctx, c)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).ToNot(BeNil())
+			Expect(cfg.Spec.CNI.Type).To(Equal(operatorv1.PluginCalico))
+			Expect(cfg.Spec.CNI.IPAM.Type).To(Equal(operatorv1.IPAMPluginCalico))
+			Expect(*cfg.Spec.CalicoNetwork.BGP).To(Equal(operatorv1.BGPDisabled))
+
+			expectedV4pool, err := convertPool(*v4pool)
+			Expect(err).ToNot(HaveOccurred())
+			expectedV6pool, err := convertPool(*v6pool)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Spec.CalicoNetwork.IPPools).To(ContainElements(expectedV4pool, expectedV6pool))
 		})
 
 		DescribeTable("test invalid ipam and backend",
@@ -774,12 +851,20 @@ var _ = Describe("Convert network tests", func() {
 			{Name: "FELIX_IPV6SUPPORT", Value: "true"}}, true),
 		Entry("should not error if IP6=none and FELIX_IPV6SUPPORT is undefined", []corev1.EnvVar{{Name: "IP6", Value: "none"}}, false),
 		Entry("should error if IPv4 only and FELIX_IPV6SUPPORT=true", []corev1.EnvVar{{Name: "FELIX_IPV6SUPPORT", Value: "true"}}, true),
-		Entry("should error if IPv6 only and CALICO_ROUTER_ID != `hash`",
+		Entry("should error if IPv6 only with bird and CALICO_ROUTER_ID != `hash`",
 			[]corev1.EnvVar{
 				{Name: "IP", Value: "none"},
 				{Name: "IP6", Value: "autodetect"},
 				{Name: "FELIX_IPV6SUPPORT", Value: "true"},
+				{Name: "CALICO_NETWORKING_BACKEND", Value: "bird"},
 				{Name: "CALICO_ROUTER_ID", Value: "not hash"}}, true),
+		Entry("should error if IPv6 only with vxlan and CALICO_ROUTER_ID == `hash`",
+			[]corev1.EnvVar{
+				{Name: "IP", Value: "none"},
+				{Name: "IP6", Value: "autodetect"},
+				{Name: "FELIX_IPV6SUPPORT", Value: "true"},
+				{Name: "CALICO_NETWORKING_BACKEND", Value: "vxlan"},
+				{Name: "CALICO_ROUTER_ID", Value: "hash"}}, true),
 	)
 
 	It("handle both IP_AUTODETECTION_METHOD and IP6_AUTODETECTION_METHOD", func() {

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -548,8 +548,8 @@ spec:
                 type: string
               flowLogsFileDomainsLimit:
                 description: 'FlowLogsFileDomainsLimit is used to configure the number
-                  of (destination) domains to include in the flow log. The domains
-                  are only included at aggregation level 0 or 1. [Default: 5]'
+                  of (destination) domains to include in the flow log. These are not
+                  included for workload or host endpoint destinations. [Default: 5]'
                 type: integer
               flowLogsFileEnabled:
                 description: FlowLogsFileEnabled when set to true, enables logging

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1357,13 +1357,9 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "IP6_AUTODETECTION_METHOD", Value: v6Method})
 		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_IPV6SUPPORT", Value: "true"})
 
-		// Set CALICO_ROUTER_ID to "hash" for IPv6 only with BGP.
-		if v4Method == "" {
-			v6pool := GetIPv6Pool(c.cfg.Installation.CalicoNetwork.IPPools)
-			encap := v6pool.Encapsulation
-			if v6pool != nil && (encap != operatorv1.EncapsulationVXLAN && encap != operatorv1.EncapsulationVXLANCrossSubnet) {
-				nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_ROUTER_ID", Value: "hash"})
-			}
+		// Set CALICO_ROUTER_ID to "hash" for IPv6-only with BGP enabled.
+		if v4Method == "" && bgpEnabled(c.cfg.Installation) {
+			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_ROUTER_ID", Value: "hash"})
 		}
 	} else {
 		// IPv6 Auto-detection is disabled.

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1357,9 +1357,13 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "IP6_AUTODETECTION_METHOD", Value: v6Method})
 		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_IPV6SUPPORT", Value: "true"})
 
-		// Set CALICO_ROUTER_ID to "hash" if IPv6 only.
+		// Set CALICO_ROUTER_ID to "hash" for IPv6 only with BGP.
 		if v4Method == "" {
-			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_ROUTER_ID", Value: "hash"})
+			v6pool := GetIPv6Pool(c.cfg.Installation.CalicoNetwork.IPPools)
+			encap := v6pool.Encapsulation
+			if v6pool != nil && (encap != operatorv1.EncapsulationVXLAN && encap != operatorv1.EncapsulationVXLANCrossSubnet) {
+				nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_ROUTER_ID", Value: "hash"})
+			}
 		}
 	} else {
 		// IPv6 Auto-detection is disabled.


### PR DESCRIPTION
## Description

This PR updates the operator migration support for IPv6 to include IPv6 VXLAN clusters as well.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
