### PR TITLE
adjust FlexVolumePath when RKE2 provider is set

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,7 +80,7 @@ type InstallationSpec struct {
 	// If the specified value is not empty, the Operator will still attempt auto-detection, but
 	// will additionally compare the auto-detected value to the specified value to confirm they match.
 	// +optional
-	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;RKE2
+	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;RKE2;
 	KubernetesProvider Provider `json:"kubernetesProvider,omitempty"`
 
 	// CNI specifies the CNI that will be used by this installation.
@@ -199,7 +199,7 @@ type ComponentResource struct {
 }
 
 // Provider represents a particular provider or flavor of Kubernetes. Valid options
-// are: EKS, GKE, AKS, OpenShift, DockerEnterprise.
+// are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise.
 type Provider string
 
 var (

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -80,7 +80,7 @@ type InstallationSpec struct {
 	// If the specified value is not empty, the Operator will still attempt auto-detection, but
 	// will additionally compare the auto-detected value to the specified value to confirm they match.
 	// +optional
-	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;
+	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;RKE2
 	KubernetesProvider Provider `json:"kubernetesProvider,omitempty"`
 
 	// CNI specifies the CNI that will be used by this installation.
@@ -207,6 +207,7 @@ var (
 	ProviderEKS       Provider = "EKS"
 	ProviderGKE       Provider = "GKE"
 	ProviderAKS       Provider = "AKS"
+	ProviderRKE2      Provider = "RKE2"
 	ProviderOpenShift Provider = "OpenShift"
 	ProviderDockerEE  Provider = "DockerEnterprise"
 )

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -681,6 +681,8 @@ func fillDefaults(instance *operator.Installation) error {
 			instance.Spec.FlexVolumePath = "/home/kubernetes/flexvolume/"
 		} else if instance.Spec.KubernetesProvider == operator.ProviderAKS {
 			instance.Spec.FlexVolumePath = "/etc/kubernetes/volumeplugins/"
+		} else if instance.Spec.KubernetesProvider == operator.ProviderRKE2 {
+			instance.Spec.FlexVolumePath = "/var/lib/kubelet/volumeplugins/"
 		} else {
 			instance.Spec.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		}

--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -112,6 +112,13 @@ func AutoDiscoverProvider(ctx context.Context, clientset kubernetes.Interface) (
 		return operatorv1.ProviderEKS, nil
 	}
 
+	// Attempt to detect RKE Version 2, which also cannot be done via API groups.
+	if rke2, err := isRKE2(ctx, clientset); err != nil {
+		return operatorv1.ProviderNone, fmt.Errorf("Failed to check if RKE2 is the provider: %s", err)
+	} else if rke2 {
+		return operatorv1.ProviderRKE2, nil
+	}
+
 	// Couldn't detect any specific platform.
 	return operatorv1.ProviderNone, nil
 }
@@ -159,6 +166,22 @@ func isDockerEE(ctx context.Context, c kubernetes.Interface) (bool, error) {
 // we use for other platforms in autodetectFromGroup.
 func isEKS(ctx context.Context, c kubernetes.Interface) (bool, error) {
 	cm, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "eks-certificates-controller", metav1.GetOptions{})
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return (cm != nil), nil
+}
+
+// isRKE2 returns true if running on an RKE2 cluster, and false otherwise.
+// While the presence of Rancher can be determined based on API Groups, it's important to
+// differentiate between versions, which requires another approach. In this case,
+// the presence of an "rke2" configmap in kube-system namespace is used.
+func isRKE2(ctx context.Context, c kubernetes.Interface) (bool, error) {
+	cm, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "rke2", metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return false, nil

--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,5 +83,17 @@ var _ = Describe("provider discovery", func() {
 		p, e := AutoDiscoverProvider(context.Background(), c)
 		Expect(e).To(BeNil())
 		Expect(p).To(Equal(operatorv1.ProviderEKS))
+	})
+
+	It("should detect RKE2 based on presence of kube-system/rke2 ConfigMap", func() {
+		c := fake.NewSimpleClientset(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rke2",
+				Namespace: "kube-system",
+			},
+		})
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderRKE2))
 	})
 })

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -459,6 +459,7 @@ spec:
                 - AKS
                 - OpenShift
                 - DockerEnterprise
+                - RKE2
                 type: string
               nodeMetricsPort:
                 description: NodeMetricsPort specifies which port calico/node serves
@@ -1209,6 +1210,7 @@ spec:
                     - AKS
                     - OpenShift
                     - DockerEnterprise
+                    - RKE2
                     type: string
                   nodeMetricsPort:
                     description: NodeMetricsPort specifies which port calico/node


### PR DESCRIPTION
## Description

Adds RKE2 as a kubernetes provider (granted, this is not the full story of where the cluster is provisioned) in order to adjust FlexVolumePath. Required in order for EG's and ALP to function.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
