### PR TITLE
allow-tigera reconciliation

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,6 +107,13 @@ func AddToManager(mgr ctrl.Manager, options options.AddOptions) error {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr, options); err != nil {
 		return fmt.Errorf("failed to create controller %s: %v", "Authentication", err)
+	}
+	if err := (&TiersReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Tiers"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr, options); err != nil {
+		return fmt.Errorf("failed to create controller %s: %v", "Tiers", err)
 	}
 	// +kubebuilder:scaffold:builder
 	return nil

--- a/controllers/tiers_controller.go
+++ b/controllers/tiers_controller.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/tiers"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TiersReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+func (r *TiersReconciler) SetupWithManager(mgr ctrl.Manager, opts options.AddOptions) error {
+	return tiers.Add(mgr, opts)
+}

--- a/pkg/controller/clusterconnection/shim_test.go
+++ b/pkg/controller/clusterconnection/shim_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ package clusterconnection
 import (
 	"context"
 
+	"github.com/tigera/operator/pkg/controller/utils"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
@@ -28,10 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func NewReconcilerWithShims(cli client.Client, schema *runtime.Scheme, status status.StatusManager, provider operatorv1.Provider) reconcile.Reconciler {
+func NewReconcilerWithShims(cli client.Client, schema *runtime.Scheme, status status.StatusManager, readyFlag *utils.ReadyFlag, provider operatorv1.Provider) reconcile.Reconciler {
 	opts := options.AddOptions{
 		ShutdownContext: context.Background(),
 	}
 
-	return newReconciler(cli, schema, status, provider, opts)
+	return newReconciler(cli, schema, status, readyFlag, provider, opts)
 }

--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -88,12 +88,13 @@ var _ = Describe("Compliance controller tests", func() {
 		// Create an object we can use throughout the test to do the compliance reconcile loops.
 		// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 		r = ReconcileCompliance{
-			client:          c,
-			scheme:          scheme,
-			provider:        operatorv1.ProviderNone,
-			status:          mockStatus,
-			clusterDomain:   dns.DefaultClusterDomain,
-			licenseAPIReady: &utils.ReadyFlag{},
+			client:             c,
+			scheme:             scheme,
+			provider:           operatorv1.ProviderNone,
+			status:             mockStatus,
+			clusterDomain:      dns.DefaultClusterDomain,
+			licenseAPIReady:    &utils.ReadyFlag{},
+			policyWatchesReady: &utils.ReadyFlag{},
 		}
 
 		// We start off with a 'standard' installation, with nothing special
@@ -118,6 +119,7 @@ var _ = Describe("Compliance controller tests", func() {
 		// The compliance reconcile loop depends on a ton of objects that should be available in your client as
 		// prerequisites. Without them, compliance will not even start creating objects. Let's create them now.
 		Expect(c.Create(ctx, &operatorv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}, Status: operatorv1.APIServerStatus{State: operatorv1.TigeraStatusReady}})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
 		Expect(c.Create(ctx, &v3.LicenseKey{ObjectMeta: metav1.ObjectMeta{Name: "default"}, Status: v3.LicenseKeyStatus{Features: []string{common.ComplianceFeature}}})).NotTo(HaveOccurred())
 		Expect(c.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.ClusterConfigConfigMapName, Namespace: common.OperatorNamespace()},
 			Data: map[string]string{
@@ -139,8 +141,9 @@ var _ = Describe("Compliance controller tests", func() {
 		cr = &operatorv1.Compliance{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}}
 		Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 
-		// mark that the watch for license key was successful
+		// mark that the watches were successful
 		r.licenseAPIReady.MarkAsReady()
+		r.policyWatchesReady.MarkAsReady()
 	})
 
 	It("should create resources for standalone clusters", func() {
@@ -508,6 +511,48 @@ var _ = Describe("Compliance controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentComplianceServer.Image,
 					"sha256:serverhash")))
+		})
+	})
+
+	Context("allow-tigera reconciliation", func() {
+		var readyFlag *utils.ReadyFlag
+
+		BeforeEach(func() {
+			mockStatus = &status.MockStatus{}
+			mockStatus.On("OnCRFound").Return()
+
+			readyFlag = &utils.ReadyFlag{}
+			readyFlag.MarkAsReady()
+			r = ReconcileCompliance{
+				client:             c,
+				scheme:             scheme,
+				provider:           operatorv1.ProviderNone,
+				status:             mockStatus,
+				clusterDomain:      dns.DefaultClusterDomain,
+				licenseAPIReady:    readyFlag,
+				policyWatchesReady: readyFlag,
+			}
+		})
+
+		It("should wait if API server is unavailable", func() {
+			utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
+		})
+
+		It("should wait if allow-tigera tier is unavailable", func() {
+			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
+		})
+
+		It("should wait if policy watches are not ready", func() {
+			r = ReconcileCompliance{
+				client:             c,
+				scheme:             scheme,
+				provider:           operatorv1.ProviderNone,
+				status:             mockStatus,
+				clusterDomain:      dns.DefaultClusterDomain,
+				licenseAPIReady:    readyFlag,
+				policyWatchesReady: &utils.ReadyFlag{},
+			}
+			utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
 		})
 	})
 

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -83,7 +83,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	go utils.WaitToAddLicenseKeyWatch(controller, k8sClient, log, licenseAPIReady)
 
 	go utils.WaitToAddResourceWatch(controller, k8sClient, log, dpiAPIReady,
-		&v3.DeepPacketInspection{TypeMeta: metav1.TypeMeta{Kind: v3.KindDeepPacketInspection}})
+		[]client.Object{&v3.DeepPacketInspection{TypeMeta: metav1.TypeMeta{Kind: v3.KindDeepPacketInspection}}})
 
 	return add(mgr, controller)
 }

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -52,97 +52,102 @@ var _ = Describe("LogCollector controller tests", func() {
 	var scheme *runtime.Scheme
 	var mockStatus *status.MockStatus
 
-	Context("image reconciliation", func() {
-		BeforeEach(func() {
-			// The schema contains all objects that should be known to the fake client when the test runs.
-			scheme = runtime.NewScheme()
-			Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
-			Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-			Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-			Expect(batchv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-			Expect(operatorv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+	BeforeEach(func() {
+		// The schema contains all objects that should be known to the fake client when the test runs.
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(batchv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(operatorv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
 
-			// Create a client that will have a crud interface of k8s objects.
-			c = fake.NewClientBuilder().WithScheme(scheme).Build()
-			ctx = context.Background()
+		// Create a client that will have a crud interface of k8s objects.
+		c = fake.NewClientBuilder().WithScheme(scheme).Build()
+		ctx = context.Background()
 
-			// Create an object we can use throughout the test to do the compliance reconcile loops.
-			mockStatus = &status.MockStatus{}
-			mockStatus.On("AddDaemonsets", mock.Anything).Return()
-			mockStatus.On("AddDeployments", mock.Anything).Return()
-			mockStatus.On("AddStatefulSets", mock.Anything).Return()
-			mockStatus.On("AddCronJobs", mock.Anything)
-			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
-			mockStatus.On("AddCertificateSigningRequests", mock.Anything).Return()
-			mockStatus.On("IsAvailable").Return(true)
-			mockStatus.On("OnCRFound").Return()
-			mockStatus.On("ClearDegraded")
-			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
-			mockStatus.On("ReadyToMonitor")
+		// Create an object we can use throughout the test to do the compliance reconcile loops.
+		mockStatus = &status.MockStatus{}
+		mockStatus.On("AddDaemonsets", mock.Anything).Return()
+		mockStatus.On("AddDeployments", mock.Anything).Return()
+		mockStatus.On("AddStatefulSets", mock.Anything).Return()
+		mockStatus.On("AddCronJobs", mock.Anything)
+		mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
+		mockStatus.On("AddCertificateSigningRequests", mock.Anything).Return()
+		mockStatus.On("IsAvailable").Return(true)
+		mockStatus.On("OnCRFound").Return()
+		mockStatus.On("ClearDegraded")
+		mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+		mockStatus.On("ReadyToMonitor")
 
-			// Create an object we can use throughout the test to do the compliance reconcile loops.
-			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
-			r = ReconcileLogCollector{
-				client:          c,
-				scheme:          scheme,
-				provider:        operatorv1.ProviderNone,
-				status:          mockStatus,
-				licenseAPIReady: &utils.ReadyFlag{},
-			}
+		// Create an object we can use throughout the test to do the compliance reconcile loops.
+		// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
+		r = ReconcileLogCollector{
+			client:             c,
+			scheme:             scheme,
+			provider:           operatorv1.ProviderNone,
+			status:             mockStatus,
+			licenseAPIReady:    &utils.ReadyFlag{},
+			policyWatchesReady: &utils.ReadyFlag{},
+		}
 
-			// We start off with a 'standard' installation, with nothing special
-			Expect(c.Create(
-				ctx,
-				&operatorv1.Installation{
-					ObjectMeta: metav1.ObjectMeta{Name: "default"},
-					Spec: operatorv1.InstallationSpec{
-						Variant:  operatorv1.TigeraSecureEnterprise,
-						Registry: "some.registry.org/",
+		// We start off with a 'standard' installation, with nothing special
+		Expect(c.Create(
+			ctx,
+			&operatorv1.Installation{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: operatorv1.InstallationSpec{
+					Variant:  operatorv1.TigeraSecureEnterprise,
+					Registry: "some.registry.org/",
+				},
+				Status: operatorv1.InstallationStatus{
+					Variant: operatorv1.TigeraSecureEnterprise,
+					Computed: &operatorv1.InstallationSpec{
+						Registry: "my-reg",
+						// The test is provider agnostic.
+						KubernetesProvider: operatorv1.ProviderNone,
 					},
-					Status: operatorv1.InstallationStatus{
-						Variant: operatorv1.TigeraSecureEnterprise,
-						Computed: &operatorv1.InstallationSpec{
-							Registry: "my-reg",
-							// The test is provider agnostic.
-							KubernetesProvider: operatorv1.ProviderNone,
-						},
-					},
-				})).NotTo(HaveOccurred())
-
-			// Create resources LogCollector depends on
-			Expect(c.Create(ctx, &operatorv1.APIServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
-				Status:     operatorv1.APIServerStatus{State: operatorv1.TigeraStatusReady},
+				},
 			})).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, &v3.LicenseKey{
-				ObjectMeta: metav1.ObjectMeta{Name: "default"}})).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, relasticsearch.NewClusterConfig("cluster", 1, 1, 1).ConfigMap())).NotTo(HaveOccurred())
-			certificateManager, err := certificatemanager.Create(c, nil, "")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))) // Persist the root-ca in the operator namespace.
-			kibanaTLS, err := certificateManager.GetOrCreateKeyPair(c, relasticsearch.PublicCertSecret, common.OperatorNamespace(), []string{relasticsearch.PublicCertSecret})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, kibanaTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.ElasticsearchLogCollectorUserSecret,
-					Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      render.ElasticsearchEksLogForwarderUserSecret,
-					Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
-			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{render.PrometheusTLSSecretName})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
-			// Apply the logcollector CR to the fake cluster.
-			Expect(c.Create(ctx, &operatorv1.LogCollector{
-				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})).NotTo(HaveOccurred())
+		// Create resources LogCollector depends on
+		Expect(c.Create(ctx, &operatorv1.APIServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			Status:     operatorv1.APIServerStatus{State: operatorv1.TigeraStatusReady},
+		})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &v3.Tier{
+			ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"},
+		})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &v3.LicenseKey{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"}})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, relasticsearch.NewClusterConfig("cluster", 1, 1, 1).ConfigMap())).NotTo(HaveOccurred())
+		certificateManager, err := certificatemanager.Create(c, nil, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))) // Persist the root-ca in the operator namespace.
+		kibanaTLS, err := certificateManager.GetOrCreateKeyPair(c, relasticsearch.PublicCertSecret, common.OperatorNamespace(), []string{relasticsearch.PublicCertSecret})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, kibanaTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchLogCollectorUserSecret,
+				Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchEksLogForwarderUserSecret,
+				Namespace: "tigera-operator"}})).NotTo(HaveOccurred())
+		prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{render.PrometheusTLSSecretName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
-			// mark that the watch for license key was successful
-			r.licenseAPIReady.MarkAsReady()
-		})
+		// Apply the logcollector CR to the fake cluster.
+		Expect(c.Create(ctx, &operatorv1.LogCollector{
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})).NotTo(HaveOccurred())
 
+		// mark that the watches were successful
+		r.licenseAPIReady.MarkAsReady()
+		r.policyWatchesReady.MarkAsReady()
+	})
+
+	Context("image reconciliation", func() {
 		It("should use builtin images", func() {
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -529,6 +534,47 @@ var _ = Describe("LogCollector controller tests", func() {
 			})
 		})
 	})
+
+	Context("allow-tigera reconciliation", func() {
+		var readyFlag *utils.ReadyFlag
+
+		BeforeEach(func() {
+			mockStatus = &status.MockStatus{}
+			mockStatus.On("OnCRFound").Return()
+
+			readyFlag = &utils.ReadyFlag{}
+			readyFlag.MarkAsReady()
+			r = ReconcileLogCollector{
+				client:             c,
+				scheme:             scheme,
+				provider:           operatorv1.ProviderNone,
+				status:             mockStatus,
+				licenseAPIReady:    readyFlag,
+				policyWatchesReady: readyFlag,
+			}
+		})
+
+		It("should wait if API server is unavailable", func() {
+			utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
+		})
+
+		It("should wait if allow-tigera tier is unavailable", func() {
+			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
+		})
+
+		It("should wait if policy watches are not ready", func() {
+			r = ReconcileLogCollector{
+				client:             c,
+				scheme:             scheme,
+				provider:           operatorv1.ProviderNone,
+				status:             mockStatus,
+				licenseAPIReady:    readyFlag,
+				policyWatchesReady: &utils.ReadyFlag{},
+			}
+			utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
+		})
+	})
+
 	Context("should test fillDefaults for logCollector", func() {
 		It("should set default values for CollectProcessPath, syslog types", func() {
 			logCollector := operatorv1.LogCollector{Spec: operatorv1.LogCollectorSpec{AdditionalStores: &operatorv1.AdditionalLogStoreSpec{

--- a/pkg/controller/logstorage/shim_test.go
+++ b/pkg/controller/logstorage/shim_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,8 @@ func NewReconcilerWithShims(
 	status status.StatusManager,
 	provider operatorv1.Provider,
 	esCliCreator utils.ElasticsearchClientCreator,
-	clusterDomain string) (*ReconcileLogStorage, error) {
+	clusterDomain string,
+	policyWatchesReady *utils.ReadyFlag) (*ReconcileLogStorage, error) {
 
 	opts := options.AddOptions{
 		DetectedProvider: provider,
@@ -41,5 +42,5 @@ func NewReconcilerWithShims(
 		ShutdownContext:  context.TODO(),
 	}
 
-	return newReconciler(cli, schema, status, opts, esCliCreator)
+	return newReconciler(cli, schema, status, opts, esCliCreator, policyWatchesReady)
 }

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/components"
 
 	"github.com/stretchr/testify/mock"
 
@@ -27,7 +28,6 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
-	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/dns"
@@ -107,12 +107,13 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
-				client:          c,
-				scheme:          scheme,
-				provider:        operatorv1.ProviderNone,
-				status:          mockStatus,
-				clusterDomain:   clusterDomain,
-				licenseAPIReady: &utils.ReadyFlag{},
+				client:             c,
+				scheme:             scheme,
+				provider:           operatorv1.ProviderNone,
+				status:             mockStatus,
+				clusterDomain:      clusterDomain,
+				licenseAPIReady:    &utils.ReadyFlag{},
+				policyWatchesReady: &utils.ReadyFlag{},
 			}
 
 			Expect(c.Create(ctx, &operatorv1.APIServer{
@@ -120,6 +121,9 @@ var _ = Describe("Manager controller tests", func() {
 				Status: operatorv1.APIServerStatus{
 					State: operatorv1.TigeraStatusReady,
 				},
+			})).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, &v3.Tier{
+				ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"},
 			})).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.LicenseKey{
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
@@ -181,8 +185,9 @@ var _ = Describe("Manager controller tests", func() {
 			}
 			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 
-			// mark that the watch for license key was successful
+			// mark that the watches were successful
 			r.licenseAPIReady.MarkAsReady()
+			r.policyWatchesReady.MarkAsReady()
 		})
 
 		It("should reconcile if user supplied a manager TLS cert", func() {
@@ -278,7 +283,7 @@ var _ = Describe("Manager controller tests", func() {
 		})
 	})
 
-	Context("image reconciliation", func() {
+	Context("reconciliation", func() {
 		var r ReconcileManager
 		var mockStatus *status.MockStatus
 
@@ -298,11 +303,12 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
-				client:          c,
-				scheme:          scheme,
-				provider:        operatorv1.ProviderNone,
-				status:          mockStatus,
-				licenseAPIReady: &utils.ReadyFlag{},
+				client:             c,
+				scheme:             scheme,
+				provider:           operatorv1.ProviderNone,
+				status:             mockStatus,
+				licenseAPIReady:    &utils.ReadyFlag{},
+				policyWatchesReady: &utils.ReadyFlag{},
 			}
 
 			Expect(c.Create(ctx, &operatorv1.APIServer{
@@ -310,6 +316,9 @@ var _ = Describe("Manager controller tests", func() {
 				Status: operatorv1.APIServerStatus{
 					State: operatorv1.TigeraStatusReady,
 				},
+			})).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, &v3.Tier{
+				ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"},
 			})).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.LicenseKey{
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
@@ -380,84 +389,127 @@ var _ = Describe("Manager controller tests", func() {
 				},
 			})).NotTo(HaveOccurred())
 
-			// mark that the watch for license key was successful
+			// mark that the watches were successful
 			r.licenseAPIReady.MarkAsReady()
+			r.policyWatchesReady.MarkAsReady()
 		})
-		It("should use builtin images", func() {
-			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
 
-			d := appsv1.Deployment{
-				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tigera-manager",
-					Namespace: render.ManagerNamespace,
-				},
-			}
-			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
-			mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
-			Expect(mgr).ToNot(BeNil())
-			Expect(mgr.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s:%s",
-					components.ComponentManager.Image,
-					components.ComponentManager.Version)))
-			esproxy := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-es-proxy")
-			Expect(esproxy).ToNot(BeNil())
-			Expect(esproxy.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s:%s",
-					components.ComponentEsProxy.Image,
-					components.ComponentEsProxy.Version)))
-			vltrn := test.GetContainer(d.Spec.Template.Spec.Containers, render.VoltronName)
-			Expect(vltrn).ToNot(BeNil())
-			Expect(vltrn.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s:%s",
-					components.ComponentManagerProxy.Image,
-					components.ComponentManagerProxy.Version)))
-		})
-		It("should use images from imageset", func() {
-			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
-			Expect(c.Create(ctx, &operatorv1.ImageSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "enterprise-" + components.EnterpriseRelease},
-				Spec: operatorv1.ImageSetSpec{
-					Images: []operatorv1.Image{
-						{Image: "tigera/cnx-manager", Digest: "sha256:cnxmanagerhash"},
-						{Image: "tigera/es-proxy", Digest: "sha256:esproxyhash"},
-						{Image: "tigera/voltron", Digest: "sha256:voltronhash"},
+		Context("image reconciliation", func() {
+			It("should use builtin images", func() {
+				mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				d := appsv1.Deployment{
+					TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-manager",
+						Namespace: render.ManagerNamespace,
 					},
-				},
-			})).ToNot(HaveOccurred())
+				}
+				Expect(test.GetResource(c, &d)).To(BeNil())
+				Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
+				mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
+				Expect(mgr).ToNot(BeNil())
+				Expect(mgr.Image).To(Equal(
+					fmt.Sprintf("some.registry.org/%s:%s",
+						components.ComponentManager.Image,
+						components.ComponentManager.Version)))
+				esproxy := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-es-proxy")
+				Expect(esproxy).ToNot(BeNil())
+				Expect(esproxy.Image).To(Equal(
+					fmt.Sprintf("some.registry.org/%s:%s",
+						components.ComponentEsProxy.Image,
+						components.ComponentEsProxy.Version)))
+				vltrn := test.GetContainer(d.Spec.Template.Spec.Containers, render.VoltronName)
+				Expect(vltrn).ToNot(BeNil())
+				Expect(vltrn.Image).To(Equal(
+					fmt.Sprintf("some.registry.org/%s:%s",
+						components.ComponentManagerProxy.Image,
+						components.ComponentManagerProxy.Version)))
+			})
+			It("should use images from imageset", func() {
+				mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
+				Expect(c.Create(ctx, &operatorv1.ImageSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "enterprise-" + components.EnterpriseRelease},
+					Spec: operatorv1.ImageSetSpec{
+						Images: []operatorv1.Image{
+							{Image: "tigera/cnx-manager", Digest: "sha256:cnxmanagerhash"},
+							{Image: "tigera/es-proxy", Digest: "sha256:esproxyhash"},
+							{Image: "tigera/voltron", Digest: "sha256:voltronhash"},
+						},
+					},
+				})).ToNot(HaveOccurred())
 
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			d := appsv1.Deployment{
-				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tigera-manager",
-					Namespace: render.ManagerNamespace,
-				},
-			}
-			Expect(test.GetResource(c, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
-			mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
-			Expect(mgr).ToNot(BeNil())
-			Expect(mgr.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s@%s",
-					components.ComponentManager.Image,
-					"sha256:cnxmanagerhash")))
-			esproxy := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-es-proxy")
-			Expect(esproxy).ToNot(BeNil())
-			Expect(esproxy.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s@%s",
-					components.ComponentEsProxy.Image,
-					"sha256:esproxyhash")))
-			vltrn := test.GetContainer(d.Spec.Template.Spec.Containers, render.VoltronName)
-			Expect(vltrn).ToNot(BeNil())
-			Expect(vltrn.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s@%s",
-					components.ComponentManagerProxy.Image,
-					"sha256:voltronhash")))
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).ShouldNot(HaveOccurred())
+				d := appsv1.Deployment{
+					TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-manager",
+						Namespace: render.ManagerNamespace,
+					},
+				}
+				Expect(test.GetResource(c, &d)).To(BeNil())
+				Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
+				mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
+				Expect(mgr).ToNot(BeNil())
+				Expect(mgr.Image).To(Equal(
+					fmt.Sprintf("some.registry.org/%s@%s",
+						components.ComponentManager.Image,
+						"sha256:cnxmanagerhash")))
+				esproxy := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-es-proxy")
+				Expect(esproxy).ToNot(BeNil())
+				Expect(esproxy.Image).To(Equal(
+					fmt.Sprintf("some.registry.org/%s@%s",
+						components.ComponentEsProxy.Image,
+						"sha256:esproxyhash")))
+				vltrn := test.GetContainer(d.Spec.Template.Spec.Containers, render.VoltronName)
+				Expect(vltrn).ToNot(BeNil())
+				Expect(vltrn.Image).To(Equal(
+					fmt.Sprintf("some.registry.org/%s@%s",
+						components.ComponentManagerProxy.Image,
+						"sha256:voltronhash")))
+			})
+		})
+
+		Context("allow-tigera reconciliation", func() {
+			var readyFlag *utils.ReadyFlag
+			BeforeEach(func() {
+				mockStatus = &status.MockStatus{}
+				mockStatus.On("OnCRFound").Return()
+
+				readyFlag = &utils.ReadyFlag{}
+				readyFlag.MarkAsReady()
+				r = ReconcileManager{
+					client:             c,
+					scheme:             scheme,
+					provider:           operatorv1.ProviderNone,
+					status:             mockStatus,
+					licenseAPIReady:    readyFlag,
+					policyWatchesReady: readyFlag,
+				}
+			})
+
+			It("should wait if API server is unavailable", func() {
+				utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
+			})
+
+			It("should wait if allow-tigera tier is unavailable", func() {
+				utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
+			})
+
+			It("should wait if policy watches are not ready", func() {
+				r = ReconcileManager{
+					client:             c,
+					scheme:             scheme,
+					provider:           operatorv1.ProviderNone,
+					status:             mockStatus,
+					licenseAPIReady:    readyFlag,
+					policyWatchesReady: &utils.ReadyFlag{},
+				}
+				utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
+			})
 		})
 	})
 })

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@ import (
 	"fmt"
 	"reflect"
 	"time"
+
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -60,10 +64,11 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return nil
 	}
 
