### PR TITLE
Refactor semaphore jobs

### DIFF
--- a/.semaphore/clean_up.yml
+++ b/.semaphore/clean_up.yml
@@ -1,0 +1,26 @@
+version: v1.0
+name: Operator Clean Up
+
+execution_time_limit:
+  hours: 4
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Clear Commit Caches
+    task:
+      jobs:
+        - name: Clear Commit Caches
+          commands:
+            - 'cache delete bin-amd64-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete go-pkg-cache-amd64-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete go-mod-cache-amd64-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete bin-arm64-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete go-pkg-cache-arm64-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete go-mod-cache-arm64-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete bin-ppc64le-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete go-pkg-cache-ppc64le-${SEMAPHORE_GIT_SHA}'
+            - 'cache delete go-mod-cache-ppc64le-${SEMAPHORE_GIT_SHA}'

--- a/.semaphore/clear_cache.yml
+++ b/.semaphore/clear_cache.yml
@@ -1,0 +1,19 @@
+version: v1.0
+name: Operator Clean Up
+
+execution_time_limit:
+  hours: 4
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Clear Entire Cache
+    task:
+      jobs:
+        - name: Clear Entire Cache
+          commands:
+            - 'cache clear'
+

--- a/.semaphore/push_images.yml
+++ b/.semaphore/push_images.yml
@@ -1,0 +1,63 @@
+version: v1.0
+name: Operator CD
+agent:
+  machine:
+    type: e1-standard-4
+    os_image: ubuntu1804
+global_job_config:
+  secrets:
+    - name: docker-hub
+    # Mount the github SSH secret for pulling private repositories.
+    - name: private-repo
+  prologue:
+    commands:
+      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Correct permissions since they are too open by default:
+      - chmod 0600 ~/.keys/*
+      # Add the key to the ssh agent:
+      - ssh-add ~/.keys/*
+      # Free up some space
+      - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during testing.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      - checkout
+      # Restore all the build specific caches
+      - 'cache restore bin-amd64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-pkg-cache-amd64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-mod-cache-amd64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore bin-arm64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-pkg-cache-arm64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-mod-cache-arm64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore bin-ppc64le-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-pkg-cache-ppc64le-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-mod-cache-ppc64le-${SEMAPHORE_GIT_SHA}'
+
+blocks:
+  - name: Push Images / Maybe Release
+    task:
+      secrets:
+        - name: quay-robot-semaphore_v2
+        - name: operator-redhat-connect
+      prologue:
+        commands:
+          - docker login -u="$QUAY_USERNAME" -p="$QUAY_TOKEN" quay.io;
+          - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+      jobs:
+        - name: Build
+          commands:
+            - make cd CONFIRM=true;
+            - make maybe-build-release;
+
+promotions:
+  - name: Clean Up
+    pipeline_file: clean_up.yml
+    # Auto promote to clean up since this likely wasn't promoted from the CI pipeline (since we only promote to the
+    # clean up pipeline if we're not running on master or a release branch).
+    # We only auto promote if the cd has passed, because if it's failed we'll likely just want to run CD again, but if
+    # we've cleared the cache it will take a long time.
+    auto_promote:
+      when: "result = 'passed'"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,8 +1,18 @@
 version: v1.0
-name: Initial Pipeline
+name: Operator CI
+
+execution_time_limit:
+  hours: 4
+
+auto_cancel:
+  running:
+    when: "branch != 'master'"
+  queued:
+    when: "branch != 'master'"
+
 agent:
   machine:
-    type: e1-standard-8
+    type: e1-standard-2
     os_image: ubuntu1804
 global_job_config:
   secrets:
@@ -11,52 +21,116 @@ global_job_config:
   - name: private-repo
   prologue:
     commands:
-    - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-    # Correct permissions since they are too open by default:
-    - chmod 0600 ~/.keys/*
-    # Add the key to the ssh agent:
-    - ssh-add ~/.keys/*
-    # Free up some space
-    - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
-    # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-    # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-    # how much we churn docker containers during testing.  Disable it.
-    - sudo systemctl stop docker
-    - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-    - sudo systemctl start docker
+      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Correct permissions since they are too open by default:
+      - chmod 0600 ~/.keys/*
+      # Add the key to the ssh agent:
+      - ssh-add ~/.keys/*
+      # Free up some space
+      - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during testing.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      - checkout
+      # Note that the 'cache restore' commands require that the "Build" block has been run. The "Build" block is what populates
+      # the cache, therefore every block that requires the use of these cached items must make the "Build" block one of
+      # it's dependencies.
+      - 'cache restore go-pkg-cache-amd64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-mod-cache-amd64-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore bin-amd64-${SEMAPHORE_GIT_SHA}'
 
 blocks:
-  - name: Build
+  - name: 'Build amd64'
+    dependencies: []
     task:
       jobs:
-        - name: Build
+        - name: Build amd64
+          execution_time_limit:
+            minutes: 45
           commands:
-            - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-            - make ci
-            - >-
-              if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then 
-                make cd CONFIRM=true;
-              fi
-            - >-
-              if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then
-                make maybe-build-release;
-              fi
-      secrets:
-        - name: quay-robot-semaphore_v2
-        - name: operator-redhat-connect
+            - make build
+            - make dirty-check
+            # Store in cache for other builds in this run
+            - 'cache store bin-amd64-${SEMAPHORE_GIT_SHA} build/_output/bin'
+            - 'cache store go-pkg-cache-amd64-${SEMAPHORE_GIT_SHA} .go-pkg-cache'
+            - 'cache store go-mod-cache-amd64-${SEMAPHORE_GIT_SHA} ${HOME}/go/pkg/mod/cache'
+  - name: 'Build / Cache arm64 and ppc64le'
+    dependencies: [ "Build amd64" ]
+    task:
       prologue:
         commands:
-          - checkout
-          - >-
-            if [[ -v SEMAPHORE_GIT_PR_NUMBER ]]; then
-              unset QUAY_USERNAME QUAY_TOKEN; docker logout; docker logout quay.io;
-            else
-              docker login -u="$QUAY_USERNAME" -p="$QUAY_TOKEN" quay.io;
-            fi
-          - cache restore go-pkg-cache
-          - cache restore go-mod-cache
-      epilogue:
-        on_pass:
+          - cache restore go-pkg-cache-amd64-${SEMAPHORE_GIT_SHA}
+          - cache restore go-mod-cache-amd64-${SEMAPHORE_GIT_SHA}
+      jobs:
+        - name: Build arm64
+          execution_time_limit:
+            minutes: 45
           commands:
-            - cache store go-pkg-cache .go-pkg-cache
-            - 'cache store go-mod-cache ${HOME}/go/pkg/mod/cache'
+            - make register build ARCH=arm64
+            # Store in cache for other builds in this run
+            - 'cache store bin-arm64-${SEMAPHORE_GIT_SHA} build/_output/bin'
+            - 'cache store go-pkg-cache-arm64-${SEMAPHORE_GIT_SHA} .go-pkg-cache'
+            - 'cache store go-mod-cache-arm64-${SEMAPHORE_GIT_SHA} ${HOME}/go/pkg/mod/cache'
+        - name: Build ppc64le
+          execution_time_limit:
+            minutes: 45
+          commands:
+            - make register build ARCH=ppc64le
+            # Store in cache for other builds in this run
+            - 'cache store bin-ppc64le-${SEMAPHORE_GIT_SHA} build/_output/bin'
+            - 'cache store go-pkg-cache-ppc64le-${SEMAPHORE_GIT_SHA} .go-pkg-cache'
+            - 'cache store go-mod-cache-ppc64le-${SEMAPHORE_GIT_SHA} ${HOME}/go/pkg/mod/cache'
+  - name: 'Static / File Generation Checks'
+    dependencies: [ "Build amd64" ]
+    task:
+      jobs:
+        - name: Static / File Generation Checks, Vet
+          execution_time_limit:
+            minutes: 15
+          commands:
+            - make format-check validate-gen-versions fmt test-crds
+            - make dirty-check
+            - make vet
+
+  - name: 'UT'
+    dependencies: [ "Build amd64" ]
+    task:
+      jobs:
+        - name: Run UTs
+          execution_time_limit:
+            minutes: 30
+          commands:
+            - make ut
+            - make dirty-check
+
+  - name: 'FV'
+    dependencies: [ "Build amd64" ]
+    task:
+      agent:
+        machine:
+          type: e1-standard-4
+          os_image: ubuntu1804
+      jobs:
+        - name: Run FVs
+          execution_time_limit:
+            minutes: 30
+          commands:
+            - make fv
+            - make dirty-check
+
+promotions:
+  - name: Push Images
+    pipeline_file: push_images.yml
+    auto_promote:
+      when: "branch =~ 'master|release-.*'"
+  - name: Clean Up
+    pipeline_file: clean_up.yml
+    # Don't auto promote if this is master or a release branch so the cache is available for the Push Images pipeline.
+    auto_promote:
+      when: "(branch !~ 'master|release-.*') OR (result != 'passed')"
+  - name: Clear Cache
+    # Never auto promote this, this is only to give an easy way for people to clear the cache.
+    pipeline_file: clear_cache.yml

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 # This is only needed when running non-native binaries.
 register:
 ifneq ($(BUILDARCH),$(ARCH))
-	docker run --rm --privileged multiarch/qemu-user-static:register || true
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset || true
 endif
 
 # list of arches *not* to build when doing *-all
@@ -221,7 +221,7 @@ else
   GIT_VERSION?=$(shell git describe --tags --dirty --always --abbrev=12)
 endif
 
-build: fmt vet $(BINDIR)/operator-$(ARCH)
+build: $(BINDIR)/operator-$(ARCH)
 $(BINDIR)/operator-$(ARCH): $(SRC_FILES)
 	mkdir -p $(BINDIR)
 	$(CONTAINERIZED) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
@@ -280,12 +280,17 @@ WHAT?=.
 GINKGO_ARGS?= -v
 GINKGO_FOCUS?=.*
 
-## Run the full set of tests
-ut: cluster-create run-uts cluster-destroy
-run-uts:
+ut:
 	-mkdir -p .go-pkg-cache report
 	$(CONTAINERIZED) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
-	ginkgo -r --skipPackage ./vendor -focus="$(GINKGO_FOCUS)" $(GINKGO_ARGS) "$(WHAT)"'
+	ginkgo -r --skipPackage "./vendor,./test" -focus="$(GINKGO_FOCUS)" $(GINKGO_ARGS) "$(WHAT)"'
+
+## Run the functional tests
+fv: cluster-create run-fvs cluster-destroy
+run-fvs:
+	-mkdir -p .go-pkg-cache report
+	$(CONTAINERIZED) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
+	ginkgo -pkgdir test -r --skipPackage ./vendor -focus="$(GINKGO_FOCUS)" $(GINKGO_ARGS) "$(WHAT)"'
 
 ## Create a local kind dual stack cluster.
 KUBECONFIG?=./kubeconfig.yaml
@@ -388,7 +393,7 @@ validate-gen-versions:
 	make dirty-check
 
 ## Deploys images to registry
-cd:
+cd: image-all
 ifndef CONFIRM
 	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
 endif
@@ -654,7 +659,7 @@ fmt:
 	go fmt ./...'
 
 # Run go vet against code
-vet:
+vet: register
 	$(CONTAINERIZED) $(CALICO_BUILD) \
 	sh -c '$(GIT_CONFIG_SSH) \
 	go vet ./...'


### PR DESCRIPTION
## Description
This commit:
- Separates the `cd` / `maybe-build-release` targets into a pipeline
  that can be promoted
- Remove `vet` as a dependency of build so we don't vet for all arches
  when creating the images (takes a very long time for non amd64 builds)
- Splits UT / FV / static tests to run asynchronously to reduce build
  time
- Build / download go dependencies for arm64 and ppc64le asynchronously
  while running the CI and cache them so the push images step doesn't
  have to spend 15-20m gettings the dependencies / building the
  binaries.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
