### PR TITLE
Fix PodSecurityStandard for intrusion detection

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -146,7 +146,7 @@ func (c *intrusionDetectionComponent) SupportedOSType() rmeta.OSType {
 func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Object) {
 	// Configure pod security standard. If syslog forwarding is enabled, we
 	// need hostpath volumes which require a privileged PSS.
-	pss := PSSRestricted
+	pss := PSSBaseline
 	if c.syslogForwardingIsEnabled() {
 		pss = PSSPrivileged
 	}


### PR DESCRIPTION
Fixes:
```
$ k describe replicaset.apps/anomaly-detection-api-5fc4f84f99
  Warning  FailedCreate  62s   replicaset-controller  Error creating: pods "anomaly-detection-api-5fc4f84f99-6hrgg" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "anomaly-detection-api" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "anomaly-detection-api" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "anomaly-detection-api" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "anomaly-detection-api" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")

```
that affects both deployments in the tigera-intrusion-detection namespace