### PR TITLE
Only install PodSecurityPolicies if the API is present

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,6 +239,7 @@ func main() {
 		setupLog.Error(err, "Failed to discover PodSecurityPolicy availability")
 		os.Exit(1)
 	}
+	setupLog.WithValues("supported", usePSP).Info("Checking if PodSecurityPolicies are supported by the cluster")
 
 	// Determine if we need to start the TSEE specific controllers.
 	enterpriseCRDExists, err := utils.RequiresTigeraSecure(mgr.GetConfig())

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", goruntime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", goruntime.GOOS, goruntime.GOARCH))
 	// TODO: Add this back if we can
-	//log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	// log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
 }
 
 func main() {
@@ -231,6 +231,15 @@ func main() {
 	}
 	setupLog.WithValues("provider", provider).Info("Checking type of cluster")
 
+	// Determine if PodSecurityPolicies are supported. PSPs were removed in
+	// Kubernetes v1.25. We can remove this check once the operator not longer
+	// supports Kubernetes < v1.25.0.
+	usePSP, err := utils.SupportsPodSecurityPolicies(ctx, clientset)
+	if err != nil {
+		setupLog.Error(err, "Failed to discover PodSecurityPolicy availability")
+		os.Exit(1)
+	}
+
 	// Determine if we need to start the TSEE specific controllers.
 	enterpriseCRDExists, err := utils.RequiresTigeraSecure(mgr.GetConfig())
 	if err != nil {
@@ -260,6 +269,7 @@ func main() {
 	options := options.AddOptions{
 		DetectedProvider:    provider,
 		EnterpriseCRDExists: enterpriseCRDExists,
+		UsePSP:              usePSP,
 		AmazonCRDExists:     amazonCRDExists,
 		ClusterDomain:       clusterDomain,
 		KubernetesVersion:   kubernetesVersion,
@@ -278,7 +288,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }
 
 // setKubernetesServiceEnv configured the environment with the location of the Kubernetes API

--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func main() {
 	// Determine if PodSecurityPolicies are supported. PSPs were removed in
 	// Kubernetes v1.25. We can remove this check once the operator not longer
 	// supports Kubernetes < v1.25.0.
-	usePSP, err := utils.SupportsPodSecurityPolicies(ctx, clientset)
+	usePSP, err := utils.SupportsPodSecurityPolicies(clientset)
 	if err != nil {
 		setupLog.Error(err, "Failed to discover PodSecurityPolicy availability")
 		os.Exit(1)

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -172,6 +172,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions) (*ReconcileInst
 		enterpriseCRDsExist:   opts.EnterpriseCRDExists,
 		clusterDomain:         opts.ClusterDomain,
 		manageCRDs:            opts.ManageCRDs,
+		usePSP:                opts.UsePSP,
 	}
 	r.status.Run(opts.ShutdownContext)
 	r.typhaAutoscaler.start(opts.ShutdownContext)
@@ -360,6 +361,7 @@ type ReconcileInstallation struct {
 	migrationChecked      bool
 	clusterDomain         string
 	manageCRDs            bool
+	usePSP                bool
 }
 
 // updateInstallationWithDefaults returns the default installation instance with defaults populated.
@@ -1166,6 +1168,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		MigrateNamespaces:      needNsMigration,
 		ClusterDomain:          r.clusterDomain,
 		FelixHealthPort:        *felixConfiguration.Spec.HealthPort,
+		UsePSP:                 r.usePSP,
 	}
 	components = append(components, render.Typha(&typhaCfg))
 
@@ -1216,6 +1219,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		PrometheusServerTLS:     nodePrometheusTLS,
 		FelixHealthPort:         *felixConfiguration.Spec.HealthPort,
 		BindMode:                bgpConfiguration.Spec.BindMode,
+		UsePSP:                  r.usePSP,
 	}
 	components = append(components, render.Node(&nodeCfg))
 
@@ -1244,6 +1248,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		MetricsPort:                 kubeControllersMetricsPort,
 		ManagerInternalSecret:       managerInternalTLSSecret,
 		Terminating:                 terminating,
+		UsePSP:                      r.usePSP,
 	}
 	components = append(components, kubecontrollers.NewCalicoKubeControllers(&kubeControllersCfg))
 

--- a/pkg/controller/logstorage/logstorage.go
+++ b/pkg/controller/logstorage/logstorage.go
@@ -182,6 +182,7 @@ func (r *ReconcileLogStorage) createLogStorage(
 		ElasticLicenseType:          esLicenseType,
 		TrustedBundle:               trustedBundle,
 		UnusedTLSSecret:             unusedTLSSecret,
+		UsePSP:                      r.usePSP,
 	}
 
 	component := render.LogStorage(logStorageCfg)
@@ -285,7 +286,8 @@ func (r *ReconcileLogStorage) applyILMPolicies(ls *operatorv1.LogStorage, reqLog
 func addLogStorageWatches(c controller.Controller) error {
 	// Watch for changes in storage classes, as new storage classes may be made available for LogStorage.
 	err := c.Watch(&source.Kind{
-		Type: &storagev1.StorageClass{}}, &handler.EnqueueRequestForObject{})
+		Type: &storagev1.StorageClass{},
+	}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return fmt.Errorf("log-storage-controller failed to watch StorageClass resource: %w", err)
 	}
@@ -327,8 +329,10 @@ func addLogStorageWatches(c controller.Controller) error {
 		return fmt.Errorf("log-storage-controller failed to watch primary resource: %w", err)
 	}
 
-	for _, name := range []string{render.OIDCUsersConfigMapName, render.OIDCUsersEsSecreteName,
-		render.ElasticsearchAdminUserSecret} {
+	for _, name := range []string{
+		render.OIDCUsersConfigMapName, render.OIDCUsersEsSecreteName,
+		render.ElasticsearchAdminUserSecret,
+	} {
 		if err = utils.AddConfigMapWatch(c, name, render.ElasticsearchNamespace); err != nil {
 			return fmt.Errorf("log-storage-controller failed to watch the ConfigMap resource: %w", err)
 		}

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -19,4 +19,7 @@ type AddOptions struct {
 	KubernetesVersion   *common.VersionInfo
 	ManageCRDs          bool
 	ShutdownContext     context.Context
+
+	// Whether or not the cluster supports PodSecurityPolicies.
+	UsePSP bool
 }

--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -191,3 +191,19 @@ func isRKE2(ctx context.Context, c kubernetes.Interface) (bool, error) {
 
 	return (cm != nil), nil
 }
+
+func SupportsPodSecurityPolicies(ctx context.Context, c kubernetes.Interface) (bool, error) {
+	resources, err := c.Discovery().ServerResourcesForGroupVersion("policy/v1beta1")
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, r := range resources.APIResources {
+		if r.Kind == "PodSecurityPolicy" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -192,7 +192,10 @@ func isRKE2(ctx context.Context, c kubernetes.Interface) (bool, error) {
 	return (cm != nil), nil
 }
 
-func SupportsPodSecurityPolicies(ctx context.Context, c kubernetes.Interface) (bool, error) {
+// SupportsPodSecurityPolicies returns true if the cluster contains the policy/v1beta1 PodSecurityPolicy API,
+// and false otherwise. This API is scheuled to be removed in Kubernetes v1.25, but should still be used
+// in earlier Kubernetes versions.
+func SupportsPodSecurityPolicies(c kubernetes.Interface) (bool, error) {
 	resources, err := c.Discovery().ServerResourcesForGroupVersion("policy/v1beta1")
 	if err != nil {
 		if kerrors.IsNotFound(err) {

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -105,7 +105,7 @@ func ConvertSecretToCredential(s *corev1.Secret) (*AmazonCredential, error) {
 
 func (c *amazonCloudIntegrationComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		CreateNamespace(AmazonCloudIntegrationNamespace, c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(AmazonCloudIntegrationNamespace, c.cfg.Installation.KubernetesProvider, PSSBaseline),
 	}
 	secrets := secret.CopyToNamespace(AmazonCloudIntegrationNamespace, c.cfg.PullSecrets...)
 	objs = append(objs, secret.ToRuntimeObjects(secrets...)...)

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -105,7 +105,7 @@ func ConvertSecretToCredential(s *corev1.Secret) (*AmazonCredential, error) {
 
 func (c *amazonCloudIntegrationComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		CreateNamespace(AmazonCloudIntegrationNamespace, c.cfg.Installation.KubernetesProvider, PSSBaseline),
+		CreateNamespace(AmazonCloudIntegrationNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 	}
 	secrets := secret.CopyToNamespace(AmazonCloudIntegrationNamespace, c.cfg.PullSecrets...)
 	objs = append(objs, secret.ToRuntimeObjects(secrets...)...)

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -183,7 +183,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 
 	// Global enterprise-only objects.
 	globalEnterpriseObjects := []client.Object{
-		CreateNamespace(rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise), c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise), c.cfg.Installation.KubernetesProvider, PSSPrivileged),
 		c.tigeraCustomResourcesClusterRole(),
 		c.tigeraCustomResourcesClusterRoleBinding(),
 		c.tierGetterClusterRole(),
@@ -205,7 +205,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 
 	// Global OSS-only objects.
 	globalCalicoObjects := []client.Object{
-		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.cfg.Installation.KubernetesProvider, PSSPrivileged),
 	}
 
 	// Compile the final arrays based on the variant.

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -89,6 +89,9 @@ type APIServerConfiguration struct {
 	PullSecrets                 []*corev1.Secret
 	Openshift                   bool
 	TunnelCASecret              certificatemanagement.KeyPairInterface
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type apiServerComponent struct {
@@ -154,7 +157,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.authReaderRoleBinding)
 	globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.webhookReaderClusterRole)
 	globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.webhookReaderClusterRoleBinding)
-	if !c.cfg.Openshift {
+	if !c.cfg.Openshift && c.cfg.UsePSP {
 		globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.apiServerPodSecurityPolicy)
 	}
 
@@ -301,7 +304,6 @@ func (c *apiServerComponent) delegateAuthClusterRoleBinding() (client.Object, cl
 				Name: nameToDelete,
 			},
 		}
-
 }
 
 // authReaderRoleBinding creates a rolebinding that allows the API server to access the
@@ -347,7 +349,6 @@ func (c *apiServerComponent) authReaderRoleBinding() (client.Object, client.Obje
 				Namespace: "kube-system",
 			},
 		}
-
 }
 
 // apiServerServiceAccount creates the service account used by the API server.
@@ -574,7 +575,6 @@ func (c *apiServerComponent) authClusterRoleBinding() (client.Object, client.Obj
 				Name: nameToDelete,
 			},
 		}
-
 }
 
 // webhookReaderClusterRole returns a ClusterRole to read MutatingWebhookConfigurations and ValidatingWebhookConfigurations and an
@@ -660,7 +660,6 @@ func (c *apiServerComponent) webhookReaderClusterRoleBinding() (client.Object, c
 			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: nameToDelete},
 		}
-
 }
 
 // apiServerService creates a service backed by the API server and - for enterprise - query server.
@@ -698,7 +697,6 @@ func (c *apiServerComponent) apiServerService() *corev1.Service {
 				TargetPort: intstr.FromInt(queryServerPort),
 			},
 		)
-
 	}
 	return s
 }

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -279,7 +279,8 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 
 	It("should render properly when PSP is not supported by the cluster", func() {
 		cfg.UsePSP = false
-		component := render.APIServer(cfg)
+		component, err := render.APIServer(cfg)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 

--- a/pkg/render/common/podsecuritypolicy/pod_secruity_policy.go
+++ b/pkg/render/common/podsecuritypolicy/pod_secruity_policy.go
@@ -11,6 +11,8 @@ import (
 func NewBasePolicy() *policyv1beta1.PodSecurityPolicy {
 	falseBool := false
 	ptrBoolFalse := &falseBool
+	// This PodSecurityPolicy is equivalent to a "restricted" pod security standard,
+	// according to: https://kubernetes.io/docs/reference/access-authn-authz/psp-to-pod-security-standards/
 	return &policyv1beta1.PodSecurityPolicy{
 		TypeMeta: metav1.TypeMeta{Kind: "PodSecurityPolicy", APIVersion: "policy/v1beta1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -30,13 +32,13 @@ func NewBasePolicy() *policyv1beta1.PodSecurityPolicy {
 				policyv1beta1.DownwardAPI,
 				policyv1beta1.PersistentVolumeClaim,
 			},
-			HostNetwork: false,
 			HostPorts: []policyv1beta1.HostPortRange{{
 				Min: int32(0),
 				Max: int32(65535),
 			}},
-			HostIPC: false,
-			HostPID: false,
+			HostNetwork: false,
+			HostIPC:     false,
+			HostPID:     false,
 			RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
 				Rule: policyv1beta1.RunAsUserStrategyMustRunAsNonRoot,
 			},

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -138,7 +138,7 @@ func (c *complianceComponent) SupportedOSType() rmeta.OSType {
 
 func (c *complianceComponent) Objects() ([]client.Object, []client.Object) {
 	complianceObjs := append(
-		[]client.Object{CreateNamespace(ComplianceNamespace, c.cfg.Installation.KubernetesProvider)},
+		[]client.Object{CreateNamespace(ComplianceNamespace, c.cfg.Installation.KubernetesProvider, PSSPrivileged)},
 		secret.ToRuntimeObjects(secret.CopyToNamespace(ComplianceNamespace, c.cfg.PullSecrets...)...)...,
 	)
 	complianceObjs = append(complianceObjs,

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -80,6 +80,9 @@ type ComplianceConfiguration struct {
 	KeyValidatorConfig          authentication.KeyValidatorConfig
 	ClusterDomain               string
 	HasNoLicense                bool
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type complianceComponent struct {
@@ -196,7 +199,7 @@ func (c *complianceComponent) Objects() ([]client.Object, []client.Object) {
 
 	if c.cfg.Openshift {
 		complianceObjs = append(complianceObjs, c.complianceBenchmarkerSecurityContextConstraints())
-	} else {
+	} else if c.cfg.UsePSP {
 		complianceObjs = append(complianceObjs,
 			c.complianceBenchmarkerPodSecurityPolicy(),
 			c.complianceControllerPodSecurityPolicy(),
@@ -224,8 +227,10 @@ func (c *complianceComponent) Ready() bool {
 	return true
 }
 
-var complianceBoolTrue = true
-var complianceReplicas int32 = 1
+var (
+	complianceBoolTrue       = true
+	complianceReplicas int32 = 1
+)
 
 const complianceServerPort = 5443
 
@@ -770,26 +775,31 @@ func (c *complianceComponent) complianceSnapshotterClusterRole() *rbacv1.Cluster
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"networking.k8s.io", "authentication.k8s.io", ""},
-			Resources: []string{"networkpolicies", "nodes", "namespaces", "pods", "serviceaccounts",
-				"endpoints", "services"},
+			Resources: []string{
+				"networkpolicies", "nodes", "namespaces", "pods", "serviceaccounts",
+				"endpoints", "services",
+			},
 			Verbs: []string{"get", "list"},
 		},
 		{
 			APIGroups: []string{"projectcalico.org"},
-			Resources: []string{"globalnetworkpolicies", "tier.globalnetworkpolicies",
+			Resources: []string{
+				"globalnetworkpolicies", "tier.globalnetworkpolicies",
 				"stagedglobalnetworkpolicies", "tier.stagedglobalnetworkpolicies",
 				"networkpolicies", "tier.networkpolicies",
 				"stagednetworkpolicies", "tier.stagednetworkpolicies",
 				"stagedkubernetesnetworkpolicies",
 				"tiers", "hostendpoints",
-				"globalnetworksets", "networksets"},
+				"globalnetworksets", "networksets",
+			},
 			Verbs: []string{"get", "list"},
 		},
 	}
 
 	if !c.cfg.Openshift {
 		// Allow access to the pod security policy in case this is enforced on the cluster
-		rules = append(rules, rbacv1.PolicyRule{APIGroups: []string{"policy"},
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
 			Resources:     []string{"podsecuritypolicies"},
 			Verbs:         []string{"use"},
 			ResourceNames: []string{ComplianceSnapshotterName},
@@ -903,7 +913,8 @@ func (c *complianceComponent) complianceBenchmarkerClusterRole() *rbacv1.Cluster
 
 	if !c.cfg.Openshift {
 		// Allow access to the pod security policy in case this is enforced on the cluster
-		rules = append(rules, rbacv1.PolicyRule{APIGroups: []string{"policy"},
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
 			Resources:     []string{"podsecuritypolicies"},
 			Verbs:         []string{"use"},
 			ResourceNames: []string{"compliance-benchmarker"},

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -69,6 +69,19 @@ var _ = Describe("compliance rendering tests", func() {
 		}
 	})
 
+	It("should render properly when PSP is not supported by the cluster", func() {
+		cfg.UsePSP = false
+		component, err := render.Compliance(cfg)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		// Should not contain any PodSecurityPolicies
+		for _, r := range resources {
+			Expect(r.GetObjectKind()).NotTo(Equal("PodSecurityPolicy"))
+		}
+	})
+
 	Context("Standalone cluster", func() {
 		It("should render all resources for a default configuration", func() {
 			component, err := render.Compliance(cfg)

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -65,12 +65,12 @@ var _ = Describe("compliance rendering tests", func() {
 			Openshift:                  notOpenshift,
 			ClusterDomain:              clusterDomain,
 			TrustedBundle:              bundle,
+			UsePSP:                     true,
 		}
 	})
 
 	Context("Standalone cluster", func() {
 		It("should render all resources for a default configuration", func() {
-
 			component, err := render.Compliance(cfg)
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
@@ -363,7 +363,7 @@ var _ = Describe("compliance rendering tests", func() {
 	})
 
 	Describe("node selection & affinity", func() {
-		var renderCompliance = func(i *operatorv1.InstallationSpec) (server, controller, snapshotter *appsv1.Deployment, reporter *corev1.PodTemplate, benchmarker *appsv1.DaemonSet) {
+		renderCompliance := func(i *operatorv1.InstallationSpec) (server, controller, snapshotter *appsv1.Deployment, reporter *corev1.PodTemplate, benchmarker *appsv1.DaemonSet) {
 			cfg.Installation = i
 			component, err := render.Compliance(cfg)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -471,14 +471,13 @@ var _ = Describe("compliance rendering tests", func() {
 	})
 
 	Context("Render Benchmarker", func() {
-
 		It("should render benchmarker properly for non GKE environments", func() {
 			cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
 			component, err := render.Compliance(cfg)
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
 
-			var dsBenchMarker = rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+			dsBenchMarker := rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 			volumeMounts := dsBenchMarker.Spec.Template.Spec.Containers[0].VolumeMounts
 
 			Expect(len(volumeMounts)).To(Equal(6))
@@ -503,7 +502,7 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
 
-			var dsBenchMarker = rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+			dsBenchMarker := rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 			volumeMounts := dsBenchMarker.Spec.Template.Spec.Containers[0].VolumeMounts
 
 			Expect(len(volumeMounts)).To(Equal(7))
@@ -524,5 +523,4 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(volumeMounts[6].MountPath).To(Equal("/home/kubernetes"))
 		})
 	})
-
 })

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -224,10 +224,7 @@ func (c *fluentdComponent) path(path string) string {
 
 func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	var objs, toDelete []client.Object
-	objs = append(objs,
-		CreateNamespace(
-			LogCollectorNamespace,
-			c.cfg.Installation.KubernetesProvider))
+	objs = append(objs, CreateNamespace(LogCollectorNamespace, c.cfg.Installation.KubernetesProvider, PSSBaseline))
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.cfg.PullSecrets...)...)...)
 	objs = append(objs, c.metricsService())
 

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -141,6 +141,9 @@ type FluentdConfiguration struct {
 	OSType           rmeta.OSType
 	MetricsServerTLS certificatemanagement.KeyPairInterface
 	TrustedBundle    certificatemanagement.TrustedBundle
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type fluentdComponent struct {
@@ -248,8 +251,10 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 		if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
 			objs = append(objs,
 				c.eksLogForwarderClusterRole(),
-				c.eksLogForwarderClusterRoleBinding(),
-				c.eksLogForwarderPodSecurityPolicy())
+				c.eksLogForwarderClusterRoleBinding())
+			if c.cfg.UsePSP {
+				objs = append(objs, c.eksLogForwarderPodSecurityPolicy())
+			}
 		}
 		objs = append(objs, c.eksLogForwarderServiceAccount(),
 			c.eksLogForwarderSecret(),
@@ -261,8 +266,10 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.cfg.OSType == rmeta.OSTypeLinux {
 		objs = append(objs,
 			c.fluentdClusterRole(),
-			c.fluentdClusterRoleBinding(),
-			c.fluentdPodSecurityPolicy())
+			c.fluentdClusterRoleBinding())
+		if c.cfg.UsePSP {
+			objs = append(objs, c.fluentdPodSecurityPolicy())
+		}
 	}
 
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.cfg.ESSecrets...)...)...)
@@ -520,7 +527,7 @@ func (c *fluentdComponent) container() corev1.Container {
 	}
 
 	isPrivileged := false
-	//On OpenShift Fluentd needs privileged access to access logs on host path volume
+	// On OpenShift Fluentd needs privileged access to access logs on host path volume
 	if c.cfg.Installation.KubernetesProvider == operatorv1.ProviderOpenShift {
 		isPrivileged = true
 	}
@@ -577,7 +584,8 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		s3 := c.cfg.LogCollector.Spec.AdditionalStores.S3
 		if s3 != nil {
 			envs = append(envs,
-				corev1.EnvVar{Name: "AWS_KEY_ID",
+				corev1.EnvVar{
+					Name: "AWS_KEY_ID",
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
@@ -585,8 +593,10 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 							},
 							Key: S3KeyIdName,
 						},
-					}},
-				corev1.EnvVar{Name: "AWS_SECRET_KEY",
+					},
+				},
+				corev1.EnvVar{
+					Name: "AWS_SECRET_KEY",
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
@@ -594,7 +604,8 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 							},
 							Key: S3KeySecretName,
 						},
-					}},
+					},
+				},
 				corev1.EnvVar{Name: "S3_STORAGE", Value: "true"},
 				corev1.EnvVar{Name: "S3_BUCKET_NAME", Value: s3.BucketName},
 				corev1.EnvVar{Name: "AWS_REGION", Value: s3.Region},
@@ -610,7 +621,8 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 				corev1.EnvVar{Name: "SYSLOG_PORT", Value: port},
 				corev1.EnvVar{Name: "SYSLOG_PROTOCOL", Value: proto},
 				corev1.EnvVar{Name: "SYSLOG_FLUSH_INTERVAL", Value: fluentdDefaultFlush},
-				corev1.EnvVar{Name: "SYSLOG_HOSTNAME",
+				corev1.EnvVar{
+					Name: "SYSLOG_HOSTNAME",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{
 							FieldPath: "spec.nodeName",
@@ -657,7 +669,8 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		if splunk != nil {
 			proto, host, port, _ := url.ParseEndpoint(splunk.Endpoint)
 			envs = append(envs,
-				corev1.EnvVar{Name: "SPLUNK_HEC_TOKEN",
+				corev1.EnvVar{
+					Name: "SPLUNK_HEC_TOKEN",
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
@@ -665,7 +678,8 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 							},
 							Key: SplunkFluentdSecretTokenKey,
 						},
-					}},
+					},
+				},
 				corev1.EnvVar{Name: "SPLUNK_FLOW_LOG", Value: "true"},
 				corev1.EnvVar{Name: "SPLUNK_AUDIT_LOG", Value: "true"},
 				corev1.EnvVar{Name: "SPLUNK_DNS_LOG", Value: "true"},

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -224,7 +224,7 @@ func (c *fluentdComponent) path(path string) string {
 
 func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	var objs, toDelete []client.Object
-	objs = append(objs, CreateNamespace(LogCollectorNamespace, c.cfg.Installation.KubernetesProvider, PSSBaseline))
+	objs = append(objs, CreateNamespace(LogCollectorNamespace, c.cfg.Installation.KubernetesProvider, PSSPrivileged))
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.cfg.PullSecrets...)...)...)
 	objs = append(objs, c.metricsService())
 

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			},
 			MetricsServerTLS: metricsSecret,
 			TrustedBundle:    certificateManager.CreateTrustedBundle(),
+			UsePSP:           true,
 		}
 	})
 
@@ -104,7 +105,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			corev1.EnvVar{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			corev1.EnvVar{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
 			corev1.EnvVar{Name: "ELASTIC_PORT", Value: "9200"},
-			corev1.EnvVar{Name: "NODENAME",
+			corev1.EnvVar{
+				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 				},
@@ -326,7 +328,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
 							Key:                  expected.secretKey,
-						}},
+						},
+					},
 				}))
 			}
 		}
@@ -403,7 +406,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
 							Key:                  expected.secretKey,
-						}},
+						},
+					},
 				}))
 			}
 		}
