### PR TITLE
Automated cherry pick of #1939: Set VXLAN encap for IPv6 pools

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1252,6 +1252,15 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		if v6pool := GetIPv6Pool(c.cfg.Installation.CalicoNetwork.IPPools); v6pool != nil {
 			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_IPV6POOL_CIDR", Value: v6pool.CIDR})
 
+			switch v6pool.Encapsulation {
+			case operatorv1.EncapsulationVXLAN:
+				nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_IPV6POOL_VXLAN", Value: "Always"})
+			case operatorv1.EncapsulationVXLANCrossSubnet:
+				nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_IPV6POOL_VXLAN", Value: "CrossSubnet"})
+			case operatorv1.EncapsulationNone:
+				nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_IPV6POOL_VXLAN", Value: "Never"})
+			}
+
 			if v6pool.BlockSize != nil {
 				nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "CALICO_IPV6POOL_BLOCK_SIZE", Value: fmt.Sprintf("%d", *v6pool.BlockSize)})
 			}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -2051,6 +2051,24 @@ var _ = Describe("Node rendering tests", func() {
 				// Enabled is the default so we don't set
 				// NAT_OUTGOING if it is enabled.
 			}),
+		Entry("Pool with VXLAN enabled (IPv6)",
+			operatorv1.IPPool{
+				CIDR:          "fc00::/48",
+				Encapsulation: operatorv1.EncapsulationVXLAN,
+			},
+			map[string]string{
+				"CALICO_IPV6POOL_CIDR":  "fc00::/48",
+				"CALICO_IPV6POOL_VXLAN": "Always",
+			}),
+		Entry("Pool with VXLAN cross subnet enabled (IPv6)",
+			operatorv1.IPPool{
+				CIDR:          "fc00::/48",
+				Encapsulation: operatorv1.EncapsulationVXLANCrossSubnet,
+			},
+			map[string]string{
+				"CALICO_IPV6POOL_CIDR":  "fc00::/48",
+				"CALICO_IPV6POOL_VXLAN": "CrossSubnet",
+			}),
 		Entry("Pool with nat outgoing disabled (IPv6)",
 			operatorv1.IPPool{
 				CIDR:        "fc00::/48",


### PR DESCRIPTION
Cherry pick of #1939 on release-v1.27.

#1939: Set VXLAN encap for IPv6 pools

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.