### PR TITLE
Log upstream service time in envoy access log

### DIFF
--- a/pkg/render/applicationlayer/envoy-config.yaml.template
+++ b/pkg/render/applicationlayer/envoy-config.yaml.template
@@ -21,6 +21,7 @@
                         domain: "%REQ(HOST?:AUTHORITY)%"
                         upstream_host: "%UPSTREAM_HOST%"
                         upstream_local_address: "%UPSTREAM_LOCAL_ADDRESS%"
+                        upstream_service_time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
 {{- end -}}
 
 {{- define "WAF" -}}


### PR DESCRIPTION
## Description

Logging upstream service time enables us to roughly calculate the
network latency between envoy proxy and upstream service. It will be
calculated as: `%DURATION% - %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%`.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