@@ -412,7 +416,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "spec.nodeName",
-				}},
+				},
+			},
 		}))
 	})
 
@@ -496,7 +501,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
 							Key:                  expected.secretKey,
-						}},
+						},
+					},
 				}))
 			}
 		}
@@ -573,7 +579,8 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
 							Key:                  expected.secretKey,
-						}},
+						},
+					},
 				}))
 			}
 		}

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -63,6 +63,18 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 	})
 
+	It("should render properly when PSP is not supported by the cluster", func() {
+		cfg.UsePSP = false
+		component := render.Fluentd(cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		// Should not contain any PodSecurityPolicies
+		for _, r := range resources {
+			Expect(r.GetObjectKind()).NotTo(Equal("PodSecurityPolicy"))
+		}
+	})
+
 	It("should render with a default configuration", func() {
 		expectedResources := []struct {
 			name    string

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -81,7 +81,7 @@ func (c *GuardianComponent) SupportedOSType() rmeta.OSType {
 
 func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		CreateNamespace(GuardianNamespace, c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(GuardianNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(GuardianNamespace, c.cfg.PullSecrets...)...)...)
 	objs = append(objs,
@@ -93,7 +93,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		secret.CopyToNamespace(GuardianNamespace, c.cfg.TunnelSecret)[0],
 		c.cfg.TrustedCertBundle.ConfigMap(GuardianNamespace),
 		// Add tigera-manager service account for impersonation
-		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 		managerServiceAccount(),
 		managerClusterRole(false, true, c.cfg.Openshift),
 		managerClusterRoleBinding(),

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -90,6 +90,9 @@ type IntrusionDetectionConfiguration struct {
 	HasNoLicense          bool
 	TrustedCertBundle     certificatemanagement.TrustedBundle
 	ADAPIServerCertSecret certificatemanagement.KeyPairInterface
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type intrusionDetectionComponent struct {
@@ -186,9 +189,11 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 
 	if !c.cfg.Openshift {
 		objs = append(objs,
-			c.intrusionDetectionPodSecurityPolicy(),
 			c.intrusionDetectionPSPClusterRole(),
 			c.intrusionDetectionPSPClusterRoleBinding())
+		if c.cfg.UsePSP {
+			objs = append(objs, c.intrusionDetectionPodSecurityPolicy())
+		}
 	}
 
 	if c.cfg.HasNoLicense {

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -142,8 +142,14 @@ func (c *intrusionDetectionComponent) SupportedOSType() rmeta.OSType {
 }
 
 func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Object) {
+	// Configure pod security standard. If syslog forwarding is enabled, we
+	// need hostpath volumes which require a privileged PSS.
+	pss := PSSRestricted
+	if c.syslogForwardingIsEnabled() {
+		pss = PSSPrivileged
+	}
 	objs := []client.Object{
-		CreateNamespace(IntrusionDetectionNamespace, c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(IntrusionDetectionNamespace, c.cfg.Installation.KubernetesProvider, PodSecurityStandard(pss)),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.cfg.PullSecrets...)...)...)
 

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 var _ = Describe("Intrusion Detection rendering tests", func() {
-
 	var cfg *render.IntrusionDetectionConfiguration
 	var bundle certificatemanagement.TrustedBundle
 	var adAPIKeyPair certificatemanagement.KeyPairInterface
@@ -64,6 +63,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			ClusterDomain:         dns.DefaultClusterDomain,
 			ESLicenseType:         render.ElasticsearchLicenseTypeUnknown,
 			ManagedCluster:        notManagedCluster,
+			UsePSP:                true,
 		}
 	})
 
@@ -125,9 +125,9 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: render.ADJobPodTemplateBaseName + ".training", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: render.ADJobPodTemplateBaseName + ".detection", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "batch", version: "v1", kind: "Job"},
-			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -288,9 +288,9 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: render.ADJobPodTemplateBaseName + ".training", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: render.ADJobPodTemplateBaseName + ".detection", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: "intrusion-detection-es-job-installer", ns: "tigera-intrusion-detection", group: "batch", version: "v1", kind: "Job"},
-			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -325,7 +325,8 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
 							Key:                  expected.secretKey,
-						}},
+						},
+					},
 				}))
 			}
 		}
