### PR TITLE
Remove cluster-wide UI Settings for now

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1338,20 +1338,13 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Verbs:     []string{"create"},
 		},
 		// User can:
-		// - read UISettings in the cluster-settings group
 		// - read and write UISettings in the user-settings group
 		// Default settings group and settings are created in manager.go.
 		{
 			APIGroups:     []string{"projectcalico.org"},
 			Resources:     []string{"uisettingsgroups"},
 			Verbs:         []string{"get"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
-		},
-		{
-			APIGroups:     []string{"projectcalico.org"},
-			Resources:     []string{"uisettingsgroups/data"},
-			Verbs:         []string{"get", "list", "watch"},
-			ResourceNames: []string{"cluster-settings"},
+			ResourceNames: []string{"user-settings"},
 		},
 		{
 			APIGroups:     []string{"projectcalico.org"},
@@ -1486,20 +1479,19 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			Verbs:     []string{"create"},
 		},
 		// User can:
-		// - read and write UISettings in the cluster-settings group, and rename the group
-		// - read and write UISettings in the user-settings group, and rename the group
+		// - read and write UISettings in the user-settings group
 		// Default settings group and settings are created in manager.go.
 		{
 			APIGroups:     []string{"projectcalico.org"},
 			Resources:     []string{"uisettingsgroups"},
-			Verbs:         []string{"get", "patch", "update"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
+			Verbs:         []string{"get"},
+			ResourceNames: []string{"user-settings"},
 		},
 		{
 			APIGroups:     []string{"projectcalico.org"},
 			Resources:     []string{"uisettingsgroups/data"},
 			Verbs:         []string{"*"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
+			ResourceNames: []string{"user-settings"},
 		},
 	}
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -997,13 +997,7 @@ var (
 			APIGroups:     []string{"projectcalico.org"},
 			Resources:     []string{"uisettingsgroups"},
 			Verbs:         []string{"get"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
-		},
-		{
-			APIGroups:     []string{"projectcalico.org"},
-			Resources:     []string{"uisettingsgroups/data"},
-			Verbs:         []string{"get", "list", "watch"},
-			ResourceNames: []string{"cluster-settings"},
+			ResourceNames: []string{"user-settings"},
 		},
 		{
 			APIGroups:     []string{"projectcalico.org"},
@@ -1108,14 +1102,14 @@ var (
 		{
 			APIGroups:     []string{"projectcalico.org"},
 			Resources:     []string{"uisettingsgroups"},
-			Verbs:         []string{"get", "patch", "update"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
+			Verbs:         []string{"get"},
+			ResourceNames: []string{"user-settings"},
 		},
 		{
 			APIGroups:     []string{"projectcalico.org"},
 			Resources:     []string{"uisettingsgroups/data"},
 			Verbs:         []string{"*"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
+			ResourceNames: []string{"user-settings"},
 		},
 		{
 			APIGroups: []string{"lma.tigera.io"},

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -97,10 +97,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		managerServiceAccount(),
 		managerClusterRole(false, true, c.cfg.Openshift),
 		managerClusterRoleBinding(),
-		managerClusterWideSettingsGroup(),
 		managerUserSpecificSettingsGroup(),
-		managerClusterWideTigeraLayer(),
-		managerClusterWideDefaultView(),
 	)
 
 	return objs, nil

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -102,10 +102,7 @@ var _ = Describe("Rendering tests", func() {
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: render.ManagerClusterSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
 			{name: render.ManagerUserSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: render.ManagerClusterSettingsLayerTigera, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: render.ManagerClusterSettingsViewDefault, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 		}
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 		for i, expectedRes := range expectedResources {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -57,10 +57,7 @@ const (
 	ManagerTLSSecretName         = "manager-tls"
 	ManagerInternalTLSSecretName = "internal-manager-tls"
 
-	ManagerClusterSettings            = "cluster-settings"
-	ManagerUserSettings               = "user-settings"
-	ManagerClusterSettingsLayerTigera = "cluster-settings.layer.tigera-infrastructure"
-	ManagerClusterSettingsViewDefault = "cluster-settings.view.default"
+	ManagerUserSettings = "user-settings"
 
 	ElasticsearchManagerUserSecret  = "tigera-ee-manager-elasticsearch-access"
 	TlsSecretHashAnnotation         = "hash.operator.tigera.io/tls-secret"
@@ -172,10 +169,7 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 		managerServiceAccount(),
 		managerClusterRole(c.cfg.ManagementCluster != nil, false, c.cfg.Openshift),
 		managerClusterRoleBinding(),
-		managerClusterWideSettingsGroup(),
 		managerUserSpecificSettingsGroup(),
-		managerClusterWideTigeraLayer(),
-		managerClusterWideDefaultView(),
 	)
 	objs = append(objs, c.getTLSObjects()...)
 	objs = append(objs,
@@ -703,21 +697,6 @@ func (c *managerComponent) managerPodSecurityPolicy() *policyv1beta1.PodSecurity
 	return psp
 }
 
-// managerClusterWideSettingsGroup returns a UISettingsGroup with the description "cluster-wide settings"
-//
-// Calico Enterprise only
-func managerClusterWideSettingsGroup() *v3.UISettingsGroup {
-	return &v3.UISettingsGroup{
-		TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ManagerClusterSettings,
-		},
-		Spec: v3.UISettingsGroupSpec{
-			Description: "Cluster Settings",
-		},
-	}
-}
-
 // managerUserSpecificSettingsGroup returns a UISettingsGroup with the description "user settings"
 //
 // Calico Enterprise only
@@ -730,79 +709,6 @@ func managerUserSpecificSettingsGroup() *v3.UISettingsGroup {
 		Spec: v3.UISettingsGroupSpec{
 			Description: "User Settings",
 			FilterType:  v3.FilterTypeUser,
-		},
-	}
-}
-
-// managerClusterWideTigeraLayer returns a UISettings layer belonging to the cluster-wide settings group that contains
-// all of the tigera namespaces.
-//
-// Calico Enterprise only
-func managerClusterWideTigeraLayer() *v3.UISettings {
-	namespaces := []string{
-		"tigera-compliance",
-		"tigera-dex",
-		"tigera-dpi",
-		"tigera-eck-operator",
-		"tigera-elasticsearch",
-		"tigera-fluentd",
-		"tigera-guardian",
-		"tigera-intrusion-detection",
-		"tigera-kibana",
-		"tigera-manager",
-		"tigera-operator",
-		"tigera-packetcapture",
-		"tigera-prometheus",
-		"tigera-system",
-		"calico-system",
-	}
-	nodes := make([]v3.UIGraphNode, len(namespaces))
-	for i := range namespaces {
-		ns := namespaces[i]
-		nodes[i] = v3.UIGraphNode{
-			ID:   "namespace/" + ns,
-			Type: "namespace",
-			Name: ns,
-		}
-	}
-
-	return &v3.UISettings{
-		TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ManagerClusterSettingsLayerTigera,
-		},
-		Spec: v3.UISettingsSpec{
-			Group:       "cluster-settings",
-			Description: "Tigera Infrastructure",
-			Layer: &v3.UIGraphLayer{
-				Nodes: nodes,
-			},
-		},
-	}
-}
-
-// managerClusterWideDefaultView returns a UISettings view belonging to the cluster-wide settings group that shows
-// everything and uses the tigera-infrastructure layer.
-//
-// Calico Enterprise only
-func managerClusterWideDefaultView() *v3.UISettings {
-	return &v3.UISettings{
-		TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ManagerClusterSettingsViewDefault,
-		},
-		Spec: v3.UISettingsSpec{
-			Group:       "cluster-settings",
-			Description: "Default",
-			View: &v3.UIGraphView{
-				Nodes: []v3.UIGraphNodeView{{
-					UIGraphNode: v3.UIGraphNode{
-						ID:   "layer/cluster-settings.layer.tigera-infrastructure",
-						Type: "layer",
-						Name: "cluster-settings.layer.tigera-infrastructure",
-					},
-				}},
-			},
 		},
 	}
 }

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	}
 	var replicas int32 = 2
 	installation := &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas}
-	const expectedResourcesNumber = 11
+	const expectedResourcesNumber = 8
 
 	It("should render all resources for a default configuration", func() {
 		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, complianceFeatureActive: true})
@@ -68,10 +68,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: render.ManagerClusterSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
 			{name: render.ManagerUserSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: render.ManagerClusterSettingsLayerTigera, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: render.ManagerClusterSettingsViewDefault, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "apps", version: "v1", kind: "Deployment"},
@@ -265,10 +262,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "tigera-manager-role", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-manager-binding", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: render.ManagerClusterSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
 			{name: render.ManagerUserSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: render.ManagerClusterSettingsLayerTigera, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: render.ManagerClusterSettingsViewDefault, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "Service"},
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "tigera-manager", ns: "tigera-manager", group: "apps", version: "v1", kind: "Deployment"},
@@ -495,10 +489,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: render.ManagerClusterSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
 			{name: render.ManagerUserSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: render.ManagerClusterSettingsLayerTigera, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: render.ManagerClusterSettingsViewDefault, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-manager", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "tigera-manager", ns: render.ManagerNamespace, group: "apps", version: "v1", kind: "Deployment"},


### PR DESCRIPTION
## Description

Removing cluster-wide settings - these still didn't make the cut for the enterprise release, so removing to avoid the UI making use of them.   User settings are still valid - so they remain.

This has now been designed and is actively being worked on by the UX team, and so it can remain in master.

Related PR removing this from previous enterprise release:  https://github.com/tigera/operator/pull/1838
Related PR originally adding this stuff: https://github.com/tigera/operator/pull/1774


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
