### PR TITLE
[release-v1.27] Auto pick #1955: Fix felix healthport: set as env var

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1174,6 +1174,7 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "false"},
 		{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 		{Name: "FELIX_HEALTHENABLED", Value: "true"},
+		{Name: "FELIX_HEALTHPORT", Value: fmt.Sprintf("%d", c.cfg.FelixHealthPort)},
 		{
 			Name: "NODENAME",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -211,6 +211,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -434,6 +435,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -655,6 +657,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -934,6 +937,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -1091,6 +1095,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -1338,6 +1343,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -1492,6 +1498,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -1660,6 +1667,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9199"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -1741,6 +1749,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9199"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
@@ -2755,6 +2764,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_IPV6SUPPORT", Value: "false"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
+			{Name: "FELIX_HEALTHPORT", Value: "9099"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Cherry pick of #1955 on release-v1.27.

#1955: Fix felix healthport: set as env var

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Original PR was missing this bit, which adjusts the health port
environment variable.

Without this, the probes are updated but this particular check in
calico/node doesn't spot the change: https://github.com/projectcalico/calico/blob/5abdb3e6acdf66c408851c8bd4dd4aeeac796795/node/pkg/health/health.go#L37-L40

ref: https://github.com/tigera/operator/pull/1846

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.