@@ -379,9 +380,9 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "tigera.io.detector.l7-bytes", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
 			{name: "tigera.io.detector.l7-latency", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
 			{name: "tigera.io.detector.process-restarts", ns: "", group: "projectcalico.org", version: "v3", kind: "GlobalAlertTemplate"},
-			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		Expect(len(resources)).To(Equal(len(expectedResources)))

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -417,6 +417,18 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		}))
 	})
 
+	It("should render properly when PSP is not supported by the cluster", func() {
+		cfg.UsePSP = false
+		component := render.IntrusionDetection(cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		// Should not contain any PodSecurityPolicies
+		for _, r := range resources {
+			Expect(r.GetObjectKind()).NotTo(Equal("PodSecurityPolicy"))
+		}
+	})
+
 	It("should apply controlPlaneNodeSelector correctly", func() {
 		cfg.Installation = &operatorv1.InstallationSpec{
 			ControlPlaneNodeSelector: map[string]string{"foo": "bar"},
@@ -429,6 +441,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		Expect(idc.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 		Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 	})
+
 	It("should apply controlPlaneTolerations correctly", func() {
 		t := corev1.Toleration{
 			Key:      "foo",

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -80,14 +80,15 @@ func (d *dpiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 func (d *dpiComponent) Objects() (objsToCreate, objsToDelete []client.Object) {
 	var toCreate, toDelete []client.Object
 	if d.cfg.HasNoLicense {
-		toDelete = append(toDelete, render.CreateNamespace(DeepPacketInspectionNamespace, d.cfg.Installation.KubernetesProvider))
+		toDelete = append(toDelete, render.CreateNamespace(DeepPacketInspectionNamespace, d.cfg.Installation.KubernetesProvider, render.PSSPrivileged))
 	} else {
-		toCreate = append(toCreate, render.CreateNamespace(DeepPacketInspectionNamespace, d.cfg.Installation.KubernetesProvider))
+		toCreate = append(toCreate, render.CreateNamespace(DeepPacketInspectionNamespace, d.cfg.Installation.KubernetesProvider, render.PSSPrivileged))
 	}
 	if d.cfg.HasNoDPIResource || d.cfg.HasNoLicense {
 		toDelete = append(toDelete, &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-			ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: DeepPacketInspectionNamespace}})
+			ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.PublicCertSecret, Namespace: DeepPacketInspectionNamespace},
+		})
 		toDelete = append(toDelete, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.PullSecrets...)...)...)
 		toDelete = append(toDelete,
 			d.dpiServiceAccount(),

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -82,6 +82,9 @@ type KubeControllersConfiguration struct {
 	ManagerInternalSecret        certificatemanagement.KeyPairInterface
 	KubeControllersGatewaySecret *corev1.Secret
 	TrustedBundle                certificatemanagement.TrustedBundle
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 func NewCalicoKubeControllers(cfg *KubeControllersConfiguration) *kubeControllersComponent {
@@ -217,7 +220,7 @@ func (c *kubeControllersComponent) Objects() ([]client.Object, []client.Object) 
 			secret.CopyToNamespace(common.CalicoNamespace, c.cfg.KubeControllersGatewaySecret)...)...)
 	}
 
-	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
+	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.cfg.UsePSP {
 		objectsToCreate = append(objectsToCreate, c.controllersPodSecurityPolicy())
 	}
 

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -124,6 +124,18 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		}
 	})
 
