### PR TITLE
Tolerate IP6_AUTODETECTION_METHOD none when IP6 is none

### DIFF
--- a/pkg/controller/migration/convert/network.go
+++ b/pkg/controller/migration/convert/network.go
@@ -138,6 +138,11 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 			if err := c.node.assertEnv(ctx, c.client, containerCalicoNode, "FELIX_IPV6SUPPORT", "false"); err != nil {
 				return err
 			}
+			// If IP6=none then if IP6_AUTODETECTION_METHOD is set it must be none. This is not a valid value
+			// for the env var but Kops sets it.
+			if err := c.node.assertEnv(ctx, c.client, containerCalicoNode, "IP6_AUTODETECTION_METHOD", "none"); err != nil {
+				return err
+			}
 		} else if *ip6 == "autodetect" {
 			if err := handleIPv6AutoDetectionMethod(c, install); err != nil {
 				return err

--- a/pkg/controller/migration/convert/network_test.go
+++ b/pkg/controller/migration/convert/network_test.go
@@ -195,7 +195,35 @@ var _ = Describe("Convert network tests", func() {
 					Value: "false",
 				},
 			)
-			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(emptyNodeSpec(), emptyKubeControllerSpec(), v4pool, emptyFelixConfig()).Build()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ds, emptyKubeControllerSpec(), v4pool, emptyFelixConfig()).Build()
+			cfg, err := Convert(ctx, c)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg).ToNot(BeNil())
+			Expect(cfg.Spec.CNI.Type).To(Equal(operatorv1.PluginCalico))
+			Expect(cfg.Spec.CNI.IPAM.Type).To(Equal(operatorv1.IPAMPluginCalico))
+			Expect(*cfg.Spec.CalicoNetwork.BGP).To(Equal(operatorv1.BGPEnabled))
+
+			expectedV4pool, err := convertPool(*v4pool)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Spec.CalicoNetwork.IPPools).To(ContainElements(expectedV4pool))
+		})
+		It("migrate default with IPv6 and Autodetection method explicitly disabled", func() {
+			ds := emptyNodeSpec()
+			ds.Spec.Template.Spec.Containers[0].Env = append(ds.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{
+					Name:  "IP6",
+					Value: "none",
+				},
+				corev1.EnvVar{
+					Name:  "IP6_AUTODETECTION_METHOD",
+					Value: "none",
+				},
+				corev1.EnvVar{
+					Name:  "FELIX_IPV6SUPPORT",
+					Value: "false",
+				},
+			)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ds, emptyKubeControllerSpec(), v4pool, emptyFelixConfig()).Build()
 			cfg, err := Convert(ctx, c)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg).ToNot(BeNil())


### PR DESCRIPTION
Even though IP6_AUTODETECTION_METHOD = none is not valid, kops sets
it when IP6 is set to none also.
https://github.com/kubernetes/kops/blob/v1.23.2/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template#L4393

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