-	var prometheusReady = &utils.ReadyFlag{}
+	prometheusReady := &utils.ReadyFlag{}
+	policyWatchesReady := &utils.ReadyFlag{}
 
 	// Create the reconciler
-	reconciler := newReconciler(mgr, opts, prometheusReady)
+	reconciler := newReconciler(mgr, opts, prometheusReady, policyWatchesReady)
 
 	// Create a new controller
 	controller, err := controller.New("monitor-controller", mgr, controller.Options{Reconciler: reconciler})
@@ -76,20 +81,29 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		log.Error(err, "Failed to establish a connection to k8s")
 		return err
 	}
-
 	go waitToAddPrometheusWatch(controller, k8sClient, log, prometheusReady)
+
+	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, policyWatchesReady, []types.NamespacedName{
+		{Name: monitor.PrometheusPolicyName, Namespace: common.TigeraPrometheusNamespace},
+		{Name: monitor.PrometheusAPIPolicyName, Namespace: common.TigeraPrometheusNamespace},
+		{Name: monitor.PrometheusOperatorPolicyName, Namespace: common.TigeraPrometheusNamespace},
+		{Name: monitor.AlertManagerPolicyName, Namespace: common.TigeraPrometheusNamespace},
+		{Name: monitor.MeshAlertManagerPolicyName, Namespace: common.TigeraPrometheusNamespace},
+		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: common.TigeraPrometheusNamespace},
+	})
 
 	return add(mgr, controller)
 }
 
-func newReconciler(mgr manager.Manager, opts options.AddOptions, prometheusReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, prometheusReady *utils.ReadyFlag, policyWatchesReady *utils.ReadyFlag) reconcile.Reconciler {
 	r := &ReconcileMonitor{
-		client:          mgr.GetClient(),
-		scheme:          mgr.GetScheme(),
-		provider:        opts.DetectedProvider,
-		status:          status.New(mgr.GetClient(), "monitor", opts.KubernetesVersion),
-		prometheusReady: prometheusReady,
-		clusterDomain:   opts.ClusterDomain,
+		client:             mgr.GetClient(),
+		scheme:             mgr.GetScheme(),
+		provider:           opts.DetectedProvider,
+		status:             status.New(mgr.GetClient(), "monitor", opts.KubernetesVersion),
+		prometheusReady:    prometheusReady,
+		clusterDomain:      opts.ClusterDomain,
+		policyWatchesReady: policyWatchesReady,
 	}
 
 	r.status.AddStatefulSets([]types.NamespacedName{
@@ -141,12 +155,13 @@ func add(mgr manager.Manager, c controller.Controller) error {
 var _ reconcile.Reconciler = &ReconcileMonitor{}
 
 type ReconcileMonitor struct {
-	client          client.Client
-	scheme          *runtime.Scheme
-	provider        operatorv1.Provider
-	status          status.StatusManager
-	prometheusReady *utils.ReadyFlag
-	clusterDomain   string
+	client             client.Client
+	scheme             *runtime.Scheme
+	provider           operatorv1.Provider
+	status             status.StatusManager
+	prometheusReady    *utils.ReadyFlag
+	clusterDomain      string
+	policyWatchesReady *utils.ReadyFlag
 }
 
 func (r *ReconcileMonitor) getMonitor(ctx context.Context) (*operatorv1.Monitor, error) {
@@ -188,6 +203,30 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 		r.setDegraded(reqLogger, err, "Failed to query Installation")
 		return reconcile.Result{}, err
+	}
+
+	// Ensure the API Server is ready, before rendering any objects that utilize the V3 API.
+	if !utils.IsAPIServerReady(r.client, reqLogger) {
+		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
+		return reconcile.Result{}, nil
+	}
+
+	if !r.policyWatchesReady.IsReady() {
+		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	// Ensure the allow-tigera tier exists, before rendering any network policies within it.
+	if err := r.client.Get(ctx, client.ObjectKey{Name: networkpolicy.TigeraComponentTierName}, &v3.Tier{}); err != nil {
+		if errors.IsNotFound(err) {
+			log.Error(err, "Waiting for Tigera component policy tier to be created")
+			r.status.SetDegraded("Waiting for Tigera component policy tier to be created", err.Error())
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		} else {
+			log.Error(err, "Error querying Tigera component policy tier")
+			r.status.SetDegraded("Error querying Tigera component policy tier", err.Error())
+			return reconcile.Result{}, err
+		}
 	}
 
 	pullSecrets, err := utils.GetNetworkingPullSecrets(install, r.client)
@@ -283,6 +322,7 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		ClientTLSSecret:          clientTLSSecret,
 		ClusterDomain:            r.clusterDomain,
 		TrustedCertBundle:        trustedBundle,
+		Openshift:                r.provider == operatorv1.ProviderOpenShift,
 	}
 
 	// Render prometheus component

--- a/pkg/controller/tiers/tiers_controller.go
+++ b/pkg/controller/tiers/tiers_controller.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiers
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/tiers"
+	"k8s.io/apimachinery/pkg/types"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// The Tiers controller reconciles system tiers and network policies using the v3 API. v3 resources require the API server to be available.
+// System tiers are reconciled here instead of the installation controller since the API server is not available until after installation completes.
+// Similarly, policies for installation and API server controllers are reconciled here to ensure the API server is available when they are reconciled.
+
+var log = logf.Log.WithName("controller_tiers")
+
+// Add creates a new Tiers Controller and adds it to the Manager.
+// The Manager will set fields on the Controller and Start it when the Manager is Started.
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnterpriseCRDExists {
+		// No need to start this controller.
+		return nil
+	}
+
+	tierWatchReady := &utils.ReadyFlag{}
+	policyWatchesReady := &utils.ReadyFlag{}
+
+	reconciler := newReconciler(mgr, opts, tierWatchReady, policyWatchesReady)
+
+	c, err := controller.New("tiers-controller", mgr, controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		log.Error(err, "Failed to establish a connection to k8s")
+		return err
+	}
+
+	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, tierWatchReady)
+
+	policyNames := []types.NamespacedName{
+		{Name: tiers.APIServerPolicyName, Namespace: rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise)},
+		{Name: tiers.KubeControllerPolicyName, Namespace: common.CalicoNamespace},
+		{Name: tiers.PacketCapturePolicyName, Namespace: render.PacketCaptureNamespace},
+	}
+	if opts.DetectedProvider == operatorv1.ProviderOpenShift {
+		policyNames = append(policyNames, types.NamespacedName{Name: tiers.ClusterDNSPolicyName, Namespace: "openshift-dns"})
+	} else {
+		policyNames = append(policyNames, types.NamespacedName{Name: tiers.ClusterDNSPolicyName, Namespace: "kube-system"})
+	}
+	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, policyWatchesReady, policyNames)
+
+	return add(mgr, c)
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, opts options.AddOptions, tierWatchReady *utils.ReadyFlag, policyWatchesReady *utils.ReadyFlag) reconcile.Reconciler {
+	r := &ReconcileTiers{
+		Client:             mgr.GetClient(),
+		scheme:             mgr.GetScheme(),
+		provider:           opts.DetectedProvider,
+		status:             status.New(mgr.GetClient(), "tiers", opts.KubernetesVersion),
+		tierWatchReady:     tierWatchReady,
+		policyWatchesReady: policyWatchesReady,
+	}
+	r.status.Run(opts.ShutdownContext)
+	return r
+}
+
+// add adds watches for resources that are available at startup.
+func add(mgr manager.Manager, c controller.Controller) error {
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileTiers{}
+
+type ReconcileTiers struct {
+	client.Client
+	scheme             *runtime.Scheme
+	provider           operatorv1.Provider
+	status             status.StatusManager
+	tierWatchReady     *utils.ReadyFlag
+	policyWatchesReady *utils.ReadyFlag
+}
+
+func (r *ReconcileTiers) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling Tiers")
+
+	if !utils.IsAPIServerReady(r.Client, reqLogger) {
+		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
+		return reconcile.Result{}, nil
+	}
+
+	if !r.tierWatchReady.IsReady() {
+		r.status.SetDegraded("Waiting for Tier watch to be established", "")
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	if !r.policyWatchesReady.IsReady() {
+		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	managementClusterConnection, err := utils.GetManagementClusterConnection(ctx, r.Client)
+	if err != nil {
+		log.Error(err, "Failed to read ManagementClusterConnection")
+		r.status.SetDegraded("Failed to read ManagementClusterConnection", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	component := tiers.Tiers(&tiers.Config{
+		Openshift:      r.provider == operatorv1.ProviderOpenShift,
+		ManagedCluster: managementClusterConnection != nil,
+	})
+
+	componentHandler := utils.NewComponentHandler(log, r.Client, r.scheme, nil)
+	err = componentHandler.CreateOrUpdateOrDelete(ctx, component, nil)
+	if err != nil {
+		r.status.SetDegraded("Error creating / updating resource", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/tiers/tiers_controller_suite_test.go
+++ b/pkg/controller/tiers/tiers_controller_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiers
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/tiers_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/controller/tiers Suite", []Reporter{junitReporter})
+}

--- a/pkg/controller/tiers/tiers_controller_test.go
+++ b/pkg/controller/tiers/tiers_controller_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("tier controller tests", func() {
+	var r ReconcileTiers
+	var c client.Client
+	var ctx context.Context
+	var scheme *runtime.Scheme
+	var mockStatus *status.MockStatus
+	var readyFlag *utils.ReadyFlag
+
+	BeforeEach(func() {
+		// The schema contains all objects that should be known to the fake client when the test runs.
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(operatorv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+		// Create a client that will have a crud interface of k8s objects.
+		c = fake.NewClientBuilder().WithScheme(scheme).Build()
+		ctx = context.Background()
+
+		mockStatus = &status.MockStatus{}
+		mockStatus.On("ReadyToMonitor").Return()
+
+		// Mark that the watches were successful.
+		readyFlag = &utils.ReadyFlag{}
+		readyFlag.MarkAsReady()
+
+		// Create an object we can use throughout the test to perform the reconcile loops.
+		r = ReconcileTiers{
+			Client:             c,
+			scheme:             scheme,
+			provider:           operatorv1.ProviderNone,
+			status:             mockStatus,
+			tierWatchReady:     readyFlag,
+			policyWatchesReady: readyFlag,
+		}
+
+		// Create objects that are prerequisites of the reconcile loop.
+		Expect(c.Create(
+			ctx,
+			&operatorv1.Installation{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: operatorv1.InstallationSpec{
+					Variant:  operatorv1.TigeraSecureEnterprise,
+					Registry: "some.registry.org/",
+				},
+				Status: operatorv1.InstallationStatus{
+					Variant: operatorv1.TigeraSecureEnterprise,
+					Computed: &operatorv1.InstallationSpec{
+						Registry: "my-reg",
+						// The test is provider agnostic.
+						KubernetesProvider: operatorv1.ProviderNone,
+					},
+				},
+			})).NotTo(HaveOccurred())
+
+		Expect(c.Create(ctx, &operatorv1.APIServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			Status:     operatorv1.APIServerStatus{State: operatorv1.TigeraStatusReady},
+		})).NotTo(HaveOccurred())
+	})
+
+	// Validate that the tier is created. Policy coverage is handled in the render tests.
+	It("reconciles the allow-tigera tier", func() {
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		tier := v3.Tier{}
+		Expect(c.Get(ctx, client.ObjectKey{Name: "allow-tigera"}, &tier)).To(BeNil())
+	})
+
+	It("waits for API server to be available before reconciling", func() {
+		mockStatus = &status.MockStatus{}
+		r = ReconcileTiers{
+			Client:             c,
+			scheme:             scheme,
+			provider:           operatorv1.ProviderNone,
+			status:             mockStatus,
+			tierWatchReady:     readyFlag,
+			policyWatchesReady: readyFlag,
+		}
+		utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
+	})
+
+	It("should wait if policy watches are not ready", func() {
+		mockStatus = &status.MockStatus{}
+		r = ReconcileTiers{
+			Client:             c,
+			scheme:             scheme,
+			provider:           operatorv1.ProviderNone,
+			status:             mockStatus,
+			tierWatchReady:     readyFlag,
+			policyWatchesReady: &utils.ReadyFlag{},
+		}
+		utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
+	})
+
+	It("should wait if tier watch is not ready", func() {
+		mockStatus = &status.MockStatus{}
+		r = ReconcileTiers{
+			Client:             c,
+			scheme:             scheme,
+			provider:           operatorv1.ProviderNone,
+			status:             mockStatus,
+			tierWatchReady:     &utils.ReadyFlag{},
+			policyWatchesReady: readyFlag,
+		}
+		mockStatus.On("SetDegraded", "Waiting for Tier watch to be established", "").Return()
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+		mockStatus.AssertExpectations(GinkgoT())
+	})
+})

--- a/pkg/controller/utils/test_utils.go
+++ b/pkg/controller/utils/test_utils.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// DeleteAPIServerAndExpectWait deletes the API server resource and expects the Reconciler issues a degraded status, waiting for
+// the API server to become available before progressing its status further. Assumes that mockStatus has any required initial status
+// progression expectations set, and that the Reconciler utilizes the mockStatus object. Assumes the API server resource has been created.
+func DeleteAPIServerAndExpectWait(ctx context.Context, c client.Client, r reconcile.Reconciler, mockStatus *status.MockStatus) {
+	err := c.Delete(ctx, &operatorv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	mockStatus.On("SetDegraded", "Waiting for Tigera API server to be ready", "").Return()
+
+	_, err = r.Reconcile(ctx, reconcile.Request{})
+	Expect(err).ShouldNot(HaveOccurred())
+	mockStatus.AssertExpectations(GinkgoT())
+}
+
+// DeleteAllowTigeraTierAndExpectWait deletes the tier resource and expects the Reconciler issues a degraded status, waiting for
+// the tier to become available before progressing its status further. Assumes that mockStatus has any required initial status
+// progression expectations set, and that the Reconciler utilizes the mockStatus object. Assumes the tier resource has been created.
+func DeleteAllowTigeraTierAndExpectWait(ctx context.Context, c client.Client, r reconcile.Reconciler, mockStatus *status.MockStatus) {
+	err := c.Delete(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	mockStatus.On("SetDegraded", "Waiting for Tigera component policy tier to be created", "tiers.projectcalico.org \"allow-tigera\" not found").Return()
+
+	_, err = r.Reconcile(ctx, reconcile.Request{})
+	Expect(err).ShouldNot(HaveOccurred())
+	mockStatus.AssertExpectations(GinkgoT())
+}
+
+// ExpectWaitForPolicyWatches expects the Reconciler issues a degraded status, waiting for NetworkPolicy watches to
+// be established. Assumes that mockStatus has any required initial status progression expectations set, and that
+// the Reconciler utilizes the mockStatus object.
+func ExpectWaitForPolicyWatches(ctx context.Context, r reconcile.Reconciler, mockStatus *status.MockStatus) {
+	mockStatus.On("SetDegraded", "Waiting for NetworkPolicy watches to be established", "").Return()
+	_, err := r.Reconcile(ctx, reconcile.Request{})
+	Expect(err).ShouldNot(HaveOccurred())
+	mockStatus.AssertExpectations(GinkgoT())
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -119,8 +119,28 @@ func AddServiceWatch(c controller.Controller, name, namespace string) error {
 	})
 }
 
-func WaitToAddLicenseKeyWatch(controller controller.Controller, client kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {
-	WaitToAddResourceWatch(controller, client, log, flag, &v3.LicenseKey{TypeMeta: metav1.TypeMeta{Kind: v3.KindLicenseKey}})
+func WaitToAddLicenseKeyWatch(controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {
+	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{&v3.LicenseKey{TypeMeta: metav1.TypeMeta{Kind: v3.KindLicenseKey}}})
+}
+
+func WaitToAddNetworkPolicyWatches(controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag, policies []types.NamespacedName) {
+	objs := []client.Object{}
+	for _, policy := range policies {
+		objs = append(objs, &v3.NetworkPolicy{
+			TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+			ObjectMeta: metav1.ObjectMeta{Name: policy.Name, Namespace: policy.Namespace},
+		})
+	}
+
+	WaitToAddResourceWatch(controller, c, log, flag, objs, createNamespacePredicate)
+}
+
+func WaitToAddTierWatch(tierName string, controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {
+	obj := &v3.Tier{
+		TypeMeta:   metav1.TypeMeta{Kind: "Tier", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{Name: tierName},
+	}
+	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{obj}, createNamePredicate)
 }
 
 // AddNamespacedWatch creates a watch on the given object. If a name and namespace are provided, then it will
@@ -131,26 +151,7 @@ func AddNamespacedWatch(c controller.Controller, obj client.Object, metaMatches 
 	if objMeta.GetNamespace() == "" {
 		return fmt.Errorf("No namespace provided for namespaced watch")
 	}
-	pred := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			if objMeta.GetName() != "" && e.Object.GetName() != objMeta.GetName() {
-				return false
-			}
-			return e.Object.GetNamespace() == objMeta.GetNamespace()
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if objMeta.GetName() != "" && e.ObjectNew.GetName() != objMeta.GetName() {
-				return false
-			}
-			return e.ObjectNew.GetNamespace() == objMeta.GetNamespace()
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if objMeta.GetName() != "" && e.Object.GetName() != objMeta.GetName() {
-				return false
-			}
-			return e.Object.GetNamespace() == objMeta.GetNamespace()
-		},
-	}
+	pred := createNamespacePredicate(objMeta)
 	return c.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}, pred)
 }
 
@@ -425,7 +426,22 @@ func StrToElasticLicenseType(license string, logger logr.Logger) render.Elastics
 
 // WaitToAddResourceWatch will check if projectcalico.org APIs are available and if so, it will add a watch for resource
 // The completion of this operation will be signaled on a ready channel
-func WaitToAddResourceWatch(controller controller.Controller, client kubernetes.Interface, log logr.Logger, flag *ReadyFlag, obj client.Object) {
+func WaitToAddResourceWatch(controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag, objs []client.Object, predFns ...func(meta metav1.Object) predicate.Predicate) {
+	// Track resources left to watch and establish their predicate functions.
+	resourcesToWatch := map[client.Object]bool{}
+	resourcePredicateFns := map[client.Object][]predicate.Predicate{}
+	for _, obj := range objs {
+		resourcesToWatch[obj] = true
+
+		var predicateFns []predicate.Predicate
+		if predFns != nil {
+			for _, predFn := range predFns {
+				predicateFns = append(predicateFns, predFn(obj))
+			}
+		}
+		resourcePredicateFns[obj] = predicateFns
+	}
+
 	maxDuration := 30 * time.Second
 	duration := 1 * time.Second
 	ticker := time.NewTicker(duration)
@@ -436,14 +452,21 @@ func WaitToAddResourceWatch(controller controller.Controller, client kubernetes.
 			duration = maxDuration
 		}
 		ticker.Reset(duration)
-		if isResourceReady(client, obj.GetObjectKind().GroupVersionKind().Kind) {
-			err := controller.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{})
-			if err != nil {
-				log.Info("failed to watch %s resource: %v. Will retry to add watch", obj.GetObjectKind().GroupVersionKind().Kind, err)
-			} else {
-				flag.MarkAsReady()
-				return
+		for obj := range resourcesToWatch {
+			if isResourceReady(c, obj.GetObjectKind().GroupVersionKind().Kind) {
+				predicateFns := resourcePredicateFns[obj]
+				err := controller.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}, predicateFns...)
+				if err != nil {
+					log.Info("failed to watch %s resource: %v. Will retry to add watch", obj.GetObjectKind().GroupVersionKind().Kind, err)
+				} else {
+					delete(resourcesToWatch, obj)
+				}
 			}
+		}
+
+		if len(resourcesToWatch) == 0 {
+			flag.MarkAsReady()
+			return
 		}
 	}
 }
@@ -463,4 +486,43 @@ func isResourceReady(client kubernetes.Interface, resourceKind string) bool {
 		}
 	}
 	return false
+}
+
+// Creates a predicate for CRUD operations that matches the object's namespace, and name if provided.
+func createNamespacePredicate(objMeta metav1.Object) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if objMeta.GetName() != "" && e.Object.GetName() != objMeta.GetName() {
+				return false
+			}
+			return e.Object.GetNamespace() == objMeta.GetNamespace()
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if objMeta.GetName() != "" && e.ObjectNew.GetName() != objMeta.GetName() {
+				return false
+			}
+			return e.ObjectNew.GetNamespace() == objMeta.GetNamespace()
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if objMeta.GetName() != "" && e.Object.GetName() != objMeta.GetName() {
+				return false
+			}
+			return e.Object.GetNamespace() == objMeta.GetNamespace()
+		},
+	}
+}
+
+// Creates a predicate for CRUD operations that matches the object's name.
+func createNamePredicate(objMeta metav1.Object) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == objMeta.GetName()
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == objMeta.GetName()
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == objMeta.GetName()
+		},
+	}
 }

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -41,8 +41,8 @@ import (
 )
 
 const (
-	apiServerPort   = 5443
-	queryServerPort = 8080
+	ApiServerPort   = 5443
+	QueryServerPort = 8080
 
 	auditLogsVolumeName   = "tigera-audit-logs"
 	auditPolicyVolumeName = "tigera-audit-policy"
@@ -679,7 +679,7 @@ func (c *apiServerComponent) apiServerService() *corev1.Service {
 					Name:       "apiserver",
 					Port:       443,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(apiServerPort),
+					TargetPort: intstr.FromInt(ApiServerPort),
 				},
 			},
 			Selector: map[string]string{
@@ -693,9 +693,9 @@ func (c *apiServerComponent) apiServerService() *corev1.Service {
 		s.Spec.Ports = append(s.Spec.Ports,
 			corev1.ServicePort{
 				Name:       "queryserver",
-				Port:       queryServerPort,
+				Port:       QueryServerPort,
 				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(queryServerPort),
+				TargetPort: intstr.FromInt(QueryServerPort),
 			},
 		)
 
@@ -852,7 +852,7 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/version",
-					Port:   intstr.FromInt(apiServerPort),
+					Port:   intstr.FromInt(ApiServerPort),
 					Scheme: corev1.URISchemeHTTPS,
 				},
 			},