+	It("should render properly when PSP is not supported by the cluster", func() {
+		cfg.UsePSP = false
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		// Should not contain any PodSecurityPolicies
+		for _, r := range resources {
+			Expect(r.GetObjectKind()).NotTo(Equal("PodSecurityPolicy"))
+		}
+	})
+
 	It("should render all resources for a custom configuration", func() {
 		expectedResources := []struct {
 			name    string

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -45,14 +45,15 @@ var _ = Describe("kube-controllers rendering tests", func() {
 	var instance *operatorv1.InstallationSpec
 	var k8sServiceEp k8sapi.ServiceEndpoint
 	var cfg kubecontrollers.KubeControllersConfiguration
-	var esEnvs = []corev1.EnvVar{
+	esEnvs := []corev1.EnvVar{
 		{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
 		{Name: "ELASTIC_SCHEME", Value: "https"},
 		{Name: "ELASTIC_HOST", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc"},
 		{Name: "ELASTIC_PORT", Value: "9200", ValueFrom: nil},
 		{Name: "ELASTIC_ACCESS_MODE", Value: "serviceuser"},
 		{Name: "ELASTIC_SSL_VERIFY", Value: "true"},
-		{Name: "ELASTIC_USER", Value: "",
+		{
+			Name: "ELASTIC_USER", Value: "",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -62,7 +63,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				},
 			},
 		},
-		{Name: "ELASTIC_USERNAME", Value: "",
+		{
+			Name: "ELASTIC_USERNAME", Value: "",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -72,7 +74,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				},
 			},
 		},
-		{Name: "ELASTIC_PASSWORD", Value: "",
+		{
+			Name: "ELASTIC_PASSWORD", Value: "",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -117,6 +120,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			ClusterDomain: dns.DefaultClusterDomain,
 			MetricsPort:   9094,
 			TrustedBundle: certificateManager.CreateTrustedBundle(),
+			UsePSP:        true,
 		}
 	})
 
@@ -139,6 +143,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			K8sServiceEp:  k8sServiceEp,
 			Installation:  instance,
 			ClusterDomain: dns.DefaultClusterDomain,
+			UsePSP:        true,
 		}
 		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -253,7 +253,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 
 		// ECK CRs
 		toCreate = append(toCreate,
-			CreateNamespace(ECKOperatorNamespace, es.cfg.Installation.KubernetesProvider),
+			CreateNamespace(ECKOperatorNamespace, es.cfg.Installation.KubernetesProvider, PSSRestricted),
 		)
 
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ECKOperatorNamespace, es.cfg.PullSecrets...)...)...)
@@ -288,7 +288,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.eckOperatorStatefulSet())
 
 		// Elasticsearch CRs
-		toCreate = append(toCreate, CreateNamespace(ElasticsearchNamespace, es.cfg.Installation.KubernetesProvider))
+		toCreate = append(toCreate, CreateNamespace(ElasticsearchNamespace, es.cfg.Installation.KubernetesProvider, PSSPrivileged))
 
 		if len(es.cfg.PullSecrets) > 0 {
 			toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ElasticsearchNamespace, es.cfg.PullSecrets...)...)...)
