### PR TITLE
[release v1.26] Cherry pick: Add mount-cgroup init container to node ds

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -824,7 +824,7 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 			// Volume for the bpffs itself, used by the main node container.
 			corev1.Volume{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
 			// Volume used by mount-cgroupv2 init container to access root cgroup name space of node.
-			corev1.Volume{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
+			corev1.Volume{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}},
 		)
 	}
 
@@ -968,8 +968,9 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 			MountPropagation: &bidirectional,
 		},
 		{
-			MountPath: "/node-proc",
-			Name:      "proc",
+			MountPath: "/initproc",
+			Name:      "init-proc",
+			ReadOnly:  true,
 		},
 	}
 

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -824,7 +824,7 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 			// Volume for the bpffs itself, used by the main node container.
 			corev1.Volume{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
 			// Volume used by mount-cgroupv2 init container to access root cgroup name space of node.
-			corev1.Volume{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}},
+			corev1.Volume{Name: "nodeproc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
 		)
 	}
 
@@ -968,8 +968,15 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 			MountPropagation: &bidirectional,
 		},
 		{
-			MountPath: "/initproc",
-			Name:      "init-proc",
+			MountPath: "/var/run/calico",
+			Name:      "var-run-calico",
+			// Bidirectional is required to ensure that the new mount we make at /var/run/calico/cgroup propagates to the host
+			// so that it outlives the init container.
+			MountPropagation: &bidirectional,
+		},
+		{
+			MountPath: "/nodeproc",
+			Name:      "nodeproc",
 			ReadOnly:  true,
 		},
 	}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -685,7 +685,6 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 
 	if c.bpfDataplaneEnabled() {
 		initContainers = append(initContainers, c.bpffsInitContainer())
-		initContainers = append(initContainers, c.cgroupv2InitContainer())
 	}
 
 	if c.runAsNonPrivileged() {
@@ -968,6 +967,10 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 			// so that it outlives the init container.
 			MountPropagation: &bidirectional,
 		},
+		{
+			MountPath: "/node-proc",
+			Name:      "proc",
+		},
 	}
 
 	return corev1.Container{
@@ -978,27 +981,6 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 			Privileged: ptr.BoolToPtr(true),
 		},
 		Command: []string{CalicoNodeObjectName, "-init"},
-	}
-}
-
-// cgroupv2InitContainer creates an init container that enters the cgroup and mount namespace of the process
-// with PID 1 running on a host to allow felix running in calico-node access the root of cgroup namespace.
-// This is needed by felix to attach CTLB programs and implement k8s services correctly.
-func (c *nodeComponent) cgroupv2InitContainer() corev1.Container {
-	cgroupv2VolumeMounts := []corev1.VolumeMount{
-		{MountPath: "/node-proc", Name: "proc"},
-	}
-
-	return corev1.Container{
-		Name:         "mount-cgroupv2",
-		Image:        c.nodeImage,
-		VolumeMounts: cgroupv2VolumeMounts,
-		SecurityContext: &corev1.SecurityContext{
-			Privileged: ptr.BoolToPtr(true),
-		},
-		Command: []string{"nsenter",
-			"--cgroup=/node-proc/1/ns/cgroup", "--mount=/node-proc/1/ns/mnt",
-			"mount", "-t", "cgroup2", "none", "/run/calico/cgroup"},
 	}
 }
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -403,7 +403,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
 
 		// Validate correct number of init containers.
-		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(4))
+		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(3))
 
 		// CNI container uses image override.
 		Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
@@ -415,12 +415,6 @@ var _ = Describe("Node rendering tests", func() {
 		mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
 		Expect(mountBpffs.Image).To(Equal(calicoNodeImage))
 		Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init"}))
-
-		// Verify the mount-cgroupv2 image and command.
-		mountCgroupv2 := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-cgroupv2")
-		Expect(mountCgroupv2.Image).To(Equal(calicoNodeImage))
-		Expect(mountCgroupv2.Command).To(Equal([]string{"nsenter", "--cgroup=/node-proc/1/ns/cgroup",
-			"--mount=/node-proc/1/ns/mnt", "mount", "-t", "cgroup2", "none", "/run/calico/cgroup"}))
 
 		// Verify env
 		expectedNodeEnv := []corev1.EnvVar{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "cni-log-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log/calico/cni"}}},
 			{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
 			{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
-			{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}},
+			{Name: "nodeproc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
 			{Name: "policysync", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/nodeagent", Type: &dirOrCreate}}},
 			{
 				Name: certificatemanagement.TrustedCertConfigMapName,

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -403,7 +403,7 @@ var _ = Describe("Node rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
 
 		// Validate correct number of init containers.
-		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(3))
+		Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(4))
 
 		// CNI container uses image override.
 		Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
@@ -415,6 +415,12 @@ var _ = Describe("Node rendering tests", func() {
 		mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
 		Expect(mountBpffs.Image).To(Equal(calicoNodeImage))
 		Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init"}))
+
+		// Verify the mount-cgroupv2 image and command.
+		mountCgroupv2 := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-cgroupv2")
+		Expect(mountCgroupv2.Image).To(Equal(calicoNodeImage))
+		Expect(mountCgroupv2.Command).To(Equal([]string{"nsenter", "--cgroup=/node-proc/1/ns/cgroup",
+			"--mount=/node-proc/1/ns/mnt", "mount", "-t", "cgroup2", "none", "/run/calico/cgroup"}))
 
 		// Verify env
 		expectedNodeEnv := []corev1.EnvVar{
@@ -488,6 +494,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "cni-log-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log/calico/cni"}}},
 			{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
 			{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
+			{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
 			{Name: "policysync", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/nodeagent", Type: &dirOrCreate}}},
 			{
 				Name: certificatemanagement.TrustedCertConfigMapName,

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Node rendering tests", func() {
 			{Name: "cni-log-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log/calico/cni"}}},
 			{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
 			{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
-			{Name: "proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc"}}},
+			{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}},
 			{Name: "policysync", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/nodeagent", Type: &dirOrCreate}}},
 			{
 				Name: certificatemanagement.TrustedCertConfigMapName,


### PR DESCRIPTION
## Description
Cherry-pick PR https://github.com/tigera/operator/pull/1957 and PR https://github.com/tigera/operator/pull/2064 to release v.1.26

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
