### PR TITLE
deploy Calico API Server with soft zone based anti-affinity by default

### DIFF
--- a/pkg/render/common/podaffinity/pod_anti_affinity.go
+++ b/pkg/render/common/podaffinity/pod_anti_affinity.go
@@ -1,8 +1,26 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package podaffinity
 
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	K8sAppLabelName string = "k8s-app"
 )
 
 func NewPodAntiAffinity(name, namespace string) *corev1.Affinity {
@@ -14,11 +32,23 @@ func NewPodAntiAffinity(name, namespace string) *corev1.Affinity {
 					PodAffinityTerm: corev1.PodAffinityTerm{
 						LabelSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"k8s-app": name,
+								K8sAppLabelName: name,
 							},
 						},
 						Namespaces:  []string{namespace},
 						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+				{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								K8sAppLabelName: name,
+							},
+						},
+						Namespaces:  []string{namespace},
+						TopologyKey: "topology.kubernetes.io/zone",
 					},
 				},
 			},


### PR DESCRIPTION
This PR deploys the Calico API Server component with zone based pod anti-affinity by default for deployments exceeding a single replica. This is "preferred" during scheduling so will NO-OP for single zone clusters (ie: those with a single `topology.kubernetes.io/zone: X` label).

I have built a development version of the image using the `v1.27` release branch + this commit and deployed it to a RedHat OpenShift 4.10 cluster running on IKS using Calico v3.23.1 (OS). I observe that the `calico-apiserver` deployment yaml is structured as expected with both zone and host pod anti-affinity rules.

I have never used Ginkgo before, but was able to modify the tests to cover the newly added pod affinity and get all tests passing.`make test` was presenting some problems, which I have yet to be able to debug. However the same error also presents when run against `master` so it seems unlikely to do with this change. Let me know what more testing is needed if any.

Thanks!

Addresses: IBM request for increased HA of components deployed via Tigera Operator, via sensible K8s deployment API defaults.

Used https://github.com/tigera/operator/pull/1937 as a guide.

Affects: Calico API Server (main concern), Tigera Operator |  dex, logStorage, manager, esGateway (NOTE: These are probably Enterprise components. I have never used these so get the a-okay to add anti-affinity for these.)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