@@ -304,7 +304,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.elasticsearchCluster())
 
 		// Kibana CRs
-		toCreate = append(toCreate, CreateNamespace(KibanaNamespace, es.cfg.Installation.KubernetesProvider))
+		toCreate = append(toCreate, CreateNamespace(KibanaNamespace, es.cfg.Installation.KubernetesProvider, PSSRestricted))
 		toCreate = append(toCreate, es.kibanaServiceAccount())
 
 		if len(es.cfg.PullSecrets) > 0 {
@@ -350,7 +350,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		}
 	} else {
 		toCreate = append(toCreate,
-			CreateNamespace(ElasticsearchNamespace, es.cfg.Installation.KubernetesProvider),
+			CreateNamespace(ElasticsearchNamespace, es.cfg.Installation.KubernetesProvider, PSSPrivileged),
 			es.elasticsearchExternalService(),
 		)
 	}

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -128,6 +128,18 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		})
 
 		Context("Initial creation", func() {
+			It("should render properly when PSP is not supported by the cluster", func() {
+				cfg.UsePSP = false
+				component := render.LogStorage(cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+
+				// Should not contain any PodSecurityPolicies
+				for _, r := range resources {
+					Expect(r.GetObjectKind()).NotTo(Equal("PodSecurityPolicy"))
+				}
+			})
+
 			It("should render an elasticsearchComponent", func() {
 				expectedCreateResources := []resourceTestObj{
 					{render.ECKOperatorNamespace, "", &corev1.Namespace{}, nil},
@@ -211,6 +223,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"--manage-webhook-certs=false",
 				}))
 			})
+
 			It("should render an elasticsearchComponent and delete the Elasticsearch and Kibana ExternalService", func() {
 				expectedCreateResources := []resourceTestObj{
 					{render.ECKOperatorNamespace, "", &corev1.Namespace{}, nil},

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				ClusterDomain:      "cluster.local",
 				ElasticLicenseType: render.ElasticsearchLicenseTypeEnterpriseTrial,
 				TrustedBundle:      trustedBundle,
+				UsePSP:             true,
 			}
 		})
 
@@ -134,12 +135,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"elastic-operator", render.ECKOperatorNamespace, &corev1.ServiceAccount{}, nil},
-					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRole{}, nil},
-					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRole{}, nil},
+					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
+					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
@@ -186,7 +187,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Expect(resources.Memory().String()).To(Equal("4Gi"))
 				Expect(esContainer.Env[0].Value).To(Equal("-Xms2G -Xmx2G"))
 