@@ -878,7 +878,7 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 
 func (c *apiServerComponent) startUpArgs() []string {
 	args := []string{
-		fmt.Sprintf("--secure-port=%d", apiServerPort),
+		fmt.Sprintf("--secure-port=%d", ApiServerPort),
 		fmt.Sprintf("--tls-private-key-file=%s", c.cfg.TLSKeyPair.VolumeMountKeyFilePath()),
 		fmt.Sprintf("--tls-cert-file=%s", c.cfg.TLSKeyPair.VolumeMountCertificateFilePath()),
 	}
@@ -926,7 +926,7 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/version",
-					Port:   intstr.FromInt(queryServerPort),
+					Port:   intstr.FromInt(QueryServerPort),
 					Scheme: corev1.URISchemeHTTPS,
 				},
 			},

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/api/pkg/lib/numorstring"
+)
+
+const TigeraComponentTierName = "allow-tigera"
+const TigeraComponentPolicyPrefix = TigeraComponentTierName + "."
+const TigeraComponentDefaultDenyPolicyName = TigeraComponentPolicyPrefix + "default-deny"
+
+var TCPProtocol = numorstring.ProtocolFromString(numorstring.ProtocolTCP)
+var UDPProtocol = numorstring.ProtocolFromString(numorstring.ProtocolUDP)
+var HighPrecedenceOrder = 1.0
+
+// AppendDNSEgressRules appends a rule to the provided slice that allows DNS egress. The appended rule utilizes label selectors and ports.
+func AppendDNSEgressRules(egressRules []v3.Rule, openShift bool) []v3.Rule {
+	if openShift {
+		egressRules = append(egressRules, []v3.Rule{
+			{
+				Action:   v3.Allow,
+				Protocol: &UDPProtocol,
+				Destination: v3.EntityRule{
+					NamespaceSelector: "projectcalico.org/name == 'openshift-dns'",
+					Selector:          "dns.operator.openshift.io/daemonset-dns == 'default'",
+					Ports:             Ports(5353),
+				},
+			},
+			{
+				Action:   v3.Allow,
+				Protocol: &TCPProtocol,
+				Destination: v3.EntityRule{
+					NamespaceSelector: "projectcalico.org/name == 'openshift-dns'",
+					Selector:          "dns.operator.openshift.io/daemonset-dns == 'default'",
+					Ports:             Ports(5353),
+				},
+			},
+		}...)
+	} else {
+		egressRules = append(egressRules, v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &UDPProtocol,
+			Destination: v3.EntityRule{
+				NamespaceSelector: "projectcalico.org/name == 'kube-system'",
+				Selector:          "k8s-app == 'kube-dns'",
+				Ports:             Ports(53),
+			},
+		})
+	}
+
+	return egressRules
+}
+
+// CreateEntityRule creates an entity rule that matches traffic using label selectors based on namespace, deployment name, and port.
+func CreateEntityRule(namespace string, deploymentName string, port uint16) v3.EntityRule {
+	return v3.EntityRule{
+		NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", namespace),
+		Selector:          fmt.Sprintf("k8s-app == '%s'", deploymentName),
+		Ports:             Ports(port),
+	}
+}
+
+// CreateSourceEntityRule creates a conventional entity rule that matches ingress traffic based on namespace and deployment name.
+func CreateSourceEntityRule(namespace string, deploymentName string) v3.EntityRule {
+	return v3.EntityRule{
+		Selector:          fmt.Sprintf("k8s-app == '%s'", deploymentName),
+		NamespaceSelector: fmt.Sprintf("name == '%s'", namespace),
+	}
+}
+
+// AppendServiceSelectorDNSEgressRules is equivalent to AppendDNSEgressRules, utilizing service selector instead of label selector and ports.
+func AppendServiceSelectorDNSEgressRules(egressRules []v3.Rule, openShift bool) []v3.Rule {
+	if openShift {
+		egressRules = append(egressRules, []v3.Rule{
+			{
+				Action:   v3.Allow,
+				Protocol: &UDPProtocol,
+				Destination: v3.EntityRule{
+					Services: &v3.ServiceMatch{
+						Namespace: "default",
+						Name:      "openshift-dns",
+					},
+				},
+			},
+			{
+				Action:   v3.Allow,
+				Protocol: &TCPProtocol,
+				Destination: v3.EntityRule{
+					Services: &v3.ServiceMatch{
+						Namespace: "default",
+						Name:      "openshift-dns",
+					},
+				},
+			},
+		}...)
+	} else {
+		egressRules = append(egressRules, v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &UDPProtocol,
+			Destination: v3.EntityRule{
+				Services: &v3.ServiceMatch{
+					Namespace: "kube-system",
+					Name:      "kube-dns",
+				},
+			},
+		})
+	}
+
+	return egressRules
+}
+
+// CreateServiceSelectorEntityRule creates an entity rule that matches traffic based on service name and namespace.
+func CreateServiceSelectorEntityRule(namespace string, name string) v3.EntityRule {
+	return v3.EntityRule{
+		Services: &v3.ServiceMatch{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func KubernetesAppSelector(deploymentNames ...string) string {
+	expressions := []string{}
+	for _, deploymentName := range deploymentNames {
+		expressions = append(expressions, fmt.Sprintf("k8s-app == '%s'", deploymentName))
+	}
+	return strings.Join(expressions, " || ")
+}
+
+func Ports(ports ...uint16) []numorstring.Port {
+	nsPorts := []numorstring.Port{}
+	for _, port := range ports {
+		nsPorts = append(nsPorts, numorstring.Port{MinPort: port, MaxPort: port})
+	}
+
+	return nsPorts
+}
+
+func AllowTigeraDefaultDeny(namespace string) *v3.NetworkPolicy {
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TigeraComponentDefaultDenyPolicyName,
+			Namespace: namespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Tier:     TigeraComponentTierName,
+			Selector: "all()",
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+		},
+	}
+}
+
+// Entity rules not belonging to Calico/Tigera components.
+var KubeAPIServerEntityRule = v3.EntityRule{
+	NamespaceSelector: "projectcalico.org/name == 'default'",
+	Selector:          "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+	Ports:             Ports(443, 6443, 12388),
+}
+var KubeAPIServerServiceSelectorEntityRule = v3.EntityRule{
+	Services: &v3.ServiceMatch{
+		Namespace: "default",
+		Name:      "kubernetes",
+	},
+}
+
+// The entity rules below are extracted from render subpackages to prevent cyclic dependencies.
+var EsGatewayEntityRule = CreateEntityRule("tigera-elasticsearch", "tigera-secure-es-gateway", 5554)
+var EsGatewaySourceEntityRule = CreateSourceEntityRule("tigera-elasticsearch", "tigera-secure-es-gateway")
+var EsGatewayServiceSelectorEntityRule = CreateServiceSelectorEntityRule("tigera-elasticsearch", "tigera-secure-es-gateway-http")
+
+const PrometheusSelector = "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')"
+
+var PrometheusEntityRule = v3.EntityRule{
+	NamespaceSelector: "projectcalico.org/name == 'tigera-prometheus'",
+	Selector:          PrometheusSelector,
+	Ports:             Ports(9095),
+}
+var PrometheusSourceEntityRule = v3.EntityRule{
+	NamespaceSelector: "name == 'tigera-prometheus'",
+	Selector:          PrometheusSelector,
+}

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -17,7 +17,13 @@ package render_test
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/testutils"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -45,6 +51,18 @@ var _ = Describe("compliance rendering tests", func() {
 	clusterDomain := dns.DefaultClusterDomain
 	var cfg *render.ComplianceConfiguration
 	var cli client.Client
+
+	expectedCompliancePolicyForUnmanaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/compliance_unmanaged.json")
+
+	expectedCompliancePolicyForManaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/compliance_managed.json")
+
+	expectedCompliancePolicyForUnmanagedOpenshift := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/compliance_unmanaged_ocp.json")
+
+	expectedCompliancePolicyForManagedOpenshift := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/compliance_managed_ocp.json")
+
+	expectedComplianceServerPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/compliance-server.json")
+
+	expectedComplianceServerPolicyForOpenshift := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/compliance-server_ocp.json")
 
 	BeforeEach(func() {
 		scheme := runtime.NewScheme()
@@ -83,6 +101,8 @@ var _ = Describe("compliance rendering tests", func() {
 				kind    string
 			}{
 				{ns, "", "", "v1", "Namespace"},
+				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
+				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-controller", ns, rbac, "v1", "Role"},
 				{"tigera-compliance-controller", "", rbac, "v1", "ClusterRole"},
@@ -107,6 +127,7 @@ var _ = Describe("compliance rendering tests", func() {
 				{"cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
+				{"allow-tigera.compliance-server", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRole"},
 				{"compliance", ns, "", "v1", "Service"},
 				{"compliance-server", ns, "apps", "v1", "Deployment"},
@@ -181,6 +202,8 @@ var _ = Describe("compliance rendering tests", func() {
 				kind    string
 			}{
 				{ns, "", "", "v1", "Namespace"},
+				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
+				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-controller", ns, rbac, "v1", "Role"},
 				{"tigera-compliance-controller", "", rbac, "v1", "ClusterRole"},
@@ -205,6 +228,7 @@ var _ = Describe("compliance rendering tests", func() {
 				{"cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
+				{"allow-tigera.compliance-server", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRole"},
 				{"compliance", ns, "", "v1", "Service"},
 				{"compliance-server", ns, "apps", "v1", "Deployment"},
@@ -307,6 +331,8 @@ var _ = Describe("compliance rendering tests", func() {
 				kind    string
 			}{
 				{ns, "", "", "v1", "Namespace"},
+				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
+				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-controller", ns, rbac, "v1", "Role"},
 				{"tigera-compliance-controller", "", rbac, "v1", "ClusterRole"},
@@ -428,6 +454,8 @@ var _ = Describe("compliance rendering tests", func() {
 				kind    string
 			}{
 				{ns, "", "", "v1", "Namespace"},
+				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
+				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-controller", ns, rbac, "v1", "Role"},
 				{"tigera-compliance-controller", "", rbac, "v1", "ClusterRole"},
@@ -452,6 +480,7 @@ var _ = Describe("compliance rendering tests", func() {
 				{"cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"},
 				{"tigera-compliance-server", ns, "", "v1", "ServiceAccount"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRoleBinding"},
+				{"allow-tigera.compliance-server", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-server", "", rbac, "v1", "ClusterRole"},
 				{"compliance", ns, "", "v1", "Service"},
 				{"compliance-server", ns, "apps", "v1", "Deployment"},
@@ -529,4 +558,50 @@ var _ = Describe("compliance rendering tests", func() {
 		})
 	})
 
+	Context("allow-tigera rendering", func() {
+		policyNames := []types.NamespacedName{
+			{Name: "allow-tigera.compliance-access", Namespace: "tigera-compliance"},
+			{Name: "allow-tigera.compliance-server", Namespace: "tigera-compliance"},
+		}
+
+		getExpectedPolicy := func(policyName types.NamespacedName, scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+			if policyName.Name == "allow-tigera.compliance-access" {
+				return testutils.SelectPolicyByClusterTypeAndProvider(
+					scenario,
+					expectedCompliancePolicyForUnmanaged,
+					expectedCompliancePolicyForUnmanagedOpenshift,
+					expectedCompliancePolicyForManaged,
+					expectedCompliancePolicyForManagedOpenshift,
+				)
+			} else if !scenario.ManagedCluster && policyName.Name == "allow-tigera.compliance-server" {
+				return testutils.SelectPolicyByProvider(scenario, expectedComplianceServerPolicy, expectedComplianceServerPolicyForOpenshift)
+			}
+
+			return nil
+		}
+
+		DescribeTable("should render allow-tigera policy",
+			func(scenario testutils.AllowTigeraScenario) {
+				cfg.Openshift = scenario.Openshift
+				if scenario.ManagedCluster {
+					cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{}
+				} else {
+					cfg.ManagementClusterConnection = nil
+				}
+				component, err := render.Compliance(cfg)
+				Expect(err).ShouldNot(HaveOccurred())
+				resources, _ := component.Objects()
+
+				for _, policyName := range policyNames {
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+					expectedPolicy := getExpectedPolicy(policyName, scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				}
+			},
+			Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+			Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
+			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
+		)
+	})
 })

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -45,6 +46,7 @@ const (
 	DexPort          = 5556
 	DexTLSSecretName = "tigera-dex-tls"
 	DexClientId      = "tigera-manager"
+	DexPolicyName    = networkpolicy.TigeraComponentPolicyPrefix + "allow-tigera-dex"
 )
 
 var DexEntityRule = networkpolicy.CreateEntityRule(DexNamespace, DexObjectName, DexPort)
@@ -106,6 +108,8 @@ func (*dexComponent) SupportedOSType() rmeta.OSType {
 
 func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
+		c.allowTigeraNetworkPolicy(),
+		allowTigeraDefaultDeny(),
 		c.serviceAccount(),
 		c.deployment(),
 		c.service(),
@@ -346,4 +350,88 @@ func (c *dexComponent) configMap() *corev1.ConfigMap {
 			"config.yaml": string(bytes),
 		},
 	}
+}
+
+func (c *dexComponent) allowTigeraNetworkPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, c.cfg.Openshift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+
+		// These rules allow egress between dex and identity providers.
+		{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
+				Nets:  []string{"0.0.0.0/0"},
+				Ports: networkpolicy.Ports(443, 6443, 389, 636),
+			},
+		},
+		{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
+				Nets:  []string{"::/0"},
+				Ports: networkpolicy.Ports(443, 6443, 389, 636),
+			},
+		},
+	}...)
+
+	dexIngressPortDestination := v3.EntityRule{
+		Ports: networkpolicy.Ports(DexPort),
+	}
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DexPolicyName,
+			Namespace: DexNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(DexObjectName),
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      ManagerSourceEntityRule,
+					Destination: dexIngressPortDestination,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      networkpolicy.EsGatewaySourceEntityRule,
+					Destination: dexIngressPortDestination,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      ComplianceServerSourceEntityRule,
+					Destination: dexIngressPortDestination,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      PacketCaptureSourceEntityRule,
+					Destination: dexIngressPortDestination,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      networkpolicy.PrometheusSourceEntityRule,
+					Destination: dexIngressPortDestination,
+				},
+			},
+			Egress: egressRules,
+		},
+	}
+}
+
+func allowTigeraDefaultDeny() *v3.NetworkPolicy {
+	return networkpolicy.AllowTigeraDefaultDeny(DexNamespace)
 }

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package render
 import (
 	"fmt"
 	"strings"
+
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
@@ -44,6 +46,8 @@ const (
 	DexTLSSecretName = "tigera-dex-tls"
 	DexClientId      = "tigera-manager"
 )
+
+var DexEntityRule = networkpolicy.CreateEntityRule(DexNamespace, DexObjectName, DexPort)
 
 func Dex(cfg *DexComponentConfiguration) Component {
 

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -1,7 +1,28 @@
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package render_test
 
 import (
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/testutils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -26,6 +47,10 @@ import (
 
 var _ = Describe("dex rendering tests", func() {
 	const clusterName = "svc.cluster.local"
+
+	expectedDexPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/dex.json")
+	expectedDexOpenshiftPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/dex_ocp.json")
+
 	Context("dex is configured for oidc", func() {
 
 		const (
@@ -115,6 +140,8 @@ var _ = Describe("dex rendering tests", func() {
 				version string
 				kind    string
 			}{
+				{render.DexPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
+				{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 				{render.DexObjectName, render.DexNamespace, "", "v1", "ServiceAccount"},
 				{render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment"},
 				{render.DexObjectName, render.DexNamespace, "", "v1", "Service"},
@@ -175,6 +202,8 @@ var _ = Describe("dex rendering tests", func() {
 				version string
 				kind    string
 			}{
+				{render.DexPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
+				{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 				{render.DexObjectName, render.DexNamespace, "", "v1", "ServiceAccount"},
 				{render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment"},
 				{render.DexObjectName, render.DexNamespace, "", "v1", "Service"},
@@ -217,5 +246,33 @@ var _ = Describe("dex rendering tests", func() {
 			Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
 			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-dex", "tigera-dex")))
 		})
+
+		Context("allow-tigera rendering", func() {
+			policyName := types.NamespacedName{Name: "allow-tigera.allow-tigera-dex", Namespace: "tigera-dex"}
+
+			getExpectedPolicy := func(scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+				if scenario.ManagedCluster {
+					return nil
+				}
+
+				return testutils.SelectPolicyByProvider(scenario, expectedDexPolicy, expectedDexOpenshiftPolicy)
+			}
+
+			DescribeTable("should render allow-tigera policy",
+				func(scenario testutils.AllowTigeraScenario) {
+					cfg.Openshift = scenario.Openshift
+					component := render.Dex(cfg)
+					resources, _ := component.Objects()
+
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+					expectedPolicy := getExpectedPolicy(scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				},
+				// Dex only renders in the presence of an Authentication CR, therefore does not have a config option for managed clusters.
+				Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+				Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			)
+		})
+
 	})
 })

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@ package render
 import (
 	"fmt"
 	"strconv"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +50,9 @@ const (
 	S3KeySecretName                          = "key-secret"
 	FluentdPrometheusTLSSecretName           = "tigera-fluentd-prometheus-tls"
 	FluentdMetricsService                    = "fluentd-metrics"
-	FluentdMetricsPort                       = "fluentd-metrics-port"
+	FluentdMetricsPortName                   = "fluentd-metrics-port"
+	FluentdMetricsPort                       = 9081
+	FluentdPolicyName                        = networkpolicy.TigeraComponentPolicyPrefix + "allow-fluentd-node"
 	filterHashAnnotation                     = "hash.operator.tigera.io/fluentd-filters"
 	s3CredentialHashAnnotation               = "hash.operator.tigera.io/s3-credentials"
 	splunkCredentialHashAnnotation           = "hash.operator.tigera.io/splunk-credentials"
@@ -86,6 +91,13 @@ const (
 	PacketCaptureAPIRole        = "packetcapture-api-role"
 	PacketCaptureAPIRoleBinding = "packetcapture-api-role-binding"
 )
+
+var FluentdSourceEntityRule = v3.EntityRule{
+	NamespaceSelector: fmt.Sprintf("name == '%s'", LogCollectorNamespace),
+	Selector:          networkpolicy.KubernetesAppSelector(FluentdNodeName, fluentdNodeWindowsName),
+}
+
+var EKSLogForwarderEntityRule = networkpolicy.CreateSourceEntityRule(LogCollectorNamespace, eksLogForwarderName)
 
 type FluentdFilters struct {
 	Flow string
@@ -141,6 +153,7 @@ type FluentdConfiguration struct {
 	OSType           rmeta.OSType
 	MetricsServerTLS certificatemanagement.KeyPairInterface
 	TrustedBundle    certificatemanagement.TrustedBundle
+	ManagedCluster   bool
 }
 
 type fluentdComponent struct {
@@ -225,6 +238,7 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 		CreateNamespace(
 			LogCollectorNamespace,
 			c.cfg.Installation.KubernetesProvider))
+	objs = append(objs, c.allowTigeraPolicy())
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.cfg.PullSecrets...)...)...)
 	objs = append(objs, c.metricsService())
 
@@ -545,7 +559,7 @@ func (c *fluentdComponent) container() corev1.Container {
 		ReadinessProbe:  c.readiness(),
 		Ports: []corev1.ContainerPort{{
 			Name:          "metrics-port",
-			ContainerPort: 9081,
+			ContainerPort: FluentdMetricsPort,
 		}},
 	}, c.cfg.ESClusterConfig.ClusterName(), ElasticsearchLogCollectorUserSecret, c.cfg.ClusterDomain, c.cfg.OSType)
 }
@@ -563,9 +577,9 @@ func (c *fluentdComponent) metricsService() *corev1.Service {
 			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       FluentdMetricsPort,
-					Port:       int32(9081),
-					TargetPort: intstr.FromInt(9081),
+					Name:       FluentdMetricsPortName,
+					Port:       int32(FluentdMetricsPort),
+					TargetPort: intstr.FromInt(FluentdMetricsPort),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -1043,6 +1057,63 @@ func (c *fluentdComponent) eksLogForwarderClusterRole() *rbacv1.ClusterRole {
 				Verbs:         []string{"use"},
 				ResourceNames: []string{eksLogForwarderName},
 			},
+		},
+	}
+}
+
+func (c *fluentdComponent) allowTigeraPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	if c.cfg.ManagedCluster {
+		egressRules = append(egressRules, v3.Rule{
+			Action:   v3.Deny,
+			Protocol: &networkpolicy.TCPProtocol,
+			Source:   v3.EntityRule{},
+			Destination: v3.EntityRule{
+				NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", GuardianNamespace),
+				Selector:          networkpolicy.KubernetesAppSelector(GuardianServiceName),
+				NotPorts:          networkpolicy.Ports(8080),
+			},
+		})
+	} else {
+		egressRules = append(egressRules, v3.Rule{
+			Action:   v3.Deny,
+			Protocol: &networkpolicy.TCPProtocol,
+			Source:   v3.EntityRule{},
+			Destination: v3.EntityRule{
+				NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
+				Selector:          networkpolicy.KubernetesAppSelector("tigera-secure-es-gateway"),
+				NotPorts:          networkpolicy.Ports(5554),
+			},
+		})
+		egressRules = networkpolicy.AppendDNSEgressRules(egressRules, c.cfg.Installation.KubernetesProvider == operatorv1.ProviderOpenShift)
+	}
+	egressRules = append(egressRules, v3.Rule{
+		Action: v3.Allow,
+	})
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      FluentdPolicyName,
+			Namespace: LogCollectorNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:                  &networkpolicy.HighPrecedenceOrder,
+			Tier:                   networkpolicy.TigeraComponentTierName,
+			Selector:               networkpolicy.KubernetesAppSelector(FluentdNodeName, fluentdNodeWindowsName),
+			ServiceAccountSelector: "",
+			Types:                  []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Source:   networkpolicy.PrometheusSourceEntityRule,
+					Destination: v3.EntityRule{
+						Ports: networkpolicy.Ports(FluentdMetricsPort),
+					},
+				},
+			},
+			Egress: egressRules,
 		},
 	}
 }

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@ package render_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -27,16 +28,22 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/testutils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 	var esConfigMap *relasticsearch.ClusterConfig
 	var cfg *render.FluentdConfiguration
+
+	expectedFluentdPolicyForUnmanaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/fluentd_unmanaged.json")
+	expectedFluentdPolicyForUnmanagedOpenshift := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/fluentd_unmanaged_ocp.json")
+	expectedFluentdPolicyForManaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/fluentd_managed.json")
 
 	BeforeEach(func() {
 		// Initialize a default instance to use. Each test can override this to its
@@ -71,6 +78,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -172,6 +180,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "fluentd-node-windows", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.PacketCaptureAPIRole, ns: render.LogCollectorNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
@@ -276,6 +285,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "log-collector-s3-credentials", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -341,6 +351,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -436,6 +447,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "logcollector-splunk-credentials", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
 			{name: "logcollector-splunk-public-certificate", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
@@ -521,6 +533,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "logcollector-splunk-credentials", ns: "tigera-fluentd", group: "", version: "v1", kind: "Secret"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -593,6 +606,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "fluentd-filters", ns: "tigera-fluentd", group: "", version: "v1", kind: "ConfigMap"},
 			{name: "tigera-fluentd", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -632,6 +646,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "eks-log-forwarder", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "eks-log-forwarder", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -689,5 +704,39 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 		fetchIntervalVal := "900"
 		Expect(envs).To(ContainElement(corev1.EnvVar{Name: "EKS_CLOUDWATCH_LOG_FETCH_INTERVAL", Value: fetchIntervalVal}))
+	})
+
+	Context("allow-tigera rendering", func() {
+		policyName := types.NamespacedName{Name: "allow-tigera.allow-fluentd-node", Namespace: "tigera-fluentd"}
+
+		getExpectedPolicy := func(scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+			if scenario.ManagedCluster {
+				return expectedFluentdPolicyForManaged
+			} else {
+				return testutils.SelectPolicyByProvider(scenario, expectedFluentdPolicyForUnmanaged, expectedFluentdPolicyForUnmanagedOpenshift)
+			}
+		}
+
+		DescribeTable("should render allow-tigera policy",
+			func(scenario testutils.AllowTigeraScenario) {
+				if scenario.Openshift {
+					cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+				} else {
+					cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
+				}
+				cfg.ManagedCluster = scenario.ManagedCluster
+
+				component := render.Fluentd(cfg)
+				resources, _ := component.Objects()
+
+				policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+				expectedPolicy := getExpectedPolicy(scenario)
+				Expect(policy).To(Equal(expectedPolicy))
+			},
+			Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+			Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
+			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
+		)
 	})
 })

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,19 +17,19 @@
 package render
 
 import (
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/common/podsecuritycontext"
+	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	operatorv1 "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/components"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-	"github.com/tigera/operator/pkg/render/common/podsecuritycontext"
-	"github.com/tigera/operator/pkg/render/common/secret"
-	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 // The names of the components related to the Guardian related rendered objects.
@@ -43,7 +43,11 @@ const (
 	GuardianServiceName            = "tigera-guardian"
 	GuardianVolumeName             = "tigera-guardian-certs"
 	GuardianSecretName             = "tigera-managed-cluster-connection"
+	GuardianTargetPort             = 8080
 )
+
+var GuardianEntityRule = networkpolicy.CreateEntityRule(GuardianNamespace, GuardianDeploymentName, GuardianTargetPort)
+var GuardianSourceEntityRule = networkpolicy.CreateSourceEntityRule(GuardianNamespace, GuardianDeploymentName)
 
 func Guardian(cfg *GuardianConfiguration) Component {
 	return &GuardianComponent{

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -16,7 +16,13 @@ package render_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/api/pkg/lib/numorstring"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/testutils"
+	"k8s.io/apimachinery/pkg/types"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
@@ -39,8 +45,7 @@ var _ = Describe("Rendering tests", func() {
 	var g render.Component
 	var resources []client.Object
 
-	var renderGuardian = func(i operatorv1.InstallationSpec) {
-		addr := "127.0.0.1:1234"
+	var renderGuardian = func(i operatorv1.InstallationSpec, addr string, openshift bool) {
 		secret := &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -71,6 +76,7 @@ var _ = Describe("Rendering tests", func() {
 			Installation:      &i,
 			TunnelSecret:      secret,
 			TrustedCertBundle: bundle,
+			Openshift:         openshift,
 		}
 		g = render.Guardian(cfg)
 		Expect(g.ResolveImages(nil)).To(BeNil())
@@ -78,7 +84,7 @@ var _ = Describe("Rendering tests", func() {
 	}
 
 	BeforeEach(func() {
-		renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"})
+		renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"}, "127.0.0.1:1234", false)
 	})
 
 	It("should render all resources for a managed cluster", func() {
@@ -90,6 +96,8 @@ var _ = Describe("Rendering tests", func() {
 			kind    string
 		}{
 			{name: render.GuardianNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.GuardianEgressPolicyName, ns: render.GuardianNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
+			{name: networkpolicy.TigeraComponentDefaultDenyPolicyName, ns: render.GuardianNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: "pull-secret", ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
 			{name: render.GuardianServiceAccountName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.GuardianClusterRoleName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -122,10 +130,75 @@ var _ = Describe("Rendering tests", func() {
 			Operator: corev1.TolerationOpEqual,
 			Value:    "bar",
 		}
-		renderGuardian(operatorv1.InstallationSpec{
-			ControlPlaneTolerations: []corev1.Toleration{t},
-		})
+		renderGuardian(operatorv1.InstallationSpec{ControlPlaneTolerations: []corev1.Toleration{t}}, "127.0.0.1:1234", false)
 		deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(deployment.Spec.Template.Spec.Tolerations).Should(ContainElements(t, rmeta.TolerateCriticalAddonsOnly, rmeta.TolerateMaster))
+	})
+
+	Context("allow-tigera rendering", func() {
+		// Dynamic policy: egress rule changes depending on ManagementClusterAddr.
+		policyName := types.NamespacedName{Name: "allow-tigera.guardian-egress", Namespace: "tigera-guardian"}
+		ipBasedExpectedEgress := []v3.Rule{
+			{
+				Action:   v3.Allow,
+				Protocol: &networkpolicy.TCPProtocol,
+				Destination: v3.EntityRule{
+					Nets:  []string{"127.0.0.1/32"},
+					Ports: []numorstring.Port{{MinPort: 1234, MaxPort: 1234}},
+				},
+			},
+		}
+		domainBasedExpectedEgress := []v3.Rule{
+			{
+				Action:   v3.Allow,
+				Protocol: &networkpolicy.TCPProtocol,
+				Destination: v3.EntityRule{
+					Domains: []string{"managementclusterdomain.io"},
+					Ports:   []numorstring.Port{{MinPort: 9000, MaxPort: 9000}},
+				},
+			},
+		}
+		getExpectedPolicy := func(scenario testutils.AllowTigeraScenario, expectedEgress []v3.Rule) *v3.NetworkPolicy {
+			if !scenario.ManagedCluster {
+				return nil
+			}
+
+			return &v3.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "allow-tigera.guardian-egress",
+					Namespace: "tigera-guardian",
+				},
+				Spec: v3.NetworkPolicySpec{
+					Order:    &networkpolicy.HighPrecedenceOrder,
+					Tier:     "allow-tigera",
+					Selector: "k8s-app == 'tigera-guardian'",
+					Types:    []v3.PolicyType{v3.PolicyTypeEgress},
+					Egress:   expectedEgress,
+				},
+			}
+		}
+
+		DescribeTable("should render allow-tigera policy",
+			func(scenario testutils.AllowTigeraScenario, managementClusterAddr string, expectedEgress []v3.Rule) {
+				renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"}, managementClusterAddr, scenario.Openshift)
+
+				policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+				expectedPolicy := getExpectedPolicy(scenario, expectedEgress)
+
+				Expect(policy.ObjectMeta).To(Equal(expectedPolicy.ObjectMeta))
+				Expect(policy.TypeMeta).To(Equal(expectedPolicy.TypeMeta))
+				Expect(policy.Spec.Order).To(Equal(expectedPolicy.Spec.Order))
+				Expect(policy.Spec.Tier).To(Equal(expectedPolicy.Spec.Tier))
+				Expect(policy.Spec.Selector).To(Equal(expectedPolicy.Spec.Selector))
+				Expect(policy.Spec.Types).To(Equal(expectedPolicy.Spec.Types))
+				Expect(policy.Spec.Egress).To(Equal(expectedEgress))
+			},
+			// Guardian only renders in the presence of an ManagementClusterConnection CR, therefore does not have a config option for unmanaged clusters.
+			Entry("for ip mgmt address, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}, "127.0.0.1:1234", ipBasedExpectedEgress),
+			Entry("for ip mgmt address, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}, "127.0.0.1:1234", ipBasedExpectedEgress),
+			Entry("for domain mgmt address, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}, "managementclusterdomain.io:9000", domainBasedExpectedEgress),
+			Entry("for domain mgmt address, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}, "managementclusterdomain.io:9000", domainBasedExpectedEgress),
+		)
 	})
 })

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -16,7 +16,9 @@ package render_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -25,12 +27,14 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/testutils"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -44,6 +48,13 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 	var cfg *render.IntrusionDetectionConfiguration
 	var bundle certificatemanagement.TrustedBundle
 	var adAPIKeyPair certificatemanagement.KeyPairInterface
+	expectedIDPolicyForUnmanaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/intrusion-detection-controller_unmanaged.json")
+	expectedIDPolicyForManaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/intrusion-detection-controller_managed.json")
+	expectedIDPolicyForUnmanagedOpenshift := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/intrusion-detection-controller_unmanaged_ocp.json")
+	expectedIDPolicyForManagedOpenshift := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/intrusion-detection-controller_managed_ocp.json")
+	expectedIDInstallerPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/intrusion-detection-elastic.json")
+	expectedIDInstallerPolicyForOpenshift := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/intrusion-detection-elastic_ocp.json")
+
 	BeforeEach(func() {
 		scheme := runtime.NewScheme()
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
@@ -80,6 +91,8 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-intrusion-detection", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: "allow-tigera.intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
+			{name: "allow-tigera.default-deny", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -123,6 +136,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: render.ADJobPodTemplateBaseName + ".training", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: render.ADJobPodTemplateBaseName + ".detection", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
+			{name: "allow-tigera.intrusion-detection-elastic", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "batch", version: "v1", kind: "Job"},
 			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -243,6 +257,8 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-intrusion-detection", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: "allow-tigera.intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
+			{name: "allow-tigera.default-deny", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -286,6 +302,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 			{name: render.ADJobPodTemplateBaseName + ".training", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: render.ADJobPodTemplateBaseName + ".detection", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
+			{name: "allow-tigera.intrusion-detection-elastic", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "batch", version: "v1", kind: "Job"},
 			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -346,6 +363,8 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-intrusion-detection", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: "allow-tigera.intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
+			{name: "allow-tigera.default-deny", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: "intrusion-detection-controller", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "intrusion-detection-controller", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -427,6 +446,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		Expect(idc.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 		Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 	})
+
 	It("should apply controlPlaneTolerations correctly", func() {
 		t := corev1.Toleration{
 			Key:      "foo",
@@ -443,5 +463,46 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		job := rtest.GetResource(resources, render.IntrusionDetectionInstallerJobName, render.IntrusionDetectionNamespace, "batch", "v1", "Job").(*batchv1.Job)
 		Expect(idc.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
 		Expect(job.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
+	})
+
+	Context("allow-tigera rendering", func() {
+		policyNames := []types.NamespacedName{
+			{Name: "allow-tigera.intrusion-detection-controller", Namespace: "tigera-intrusion-detection"},
+			{Name: "allow-tigera.intrusion-detection-elastic", Namespace: "tigera-intrusion-detection"},
+		}
+
+		getExpectedPolicy := func(policyName types.NamespacedName, scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+			if policyName.Name == "allow-tigera.intrusion-detection-controller" {
+				return testutils.SelectPolicyByClusterTypeAndProvider(scenario,
+					expectedIDPolicyForUnmanaged,
+					expectedIDPolicyForUnmanagedOpenshift,
+					expectedIDPolicyForManaged,
+					expectedIDPolicyForManagedOpenshift,
+				)
+			} else if !scenario.ManagedCluster && policyName.Name == "allow-tigera.intrusion-detection-elastic" {
+				return testutils.SelectPolicyByProvider(scenario, expectedIDInstallerPolicy, expectedIDInstallerPolicyForOpenshift)
+			}
+
+			return nil
+		}
+
+		DescribeTable("should render allow-tigera policy",
+			func(scenario testutils.AllowTigeraScenario) {
+				cfg.Openshift = scenario.Openshift
+				cfg.ManagedCluster = scenario.ManagedCluster
+				component := render.IntrusionDetection(cfg)
+				resources, _ := component.Objects()
+
+				for _, policyName := range policyNames {
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+					expectedPolicy := getExpectedPolicy(policyName, scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				}
+			},
+			Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+			Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
+			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
+		)
 	})
 })

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -15,6 +15,7 @@
 package dpi
 
 import (
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
@@ -22,6 +23,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/render/common/meta"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,13 +35,16 @@ import (
 )
 
 const (
-	DeepPacketInspectionNamespace = "tigera-dpi"
-	DeepPacketInspectionName      = "tigera-dpi"
-	DefaultMemoryLimit            = "1Gi"
-	DefaultMemoryRequest          = "100Mi"
-	DefaultCPULimit               = "1"
-	DefaultCPURequest             = "100m"
+	DeepPacketInspectionNamespace  = "tigera-dpi"
+	DeepPacketInspectionName       = "tigera-dpi"
+	DeepPacketInspectionPolicyName = networkpolicy.TigeraComponentPolicyPrefix + DeepPacketInspectionName
+	DefaultMemoryLimit             = "1Gi"
+	DefaultMemoryRequest           = "100Mi"
+	DefaultCPULimit                = "1"
+	DefaultCPURequest              = "100m"
 )
+
+var DPISourceEntityRule = networkpolicy.CreateSourceEntityRule(DeepPacketInspectionNamespace, DeepPacketInspectionName)
 
 type DPIConfig struct {
 	IntrusionDetection *operatorv1.IntrusionDetection
@@ -47,6 +52,7 @@ type DPIConfig struct {
 	TyphaNodeTLS       *render.TyphaNodeTLS
 	PullSecrets        []*corev1.Secret
 	Openshift          bool
+	ManagedCluster     bool
 	HasNoLicense       bool
 	HasNoDPIResource   bool
 	ESSecrets          []*corev1.Secret
@@ -85,6 +91,7 @@ func (d *dpiComponent) Objects() (objsToCreate, objsToDelete []client.Object) {
 		toCreate = append(toCreate, render.CreateNamespace(DeepPacketInspectionNamespace, d.cfg.Installation.KubernetesProvider))
 	}
 	if d.cfg.HasNoDPIResource || d.cfg.HasNoLicense {
+		toDelete = append(toDelete, d.dpiAllowTigeraPolicy())
 		toDelete = append(toDelete, &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: DeepPacketInspectionNamespace}})
@@ -96,6 +103,7 @@ func (d *dpiComponent) Objects() (objsToCreate, objsToDelete []client.Object) {
 			d.dpiDaemonset(),
 		)
 	} else {
+		toCreate = append(toCreate, d.dpiAllowTigeraPolicy())
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.ESSecrets...)...)...)
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.PullSecrets...)...)...)
 		toCreate = append(toCreate,
@@ -330,4 +338,46 @@ func (d *dpiComponent) dpiAnnotations() map[string]string {
 	annotations := d.cfg.TyphaNodeTLS.TrustedBundle.HashAnnotations()
 	annotations[d.cfg.TyphaNodeTLS.NodeSecret.HashAnnotationKey()] = d.cfg.TyphaNodeTLS.NodeSecret.HashAnnotationValue()
 	return annotations
+}
+
+// This policy uses service selectors.
+func (d *dpiComponent) dpiAllowTigeraPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerServiceSelectorEntityRule,
+		},
+	}
+	egressRules = networkpolicy.AppendServiceSelectorDNSEgressRules(egressRules, d.cfg.Openshift)
+
+	if d.cfg.ManagedCluster {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianServiceSelectorEntityRule,
+		})
+	} else {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.EsGatewayServiceSelectorEntityRule,
+		})
+	}
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeepPacketInspectionPolicyName,
+			Namespace: DeepPacketInspectionNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(DeepPacketInspectionName),
+			Types:    []v3.PolicyType{v3.PolicyTypeEgress},
+			Egress:   egressRules,
+		},
+	}
+
 }

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -17,7 +17,12 @@ package kubecontrollers_test
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -88,6 +93,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		{Name: "ES_CURATOR_BACKEND_CERT", Value: "/etc/ssl/elastic/ca.pem"},
 	}
 	var internalManagerTLSSecret certificatemanagement.KeyPairInterface
+	var expectedESPolicy = testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/es-kubecontrollers.json")
+	var expectedESPolicyForOpenshift = testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/es-kubecontrollers_ocp.json")
 
 	BeforeEach(func() {
 		// Initialize a default instance to use. Each test can override this to its
@@ -234,6 +241,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			version string
 			kind    string
 		}{
+			{name: kubecontrollers.EsKubeControllerPolicyName, ns: common.CalicoNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: kubecontrollers.EsKubeControllerServiceAccount, ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: kubecontrollers.EsKubeControllerRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: kubecontrollers.EsKubeControllerRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -353,6 +361,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			version string
 			kind    string
 		}{
+			{name: kubecontrollers.EsKubeControllerPolicyName, ns: common.CalicoNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: kubecontrollers.EsKubeControllerServiceAccount, ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: kubecontrollers.EsKubeControllerRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: kubecontrollers.EsKubeControllerRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -600,5 +609,48 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(depResource).ToNot(BeNil())
 		deployment := depResource.(*appsv1.Deployment)
 		rtest.ExpectNoK8sServiceEpEnvVars(deployment.Spec.Template.Spec)
+	})
+
+	Context("es-kube-controllers allow-tigera rendering", func() {
+		policyName := types.NamespacedName{Name: "allow-tigera.es-kube-controller-access", Namespace: "calico-system"}
+
+		getExpectedPolicy := func(scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+			if scenario.ManagedCluster {
+				return nil
+			}
+
+			return testutils.SelectPolicyByProvider(scenario, expectedESPolicy, expectedESPolicyForOpenshift)
+		}
+
+		DescribeTable("should render allow-tigera policy",
+			func(scenario testutils.AllowTigeraScenario) {
+				if scenario.Openshift {
+					cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+				} else {
+					cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
+				}
+				if scenario.ManagedCluster {
+					cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{}
+				} else {
+					cfg.ManagementClusterConnection = nil
+				}
+				instance.Variant = operatorv1.TigeraSecureEnterprise
+				cfg.LogStorageExists = true
+				cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
+				cfg.ElasticsearchSecret = &testutils.ElasticsearchSecret
+				cfg.ManagerInternalSecret = internalManagerTLSSecret
+				cfg.EnabledESOIDCWorkaround = true
+				component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
+				resources, _ := component.Objects()
+
+				policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+				expectedPolicy := getExpectedPolicy(scenario)
+				Expect(policy).To(Equal(expectedPolicy))
+			},
+			Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+			Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
+			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
+		)
 	})
 })

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,10 @@ import (
 	"hash/fnv"
 	"net/url"
 	"strings"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/api/pkg/lib/numorstring"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 
 	cmnv1 "github.com/elastic/cloud-on-k8s/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/pkg/apis/elasticsearch/v1"
@@ -59,6 +63,7 @@ const (
 	ECKOperatorName         = "elastic-operator"
 	ECKOperatorNamespace    = "tigera-eck-operator"
 	ECKLicenseConfigMapName = "elastic-licensing"
+	ECKOperatorPolicyName   = networkpolicy.TigeraComponentPolicyPrefix + "elastic-operator-access"
 
 	ElasticsearchNamespace = "tigera-elasticsearch"
 
@@ -69,9 +74,12 @@ const (
 	ElasticsearchServiceName              = "tigera-secure-es-http"
 	ESGatewayServiceName                  = "tigera-secure-es-gateway-http"
 	ElasticsearchDefaultPort              = 9200
+	ElasticsearchInternalPort             = 9300
 	ElasticsearchSecureSettingsSecretName = "tigera-elasticsearch-secure-settings"
 	ElasticsearchOperatorUserSecret       = "tigera-ee-operator-elasticsearch-access"
 	ElasticsearchAdminUserSecret          = "tigera-secure-es-elastic-user"
+	ElasticsearchPolicyName               = networkpolicy.TigeraComponentPolicyPrefix + "elasticsearch-access"
+	ElasticsearchInternalPolicyName       = networkpolicy.TigeraComponentPolicyPrefix + "elasticsearch-internal"
 
 	KibanaName               = "tigera-secure"
 	KibanaNamespace          = "tigera-kibana"
@@ -81,6 +89,8 @@ const (
 	KibanaBasePath           = "tigera-kibana"
 	KibanaServiceName        = "tigera-secure-kb-http"
 	KibanaDefaultRoute       = "/app/kibana#/dashboards?%s&title=%s"
+	KibanaPolicyName         = networkpolicy.TigeraComponentPolicyPrefix + "kibana-access"
+	KibanaPort               = 5601
 
 	DefaultElasticsearchClusterName = "cluster"
 	DefaultElasticsearchReplicas    = 0
@@ -88,6 +98,7 @@ const (
 
 	EsCuratorName           = "elastic-curator"
 	EsCuratorServiceAccount = "tigera-elastic-curator"
+	EsCuratorPolicyName     = networkpolicy.TigeraComponentPolicyPrefix + "allow-elastic-curator"
 
 	OIDCUsersConfigMapName = "tigera-known-oidc-users"
 	OIDCUsersEsSecreteName = "tigera-oidc-users-elasticsearch-credentials"
@@ -138,6 +149,22 @@ const (
 	// Volume name that is added by ECK for the purpose of mounting certs.
 	caVolumeName = "elasticsearch-certs"
 )
+
+var ElasticsearchSelector = fmt.Sprintf("elasticsearch.k8s.elastic.co/cluster-name == '%s'", ElasticsearchName)
+var ElasticsearchEntityRule = v3.EntityRule{
+	NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
+	Selector:          ElasticsearchSelector,
+	Ports:             []numorstring.Port{{MinPort: ElasticsearchDefaultPort, MaxPort: ElasticsearchDefaultPort}},
+}
+var InternalElasticsearchEntityRule = v3.EntityRule{
+	NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
+	Selector:          ElasticsearchSelector,
+	Ports:             []numorstring.Port{{MinPort: ElasticsearchInternalPort, MaxPort: ElasticsearchInternalPort}},
+}
+var KibanaEntityRule = networkpolicy.CreateEntityRule(KibanaNamespace, KibanaName, KibanaPort)
+var KibanaSourceEntityRule = networkpolicy.CreateSourceEntityRule(KibanaNamespace, KibanaName)
+var ECKOperatorSourceEntityRule = networkpolicy.CreateSourceEntityRule(ECKOperatorNamespace, ECKOperatorName)
+var ESCuratorSourceEntityRule = networkpolicy.CreateSourceEntityRule(ElasticsearchNamespace, EsCuratorName)
 
 var log = logf.Log.WithName("render")
 
@@ -269,6 +296,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		// ECK CRs
 		toCreate = append(toCreate,
 			CreateNamespace(ECKOperatorNamespace, es.cfg.Installation.KubernetesProvider),
+			es.eckOperatorAllowTigeraPolicy(),
 		)
 
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ECKOperatorNamespace, es.cfg.PullSecrets...)...)...)
@@ -300,6 +328,9 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 
 		// Elasticsearch CRs
 		toCreate = append(toCreate, CreateNamespace(ElasticsearchNamespace, es.cfg.Installation.KubernetesProvider))
+		toCreate = append(toCreate, es.elasticsearchAllowTigeraPolicy())
+		toCreate = append(toCreate, es.elasticsearchInternalAllowTigeraPolicy())
+		toCreate = append(toCreate, elasticsearchDefaultDenyAllowTigeraPolicy())
 
 		if len(es.cfg.PullSecrets) > 0 {
 			toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ElasticsearchNamespace, es.cfg.PullSecrets...)...)...)
@@ -316,6 +347,8 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 
 		// Kibana CRs
 		toCreate = append(toCreate, CreateNamespace(KibanaNamespace, es.cfg.Installation.KubernetesProvider))
+		toCreate = append(toCreate, es.kibanaAllowTigeraPolicy())
+		toCreate = append(toCreate, kibanaDefaultDenyAllowTigeraPolicy())
 		toCreate = append(toCreate, es.kibanaServiceAccount())
 
 		if len(es.cfg.PullSecrets) > 0 {
@@ -331,6 +364,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		// Curator CRs
 		// If we have the curator secrets then create curator
 		if len(es.cfg.CuratorSecrets) > 0 {
+			toCreate = append(toCreate, es.esCuratorAllowTigeraPolicy())
 			toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ElasticsearchNamespace, es.cfg.CuratorSecrets...)...)...)
 			toCreate = append(toCreate, es.esCuratorServiceAccount())
 
@@ -1273,7 +1307,7 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 								HTTPGet: &corev1.HTTPGetAction{
 									Path: fmt.Sprintf("/%s/login", KibanaBasePath),
 									Port: intstr.IntOrString{
-										IntVal: 5601,
+										IntVal: KibanaPort,
 									},
 									Scheme: corev1.URISchemeHTTPS,
 								},
@@ -1553,6 +1587,251 @@ func (es elasticsearchComponent) oidcUserRoleBinding() client.Object {
 			},
 		},
 	}
+}
+
+// Allow the elastic-operator to communicate with API server, DNS and elastic search.
+func (es *elasticsearchComponent) eckOperatorAllowTigeraPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, es.cfg.Provider == operatorv1.ProviderOpenShift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: ElasticsearchEntityRule,
+		},
+	}...)
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ECKOperatorPolicyName,
+			Namespace: ECKOperatorNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(ECKOperatorName),
+			Types:    []v3.PolicyType{v3.PolicyTypeEgress},
+			Egress:   egressRules,
+		},
+	}
+}
+
+// Allow access to Elasticsearch client nodes from Kibana, ECK Operator and ES Gateway.
+func (es *elasticsearchComponent) elasticsearchAllowTigeraPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, es.cfg.Provider == operatorv1.ProviderOpenShift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: DexEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.EsGatewayEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+	}...)
+
+	elasticSearchIngressDestinationEntityRule := v3.EntityRule{
+		Ports: networkpolicy.Ports(ElasticsearchDefaultPort),
+	}
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ElasticsearchPolicyName,
+			Namespace: ElasticsearchNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: ElasticsearchSelector,
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      KibanaSourceEntityRule,
+					Destination: elasticSearchIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      networkpolicy.EsGatewaySourceEntityRule,
+					Destination: elasticSearchIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      ECKOperatorSourceEntityRule,
+					Destination: elasticSearchIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Destination: elasticSearchIngressDestinationEntityRule,
+					// Allow all sources, as node CIDRs are not known.
+				},
+			},
+			Egress: egressRules,
+		},
+	}
+}
+
+// Allow internal communication within the ElasticSearch cluster
+func (es *elasticsearchComponent) elasticsearchInternalAllowTigeraPolicy() *v3.NetworkPolicy {
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ElasticsearchInternalPolicyName,
+			Namespace: ElasticsearchNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: ElasticsearchSelector,
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Source: v3.EntityRule{
+						Selector: ElasticsearchSelector,
+					},
+					Destination: v3.EntityRule{
+						Ports: networkpolicy.Ports(9300),
+					},
+				},
+			},
+			Egress: []v3.Rule{
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Destination: InternalElasticsearchEntityRule,
+				},
+			},
+		},
+	}
+}
+
+// Allow access to Kibana
+func (es *elasticsearchComponent) kibanaAllowTigeraPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Source:      v3.EntityRule{},
+			Destination: ElasticsearchEntityRule,
+		},
+	}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, es.cfg.Provider == operatorv1.ProviderOpenShift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.EsGatewayEntityRule,
+		},
+	}...)
+
+	kibanaPortIngressDestination := v3.EntityRule{
+		Ports: networkpolicy.Ports(KibanaPort),
+	}
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KibanaPolicyName,
+			Namespace: KibanaNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(KibanaName),
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Source: v3.EntityRule{
+						// This policy allows access to Kibana from anywhere.
+						Nets: []string{"0.0.0.0/0"},
+					},
+					Destination: kibanaPortIngressDestination,
+				},
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Source: v3.EntityRule{
+						// This policy allows access to Kibana from anywhere.
+						Nets: []string{"::/0"},
+					},
+					Destination: kibanaPortIngressDestination,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      networkpolicy.EsGatewaySourceEntityRule,
+					Destination: kibanaPortIngressDestination,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      ECKOperatorSourceEntityRule,
+					Destination: kibanaPortIngressDestination,
+				},
+			},
+			Egress: egressRules,
+		},
+	}
+}
+
+func (es *elasticsearchComponent) esCuratorAllowTigeraPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, es.cfg.Provider == operatorv1.ProviderOpenShift)
+	egressRules = append(egressRules, v3.Rule{
+		Action:      v3.Allow,
+		Protocol:    &networkpolicy.TCPProtocol,
+		Source:      v3.EntityRule{},
+		Destination: networkpolicy.EsGatewayEntityRule,
+	})
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      EsCuratorPolicyName,
+			Namespace: ElasticsearchNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(EsCuratorName),
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Egress:   egressRules,
+		},
+	}
+}
+
+func elasticsearchDefaultDenyAllowTigeraPolicy() *v3.NetworkPolicy {
+	return networkpolicy.AllowTigeraDefaultDeny(ElasticsearchNamespace)
+}
+
+func kibanaDefaultDenyAllowTigeraPolicy() *v3.NetworkPolicy {
+	return networkpolicy.AllowTigeraDefaultDeny(KibanaNamespace)
 }
 
 // overrideResourceRequirements replaces individual ResourceRequirements field's default value with user's value.

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,12 @@ package esgateway
 import (
 	"fmt"
 	"strings"
+
+	"github.com/tigera/operator/pkg/render/intrusiondetection/dpi"
+	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,15 +48,14 @@ const (
 	RoleName              = "tigera-secure-es-gateway"
 	VolumeName            = "tigera-secure-es-gateway-certs"
 	ServiceName           = "tigera-secure-es-gateway-http"
+	PolicyName            = networkpolicy.TigeraComponentPolicyPrefix + "es-gateway-access"
 	ElasticsearchPortName = "es-gateway-elasticsearch-port"
 	KibanaPortName        = "es-gateway-kibana-port"
 	Port                  = 5554
 
 	ElasticsearchHTTPSEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
-	ElasticsearchPort          = 9200
 
 	KibanaHTTPSEndpoint = "https://tigera-secure-kb-http.tigera-kibana.svc:5601"
-	KibanaPort          = 5601
 )
 
 func EsGateway(c *Config) render.Component {
@@ -127,6 +132,7 @@ func (e *esGateway) ResolveImages(is *operatorv1.ImageSet) error {
 }
 
 func (e *esGateway) Objects() (toCreate, toDelete []client.Object) {
+	toCreate = append(toCreate, e.esGatewayAllowTigeraPolicy())
 	toCreate = append(toCreate, e.esGatewaySecrets()...)
 	toCreate = append(toCreate, e.esGatewayService())
 	toCreate = append(toCreate, e.esGatewayRole())
@@ -350,17 +356,157 @@ func (e esGateway) esGatewayService() *corev1.Service {
 			Ports: []corev1.ServicePort{
 				{
 					Name:       ElasticsearchPortName,
-					Port:       int32(ElasticsearchPort),
+					Port:       int32(render.ElasticsearchDefaultPort),
 					TargetPort: intstr.FromInt(Port),
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
 					Name:       KibanaPortName,
-					Port:       int32(KibanaPort),
+					Port:       int32(render.KibanaPort),
 					TargetPort: intstr.FromInt(Port),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
+		},
+	}
+}
+
+// Allow access to ES Gateway from components that need to talk to Elasticsearch or Kibana.
+func (e *esGateway) esGatewayAllowTigeraPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, e.installation.KubernetesProvider == operatorv1.ProviderOpenShift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.DexEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.ElasticsearchEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.KibanaEntityRule,
+		},
+	}...)
+
+	esgatewayIngressDestinationEntityRule := v3.EntityRule{
+		Ports: networkpolicy.Ports(Port),
+	}
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PolicyName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(DeploymentName),
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.FluentdSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.EKSLogForwarderEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.IntrusionDetectionInstallerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ESCuratorSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ManagerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceBenchmarkerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceControllerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceServerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceSnapshotterSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceReporterSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.IntrusionDetectionSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ECKOperatorSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      esmetrics.ESMetricsSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      dpi.DPISourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Destination: esgatewayIngressDestinationEntityRule,
+					// The operator needs access to Elasticsearch and Kibana (through ES Gateway), however, since the
+					// operator is on the hostnetwork it's hard to create specific network policies for it.
+					// Allow all sources, as node CIDRs are not known.
+				},
+			},
+			Egress: egressRules,
 		},
 	}
 }

