### PR TITLE
Fix EE issue introduced by https://github.com/tigera/operator/pull/2028

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -843,9 +843,12 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 			corev1.Volume{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
 			// Volume for the bpffs itself, used by the main node container.
 			corev1.Volume{Name: "bpffs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs/bpf", Type: &dirMustExist}}},
-			// Volume used by mount-cgroupv2 init container to access root cgroup name space of node.
-			corev1.Volume{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}},
 		)
+
+		if c.cfg.Installation.Variant == operatorv1.Calico {
+			// Volume used by mount-cgroupv2 init container to access root cgroup name space of node.
+			volumes = append(volumes, corev1.Volume{Name: "init-proc", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/1"}}})
+		}
 	}
 
 	if c.vppDataplaneEnabled() {
@@ -987,11 +990,14 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 			// so that it outlives the init container.
 			MountPropagation: &bidirectional,
 		},
-		{
+	}
+
+	if c.cfg.Installation.Variant == operatorv1.Calico {
+		mounts = append(mounts, corev1.VolumeMount{
 			MountPath: "/initproc",
 			Name:      "init-proc",
 			ReadOnly:  true,
-		},
+		})
 	}
 
 	return corev1.Container{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -330,6 +330,7 @@ var _ = Describe("Node rendering tests", func() {
 			{name: common.NodeDaemonSetName, ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
 		}
 
+		defaultInstance.Variant = operatorv1.Calico
 		defaultInstance.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		dpBPF := operatorv1.LinuxDataplaneBPF
 		defaultInstance.CalicoNetwork.LinuxDataplane = &dpBPF


### PR DESCRIPTION
This PR just checks the product vairant and mounts the node volumes from
the previous PR only if it's Calico.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