-				//Check that the expected config made it's way to the Elastic CR
+				// Check that the expected config made it's way to the Elastic CR
 				Expect(nodeSet.Config.Data).Should(Equal(map[string]interface{}{
 					"node.master":                 "true",
 					"node.data":                   "true",
@@ -217,12 +218,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"elastic-operator", render.ECKOperatorNamespace, &corev1.ServiceAccount{}, nil},
-					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRole{}, nil},
-					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRole{}, nil},
+					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
+					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
@@ -262,7 +263,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			})
 
 			It("should render an elasticsearchComponent with certificate management enabled", func() {
-
 				cfg.Installation.CertificateManagement = &operatorv1.CertificateManagement{
 					CACert:             cfg.ElasticsearchKeyPair.GetCertificatePEM(),
 					SignerName:         "my signer name",
@@ -278,12 +278,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"elastic-operator", render.ECKOperatorNamespace, &corev1.ServiceAccount{}, nil},
-					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRole{}, nil},
-					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRole{}, nil},
+					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
+					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
@@ -347,12 +347,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{"elastic-operator", "", &rbacv1.ClusterRole{}, nil},
 					{"elastic-operator", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"elastic-operator", render.ECKOperatorNamespace, &corev1.ServiceAccount{}, nil},
-					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-elasticsearch", "", &rbacv1.ClusterRole{}, nil},
-					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRoleBinding{}, nil},
 					{"tigera-kibana", "", &rbacv1.ClusterRole{}, nil},
+					{render.ECKOperatorName, "", &policyv1beta1.PodSecurityPolicy{}, nil},
+					{"tigera-elasticsearch", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{"tigera-kibana", "", &policyv1beta1.PodSecurityPolicy{}, nil},
 					{render.ECKOperatorName, render.ECKOperatorNamespace, &appsv1.StatefulSet{}, nil},
 					{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
@@ -552,6 +552,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Provider:           operatorv1.ProviderNone,
 				ClusterDomain:      "cluster.local",
 				ElasticLicenseType: render.ElasticsearchLicenseTypeEnterpriseTrial,
+				UsePSP:             true,
 			}
 		})
 		Context("Initial creation", func() {
@@ -624,6 +625,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Provider:           operatorv1.ProviderNone,
 				ClusterDomain:      "cluster.local",
 				ElasticLicenseType: render.ElasticsearchLicenseTypeEnterpriseTrial,
+				UsePSP:             true,
 			}
 		})
 		Context("Node distribution", func() {
@@ -1031,18 +1033,20 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 							NodeSelectorTerms: []corev1.NodeSelectorTerm{
 								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{{
-										Key:      "failure-domain.beta.kubernetes.io/zone",
-										Operator: corev1.NodeSelectorOpIn,
-										Values:   []string{"us-west-2b"},
-									},
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      "failure-domain.beta.kubernetes.io/zone",
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{"us-west-2b"},
+										},
 										{
 											Key:      "some-rack-label.kubernetes.io/rack",
 											Operator: corev1.NodeSelectorOpIn,
 											Values:   []string{"rack1"},
 										},
 									},
-								}},
+								},
+							},
 						},
 					}))
 					Expect(nodeSets[1].Config.Data).Should(Equal(map[string]interface{}{
@@ -1112,6 +1116,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				Provider:           operatorv1.ProviderNone,
 				ClusterDomain:      "cluster.local",
 				ElasticLicenseType: render.ElasticsearchLicenseTypeEnterpriseTrial,
+				UsePSP:             true,
 			}
 		})
 
