### PR TITLE
Set apiserver startup arg --operatorNamespace to active operator ns

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/ptr"
@@ -894,7 +895,9 @@ func (c *apiServerComponent) startUpArgs() []string {
 		args = append(args,
 			"--enable-managed-clusters-create-api=true",
 			fmt.Sprintf("--set-managed-clusters-ca-cert=%s", c.cfg.TunnelCASecret.VolumeMountCertificateFilePath()),
-			fmt.Sprintf("--set-managed-clusters-ca-key=%s", c.cfg.TunnelCASecret.VolumeMountKeyFilePath()))
+			fmt.Sprintf("--set-managed-clusters-ca-key=%s", c.cfg.TunnelCASecret.VolumeMountKeyFilePath()),
+			fmt.Sprintf("--operatorNamespace=%s", common.OperatorNamespace()),
+		)
 		if c.cfg.ManagementCluster.Spec.Address != "" {
 			args = append(args, fmt.Sprintf("--managementClusterAddr=%s", c.cfg.ManagementCluster.Spec.Address))
 		}

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -683,6 +683,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			"--set-managed-clusters-ca-cert=/tigera-management-cluster-connection/tls.crt",
 			"--set-managed-clusters-ca-key=/tigera-management-cluster-connection/tls.key",
 			"--managementClusterAddr=example.com:1234",
+			fmt.Sprintf("--operatorNamespace=%s", common.OperatorNamespace()),
 		}
 		Expect((dep.(*appsv1.Deployment)).Spec.Template.Spec.Containers[0].Args).To(ConsistOf(expectedArgs))
 	})
@@ -751,6 +752,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			"--set-managed-clusters-ca-cert=/tigera-management-cluster-connection/tls.crt",
 			"--set-managed-clusters-ca-key=/tigera-management-cluster-connection/tls.key",
 			"--managementClusterAddr=example.com:1234",
+			fmt.Sprintf("--operatorNamespace=%s", common.OperatorNamespace()),
 		}
 		Expect((dep.(*appsv1.Deployment)).Spec.Template.Spec.Containers[0].Args).To(ConsistOf(expectedArgs))
 	})


### PR DESCRIPTION

## Description
The apiserver will no longer hardcode the operator namespace it uses.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
