### PR TITLE
[release-v1.27] Auto pick #1976: Add kibana_login permissions to network admin cluster role

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1503,7 +1503,7 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "elasticsearch_superuser",
+				"flows", "audit*", "l7", "events", "dns", "kibana_login", "elasticsearch_superuser",
 			},
 			Verbs: []string{"get"},
 		})

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1115,7 +1115,7 @@ var (
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "elasticsearch_superuser",
+				"flows", "audit*", "l7", "events", "dns", "kibana_login", "elasticsearch_superuser",
 			},
 			Verbs: []string{"get"},
 		},


### PR DESCRIPTION
Cherry pick of #1976 on release-v1.27.

#1976: Add kibana_login permissions to network admin cluster role

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.