@@ -1234,6 +1239,7 @@ var deleteLogStorageTests = func(managementCluster *operatorv1.ManagementCluster
 				Provider:           operatorv1.ProviderNone,
 				ClusterDomain:      "cluster.local",
 				ElasticLicenseType: render.ElasticsearchLicenseTypeEnterpriseTrial,
+				UsePSP:             true,
 			}
 		})
 		It("returns Elasticsearch and Kibana CR's to delete and keeps the finalizers on the LogStorage CR", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -118,6 +118,9 @@ type ManagerConfiguration struct {
 	ESLicenseType           ElasticsearchLicenseType
 	Replicas                *int32
 	ComplianceFeatureActive bool
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type managerComponent struct {
@@ -183,7 +186,7 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	// If we're running on openshift, we need to add in an SCC.
 	if c.cfg.Openshift {
 		objs = append(objs, c.securityContextConstraints())
-	} else {
+	} else if c.cfg.UsePSP {
 		// If we're not running openshift, we need to add pod security policies.
 		objs = append(objs, c.managerPodSecurityPolicy())
 	}
@@ -365,7 +368,8 @@ func (c *managerComponent) managerOAuth2EnvVars() []corev1.EnvVar {
 	} else {
 		envs = []corev1.EnvVar{
 			{Name: "CNX_WEB_AUTHENTICATION_TYPE", Value: "OIDC"},
-			{Name: "CNX_WEB_OIDC_CLIENT_ID", Value: c.cfg.KeyValidatorConfig.ClientID()}}
+			{Name: "CNX_WEB_OIDC_CLIENT_ID", Value: c.cfg.KeyValidatorConfig.ClientID()},
+		}
 
 		switch c.cfg.KeyValidatorConfig.(type) {
 		case *DexKeyValidatorConfig:
@@ -427,7 +431,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 }
 
 func (c *managerComponent) volumeMountsForProxyManager() []corev1.VolumeMount {
-	var mounts = []corev1.VolumeMount{
+	mounts := []corev1.VolumeMount{
 		{Name: ManagerTLSSecretName, MountPath: "/manager-tls", ReadOnly: true},
 		c.cfg.TrustedCertBundle.VolumeMount(c.SupportedOSType()),
 	}

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -165,7 +165,7 @@ func (c *managerComponent) SupportedOSType() rmeta.OSType {
 
 func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ManagerNamespace, c.cfg.PullSecrets...)...)...)
 

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -86,9 +86,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(len(deployment.Spec.Template.Spec.Containers)).Should(Equal(3))
-		var manager = deployment.Spec.Template.Spec.Containers[0]
-		var esProxy = deployment.Spec.Template.Spec.Containers[1]
-		var voltron = deployment.Spec.Template.Spec.Containers[2]
+		manager := deployment.Spec.Template.Spec.Containers[0]
+		esProxy := deployment.Spec.Template.Spec.Containers[1]
+		voltron := deployment.Spec.Template.Spec.Containers[2]
 
 		Expect(manager.Image).Should(Equal(components.TigeraRegistry + "tigera/cnx-manager:" + components.ComponentManager.Version))
 		Expect(esProxy.Image).Should(Equal(components.TigeraRegistry + "tigera/es-proxy:" + components.ComponentEsProxy.Version))
@@ -432,6 +432,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			Installation:      i,
 			ESLicenseType:     render.ElasticsearchLicenseTypeUnknown,
 			Replicas:          &replicas,
+			UsePSP:            true,
 		}
 		component, err := render.Manager(cfg)
 		Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)
@@ -552,7 +553,9 @@ func renderObjects(roc renderConfig) []client.Object {
 		authentication := &operatorv1.Authentication{
 			Spec: operatorv1.AuthenticationSpec{
 				ManagerDomain: "https://127.0.0.1",
-				OIDC:          &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"}}}
+				OIDC:          &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"},
+			},
+		}
 
 		dexCfg = render.NewDexKeyValidatorConfig(authentication, nil, dns.DefaultClusterDomain)
 	}
@@ -589,6 +592,7 @@ func renderObjects(roc renderConfig) []client.Object {
 		ESLicenseType:           render.ElasticsearchLicenseTypeEnterpriseTrial,
 		Replicas:                roc.installation.ControlPlaneReplicas,
 		ComplianceFeatureActive: roc.complianceFeatureActive,
+		UsePSP:                  true,
 	}
 	component, err := render.Manager(cfg)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -128,7 +128,7 @@ func (mc *monitorComponent) SupportedOSType() rmeta.OSType {
 
 func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 	toCreate := []client.Object{
-		render.CreateNamespace(common.TigeraPrometheusNamespace, mc.cfg.Installation.KubernetesProvider),
+		render.CreateNamespace(common.TigeraPrometheusNamespace, mc.cfg.Installation.KubernetesProvider, render.PSSRestricted),
 	}
 
 	// Create role and role bindings first.

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -57,7 +57,7 @@ func (c *namespaceComponent) Objects() ([]client.Object, []client.Object) {
 	}
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		// We need to always have ns tigera-dex even when the Authentication CR is not present, so policies can be added to this namespace.
-		ns = append(ns, CreateNamespace(DexObjectName, c.cfg.Installation.KubernetesProvider, PSSBaseline))
+		ns = append(ns, CreateNamespace(DexObjectName, c.cfg.Installation.KubernetesProvider, PSSRestricted))
 	}
 	if len(c.cfg.PullSecrets) > 0 {
 		ns = append(ns, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.cfg.PullSecrets...)...)...)

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -74,6 +74,7 @@ func (c *namespaceComponent) Ready() bool {
 	return true
 }
 
+// TODO: Add in Pod Security Admission labels.
 func CreateNamespace(name string, provider operatorv1.Provider) *corev1.Namespace {
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -53,11 +53,11 @@ func (c *namespaceComponent) SupportedOSType() rmeta.OSType {
 
 func (c *namespaceComponent) Objects() ([]client.Object, []client.Object) {
 	ns := []client.Object{
-		CreateNamespace(common.CalicoNamespace, c.cfg.Installation.KubernetesProvider),
+		CreateNamespace(common.CalicoNamespace, c.cfg.Installation.KubernetesProvider, PSSPrivileged),
 	}
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		// We need to always have ns tigera-dex even when the Authentication CR is not present, so policies can be added to this namespace.
-		ns = append(ns, CreateNamespace(DexObjectName, c.cfg.Installation.KubernetesProvider))
+		ns = append(ns, CreateNamespace(DexObjectName, c.cfg.Installation.KubernetesProvider, PSSBaseline))
 	}
 	if len(c.cfg.PullSecrets) > 0 {
 		ns = append(ns, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.cfg.PullSecrets...)...)...)
@@ -74,16 +74,30 @@ func (c *namespaceComponent) Ready() bool {
 	return true
 }
 
-// TODO: Add in Pod Security Admission labels.
-func CreateNamespace(name string, provider operatorv1.Provider) *corev1.Namespace {
+type PodSecurityStandard string
+
+const (
+	PSSPrivileged = "privileged"
+	PSSBaseline   = "baseline"
+	PSSRestricted = "restricted"
+)
+
+func CreateNamespace(name string, provider operatorv1.Provider, pss PodSecurityStandard) *corev1.Namespace {
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Labels:      map[string]string{"name": name},
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
 			Annotations: map[string]string{},
 		},
 	}
+
+	// Add in labels for configuring pod security standards.
+	// https://kubernetes.io/docs/concepts/security/pod-security-standards/
+	ns.Labels["pod-security.kubernetes.io/enforce"] = string(pss)
+	ns.Labels["pod-security.kubernetes.io/enforce-version"] = "latest"
 
 	switch provider {
 	case operatorv1.ProviderOpenShift:

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -113,6 +113,9 @@ type NodeConfiguration struct {
 	// The bindMode read from the default BGPConfiguration. Used to trigger rolling updates
 	// should this value change.
 	BindMode string
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 // Node creates the node daemonset and other resources for the daemonset to operate normally.
@@ -208,7 +211,7 @@ func (c *nodeComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, c.clusterAdminClusterRoleBinding())
 	}
 
-	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
+	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.cfg.UsePSP {
 		objs = append(objs, c.nodePodSecurityPolicy())
 	}
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -104,6 +104,7 @@ var _ = Describe("Node rendering tests", func() {
 			TLS:             typhaNodeTLS,
 			ClusterDomain:   defaultClusterDomain,
 			FelixHealthPort: 9099,
+			UsePSP:          true,
 		}
 	})
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -108,6 +108,18 @@ var _ = Describe("Node rendering tests", func() {
 		}
 	})
 