--- a/pkg/render/logstorage/esgateway/esgateway_test.go
+++ b/pkg/render/logstorage/esgateway/esgateway_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,13 @@ package esgateway
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/testutils"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -47,7 +53,10 @@ var _ = Describe("ES Gateway rendering tests", func() {
 	Context("ES Gateway deployment", func() {
 		var installation *operatorv1.InstallationSpec
 		var replicas int32
+		var cfg *Config
 		clusterDomain := "cluster.local"
+		expectedPolicy := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/es-gateway.json")
+		expectedPolicyForOpenshift := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/es-gateway_ocp.json")
 
 		BeforeEach(func() {
 			installation = &operatorv1.InstallationSpec{
@@ -56,25 +65,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 				Registry:             "testregistry.com/",
 			}
 			replicas = 2
-		})
-
-		It("should render an ES Gateway deployment and all supporting resources", func() {
-			expectedResources := []resourceTestObj{
-				{relasticsearch.PublicCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
-				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-				{relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-				{render.KibanaInternalCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-				{kubecontrollers.ElasticsearchKubeControllersUserSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
-				{kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-				{kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-				{ServiceName, render.ElasticsearchNamespace, &corev1.Service{}, nil},
-				{RoleName, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
-				{RoleName, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
-				{ServiceAccountName, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
-				{DeploymentName, render.ElasticsearchNamespace, &appsv1.Deployment{}, nil},
-			}
-
-			component := EsGateway(&Config{
+			cfg = &Config{
 				installation,
 				[]*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
@@ -91,7 +82,27 @@ var _ = Describe("ES Gateway rendering tests", func() {
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: common.OperatorNamespace()}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
 				clusterDomain, "elastic",
-			})
+			}
+		})
+
+		It("should render an ES Gateway deployment and all supporting resources", func() {
+			expectedResources := []resourceTestObj{
+				{PolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+				{relasticsearch.PublicCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
+				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{render.KibanaInternalCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersUserSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{ServiceName, render.ElasticsearchNamespace, &corev1.Service{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
+				{ServiceAccountName, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
+				{DeploymentName, render.ElasticsearchNamespace, &appsv1.Deployment{}, nil},
+			}
+
+			component := EsGateway(cfg)
 
 			createResources, _ := component.Objects()
 			compareResources(createResources, expectedResources)
@@ -100,6 +111,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 		It("should render an ES Gateway deployment and all supporting resources when CertificateManagement is enabled", func() {
 			installation.CertificateManagement = &operatorv1.CertificateManagement{}
 			expectedResources := []resourceTestObj{
+				{PolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
 				{relasticsearch.PublicCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 				{relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
@@ -115,24 +127,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 				{RoleName + ":csr-creator", "", &rbacv1.ClusterRoleBinding{}, nil},
 			}
 
-			component := EsGateway(&Config{
-				installation,
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
-				},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: common.OperatorNamespace()}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
-				clusterDomain, "elastic",
-			})
+			component := EsGateway(cfg)
 
 			createResources, _ := component.Objects()
 			compareResources(createResources, expectedResources)
@@ -142,24 +137,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 			var replicas int32 = 1
 			installation.ControlPlaneReplicas = &replicas
 
-			component := EsGateway(&Config{
-				installation,
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
-				},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: common.OperatorNamespace()}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
-				clusterDomain, "elastic",
-			})
+			component := EsGateway(cfg)
 
 			resources, _ := component.Objects()
 			deploy, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
@@ -171,24 +149,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 			var replicas int32 = 2
 			installation.ControlPlaneReplicas = &replicas
 
-			component := EsGateway(&Config{
-				installation,
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
-				},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: common.OperatorNamespace()}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
-				clusterDomain, "elastic",
-			})
+			component := EsGateway(cfg)
 
 			resources, _ := component.Objects()
 			deploy, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
@@ -200,24 +161,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 		It("should apply controlPlaneNodeSelector correctly", func() {
 			installation.ControlPlaneNodeSelector = map[string]string{"foo": "bar"}
 
-			component := EsGateway(&Config{
-				installation,
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
-				},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: common.OperatorNamespace()}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
-				clusterDomain, "elastic",
-			})
+			component := EsGateway(cfg)
 
 			resources, _ := component.Objects()
 			d, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
@@ -233,29 +177,44 @@ var _ = Describe("ES Gateway rendering tests", func() {
 			}
 
 			installation.ControlPlaneTolerations = []corev1.Toleration{t}
-			component := EsGateway(&Config{
-				installation,
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
-				},
-				[]*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
-				},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaInternalCertSecret, Namespace: common.OperatorNamespace()}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.InternalCertSecret, Namespace: render.ElasticsearchNamespace}},
-				clusterDomain, "elastic",
-			})
+			component := EsGateway(cfg)
 
 			resources, _ := component.Objects()
 			d, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue())
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
+		})
+
+		Context("allow-tigera rendering", func() {
+			policyName := types.NamespacedName{Name: "allow-tigera.es-gateway-access", Namespace: "tigera-elasticsearch"}
+
+			getExpectedPolicy := func(scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+				if scenario.ManagedCluster {
+					return nil
+				}
+
+				return testutils.SelectPolicyByProvider(scenario, expectedPolicy, expectedPolicyForOpenshift)
+			}
+
+			DescribeTable("should render allow-tigera policy",
+				func(scenario testutils.AllowTigeraScenario) {
+					if scenario.Openshift {
+						cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+					} else {
+						cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
+					}
+					component := EsGateway(cfg)
+					resources, _ := component.Objects()
+
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+					expectedPolicy := getExpectedPolicy(scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				},
+				// ES Gateway only renders in the presence of an LogStorage CR and absence of a ManagementClusterConnection CR, therefore
+				// does not have a config option for managed clusters.
+				Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+				Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			)
 		})
 	})
 })

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@ package esmetrics
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/testutils"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -38,6 +42,8 @@ var _ = Describe("Elasticsearch metrics", func() {
 	Context("Rendering resources", func() {
 		var esConfig *relasticsearch.ClusterConfig
 		var cfg *Config
+		expectedPolicy := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/es-metrics.json")
+		expectedPolicyForOpenshift := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/es-metrics_ocp.json")
 
 		BeforeEach(func() {
 			installation := &operatorv1.InstallationSpec{
@@ -91,6 +97,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 				version string
 				kind    string
 			}{
+				{ElasticsearchMetricsPolicyName, render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 				{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, "", "v1", "Secret"},
 				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "", "v1", "Service"},
 				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "apps", "v1", "Deployment"},
@@ -254,6 +261,38 @@ var _ = Describe("Elasticsearch metrics", func() {
 			d, ok := rtest.GetResource(resources, ElasticsearchMetricsName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue())
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
+		})
+
+		Context("allow-tigera rendering", func() {
+			policyName := types.NamespacedName{Name: "allow-tigera.elasticsearch-metrics", Namespace: "tigera-elasticsearch"}
+
+			getExpectedPolicy := func(scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+				if scenario.ManagedCluster {
+					return nil
+				}
+
+				return testutils.SelectPolicyByProvider(scenario, expectedPolicy, expectedPolicyForOpenshift)
+			}
+
+			DescribeTable("should render allow-tigera policy",
+				func(scenario testutils.AllowTigeraScenario) {
+					if scenario.Openshift {
+						cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+					} else {
+						cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
+					}
+					component := ElasticsearchMetrics(cfg)
+					resources, _ := component.Objects()
+
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+					expectedPolicy := getExpectedPolicy(scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				},
+				// ES Gateway only renders in the presence of an LogStorage CR and absence of a ManagementClusterConnection CR, therefore
+				// does not have a config option for managed clusters.
+				Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+				Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			)
 		})
 	})
 })

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,13 @@ package render_test
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/testutils"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta "k8s.io/api/batch/v1beta1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -27,6 +34,7 @@ import (
 	kbv1 "github.com/elastic/cloud-on-k8s/pkg/apis/kibana/v1"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -51,6 +59,44 @@ type resourceTestObj struct {
 }
 
 var _ = Describe("Elasticsearch rendering tests", func() {
+	// Setup shared policies utilities that require Ginkgo context.
+	var (
+		expectedOperatorPolicy             = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/elastic-operator.json")
+		expectedOperatorPolicyForOpenshift = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/elastic-operator_ocp.json")
+		expectedESPolicy                   = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/elasticsearch.json")
+		expectedESPolicyForOpenshift       = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/elasticsearch_ocp.json")
+		expectedESInternalPolicy           = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/elasticsearch-internal.json")
+		expectedKibanaPolicy               = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/kibana.json")
+		expectedKibanaPolicyForOpenshift   = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/kibana_ocp.json")
+		expectedCuratorPolicy              = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/elastic-curator.json")
+		expectedCuratorPolicyForOpenshift  = testutils.GetExpectedPolicyFromFile("testutils/expected_policies/elastic-curator_ocp.json")
+	)
+	getExpectedPolicy := func(policyName types.NamespacedName, scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+		if scenario.ManagedCluster {
+			return nil
+		}
+
+		switch policyName.Name {
+		case "allow-tigera.elasticsearch-access":
+			return testutils.SelectPolicyByProvider(scenario, expectedESPolicy, expectedESPolicyForOpenshift)
+
+		case "allow-tigera.allow-elastic-curator":
+			return testutils.SelectPolicyByProvider(scenario, expectedCuratorPolicy, expectedCuratorPolicyForOpenshift)
+
+		case "allow-tigera.kibana-access":
+			return testutils.SelectPolicyByProvider(scenario, expectedKibanaPolicy, expectedKibanaPolicyForOpenshift)
+
+		case "allow-tigera.elastic-operator-access":
+			return testutils.SelectPolicyByProvider(scenario, expectedOperatorPolicy, expectedOperatorPolicyForOpenshift)
+
+		case "allow-tigera.elasticsearch-internal":
+			return expectedESInternalPolicy
+
+		default:
+			return nil
+		}
+	}
+
 	Context("Standalone cluster type", func() {
 		var cfg *render.ElasticsearchConfiguration
 		replicas := int32(1)
@@ -126,6 +172,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			It("should render an elasticsearchComponent", func() {
 				expectedCreateResources := []resourceTestObj{
 					{render.ECKOperatorNamespace, "", &corev1.Namespace{}, nil},
+					{render.ECKOperatorPolicyName, render.ECKOperatorNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ECKOperatorNamespace, &corev1.Secret{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
@@ -139,6 +186,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
+					{render.ElasticsearchPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{render.ElasticsearchInternalPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
@@ -146,6 +196,8 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{relasticsearch.ClusterConfigConfigMapName, common.OperatorNamespace(), &corev1.ConfigMap{}, nil},
 					{render.ElasticsearchName, render.ElasticsearchNamespace, &esv1.Elasticsearch{}, nil},
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
+					{render.KibanaPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
@@ -212,6 +264,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			It("should render an elasticsearchComponent and delete the Elasticsearch and Kibana ExternalService", func() {
 				expectedCreateResources := []resourceTestObj{
 					{render.ECKOperatorNamespace, "", &corev1.Namespace{}, nil},
+					{render.ECKOperatorPolicyName, render.ECKOperatorNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ECKOperatorNamespace, &corev1.Secret{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
@@ -225,6 +278,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
+					{render.ElasticsearchPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{render.ElasticsearchInternalPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
@@ -232,6 +288,8 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{relasticsearch.ClusterConfigConfigMapName, common.OperatorNamespace(), &corev1.ConfigMap{}, nil},
 					{render.ElasticsearchName, render.ElasticsearchNamespace, &esv1.Elasticsearch{}, nil},
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
+					{render.KibanaPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
@@ -273,6 +331,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				}
 				expectedCreateResources := []resourceTestObj{
 					{render.ECKOperatorNamespace, "", &corev1.Namespace{}, nil},
+					{render.ECKOperatorPolicyName, render.ECKOperatorNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ECKOperatorNamespace, &corev1.Secret{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
@@ -286,6 +345,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
+					{render.ElasticsearchPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{render.ElasticsearchInternalPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
@@ -293,6 +355,8 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{relasticsearch.ClusterConfigConfigMapName, common.OperatorNamespace(), &corev1.ConfigMap{}, nil},
 					{render.ElasticsearchName, render.ElasticsearchNamespace, &esv1.Elasticsearch{}, nil},
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
+					{render.KibanaPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
@@ -340,9 +404,25 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		})
 
 		Context("Elasticsearch and Kibana both ready", func() {
+			BeforeEach(func() {
+				cfg.ElasticsearchSecrets = []*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.ElasticsearchNamespace}},
+					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
+				}
+				cfg.KibanaCertSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}}
+				cfg.KibanaInternalCertSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}}
+				cfg.CuratorSecrets = []*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: common.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
+				}
+				cfg.ClusterDomain = dns.DefaultClusterDomain
+			})
+
 			It("should render correctly", func() {
 				expectedCreateResources := []resourceTestObj{
 					{render.ECKOperatorNamespace, "", &corev1.Namespace{}, nil},
+					{render.ECKOperatorPolicyName, render.ECKOperatorNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ECKOperatorNamespace, &corev1.Secret{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
@@ -356,6 +436,9 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
+					{render.ElasticsearchPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{render.ElasticsearchInternalPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-pull-secret", render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.TigeraElasticsearchCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
@@ -364,11 +447,14 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{relasticsearch.ClusterConfigConfigMapName, common.OperatorNamespace(), &corev1.ConfigMap{}, nil},
 					{render.ElasticsearchName, render.ElasticsearchNamespace, &esv1.Elasticsearch{}, nil},
 					{render.KibanaNamespace, "", &corev1.Namespace{}, nil},
+					{render.KibanaPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
+					{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.KibanaNamespace, &v3.NetworkPolicy{}, nil},
 					{"tigera-kibana", render.KibanaNamespace, &corev1.ServiceAccount{}, nil},
 					{"tigera-pull-secret", render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.TigeraKibanaCertSecret, render.KibanaNamespace, &corev1.Secret{}, nil},
 					{render.KibanaPublicCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
 					{render.KibanaName, render.KibanaNamespace, &kbv1.Kibana{}, nil},
+					{render.EsCuratorPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
 					{render.ElasticsearchCuratorUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 					{relasticsearch.PublicCertSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
 					{render.EsCuratorServiceAccount, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
@@ -380,24 +466,44 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{render.EsManagerRoleBinding, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
 				}
 
-				cfg.ElasticsearchSecrets = []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraElasticsearchCertSecret, Namespace: render.ElasticsearchNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
-				}
-				cfg.KibanaCertSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraKibanaCertSecret, Namespace: common.OperatorNamespace()}}
-				cfg.KibanaInternalCertSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.KibanaPublicCertSecret, Namespace: render.KibanaNamespace}}
-				cfg.CuratorSecrets = []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchCuratorUserSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: common.OperatorNamespace()}},
-				}
-				cfg.ClusterDomain = dns.DefaultClusterDomain
+				cfg.Provider = operatorv1.ProviderNone
 				component := render.LogStorage(cfg)
 
 				createResources, deleteResources := component.Objects()
 
 				compareResources(createResources, expectedCreateResources)
 				compareResources(deleteResources, []resourceTestObj{})
+			})
+
+			Context("allow-tigera rendering", func() {
+				policyNames := []types.NamespacedName{
+					{Name: "allow-tigera.elasticsearch-access", Namespace: "tigera-elasticsearch"},
+					{Name: "allow-tigera.allow-elastic-curator", Namespace: "tigera-elasticsearch"},
+					{Name: "allow-tigera.kibana-access", Namespace: "tigera-kibana"},
+					{Name: "allow-tigera.elastic-operator-access", Namespace: "tigera-eck-operator"},
+					{Name: "allow-tigera.elasticsearch-internal", Namespace: "tigera-elasticsearch"},
+				}
+
+				DescribeTable("should render allow-tigera policy",
+					func(scenario testutils.AllowTigeraScenario) {
+						if scenario.Openshift {
+							cfg.Provider = operatorv1.ProviderOpenShift
+						} else {
+							cfg.Provider = operatorv1.ProviderNone
+						}
+
+						component := render.LogStorage(cfg)
+						resources, _ := component.Objects()
+
+						for _, policyName := range policyNames {
+							policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+							expectedPolicy := getExpectedPolicy(policyName, scenario)
+							Expect(policy).To(Equal(expectedPolicy))
+						}
+					},
+					Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+					Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+				)
 			})
 		})
 
@@ -530,7 +636,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 	Context("Managed cluster", func() {
 		var cfg *render.ElasticsearchConfiguration
 		var managementClusterConnection *operatorv1.ManagementClusterConnection
-
 		BeforeEach(func() {
 			replicas := int32(1)
 			installation := &operatorv1.InstallationSpec{
@@ -573,6 +678,36 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			})
 		})
 		Context("Deleting LogStorage", deleteLogStorageTests(nil, managementClusterConnection))
+		Context("allow-tigera rendering", func() {
+			policyNames := []types.NamespacedName{
+				{Name: "allow-tigera.elasticsearch-access", Namespace: "tigera-elasticsearch"},
+				{Name: "allow-tigera.allow-elastic-curator", Namespace: "tigera-elasticsearch"},
+				{Name: "allow-tigera.kibana-access", Namespace: "tigera-kibana"},
+				{Name: "allow-tigera.elastic-operator-access", Namespace: "tigera-eck-operator"},
+				{Name: "allow-tigera.elasticsearch-internal", Namespace: "tigera-elasticsearch"},
+			}
+
+			DescribeTable("should render allow-tigera policy",
+				func(scenario testutils.AllowTigeraScenario) {
+					if scenario.Openshift {
+						cfg.Provider = operatorv1.ProviderOpenShift
+					} else {
+						cfg.Provider = operatorv1.ProviderNone
+					}
+
+					component := render.LogStorage(cfg)
+					resources, _ := component.Objects()
+
+					for _, policyName := range policyNames {
+						policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+						expectedPolicy := getExpectedPolicy(policyName, scenario)
+						Expect(policy).To(Equal(expectedPolicy))
+					}
+				},
+				Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
+				Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
+			)
+		})
 	})
 
 	Context("NodeSet configuration", func() {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -17,9 +17,14 @@ package render_test
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	networkpolicy "github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/testutils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -51,7 +56,10 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	}
 	var replicas int32 = 2
 	installation := &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas}
-	const expectedResourcesNumber = 11
+	const expectedResourcesNumber = 13
+
+	expectedManagerPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/manager.json")
+	expectedManagerOpenshiftPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/manager_ocp.json")
 
 	It("should render all resources for a default configuration", func() {
 		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, complianceFeatureActive: true})
@@ -65,6 +73,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			kind    string
 		}{
 			{name: render.ManagerNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.ManagerPolicyName, ns: "tigera-manager", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
+			{name: networkpolicy.TigeraComponentDefaultDenyPolicyName, ns: "tigera-manager", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -262,6 +272,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			kind    string
 		}{
 			{name: "tigera-manager", ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.ManagerPolicyName, ns: "tigera-manager", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
+			{name: networkpolicy.TigeraComponentDefaultDenyPolicyName, ns: "tigera-manager", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: "tigera-manager", ns: "tigera-manager", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "tigera-manager-role", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-manager-binding", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -492,6 +504,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			kind    string
 		}{
 			{name: render.ManagerNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+			{name: render.ManagerPolicyName, ns: "tigera-manager", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
+			{name: networkpolicy.TigeraComponentDefaultDenyPolicyName, ns: "tigera-manager", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -549,6 +563,38 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
 		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-manager", render.ManagerNamespace)))
 	})
+
+	Context("allow-tigera rendering", func() {
+		policyName := types.NamespacedName{Name: "allow-tigera.manager-access", Namespace: "tigera-manager"}
+
+		getExpectedPolicy := func(scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+			if scenario.ManagedCluster {
+				return nil
+			}
+
+			return testutils.SelectPolicyByProvider(scenario, expectedManagerPolicy, expectedManagerOpenshiftPolicy)
+		}
+
+		DescribeTable("should render allow-tigera policy",
+			func(scenario testutils.AllowTigeraScenario) {
+				// Default configuration.
+				resources := renderObjects(renderConfig{
+					openshift:               scenario.Openshift,
+					oidc:                    false,
+					managementCluster:       nil,
+					installation:            installation,
+					complianceFeatureActive: true,
+				})
+
+				policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+				expectedPolicy := getExpectedPolicy(scenario)
+				Expect(policy).To(Equal(expectedPolicy))
+			},
+			// Manager only renders in the presence of a Manager CR, therefore does not have a config option for managed clusters.
+			Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+			Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+		)
+	})
 })
 
 type renderConfig struct {
@@ -556,6 +602,7 @@ type renderConfig struct {
 	managementCluster       *operatorv1.ManagementCluster
 	installation            *operatorv1.InstallationSpec
 	complianceFeatureActive bool
+	openshift               bool
 }
 
 func renderObjects(roc renderConfig) []client.Object {
@@ -601,6 +648,7 @@ func renderObjects(roc renderConfig) []client.Object {
 		ESLicenseType:           render.ElasticsearchLicenseTypeEnterpriseTrial,
 		Replicas:                roc.installation.ControlPlaneReplicas,
 		ComplianceFeatureActive: roc.complianceFeatureActive,
+		Openshift:               roc.openshift,
 	}
 	component, err := render.Manager(cfg)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -334,6 +334,13 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				APIGroups: []string{""},
 				Resources: []string{"pods/status"},
 				Verbs:     []string{"patch"},
+			},
+			{
+				//Used for creating service account tokens to be used by the CNI plugin
+				APIGroups:     []string{""},
+				Resources:     []string{"serviceaccounts/token"},
+				ResourceNames: []string{"calico-node"},
+				Verbs:         []string{"create"},
 			},
 			{
 				// Calico needs to query configmaps for pool auto-detection on kubeadm.

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package render
 
 import (
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -43,9 +44,13 @@ const (
 	PacketCaptureClusterRoleBindingName = PacketCaptureName
 	PacketCaptureDeploymentName         = PacketCaptureName
 	PacketCaptureServiceName            = PacketCaptureName
+	PacketCapturePort                   = 8444
 
 	PacketCaptureCertSecret = "tigera-packetcapture-server-tls"
 )
+
+var PacketCaptureEntityRule = networkpolicy.CreateEntityRule(PacketCaptureNamespace, PacketCaptureDeploymentName, PacketCapturePort)
+var PacketCaptureSourceEntityRule = networkpolicy.CreateSourceEntityRule(PacketCaptureNamespace, PacketCaptureDeploymentName)
 
 // PacketCaptureApiConfiguration contains all the config information needed to render the component.
 type PacketCaptureApiConfiguration struct {
@@ -132,7 +137,7 @@ func (pc *packetCaptureApiComponent) service() *corev1.Service {
 					Name:       PacketCaptureName,
 					Port:       443,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(8444),
+					TargetPort: intstr.FromInt(PacketCapturePort),
 				},
 			},
 		},
@@ -285,7 +290,7 @@ func (pc *packetCaptureApiComponent) healthProbe() *corev1.Probe {
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   "/health",
-				Port:   intstr.FromInt(8444),
+				Port:   intstr.FromInt(PacketCapturePort),
 				Scheme: corev1.URISchemeHTTPS,
 			},
 		},

--- a/pkg/render/testutils/expected_policies/alertmanager-mesh.json
+++ b/pkg/render/testutils/expected_policies/alertmanager-mesh.json
@@ -1,0 +1,72 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.calico-node-alertmanager-mesh",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/alertmanager-mesh_ocp.json
+++ b/pkg/render/testutils/expected_policies/alertmanager-mesh_ocp.json
@@ -1,0 +1,83 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.calico-node-alertmanager-mesh",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/alertmanager.json
+++ b/pkg/render/testutils/expected_policies/alertmanager.json
@@ -1,0 +1,45 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.calico-node-alertmanager",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9093
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/alertmanager_ocp.json
+++ b/pkg/render/testutils/expected_policies/alertmanager_ocp.json
@@ -1,0 +1,56 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.calico-node-alertmanager",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9093
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/apiserver.json
+++ b/pkg/render/testutils/expected_policies/apiserver.json
@@ -1,0 +1,82 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.cnx-apiserver-access",
+    "namespace": "tigera-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-apiserver'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/apiserver_ocp.json
+++ b/pkg/render/testutils/expected_policies/apiserver_ocp.json
@@ -1,0 +1,93 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.cnx-apiserver-access",
+    "namespace": "tigera-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-apiserver'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/compliance-server.json
+++ b/pkg/render/testutils/expected_policies/compliance-server.json
@@ -1,0 +1,91 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.compliance-server",
+    "namespace": "tigera-compliance"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'compliance-server'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            5443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
+          "selector": "k8s-app == 'tigera-manager'",
+          "ports": [
+            9443
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/compliance-server_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance-server_ocp.json
@@ -1,0 +1,102 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.compliance-server",
+    "namespace": "tigera-compliance"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'compliance-server'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            5443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
+          "selector": "k8s-app == 'tigera-manager'",
+          "ports": [
+            9443
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/compliance_managed.json
+++ b/pkg/render/testutils/expected_policies/compliance_managed.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.compliance-access",
+    "namespace": "tigera-compliance"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'compliance-benchmarker' || k8s-app == 'compliance-controller' || k8s-app == 'compliance-snapshotter' || k8s-app == 'compliance-reporter'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/compliance_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance_managed_ocp.json
@@ -1,0 +1,64 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.compliance-access",
+    "namespace": "tigera-compliance"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'compliance-benchmarker' || k8s-app == 'compliance-controller' || k8s-app == 'compliance-snapshotter' || k8s-app == 'compliance-reporter'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/compliance_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/compliance_unmanaged.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.compliance-access",
+    "namespace": "tigera-compliance"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'compliance-benchmarker' || k8s-app == 'compliance-controller' || k8s-app == 'compliance-snapshotter' || k8s-app == 'compliance-reporter'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/compliance_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance_unmanaged_ocp.json
@@ -1,0 +1,64 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.compliance-access",
+    "namespace": "tigera-compliance"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'compliance-benchmarker' || k8s-app == 'compliance-controller' || k8s-app == 'compliance-snapshotter' || k8s-app == 'compliance-reporter'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dex.json
+++ b/pkg/render/testutils/expected_policies/dex.json
@@ -1,0 +1,140 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.allow-tigera-dex",
+    "namespace": "tigera-dex"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-dex'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5556
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-server'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5556
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-packetcapture'",
+          "namespaceSelector": "name == 'tigera-packetcapture'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5556
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            389,
+            636
+          ],
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            389,
+            636
+          ],
+          "nets": [
+            "::/0"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dex_ocp.json
+++ b/pkg/render/testutils/expected_policies/dex_ocp.json
@@ -1,0 +1,151 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.allow-tigera-dex",
+    "namespace": "tigera-dex"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-dex'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5556
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-server'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5556
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-packetcapture'",
+          "namespaceSelector": "name == 'tigera-packetcapture'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5556
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            389,
+            636
+          ],
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            389,
+            636
+          ],
+          "nets": [
+            "::/0"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dns.json
+++ b/pkg/render/testutils/expected_policies/dns.json
@@ -1,0 +1,39 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.cluster-dns",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "tier": "allow-tigera",
+    "order": 1,
+    "ingress": [
+      {
+        "action": "Allow",
+        "source": {
+          "selector": "projectcalico.org/namespace in {'tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-prometheus','tigera-skraper','tigera-eck-operator','tigera-packetcapture','tigera-system','calico-system'}",
+          "namespaceSelector": "all()"
+        },
+        "destination": {}
+      },
+      {
+        "action": "Pass",
+        "source": {},
+        "destination": {}
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "source": {},
+        "destination": {}
+      }
+    ],
+    "selector": "k8s-app == 'kube-dns'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dns_ocp.json
+++ b/pkg/render/testutils/expected_policies/dns_ocp.json
@@ -1,0 +1,39 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.cluster-dns",
+    "namespace": "openshift-dns"
+  },
+  "spec": {
+    "tier":"allow-tigera",
+    "order":1,
+    "ingress":[
+      {
+        "action":"Allow",
+        "source":{
+          "selector":"projectcalico.org/namespace in {'tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-prometheus','tigera-skraper','tigera-eck-operator','tigera-packetcapture','tigera-system','calico-system'}",
+          "namespaceSelector":"all()"
+        },
+        "destination":{}
+      },
+      {
+        "action":"Pass",
+        "source":{},
+        "destination":{}
+      }
+    ],
+    "egress":[
+      {
+        "action":"Allow",
+        "source":{},
+        "destination":{}
+      }
+    ],
+    "selector":"dns.operator.openshift.io/daemonset-dns == 'default'",
+    "types":[
+      "Ingress",
+      "Egress"
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dpi_managed.json
+++ b/pkg/render/testutils/expected_policies/dpi_managed.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-dpi",
+    "namespace": "tigera-dpi"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-dpi'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "kubernetes"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "services": {
+            "namespace": "kube-system",
+            "name": "kube-dns"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "tigera-guardian",
+            "name": "tigera-guardian"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dpi_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/dpi_managed_ocp.json
@@ -1,0 +1,58 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-dpi",
+    "namespace": "tigera-dpi"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-dpi'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "kubernetes"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "openshift-dns"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "openshift-dns"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "tigera-guardian",
+            "name": "tigera-guardian"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dpi_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/dpi_unmanaged.json
@@ -1,0 +1,48 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-dpi",
+    "namespace": "tigera-dpi"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-dpi'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "kubernetes"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "services": {
+            "namespace": "kube-system",
+            "name": "kube-dns"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "tigera-elasticsearch",
+            "name": "tigera-secure-es-gateway-http"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/dpi_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/dpi_unmanaged_ocp.json
@@ -1,0 +1,58 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-dpi",
+    "namespace": "tigera-dpi"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-dpi'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "kubernetes"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "openshift-dns"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "default",
+            "name": "openshift-dns"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "namespace": "tigera-elasticsearch",
+            "name": "tigera-secure-es-gateway-http"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/elastic-curator.json
+++ b/pkg/render/testutils/expected_policies/elastic-curator.json
@@ -1,0 +1,43 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.allow-elastic-curator",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ],
+          "selector": "k8s-app == 'tigera-secure-es-gateway'"
+        },
+        "protocol": "TCP",
+        "source": {
+        }
+      }
+    ],
+    "order": 1,
+    "selector": "k8s-app == 'elastic-curator'",
+    "tier": "allow-tigera",
+    "types": [
+      "Ingress",
+      "Egress"
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/elastic-curator_ocp.json
+++ b/pkg/render/testutils/expected_policies/elastic-curator_ocp.json
@@ -1,0 +1,54 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.allow-elastic-curator",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ],
+          "selector": "k8s-app == 'tigera-secure-es-gateway'"
+        },
+        "protocol": "TCP",
+        "source": {
+        }
+      }
+    ],
+    "order": 1,
+    "selector": "k8s-app == 'elastic-curator'",
+    "tier": "allow-tigera",
+    "types": [
+      "Ingress",
+      "Egress"
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/elastic-operator.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.elastic-operator-access",
+    "namespace": "tigera-eck-operator"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'elastic-operator'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            9200
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
@@ -1,0 +1,64 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.elastic-operator-access",
+    "namespace": "tigera-eck-operator"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'elastic-operator'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            9200
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/elasticsearch-internal.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch-internal.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.elasticsearch-internal",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'"
+        },
+        "destination": {
+          "ports": [
+            9300
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "ports": [
+            9300
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/elasticsearch.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch.json
@@ -1,0 +1,115 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.elasticsearch-access",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure'",
+          "namespaceSelector": "name == 'tigera-kibana'"
+        },
+        "destination": {
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            9200
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            9200
+          ]
+        },
+        "protocol": "TCP"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
@@ -1,0 +1,126 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.elasticsearch-access",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure'",
+          "namespaceSelector": "name == 'tigera-kibana'"
+        },
+        "destination": {
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            9200
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            9200
+          ]
+        },
+        "protocol": "TCP"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/es-gateway.json
+++ b/pkg/render/testutils/expected_policies/es-gateway.json
@@ -1,0 +1,269 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.es-gateway-access",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-secure-es-gateway'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'eks-log-forwarder'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "job-name == 'intrusion-detection-es-job-installer'",
+          "namespaceSelector": "name == 'tigera-intrusion-detection'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-curator'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-benchmarker'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-controller'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-server'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-snapshotter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-reporter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'intrusion-detection-controller'",
+          "namespaceSelector": "name == 'tigera-intrusion-detection'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-dpi'",
+          "namespaceSelector": "name == 'tigera-dpi'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
+          "selector": "k8s-app == 'tigera-secure'",
+          "ports": [
+            5601
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/es-gateway_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-gateway_ocp.json
@@ -1,0 +1,280 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.es-gateway-access",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-secure-es-gateway'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'eks-log-forwarder'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "job-name == 'intrusion-detection-es-job-installer'",
+          "namespaceSelector": "name == 'tigera-intrusion-detection'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-curator'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-benchmarker'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-controller'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-server'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-snapshotter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-reporter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'intrusion-detection-controller'",
+          "namespaceSelector": "name == 'tigera-intrusion-detection'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-dpi'",
+          "namespaceSelector": "name == 'tigera-dpi'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ]
+        },
+        "protocol": "TCP"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
+          "selector": "k8s-app == 'tigera-secure'",
+          "ports": [
+            5601
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/es-kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/es-kubecontrollers.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.es-kube-controller-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'es-calico-kube-controllers'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
+          "ports": [
+            9443
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/es-kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-kubecontrollers_ocp.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.es-kube-controller-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'es-calico-kube-controllers'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
+          "ports": [
+            9443
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/es-metrics.json
+++ b/pkg/render/testutils/expected_policies/es-metrics.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.elasticsearch-metrics",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "tier": "allow-tigera",
+    "order": 1,
+    "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+    "serviceAccountSelector": "",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9081"
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            "5554"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/es-metrics_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-metrics_ocp.json
@@ -1,0 +1,70 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.elasticsearch-metrics",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "tier": "allow-tigera",
+    "order": 1,
+    "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+    "serviceAccountSelector": "",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9081"
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            "5554"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/fluentd_managed.json
+++ b/pkg/render/testutils/expected_policies/fluentd_managed.json
@@ -1,0 +1,50 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.allow-fluentd-node",
+    "namespace": "tigera-fluentd"
+  },
+  "spec": {
+    "tier": "allow-tigera",
+    "order": 1,
+    "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9081"
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "notPorts": [
+            8080
+          ]
+        }
+      },
+      {
+        "action": "Allow"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.allow-fluentd-node",
+    "namespace": "tigera-fluentd"
+  },
+  "spec": {
+    "tier": "allow-tigera",
+    "order": 1,
+    "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+    "serviceAccountSelector": "",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9081"
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "notPorts": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
@@ -1,0 +1,73 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.allow-fluentd-node",
+    "namespace": "tigera-fluentd"
+  },
+  "spec": {
+    "tier": "allow-tigera",
+    "order": 1,
+    "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+    "serviceAccountSelector": "",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9081"
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "notPorts": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
@@ -1,0 +1,80 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.intrusion-detection-controller",
+    "namespace": "tigera-intrusion-detection"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'intrusion-detection-controller'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Deny"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "169.254.0.0/16"
+          ]
+        }
+      },
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "fe80::/10"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
@@ -1,0 +1,91 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.intrusion-detection-controller",
+    "namespace": "tigera-intrusion-detection"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'intrusion-detection-controller'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Deny"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "169.254.0.0/16"
+          ]
+        }
+      },
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "fe80::/10"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged.json
@@ -1,0 +1,80 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.intrusion-detection-controller",
+    "namespace": "tigera-intrusion-detection"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'intrusion-detection-controller'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Deny"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "169.254.0.0/16"
+          ]
+        }
+      },
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "fe80::/10"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_unmanaged_ocp.json
@@ -1,0 +1,91 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.intrusion-detection-controller",
+    "namespace": "tigera-intrusion-detection"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'intrusion-detection-controller'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Deny"
+      }
+    ],
+    "egress": [
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "169.254.0.0/16"
+          ]
+        }
+      },
+      {
+        "action": "Deny",
+        "protocol": "TCP",
+        "destination": {
+          "nets": [
+            "fe80::/10"
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/intrusion-detection-elastic.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-elastic.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.intrusion-detection-elastic",
+    "namespace": "tigera-intrusion-detection"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "job-name == 'intrusion-detection-es-job-installer'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/intrusion-detection-elastic_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-elastic_ocp.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.intrusion-detection-elastic",
+    "namespace": "tigera-intrusion-detection"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "job-name == 'intrusion-detection-es-job-installer'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/kibana.json
+++ b/pkg/render/testutils/expected_policies/kibana.json
@@ -1,0 +1,123 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.kibana-access",
+    "namespace": "tigera-kibana"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-secure'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            5601
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            5601
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            5601
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5601
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ],
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+        },
+        "protocol": "TCP"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/kibana_ocp.json
+++ b/pkg/render/testutils/expected_policies/kibana_ocp.json
@@ -1,0 +1,134 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.kibana-access",
+    "namespace": "tigera-kibana"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-secure'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            5601
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            5601
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            5601
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5601
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            5554
+          ],
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+        },
+        "protocol": "TCP"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.kube-controller-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'calico-kube-controllers'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
+          "ports": [
+            9443
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.kube-controller-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'calico-kube-controllers'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.kube-controller-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'calico-kube-controllers'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.kube-controller-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'calico-kube-controllers'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
+          "ports": [
+            9443
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/manager.json
+++ b/pkg/render/testutils/expected_policies/manager.json
@@ -1,0 +1,141 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.manager-access",
+    "namespace": "tigera-manager"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-manager'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            9443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            9443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "ports": [
+            9449
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
+          "selector": "k8s-app == 'compliance-server'",
+          "ports": [
+            5443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'",
+          "selector": "k8s-app == 'tigera-packetcapture'",
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/manager_ocp.json
+++ b/pkg/render/testutils/expected_policies/manager_ocp.json
@@ -1,0 +1,152 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.manager-access",
+    "namespace": "tigera-manager"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-manager'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            9443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            9443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "ports": [
+            9449
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
+          "selector": "k8s-app == 'compliance-server'",
+          "ports": [
+            5443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'",
+          "selector": "k8s-app == 'tigera-packetcapture'",
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/packetcapture.json
+++ b/pkg/render/testutils/expected_policies/packetcapture.json
@@ -1,0 +1,69 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-packetcapture",
+    "namespace": "tigera-packetcapture"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-packetcapture'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/packetcapture_managed.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed.json
@@ -1,0 +1,58 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-packetcapture",
+    "namespace": "tigera-packetcapture"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-packetcapture'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "name == 'tigera-guardian'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
@@ -1,0 +1,69 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-packetcapture",
+    "namespace": "tigera-packetcapture"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-packetcapture'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-guardian'",
+          "namespaceSelector": "name == 'tigera-guardian'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/packetcapture_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_ocp.json
@@ -1,0 +1,80 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-packetcapture",
+    "namespace": "tigera-packetcapture"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-packetcapture'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/prometheus-api.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api.json
@@ -1,0 +1,52 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-prometheus-api",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-prometheus-api'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.tigera-prometheus-api",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'tigera-prometheus-api'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/prometheus-operator.json
+++ b/pkg/render/testutils/expected_policies/prometheus-operator.json
@@ -1,0 +1,42 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.prometheus-operator",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "operator == 'prometheus'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
@@ -1,0 +1,53 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.prometheus-operator",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "operator == 'prometheus'",
+    "types": [
+      "Egress"
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/prometheus.json
+++ b/pkg/render/testutils/expected_policies/prometheus.json
@@ -1,0 +1,94 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.prometheus",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9081,
+            9091
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9900
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9093
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/prometheus_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus_ocp.json
@@ -1,0 +1,105 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.prometheus",
+    "namespace": "tigera-prometheus"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9095
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'default'",
+          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
+          "ports": [
+            443,
+            6443,
+            12388
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9081,
+            9091
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "ports": [
+            9900
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
+          "ports": [
+            9093
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "selector": "k8s-app == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/policy.go
+++ b/pkg/render/testutils/policy.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	. "github.com/onsi/gomega"
+
+	"encoding/json"
+	"io"
+	"os"
+
+	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+)
+
+// AllowTigeraScenario represents valid render cases for allow-tigera policies. Render components should test that their
+// allow-tigera policies correctly adapt for each relevant potential case. Update if new scenarios arise.
+type AllowTigeraScenario struct {
+	ManagedCluster bool
+	Openshift      bool
+}
+
+func GetAllowTigeraPolicyFromResources(name types.NamespacedName, resources []client.Object) *v3.NetworkPolicy {
+	resource := rtest.GetResource(resources, name.Name, name.Namespace, "projectcalico.org", "v3", "NetworkPolicy")
+	if resource == nil {
+		return nil
+	} else {
+		return resource.(*v3.NetworkPolicy)
+	}
+}
+
+func GetExpectedPolicyFromFile(name string) *v3.NetworkPolicy {
+	jsonFile, err := os.Open(name)
+	Expect(err).ShouldNot(HaveOccurred())
+	defer jsonFile.Close()
+
+	byteValue, err := io.ReadAll(jsonFile)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	var policy v3.NetworkPolicy
+	err = json.Unmarshal(byteValue, &policy)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return &policy
+}
+
+// SelectPolicyByClusterTypeAndProvider simply selects a variant of a policy that varies depending on cluster and provider type.
+func SelectPolicyByClusterTypeAndProvider(scenario AllowTigeraScenario,
+	unmanagedNoProviderPolicy *v3.NetworkPolicy,
+	unmanagedOpenshiftPolicy *v3.NetworkPolicy,
+	managedNoProviderPolicy *v3.NetworkPolicy,
+	managedOpenshiftPolicy *v3.NetworkPolicy,
+) *v3.NetworkPolicy {
+	switch scenario {
+	case AllowTigeraScenario{ManagedCluster: false, Openshift: false}:
+		return unmanagedNoProviderPolicy
+	case AllowTigeraScenario{ManagedCluster: false, Openshift: true}:
+		return unmanagedOpenshiftPolicy
+	case AllowTigeraScenario{ManagedCluster: true, Openshift: false}:
+		return managedNoProviderPolicy
+	case AllowTigeraScenario{ManagedCluster: true, Openshift: true}:
+		return managedOpenshiftPolicy
+	default:
+		return nil
+	}
+}
+
+// SelectPolicyByProvider simply selects a variant of a policy that varies depending on provider type only.
+func SelectPolicyByProvider(scenario AllowTigeraScenario, noProviderPolicy *v3.NetworkPolicy, openshiftProviderPolicy *v3.NetworkPolicy) *v3.NetworkPolicy {
+	if scenario.Openshift {
+		return openshiftProviderPolicy
+	} else {
+		return noProviderPolicy
+	}
+}

--- a/pkg/render/tiers/tiers.go
+++ b/pkg/render/tiers/tiers.go
@@ -1,0 +1,333 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiers
+
+import (
+	"strings"
+
+	"github.com/tigera/operator/pkg/render/kubecontrollers"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	APIServerPolicyName      = networkpolicy.TigeraComponentPolicyPrefix + "cnx-apiserver-access"
+	ClusterDNSPolicyName     = networkpolicy.TigeraComponentPolicyPrefix + "cluster-dns"
+	KubeControllerPolicyName = networkpolicy.TigeraComponentPolicyPrefix + "kube-controller-access"
+	PacketCapturePolicyName  = networkpolicy.TigeraComponentPolicyPrefix + render.PacketCaptureName
+)
+
+var DNSIngressNamespaceSelector = createDNSIngressNamespaceSelector(
+	render.GuardianNamespace,
+	render.ComplianceNamespace,
+	render.DexNamespace,
+	render.ElasticsearchNamespace,
+	render.LogCollectorNamespace,
+	render.IntrusionDetectionNamespace,
+	render.KibanaNamespace,
+	render.ManagerNamespace,
+	common.TigeraPrometheusNamespace,
+	"tigera-skraper",
+	render.ECKOperatorNamespace,
+	render.PacketCaptureNamespace,
+	rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise),
+	common.CalicoNamespace,
+)
+
+var defaultTierOrder = 100.0
+
+func Tiers(cfg *Config) render.Component {
+	return tiersComponent{cfg: cfg}
+}
+
+type Config struct {
+	Openshift      bool
+	ManagedCluster bool
+}
+
+type tiersComponent struct {
+	cfg *Config
+}
+
+func (t tiersComponent) ResolveImages(is *operatorv1.ImageSet) error {
+	return nil
+}
+
+func (t tiersComponent) Objects() ([]client.Object, []client.Object) {
+	objsToCreate := []client.Object{
+		t.allowTigeraTier(),
+		t.allowTigeraClusterDNSPolicy(),
+		t.allowTigeraAPIServerPolicy(),
+		t.allowTigeraKubeControllersPolicy(),
+		t.allowTigeraPacketCapturePolicy(),
+	}
+
+	// Delete equivalent policies under different namespaced names previously managed outside the operator.
+	objsToDelete := []client.Object{}
+	if !t.cfg.Openshift {
+		objsToDelete = append(objsToDelete, &v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.kube-dns", Namespace: "kube-system"}})
+		objsToDelete = append(objsToDelete, &v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.kube-dns-egress", Namespace: "kube-system"}})
+	}
+
+	return objsToCreate, objsToDelete
+}
+
+func (t tiersComponent) Ready() bool {
+	return true
+}
+
+func (t tiersComponent) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeAny
+}
+
+func (t tiersComponent) allowTigeraTier() *v3.Tier {
+	return &v3.Tier{
+		TypeMeta: metav1.TypeMeta{Kind: "Tier", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: networkpolicy.TigeraComponentTierName,
+			Labels: map[string]string{
+				"projectcalico.org/system-tier": "true",
+			},
+		},
+		Spec: v3.TierSpec{
+			Order: &defaultTierOrder,
+		},
+	}
+}
+
+func (t tiersComponent) allowTigeraClusterDNSPolicy() *v3.NetworkPolicy {
+	var dnsPolicySelector string
+	var dnsPolicyNamespace string
+	if t.cfg.Openshift {
+		dnsPolicySelector = "dns.operator.openshift.io/daemonset-dns == 'default'"
+		dnsPolicyNamespace = "openshift-dns"
+	} else {
+		dnsPolicySelector = "k8s-app == 'kube-dns'"
+		dnsPolicyNamespace = "kube-system"
+	}
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ClusterDNSPolicyName,
+			Namespace: dnsPolicyNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: dnsPolicySelector,
+			Ingress: []v3.Rule{
+				{
+					Action: v3.Allow,
+					Source: v3.EntityRule{
+						NamespaceSelector: "all()",
+						Selector:          DNSIngressNamespaceSelector,
+					},
+				},
+				{
+					Action: v3.Pass,
+				},
+			},
+			Egress: []v3.Rule{
+				{
+					Action: v3.Allow,
+				},
+			},
+			Types: []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+		},
+	}
+}
+
+// Allow the Kubernetes API Server access to Calico Enterprise API Server.
+// Reconciled here rather than the API Server controller since the creation of v3 NetworkPolicy depends on the API Server.
+func (t *tiersComponent) allowTigeraAPIServerPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, t.cfg.Openshift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+		{
+			// Pass to subsequent tiers for further enforcement
+			Action: v3.Pass,
+		},
+	}...)
+
+	// The ports Calico Enterprise API Server and Calico Enterprise Query Server are configured to listen on.
+	ingressPorts := networkpolicy.Ports(443, render.ApiServerPort, render.QueryServerPort, 10443)
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      APIServerPolicyName,
+			Namespace: rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise),
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector("tigera-apiserver"),
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					// This policy allows Calico Enterprise API Server access from anywhere.
+					Source: v3.EntityRule{
+						Nets: []string{"0.0.0.0/0"},
+					},
+					Destination: v3.EntityRule{
+						Ports: ingressPorts,
+					},
+				},
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Source: v3.EntityRule{
+						Nets: []string{"::/0"},
+					},
+					Destination: v3.EntityRule{
+						Ports: ingressPorts,
+					},
+				},
+			},
+			Egress: egressRules,
+		},
+	}
+}
+
+// Reconciled here rather than the core controller since the creation of v3 NetworkPolicy depends on the API Server, and
+// the core controller is a prerequisite of the API server controller.
+func (t *tiersComponent) allowTigeraKubeControllersPolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, t.cfg.Openshift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
+				Ports: networkpolicy.Ports(443, 6443, 12388),
+			},
+		},
+	}...)
+
+	if t.cfg.ManagedCluster {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		})
+	} else {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.ManagerEntityRule,
+		})
+	}
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeControllerPolicyName,
+			Namespace: common.CalicoNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(kubecontrollers.KubeController),
+			Types:    []v3.PolicyType{v3.PolicyTypeEgress},
+			Egress:   egressRules,
+		},
+	}
+}
+
+// Reconciled here rather than the API Server controller since the creation of v3 NetworkPolicy depends on the API Server.
+func (t *tiersComponent) allowTigeraPacketCapturePolicy() *v3.NetworkPolicy {
+	egressRules := []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+	}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, t.cfg.Openshift)
+	if !t.cfg.ManagedCluster {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.DexEntityRule,
+		})
+	}
+
+	ingressRules := []v3.Rule{}
+	if t.cfg.ManagedCluster {
+		ingressRules = append(ingressRules, v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Source:   render.GuardianSourceEntityRule,
+			Destination: v3.EntityRule{
+				Ports: networkpolicy.Ports(render.PacketCapturePort),
+			},
+		})
+	} else {
+		ingressRules = append(ingressRules, v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Source:   render.ManagerSourceEntityRule,
+			Destination: v3.EntityRule{
+				Ports: networkpolicy.Ports(render.PacketCapturePort),
+			},
+		})
+	}
+
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PacketCapturePolicyName,
+			Namespace: render.PacketCaptureNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(render.PacketCaptureName),
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress:  ingressRules,
+			Egress:   egressRules,
+		},
+	}
+}
+
+func createDNSIngressNamespaceSelector(namespaces ...string) string {
+	var builder strings.Builder
+	builder.WriteString("projectcalico.org/namespace in {")
+	for idx, namespace := range namespaces {
+		builder.WriteByte('\'')
+		builder.WriteString(namespace)
+		builder.WriteByte('\'')
+		if idx != len(namespaces)-1 {
+			builder.WriteByte(',')
+		}
+	}
+	builder.WriteByte('}')
+	return builder.String()
+}

