### PR TITLE
Remove Components from list that are not for images

### DIFF
--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -68,7 +68,7 @@ var (
 		Image:   "tigera/operator",
 	}
 
-	CalicoComponents = []component{
+	CalicoImages = []component{
 		ComponentCalicoCNI,
 		ComponentCalicoKubeControllers,
 		ComponentCalicoNode,

--- a/hack/gen-versions/common.go.tpl
+++ b/hack/gen-versions/common.go.tpl
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ var ({{ with index .Components "key-cert-provisioner" }}
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
-	CommonComponents = []component{
+	CommonImages = []component{
 		ComponentCSRInitContainer,
 	}
 )

--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,11 +32,11 @@ var defaultImages = map[string]string{
 	"flannel":                    "coreos/flannel",
 	"flexvol":                    "calico/pod2daemon-flexvol",
 	"typha":                      "calico/typha",
-	"eck-elasticsearch":          "tigera/elasticsearch",
-	"eck-elasticsearch-operator": "tigera/eck-operator",
-	"eck-kibana":                 "tigera/kibana",
-	"coreos-prometheus":          "tigera/prometheus",
-	"coreos-alertmanager":        "tigera/alertmanager",
+	"eck-elasticsearch":          "unused/image",
+	"eck-elasticsearch-operator": "unused/image",
+	"eck-kibana":                 "unused/image",
+	"coreos-prometheus":          "unused/image",
+	"coreos-alertmanager":        "unused/image",
 	"guardian":                   "tigera/guardian",
 	"tigera-cni":                 "tigera/cni",
 	"key-cert-provisioner":       "tigera/key-cert-provisioner",

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -64,13 +64,11 @@ var (
 {{ with index .Components "eck-elasticsearch" }}
 	ComponentEckElasticsearch = component{
 		Version: "{{ .Version }}",
-		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components "eck-kibana" }}
 	ComponentEckKibana = component{
 		Version: "{{ .Version }}",
-		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components "elastic-tsee-installer" }}
@@ -88,7 +86,6 @@ var (
 {{ with index .Components "eck-elasticsearch-operator" }}
 	ComponentECKElasticsearchOperator = component{
 		Version: "{{ .Version }}",
-		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components "elasticsearch-operator" }}
@@ -202,7 +199,6 @@ var (
 {{ with index .Components "coreos-prometheus" }}
 	ComponentCoreOSPrometheus = component{
 		Version: "{{ .Version }}",
-		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components "prometheus" }}
@@ -220,7 +216,6 @@ var (
 {{ with index .Components "coreos-alertmanager" }}
 	ComponentCoreOSAlertmanager = component{
 		Version: "{{ .Version }}",
-		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components "alertmanager" }}
@@ -277,7 +272,9 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
-	EnterpriseComponents = []component{
+	// Only components that correspond directly to images should be included in this list,
+	// Components that are only for providing a version should be left out of this list.
+	EnterpriseImages = []component{
 		ComponentAPIServer,
 		ComponentComplianceBenchmarker,
 		ComponentComplianceController,
@@ -285,11 +282,8 @@ var (
 		ComponentComplianceServer,
 		ComponentComplianceSnapshotter,
 		ComponentDeepPacketInspection,
-		ComponentEckElasticsearch,
-		ComponentEckKibana,
 		ComponentElasticTseeInstaller,
 		ComponentElasticsearch,
-		ComponentECKElasticsearchOperator,
 		ComponentElasticsearchOperator,
 		ComponentEsCurator,
 		ComponentEsProxy,
@@ -306,10 +300,8 @@ var (
 		ComponentPacketCapture,
 		ComponentL7Collector,
 		ComponentEnvoyProxy,
-		ComponentCoreOSPrometheus,
 		ComponentPrometheus,
 		ComponentTigeraPrometheusService,
-		ComponentCoreOSAlertmanager,
 		ComponentPrometheusAlertmanager,
 		ComponentQueryServer,
 		ComponentTigeraKubeControllers,

--- a/main.go
+++ b/main.go
@@ -119,9 +119,9 @@ func main() {
 	}
 	if printImages != "" {
 		if strings.ToLower(printImages) == "list" {
-			cmpnts := components.CalicoComponents
-			cmpnts = append(cmpnts, components.EnterpriseComponents...)
-			cmpnts = append(cmpnts, components.CommonComponents...)
+			cmpnts := components.CalicoImages
+			cmpnts = append(cmpnts, components.EnterpriseImages...)
+			cmpnts = append(cmpnts, components.CommonImages...)
 
 			for _, x := range cmpnts {
 				ref, _ := components.GetReference(x, "", "", "", nil)

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -61,7 +61,7 @@ var (
 		Image:   "tigera/operator",
 	}
 
-	CalicoComponents = []component{
+	CalicoImages = []component{
 		ComponentCalicoCNI,
 		ComponentCalicoKubeControllers,
 		ComponentCalicoNode,

--- a/pkg/components/common.go
+++ b/pkg/components/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ var (
 		Version: "master",
 		Image:   "tigera/key-cert-provisioner",
 	}
-	CommonComponents = []component{
+	CommonImages = []component{
 		ComponentCSRInitContainer,
 	}
 )

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -57,12 +57,10 @@ var (
 
 	ComponentEckElasticsearch = component{
 		Version: "7.16.2",
-		Image:   "tigera/elasticsearch",
 	}
 
 	ComponentEckKibana = component{
 		Version: "7.16.2",
-		Image:   "tigera/kibana",
 	}
 
 	ComponentElasticTseeInstaller = component{
@@ -77,7 +75,6 @@ var (
 
 	ComponentECKElasticsearchOperator = component{
 		Version: "1.8.0",
-		Image:   "tigera/eck-operator",
 	}
 
 	ComponentElasticsearchOperator = component{
@@ -172,7 +169,6 @@ var (
 
 	ComponentCoreOSPrometheus = component{
 		Version: "v2.32.0",
-		Image:   "tigera/prometheus",
 	}
 
 	ComponentPrometheus = component{
@@ -187,7 +183,6 @@ var (
 
 	ComponentCoreOSAlertmanager = component{
 		Version: "v0.23.0",
-		Image:   "tigera/alertmanager",
 	}
 
 	ComponentPrometheusAlertmanager = component{
@@ -234,7 +229,9 @@ var (
 		Version: "master",
 		Image:   "tigera/calico-windows-upgrade",
 	}
-	EnterpriseComponents = []component{
+	// Only components that correspond directly to images should be included in this list,
+	// Components that are only for providing a version should be left out of this list.
+	EnterpriseImages = []component{
 		ComponentAPIServer,
 		ComponentComplianceBenchmarker,
 		ComponentComplianceController,
@@ -242,11 +239,8 @@ var (
 		ComponentComplianceServer,
 		ComponentComplianceSnapshotter,
 		ComponentDeepPacketInspection,
-		ComponentEckElasticsearch,
-		ComponentEckKibana,
 		ComponentElasticTseeInstaller,
 		ComponentElasticsearch,
-		ComponentECKElasticsearchOperator,
 		ComponentElasticsearchOperator,
 		ComponentEsCurator,
 		ComponentEsProxy,
@@ -263,10 +257,8 @@ var (
 		ComponentPacketCapture,
 		ComponentL7Collector,
 		ComponentEnvoyProxy,
-		ComponentCoreOSPrometheus,
 		ComponentPrometheus,
 		ComponentTigeraPrometheusService,
-		ComponentCoreOSAlertmanager,
 		ComponentPrometheusAlertmanager,
 		ComponentQueryServer,
 		ComponentTigeraKubeControllers,

--- a/pkg/controller/utils/imageset/imageset.go
+++ b/pkg/controller/utils/imageset/imageset.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ func ValidateImageSet(is *operator.ImageSet) error {
 	unknownImages := []string{}
 	for _, img := range is.Spec.Images {
 		valid := false
-		for _, x := range components.CalicoComponents {
+		for _, x := range components.CalicoImages {
 			if img.Image == x.Image {
 				valid = true
 				break
@@ -103,7 +103,7 @@ func ValidateImageSet(is *operator.ImageSet) error {
 		if valid {
 			continue
 		}
-		for _, x := range components.EnterpriseComponents {
+		for _, x := range components.EnterpriseImages {
 			if img.Image == x.Image {
 				valid = true
 				break
@@ -113,7 +113,7 @@ func ValidateImageSet(is *operator.ImageSet) error {
 			continue
 		}
 
-		for _, x := range components.CommonComponents {
+		for _, x := range components.CommonImages {
 			if img.Image == x.Image {
 				valid = true
 				break


### PR DESCRIPTION
## Description

This PR drops the "Components" from the EnterpriseComponents (EnterpriseImages) that are only used for specifying a version of a component (like for elasticsearch or prometheus) that needs to be passed to an operator for configuration of those components version. (for example, we have to pass a version of ES to the eck-operator)

Output of `operator --print-images=list` is now
```
docker.io/calico/cni:master
docker.io/calico/kube-controllers:master
docker.io/calico/node:master
docker.io/calico/typha:master
docker.io/calico/pod2daemon-flexvol:master
quay.io/tigera/operator:v1.23.0-1.dev-447-gce924bb721de-dirty
docker.io/calico/apiserver:master
docker.io/calico/windows-upgrade:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-apiserver:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-benchmarker:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-controller:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-reporter:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-server:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-snapshotter:master
gcr.io/unique-caldron-775/cnx/tigera/deep-packet-inspection:master
gcr.io/unique-caldron-775/cnx/tigera/intrusion-detection-job-installer:master
gcr.io/unique-caldron-775/cnx/tigera/elasticsearch:master
gcr.io/unique-caldron-775/cnx/tigera/eck-operator:master
gcr.io/unique-caldron-775/cnx/tigera/es-curator:master
gcr.io/unique-caldron-775/cnx/tigera/es-proxy:master
gcr.io/unique-caldron-775/cnx/tigera/fluentd:master
gcr.io/unique-caldron-775/cnx/tigera/fluentd-windows:master
gcr.io/unique-caldron-775/cnx/tigera/guardian:master
gcr.io/unique-caldron-775/cnx/tigera/intrusion-detection-controller:master
gcr.io/unique-caldron-775/cnx/tigera/anomaly_detection_jobs:master
gcr.io/unique-caldron-775/cnx/tigera/anomaly-detection-api:master
gcr.io/unique-caldron-775/cnx/tigera/kibana:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-manager:master
gcr.io/unique-caldron-775/cnx/tigera/dex:master
gcr.io/unique-caldron-775/cnx/tigera/voltron:master
gcr.io/unique-caldron-775/cnx/tigera/packetcapture:master
gcr.io/unique-caldron-775/cnx/tigera/l7-collector:master
gcr.io/unique-caldron-775/cnx/tigera/envoy:master
gcr.io/unique-caldron-775/cnx/tigera/prometheus:master
gcr.io/unique-caldron-775/cnx/tigera/prometheus-service:master
gcr.io/unique-caldron-775/cnx/tigera/alertmanager:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-queryserver:master
gcr.io/unique-caldron-775/cnx/tigera/kube-controllers:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-node:master
gcr.io/unique-caldron-775/cnx/tigera/typha:master
gcr.io/unique-caldron-775/cnx/tigera/cni:master
gcr.io/unique-caldron-775/cnx/tigera/cloud-controllers:master
gcr.io/unique-caldron-775/cnx/tigera/elasticsearch-metrics:master
gcr.io/unique-caldron-775/cnx/tigera/es-gateway:master
gcr.io/unique-caldron-775/cnx/tigera/calico-windows-upgrade:master
gcr.io/unique-caldron-775/cnx/tigera/dikastes:master
quay.io/tigera/key-cert-provisioner:master
```
Before this PR the output is
```
docker.io/calico/cni:master
docker.io/calico/kube-controllers:master
docker.io/calico/node:master
docker.io/calico/typha:master
docker.io/calico/pod2daemon-flexvol:master
quay.io/tigera/operator:v1.23.0-1.dev-446-g2c324e7d5e35
docker.io/calico/apiserver:master
docker.io/calico/windows-upgrade:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-apiserver:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-benchmarker:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-controller:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-reporter:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-server:master
gcr.io/unique-caldron-775/cnx/tigera/compliance-snapshotter:master
gcr.io/unique-caldron-775/cnx/tigera/deep-packet-inspection:master
gcr.io/unique-caldron-775/cnx/tigera/elasticsearch:7.16.2
gcr.io/unique-caldron-775/cnx/tigera/kibana:7.16.2
gcr.io/unique-caldron-775/cnx/tigera/intrusion-detection-job-installer:master
gcr.io/unique-caldron-775/cnx/tigera/elasticsearch:master
gcr.io/unique-caldron-775/cnx/tigera/eck-operator:1.8.0
gcr.io/unique-caldron-775/cnx/tigera/eck-operator:master
gcr.io/unique-caldron-775/cnx/tigera/es-curator:master
gcr.io/unique-caldron-775/cnx/tigera/es-proxy:master
gcr.io/unique-caldron-775/cnx/tigera/fluentd:master
gcr.io/unique-caldron-775/cnx/tigera/fluentd-windows:master
gcr.io/unique-caldron-775/cnx/tigera/guardian:master
gcr.io/unique-caldron-775/cnx/tigera/intrusion-detection-controller:master
gcr.io/unique-caldron-775/cnx/tigera/anomaly_detection_jobs:master
gcr.io/unique-caldron-775/cnx/tigera/anomaly-detection-api:master
gcr.io/unique-caldron-775/cnx/tigera/kibana:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-manager:master
gcr.io/unique-caldron-775/cnx/tigera/dex:master
gcr.io/unique-caldron-775/cnx/tigera/voltron:master
gcr.io/unique-caldron-775/cnx/tigera/packetcapture:master
gcr.io/unique-caldron-775/cnx/tigera/l7-collector:master
gcr.io/unique-caldron-775/cnx/tigera/envoy:master
gcr.io/unique-caldron-775/cnx/tigera/prometheus:v2.32.0
gcr.io/unique-caldron-775/cnx/tigera/prometheus:master
gcr.io/unique-caldron-775/cnx/tigera/prometheus-service:master
gcr.io/unique-caldron-775/cnx/tigera/alertmanager:v0.23.0
gcr.io/unique-caldron-775/cnx/tigera/alertmanager:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-queryserver:master
gcr.io/unique-caldron-775/cnx/tigera/kube-controllers:master
gcr.io/unique-caldron-775/cnx/tigera/cnx-node:master
gcr.io/unique-caldron-775/cnx/tigera/typha:master
gcr.io/unique-caldron-775/cnx/tigera/cni:master
gcr.io/unique-caldron-775/cnx/tigera/cloud-controllers:master
gcr.io/unique-caldron-775/cnx/tigera/elasticsearch-metrics:master
gcr.io/unique-caldron-775/cnx/tigera/es-gateway:master
gcr.io/unique-caldron-775/cnx/tigera/calico-windows-upgrade:master
gcr.io/unique-caldron-775/cnx/tigera/dikastes:master
quay.io/tigera/key-cert-provisioner:master
```
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