+	It("should render properly when PSP is not supported by the cluster", func() {
+		cfg.UsePSP = false
+		component := render.Node(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		// Should not contain any PodSecurityPolicies
+		for _, r := range resources {
+			Expect(r.GetObjectKind()).NotTo(Equal("PodSecurityPolicy"))
+		}
+	})
+
 	It("should render all resources for a default configuration", func() {
 		expectedResources := []struct {
 			name    string

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -64,7 +64,6 @@ type packetCaptureApiComponent struct {
 }
 
 func PacketCaptureAPI(cfg *PacketCaptureApiConfiguration) Component {
-
 	return &packetCaptureApiComponent{
 		cfg: cfg,
 	}
@@ -89,7 +88,7 @@ func (pc *packetCaptureApiComponent) SupportedOSType() rmeta.OSType {
 
 func (pc *packetCaptureApiComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		CreateNamespace(PacketCaptureNamespace, pc.cfg.Installation.KubernetesProvider),
+		CreateNamespace(PacketCaptureNamespace, pc.cfg.Installation.KubernetesProvider, PSSRestricted),
 	}
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(PacketCaptureNamespace, pc.cfg.PullSecrets...)...)...)
 
@@ -147,7 +146,6 @@ func (pc *packetCaptureApiComponent) serviceAccount() client.Object {
 }
 
 func (pc *packetCaptureApiComponent) clusterRole() client.Object {
-
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"authorization.k8s.io"},
@@ -242,7 +240,7 @@ func (pc *packetCaptureApiComponent) initContainers() []corev1.Container {
 }
 
 func (pc *packetCaptureApiComponent) container() corev1.Container {
-	var volumeMounts = []corev1.VolumeMount{
+	volumeMounts := []corev1.VolumeMount{
 		pc.cfg.ServerCertSecret.VolumeMount(pc.SupportedOSType()),
 	}
 	env := []corev1.EnvVar{
@@ -284,7 +282,7 @@ func (pc *packetCaptureApiComponent) healthProbe() *corev1.Probe {
 }
 
 func (pc *packetCaptureApiComponent) volumes() []corev1.Volume {
-	var volumes = []corev1.Volume{
+	volumes := []corev1.Volume{
 		pc.cfg.ServerCertSecret.Volume(),
 	}
 
@@ -296,7 +294,7 @@ func (pc *packetCaptureApiComponent) volumes() []corev1.Volume {
 }
 
 func (pc *packetCaptureApiComponent) annotations() map[string]string {
-	var annotations = map[string]string{
+	annotations := map[string]string{
 		pc.cfg.ServerCertSecret.HashAnnotationKey(): pc.cfg.ServerCertSecret.HashAnnotationValue(),
 	}
 

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -89,6 +89,7 @@ func allCalicoComponents(
 		BirdTemplates:           bt,
 		MigrateNamespaces:       up,
 		FelixHealthPort:         9099,
+		UsePSP:                  true,
 	}
 	typhaCfg := &render.TyphaConfiguration{
 		K8sServiceEp:           k8sServiceEp,
@@ -98,6 +99,7 @@ func allCalicoComponents(
 		AmazonCloudIntegration: aci,
 		MigrateNamespaces:      up,
 		FelixHealthPort:        9099,
+		UsePSP:                 true,
 	}
 	kcCfg := &kubecontrollers.KubeControllersConfiguration{
 		K8sServiceEp:                k8sServiceEp,
@@ -107,6 +109,7 @@ func allCalicoComponents(
 		ManagerInternalSecret:       managerInternalTLSSecret,
 		ClusterDomain:               clusterDomain,
 		MetricsPort:                 kubeControllersMetricsPort,
+		UsePSP:                      true,
 	}
 	winCfg := &render.WindowsConfig{
 		Installation: cr,
@@ -266,7 +269,7 @@ var _ = Describe("Rendering tests", func() {
 
 		var resources []client.Object
 		for _, component := range c {
-			var toCreate, _ = component.Objects()
+			toCreate, _ := component.Objects()
 			resources = append(resources, toCreate...)
 		}
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -447,7 +450,7 @@ func componentCount(components []render.Component) int {
 func getAKSWindowsUpgraderComponentCount(components []render.Component) int {
 	var resources []client.Object
 	for _, component := range components {
-		var toCreate, _ = component.Objects()
+		toCreate, _ := component.Objects()
 		resources = append(resources, toCreate...)
 	}
 	count := 0

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -63,6 +63,9 @@ type TyphaConfiguration struct {
 	// The health port that Felix is bound to. We configure Typha to bind to the port
 	// that is one less.
 	FelixHealthPort int
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 // Typha creates the typha daemonset and other resources for the daemonset to operate normally.
@@ -107,7 +110,7 @@ func (c *typhaComponent) Objects() ([]client.Object, []client.Object) {
 		c.typhaPodDisruptionBudget(),
 	}
 
-	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
+	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.cfg.UsePSP {
 		objs = append(objs, c.typhaPodSecurityPolicy())
 	}
 

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -69,6 +69,7 @@ var _ = Describe("Typha rendering tests", func() {
 			Installation:    installation,
 			ClusterDomain:   defaultClusterDomain,
 			FelixHealthPort: 9099,
+			UsePSP:          true,
 		}
 	})
 

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -73,6 +73,18 @@ var _ = Describe("Typha rendering tests", func() {
 		}
 	})
 
+	It("should render properly when PSP is not supported by the cluster", func() {
+		cfg.UsePSP = false
+		component := render.Typha(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		// Should not contain any PodSecurityPolicies
+		for _, r := range resources {
+			Expect(r.GetObjectKind()).NotTo(Equal("PodSecurityPolicy"))
+		}
+	})
+
 	It("should render all resources for a default configuration", func() {
 		expectedResources := []struct {
 			name    string

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tigera/operator/controllers"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/crds"
 )
 
@@ -164,7 +165,6 @@ var _ = Describe("Mainline component function tests", func() {
 				}
 				return nil
 			}, 30*time.Second, 500*time.Millisecond).Should(BeNil())
-
 		})
 	})
 
@@ -278,11 +278,23 @@ func setupManager(manageCRDs bool) (client.Client, context.Context, context.Canc
 		MapperProvider: func(c *rest.Config) (kmeta.RESTMapper, error) { return apiutil.NewDynamicRESTMapper(c) },
 	})
 	Expect(err).NotTo(HaveOccurred())
+
+	cs, err := kubernetes.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Auto-detect whether the cluster supports PSP. Since we use a kind cluster
+	// from before v1.25, we expect this to be true. Once we update our kind
+	// version >= v1.25, we should instead expect this to return "false".
+	usePSP, err := utils.SupportsPodSecurityPolicies(context.TODO(), cs)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(usePSP).To(BeTrue())
+
 	// Setup Scheme for all resources
 	err = apis.AddToScheme(mgr.GetScheme())
 	Expect(err).NotTo(HaveOccurred())
 
 	ctx, cancel := context.WithCancel(context.TODO())
+
 	// Setup all Controllers
 	err = controllers.AddToManager(mgr, options.AddOptions{
 		DetectedProvider:    operator.ProviderNone,
@@ -290,6 +302,7 @@ func setupManager(manageCRDs bool) (client.Client, context.Context, context.Canc
 		AmazonCRDExists:     true,
 		ManageCRDs:          manageCRDs,
 		ShutdownContext:     ctx,
+		UsePSP:              usePSP,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	return mgr.GetClient(), ctx, cancel, mgr

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -285,7 +285,7 @@ func setupManager(manageCRDs bool) (client.Client, context.Context, context.Canc
 	// Auto-detect whether the cluster supports PSP. Since we use a kind cluster
 	// from before v1.25, we expect this to be true. Once we update our kind
 	// version >= v1.25, we should instead expect this to return "false".
-	usePSP, err := utils.SupportsPodSecurityPolicies(context.TODO(), cs)
+	usePSP, err := utils.SupportsPodSecurityPolicies(cs)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(usePSP).To(BeTrue())
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

More details here: https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/

PodSecurityPolicy has been deprecated, and is scheduled to be removed
completely in Kubernetes v1.25. We want to remove them from our product
sufficiently early so that upgrades to v1.25 are not impacted on older
releases.

Replaced with Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/

Useful translation guide: https://kubernetes.io/docs/reference/access-authn-authz/psp-to-pod-security-standards/

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.