--- a/pkg/render/tiers/tiers_suite_test.go
+++ b/pkg/render/tiers/tiers_suite_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tiers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestRender(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/monitor_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/render/tiers Suite", []Reporter{junitReporter})
+}

--- a/pkg/render/tiers/tiers_test.go
+++ b/pkg/render/tiers/tiers_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/testutils"
+	"github.com/tigera/operator/pkg/render/tiers"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Tiers rendering tests", func() {
+	var cfg *tiers.Config
+
+	apiServerPolicy := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/apiserver.json")
+	apiServerPolicyForOCP := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/apiserver_ocp.json")
+	clusterDNSPolicy := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/dns.json")
+	clusterDNSPolicyForOCP := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/dns_ocp.json")
+	kcPolicyForUnmanaged := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/kubecontrollers.json")
+	kcPolicyForUnmanagedOCP := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/kubecontrollers_ocp.json")
+	kcPolicyForManaged := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/kubecontrollers_managed.json")
+	kcPolicyForManagedOCP := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/kubecontrollers_managed_ocp.json")
+	pcPolicyForUnmanaged := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/packetcapture.json")
+	pcPolicyForUnmanagedOCP := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/packetcapture_ocp.json")
+	pcPolicyForManaged := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/packetcapture_managed.json")
+	pcPolicyForManagedOCP := testutils.GetExpectedPolicyFromFile("../testutils/expected_policies/packetcapture_managed_ocp.json")
+
+	BeforeEach(func() {
+		// Establish default config for test cases to override.
+		cfg = &tiers.Config{
+			Openshift:      false,
+			ManagedCluster: false,
+		}
+	})
+
+	Context("allow-tigera rendering", func() {
+		policyNames := []types.NamespacedName{
+			{Name: "allow-tigera.cnx-apiserver-access", Namespace: "tigera-system"},
+			{Name: "allow-tigera.cluster-dns", Namespace: "kube-system"},
+			{Name: "allow-tigera.cluster-dns", Namespace: "openshift-dns"},
+			{Name: "allow-tigera.kube-controller-access", Namespace: "calico-system"},
+			{Name: "allow-tigera.tigera-packetcapture", Namespace: "tigera-packetcapture"},
+		}
+
+		getExpectedPolicy := func(name types.NamespacedName, scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+			if name.Name == "allow-tigera.cnx-apiserver-access" {
+				return testutils.SelectPolicyByProvider(scenario, apiServerPolicy, apiServerPolicyForOCP)
+			} else if name.Name == "allow-tigera.kube-controller-access" {
+				return testutils.SelectPolicyByClusterTypeAndProvider(
+					scenario,
+					kcPolicyForUnmanaged,
+					kcPolicyForUnmanagedOCP,
+					kcPolicyForManaged,
+					kcPolicyForManagedOCP,
+				)
+			} else if name.Name == "allow-tigera.tigera-packetcapture" {
+				return testutils.SelectPolicyByClusterTypeAndProvider(
+					scenario,
+					pcPolicyForUnmanaged,
+					pcPolicyForUnmanagedOCP,
+					pcPolicyForManaged,
+					pcPolicyForManagedOCP,
+				)
+			} else if name.Name == "allow-tigera.cluster-dns" &&
+				((scenario.Openshift && name.Namespace == "openshift-dns") || (!scenario.Openshift && name.Namespace == "kube-system")) {
+				return testutils.SelectPolicyByProvider(scenario, clusterDNSPolicy, clusterDNSPolicyForOCP)
+			}
+
+			return nil
+		}
+
+		DescribeTable("should render allow-tigera policy",
+			func(scenario testutils.AllowTigeraScenario) {
+				cfg.Openshift = scenario.Openshift
+				cfg.ManagedCluster = scenario.ManagedCluster
+				component := tiers.Tiers(cfg)
+				resourcesToCreate, resourcesToDelete := component.Objects()
+
+				// Validate tier render
+				allowTigera := rtest.GetResource(resourcesToCreate, "allow-tigera", "", "projectcalico.org", "v3", "Tier").(*v3.Tier)
+				Expect(*allowTigera.Spec.Order).To(Equal(100.0))
+
+				// Validate created policy render
+				for _, policyName := range policyNames {
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resourcesToCreate)
+					expectedPolicy := getExpectedPolicy(policyName, scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				}
+
+				// Validate deleted policy render
+				if !scenario.Openshift {
+					Expect(resourcesToDelete).To(HaveLen(2))
+					Expect(resourcesToDelete[0].GetName()).To(Equal("allow-tigera.kube-dns"))
+					Expect(resourcesToDelete[0].GetNamespace()).To(Equal("kube-system"))
+					Expect(resourcesToDelete[1].GetName()).To(Equal("allow-tigera.kube-dns-egress"))
+					Expect(resourcesToDelete[1].GetNamespace()).To(Equal("kube-system"))
+				} else {
+					Expect(resourcesToDelete).To(BeEmpty())
+				}
+			},
+			Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+			Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
+			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
+		)
+	})
+})


