### PR TITLE
Update windows fluentd bash.exe path

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ func (c *fluentdComponent) fluentdNodeName() string {
 func (c *fluentdComponent) readinessCmd() []string {
 	if c.cfg.OSType == rmeta.OSTypeWindows {
 		// On Windows, we rely on bash via msys2 installed by the fluentd base image.
-		return []string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/readiness.sh`}
+		return []string{`c:\ruby\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/readiness.sh`}
 	}
 	return []string{"sh", "-c", "/bin/readiness.sh"}
 }
@@ -198,7 +198,7 @@ func (c *fluentdComponent) readinessCmd() []string {
 func (c *fluentdComponent) livenessCmd() []string {
 	if c.cfg.OSType == rmeta.OSTypeWindows {
 		// On Windows, we rely on bash via msys2 installed by the fluentd base image.
-		return []string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}
+		return []string{`c:\ruby\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}
 	}
 	return []string{"sh", "-c", "/bin/liveness.sh"}
 }

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -239,17 +239,17 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 		container := ds.Spec.Template.Spec.Containers[0]
 
-		Expect(container.ReadinessProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/readiness.sh`}))
+		Expect(container.ReadinessProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/readiness.sh`}))
 		Expect(container.ReadinessProbe.TimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(container.ReadinessProbe.PeriodSeconds).To(BeEquivalentTo(10))
 		Expect(container.ReadinessProbe.FailureThreshold).To(BeEquivalentTo(3))
 
-		Expect(container.LivenessProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}))
+		Expect(container.LivenessProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}))
 		Expect(container.LivenessProbe.TimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(container.LivenessProbe.PeriodSeconds).To(BeEquivalentTo(10))
 		Expect(container.LivenessProbe.FailureThreshold).To(BeEquivalentTo(3))
 
-		Expect(container.StartupProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby26\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}))
+		Expect(container.StartupProbe.Exec.Command).To(ConsistOf([]string{`c:\ruby\msys64\usr\bin\bash.exe`, `-lc`, `/c/bin/liveness.sh`}))
 		Expect(container.StartupProbe.TimeoutSeconds).To(BeEquivalentTo(20))
 		Expect(container.StartupProbe.PeriodSeconds).To(BeEquivalentTo(20))
 		Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(10))


### PR DESCRIPTION
## Description

We've bumped the base fluentd version which uses ruby 2.7, meaning the
base path for the ruby install is c:\ruby27

In the fluentd build we will now add a symlink to c:\ruby27 from c:\ruby
This commit updates the path of bash.exe to point to that symlinked
path.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
