### PR TITLE
[release v1.25] Cherry pick: Add mount-cgroup init container to node ds

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -857,7 +857,7 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 			// Volume for the bpffs itself, used by the main node container.
 			corev1.Volume{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
 			// Volume used by mount-cgroupv2 init container to access root cgroup name space of node.
-			corev1.Volume{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
+			corev1.Volume{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}},
 		)
 	}
 
@@ -1011,8 +1011,9 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 			MountPropagation: &bidirectional,
 		},
 		{
-			MountPath: "/node-proc",
-			Name:      "proc",
+			MountPath: "/initproc",
+			Name:      "init-proc",
+			ReadOnly:  true,
 		},
 	}
 

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -706,6 +706,7 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 
 	if c.bpfDataplaneEnabled() {
 		initContainers = append(initContainers, c.bpffsInitContainer())
+		initContainers = append(initContainers, c.cgroupv2InitContainer())
 	}
 
 	if c.runAsNonPrivileged() {
@@ -856,6 +857,8 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 			corev1.Volume{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
 			// Volume for the bpffs itself, used by the main node container.
 			corev1.Volume{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
+			// Volume used by mount-cgroupv2 init container to access root cgroup name space of node.
+			corev1.Volume{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
 		)
 	}
 
@@ -1018,6 +1021,27 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 			Privileged: ptr.BoolToPtr(true),
 		},
 		Command: []string{"calico-node", "-init"},
+	}
+}
+
+// cgroupv2InitContainer creates an init container that enters the cgroup and mount namespace of the process
+// with PID 1 running on a host to allow felix running in calico-node access the root of cgroup namespace.
+// This is needed by felix to attach CTLB programs and implement k8s services correctly.
+func (c *nodeComponent) cgroupv2InitContainer() corev1.Container {
+	cgroupv2VolumeMounts := []corev1.VolumeMount{
+		{MountPath: "/node-proc", Name: "proc"},
+	}
+
+	return corev1.Container{
+		Name:         "mount-cgroupv2",
+		Image:        c.nodeImage,
+		VolumeMounts: cgroupv2VolumeMounts,
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: ptr.BoolToPtr(true),
+		},
+		Command: []string{"nsenter",
+			"--cgroup=/node-proc/1/ns/cgroup", "--mount=/node-proc/1/ns/mnt",
+			"mount", "-t", "cgroup2", "none", "/run/calico/cgroup"},
 	}
 }
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -531,7 +531,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "cni-log-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log/calico/cni"}}},
 			{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
 			{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
-			{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
+			{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}},
 			{Name: "policysync", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/nodeagent", Type: &dirOrCreate}}},
 			{
 				Name: "typha-ca",

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -427,7 +427,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
 
 		// Validate correct number of init containers.
-		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(4))
+		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(3))
 
 		// CNI container uses image override.
 		Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
@@ -440,14 +440,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(mountBpffs.Image).To(Equal(calicoNodeImage))
 		Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init"}))
 
-		// Verify the mount-cgroupv2 image and command.
-		mountCgroupv2 := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-cgroupv2")
-		Expect(mountCgroupv2.Image).To(Equal(calicoNodeImage))
-		Expect(mountCgroupv2.Command).To(Equal([]string{"nsenter", "--cgroup=/node-proc/1/ns/cgroup",
-			"--mount=/node-proc/1/ns/mnt", "mount", "-t", "cgroup2", "none", "/run/calico/cgroup"}))
-
 		optional := true
-
 		// Verify env
 		expectedNodeEnv := []corev1.EnvVar{
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -427,7 +427,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
 
 		// Validate correct number of init containers.
-		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(3))
+		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(4))
 
 		// CNI container uses image override.
 		Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
@@ -440,7 +440,14 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(mountBpffs.Image).To(Equal(calicoNodeImage))
 		Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init"}))
 
+		// Verify the mount-cgroupv2 image and command.
+		mountCgroupv2 := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-cgroupv2")
+		Expect(mountCgroupv2.Image).To(Equal(calicoNodeImage))
+		Expect(mountCgroupv2.Command).To(Equal([]string{"nsenter", "--cgroup=/node-proc/1/ns/cgroup",
+			"--mount=/node-proc/1/ns/mnt", "mount", "-t", "cgroup2", "none", "/run/calico/cgroup"}))
+
 		optional := true
+
 		// Verify env
 		expectedNodeEnv := []corev1.EnvVar{
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -531,6 +538,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "cni-log-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log/calico/cni"}}},
 			{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
 			{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
+			{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
 			{Name: "policysync", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/nodeagent", Type: &dirOrCreate}}},
 			{
 				Name: "typha-ca",


### PR DESCRIPTION
## Description
Cherry-pick PR https://github.com/tigera/operator/pull/1957 to release v.1.25

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