### PR DESCRIPTION
## Description
This PR brings reconciliation of the allow-tigera tier into the operator, in line with the design spec discussed internally.

### Reviewer notes
* Please review commit-by-commit. In retrospect, I would have executed on this with multiple PRs in mind instead of one. I've tried to split the work by commit to introduce the approach gradually, but I'm happy to adjust/split the PR in whatever way makes the review/release process easiest.
* The PR aims to mirror the existing policies as closely as possible. In some cases, there are slight changes that make policies more uniform across components. In order to make these changes easily reviewable, I've created a [dummy PR here](https://github.com/pasanw/operator/pull/1).
* There will be some self-review comments to highlight some areas of the code that I'd like to discuss with you


### Implementation notes
* Policies, wherever possible, are rendered in the component they ensure access to.
* Policies are reconciled using the V3 API. This means that controllers must wait for the V3 API to be available, in addition to waiting for the allow-tigera Tier to be created.
* A Tiers controller is established, which creates the allow-tigera Tier resource, and houses core and apiserver policies to decouple their policies from the creation of the API server.
* Render packages export EntityRules that standardize how components are referenced for egress and ingress rules.
* Tests for render packages verify that policies correctly adapt for cluster and provider type. Expected policies are stored as JSON files.
* In addition to new render and controller tests, manual validation of rendered policy was performed for a standalone K8S cluster

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.