### PR TITLE
allow-tigera reconciliation: follow-ups

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -71,7 +71,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		}
 
 		// Watch for changes to Tier, as its status is used as input to determine whether network policy should be reconciled by this controller.
-		go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log)
+		go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, nil)
 
 		go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
 			{Name: render.APIServerPolicyName, Namespace: rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise)},

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -69,7 +69,8 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	// Create the reconciler
-	reconciler := newReconciler(mgr, opts)
+	tierWatchReady := &utils.ReadyFlag{}
+	reconciler := newReconciler(mgr, opts, tierWatchReady)
 
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -82,6 +83,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return fmt.Errorf("%s failed to establish a connection to k8s: %w", controllerName, err)
 	}
 
+	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, tierWatchReady)
 	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
 		{Name: render.DexPolicyName, Namespace: render.DexNamespace},
 		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.DexNamespace},
@@ -91,13 +93,14 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opts options.AddOptions) *ReconcileAuthentication {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, tierWatchReady *utils.ReadyFlag) *ReconcileAuthentication {
 	r := &ReconcileAuthentication{
-		client:        mgr.GetClient(),
-		scheme:        mgr.GetScheme(),
-		provider:      opts.DetectedProvider,
-		status:        status.New(mgr.GetClient(), "authentication", opts.KubernetesVersion),
-		clusterDomain: opts.ClusterDomain,
+		client:         mgr.GetClient(),
+		scheme:         mgr.GetScheme(),
+		provider:       opts.DetectedProvider,
+		status:         status.New(mgr.GetClient(), "authentication", opts.KubernetesVersion),
+		clusterDomain:  opts.ClusterDomain,
+		tierWatchReady: tierWatchReady,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -142,11 +145,12 @@ var _ reconcile.Reconciler = &ReconcileAuthentication{}
 
 // ReconcileAuthentication reconciles an Authentication object
 type ReconcileAuthentication struct {
-	client        client.Client
-	scheme        *runtime.Scheme
-	provider      oprv1.Provider
-	status        status.StatusManager
-	clusterDomain string
+	client         client.Client
+	scheme         *runtime.Scheme
+	provider       oprv1.Provider
+	status         status.StatusManager
+	clusterDomain  string
+	tierWatchReady *utils.ReadyFlag
 }
 
 // Reconciles the cluster state with the Authentication object that is found in the cluster.
@@ -215,6 +219,12 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 			r.status.SetDegraded("Error querying tigera-dex namespace", err.Error())
 			return reconcile.Result{}, err
 		}
+	}
+
+	// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
+	if !r.tierWatchReady.IsReady() {
+		r.status.SetDegraded("Waiting for Tier watch to be established", "")
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -206,12 +206,6 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, nil
 	}
 
-	// Ensure the API Server is ready, before rendering any objects that utilize the V3 API.
-	if !utils.IsAPIServerReady(r.client, reqLogger) {
-		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
 	if !r.policyWatchesReady.IsReady() {
 		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -82,7 +82,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return fmt.Errorf("%s failed to establish a connection to k8s: %w", controllerName, err)
 	}
 
-	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, reconciler.policyWatchesReady, []types.NamespacedName{
+	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
 		{Name: render.DexPolicyName, Namespace: render.DexNamespace},
 		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.DexNamespace},
 	})
@@ -93,12 +93,11 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, opts options.AddOptions) *ReconcileAuthentication {
 	r := &ReconcileAuthentication{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		provider:           opts.DetectedProvider,
-		status:             status.New(mgr.GetClient(), "authentication", opts.KubernetesVersion),
-		clusterDomain:      opts.ClusterDomain,
-		policyWatchesReady: &utils.ReadyFlag{},
+		client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		provider:      opts.DetectedProvider,
+		status:        status.New(mgr.GetClient(), "authentication", opts.KubernetesVersion),
+		clusterDomain: opts.ClusterDomain,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -143,12 +142,11 @@ var _ reconcile.Reconciler = &ReconcileAuthentication{}
 
 // ReconcileAuthentication reconciles an Authentication object
 type ReconcileAuthentication struct {
-	client             client.Client
-	scheme             *runtime.Scheme
-	provider           oprv1.Provider
-	status             status.StatusManager
-	clusterDomain      string
-	policyWatchesReady *utils.ReadyFlag
+	client        client.Client
+	scheme        *runtime.Scheme
+	provider      oprv1.Provider
+	status        status.StatusManager
+	clusterDomain string
 }
 
 // Reconciles the cluster state with the Authentication object that is found in the cluster.
@@ -204,11 +202,6 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		log.Error(err, fmt.Sprintf("Waiting for network to be %s", oprv1.TigeraSecureEnterprise))
 		r.status.SetDegraded(fmt.Sprintf("Waiting for network to be %s", oprv1.TigeraSecureEnterprise), "")
 		return reconcile.Result{}, nil
-	}
-
-	if !r.policyWatchesReady.IsReady() {
-		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Make sure the tigera-dex namespace exists, before rendering any objects there.

--- a/pkg/controller/authentication/authentication_controller_test.go
+++ b/pkg/controller/authentication/authentication_controller_test.go
@@ -266,10 +266,6 @@ var _ = Describe("authentication controller tests", func() {
 			}
 		})
 
-		It("should wait if API server is unavailable", func() {
-			utils.DeleteAPIServerAndExpectWait(ctx, cli, r, mockStatus)
-		})
-
 		It("should wait if allow-tigera tier is unavailable", func() {
 			utils.DeleteAllowTigeraTierAndExpectWait(ctx, cli, r, mockStatus)
 		})

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/status"
-	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/test"
 
@@ -54,10 +53,6 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 	var dpl *appsv1.Deployment
 	var mockStatus *status.MockStatus
 
-	notReady := &utils.ReadyFlag{}
-	ready := &utils.ReadyFlag{}
-	ready.MarkAsReady()
-
 	BeforeEach(func() {
 		// Create a Kubernetes client.
 		scheme = runtime.NewScheme()
@@ -80,7 +75,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ReadyToMonitor")
 
-		r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, ready, ready)
+		r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone)
 		dpl = &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -152,7 +147,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 
 	Context("image reconciliation", func() {
 		It("should use builtin images", func() {
-			r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, ready, ready)
+			r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone)
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -182,7 +177,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				},
 			})).ToNot(HaveOccurred())
 
-			r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, ready, ready)
+			r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone)
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -218,11 +213,11 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 			}
 			Expect(c.Create(ctx, licenseKey)).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
-			r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, ready, ready)
+			r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone)
 		})
 
 		Context("IP-based management cluster address", func() {
-			It("should render allow-tigera policy when tier and watches are ready", func() {
+			It("should render allow-tigera policy when tier is ready", func() {
 				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -234,49 +229,10 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				Expect(policies.Items[1].Name).To(Equal("allow-tigera.guardian-access"))
 			})
 
-			It("should omit allow-tigera policy when watches are ready but tier is not ready", func() {
+			It("should omit allow-tigera policy and not degrade when tier is not ready", func() {
 				Expect(c.Delete(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
 				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
-
-				policies := v3.NetworkPolicyList{}
-				Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-				Expect(policies.Items).To(HaveLen(0))
-			})
-
-			It("should degrade and wait when tier is ready, but license watch is not ready", func() {
-				mockStatus = &status.MockStatus{}
-				mockStatus.On("Run").Return()
-				mockStatus.On("OnCRFound").Return()
-
-				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, notReady, ready, ready)
-				utils.ExpectWaitForLicenseWatch(ctx, r, mockStatus)
-
-				policies := v3.NetworkPolicyList{}
-				Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-				Expect(policies.Items).To(HaveLen(0))
-			})
-
-			It("should degrade and wait when tier is ready, but tier watch is not ready", func() {
-				mockStatus = &status.MockStatus{}
-				mockStatus.On("Run").Return()
-				mockStatus.On("OnCRFound").Return()
-
-				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, notReady, ready)
-				utils.ExpectWaitForTierWatch(ctx, r, mockStatus)
-
-				policies := v3.NetworkPolicyList{}
-				Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-				Expect(policies.Items).To(HaveLen(0))
-			})
-
-			It("should degrade and wait when tier is ready, but policy watch is not ready", func() {
-				mockStatus = &status.MockStatus{}
-				mockStatus.On("Run").Return()
-				mockStatus.On("OnCRFound").Return()
-
-				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, ready, notReady)
-				utils.ExpectWaitForPolicyWatches(ctx, r, mockStatus)
 
 				policies := v3.NetworkPolicyList{}
 				Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
@@ -290,7 +246,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				Expect(c.Update(ctx, cfg)).NotTo(HaveOccurred())
 			})
 
-			It("should render allow-tigera policy when license, tier, and watches are ready", func() {
+			It("should render allow-tigera policy when license and tier are ready", func() {
 				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -302,7 +258,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				Expect(policies.Items[1].Name).To(Equal("allow-tigera.guardian-access"))
 			})
 
-			It("should degrade and wait when tier and watches are ready, but license is not sufficient", func() {
+			It("should degrade and wait when tier is ready, but license is not sufficient", func() {
 				licenseKey.Status.Features = []string{common.TiersFeature}
 				Expect(c.Update(ctx, licenseKey)).NotTo(HaveOccurred())
 
@@ -311,49 +267,10 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				mockStatus.On("OnCRFound").Return()
 				mockStatus.On("SetDegraded", "Feature is not active", "License does not support feature: egress-access-control").Return()
 
-				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, ready, ready)
+				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone)
 				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
 				mockStatus.AssertExpectations(GinkgoT())
-			})
-
-			It("should degrade and wait when tier and license are ready, but license watch is not ready", func() {
-				mockStatus = &status.MockStatus{}
-				mockStatus.On("Run").Return()
-				mockStatus.On("OnCRFound").Return()
-
-				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, notReady, ready, ready)
-				utils.ExpectWaitForLicenseWatch(ctx, r, mockStatus)
-
-				policies := v3.NetworkPolicyList{}
-				Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-				Expect(policies.Items).To(HaveLen(0))
-			})
-
-			It("should degrade and wait when tier and license are ready, but tier watch is not ready", func() {
-				mockStatus = &status.MockStatus{}
-				mockStatus.On("Run").Return()
-				mockStatus.On("OnCRFound").Return()
-
-				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, notReady, ready)
-				utils.ExpectWaitForTierWatch(ctx, r, mockStatus)
-
-				policies := v3.NetworkPolicyList{}
-				Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-				Expect(policies.Items).To(HaveLen(0))
-			})
-
-			It("should degrade and wait when tier and license are ready, but policy watch is not ready", func() {
-				mockStatus = &status.MockStatus{}
-				mockStatus.On("Run").Return()
-				mockStatus.On("OnCRFound").Return()
-
-				r = clusterconnection.NewReconcilerWithShims(c, scheme, mockStatus, operatorv1.ProviderNone, ready, ready, notReady)
-				utils.ExpectWaitForPolicyWatches(ctx, r, mockStatus)
-
-				policies := v3.NetworkPolicyList{}
-				Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-				Expect(policies.Items).To(HaveLen(0))
 			})
 
 			It("should omit allow-tigera policy when tier is ready but license is not ready", func() {

--- a/pkg/controller/clusterconnection/shim_test.go
+++ b/pkg/controller/clusterconnection/shim_test.go
@@ -19,6 +19,7 @@ package clusterconnection
 
 import (
 	"context"
+	"github.com/tigera/operator/pkg/controller/utils"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/options"
@@ -33,10 +34,11 @@ func NewReconcilerWithShims(
 	schema *runtime.Scheme,
 	status status.StatusManager,
 	provider operatorv1.Provider,
+	tierWatchReady *utils.ReadyFlag,
 ) reconcile.Reconciler {
 	opts := options.AddOptions{
 		ShutdownContext: context.Background(),
 	}
 
-	return newReconciler(cli, schema, status, provider, opts)
+	return newReconciler(cli, schema, status, provider, tierWatchReady, opts)
 }

--- a/pkg/controller/clusterconnection/shim_test.go
+++ b/pkg/controller/clusterconnection/shim_test.go
@@ -20,8 +20,6 @@ package clusterconnection
 import (
 	"context"
 
-	"github.com/tigera/operator/pkg/controller/utils"
-
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
@@ -35,13 +33,10 @@ func NewReconcilerWithShims(
 	schema *runtime.Scheme,
 	status status.StatusManager,
 	provider operatorv1.Provider,
-	licenseWatchReady *utils.ReadyFlag,
-	tierWatchReady *utils.ReadyFlag,
-	policyWatchReady *utils.ReadyFlag,
 ) reconcile.Reconciler {
 	opts := options.AddOptions{
 		ShutdownContext: context.Background(),
 	}
 
-	return newReconciler(cli, schema, status, provider, licenseWatchReady, tierWatchReady, policyWatchReady, opts)
+	return newReconciler(cli, schema, status, provider, opts)
 }

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -59,10 +59,9 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return nil
 	}
 	licenseAPIReady := &utils.ReadyFlag{}
-	policyWatchesReady := &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts, licenseAPIReady, policyWatchesReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("compliance-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -78,7 +77,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	go utils.WaitToAddLicenseKeyWatch(controller, k8sClient, log, licenseAPIReady)
 
-	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, policyWatchesReady, []types.NamespacedName{
+	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, []types.NamespacedName{
 		{Name: render.ComplianceAccessPolicyName, Namespace: render.ComplianceNamespace},
 		{Name: render.ComplianceServerPolicyName, Namespace: render.ComplianceNamespace},
 		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.ComplianceNamespace},
@@ -88,16 +87,15 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new *reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag, policyWatchesReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	r := &ReconcileCompliance{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		provider:           opts.DetectedProvider,
-		status:             status.New(mgr.GetClient(), "compliance", opts.KubernetesVersion),
-		clusterDomain:      opts.ClusterDomain,
-		licenseAPIReady:    licenseAPIReady,
-		policyWatchesReady: policyWatchesReady,
-		usePSP:             opts.UsePSP,
+		client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "compliance", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
+		licenseAPIReady: licenseAPIReady,
+		usePSP:          opts.UsePSP,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -170,14 +168,13 @@ var _ reconcile.Reconciler = &ReconcileCompliance{}
 type ReconcileCompliance struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client             client.Client
-	scheme             *runtime.Scheme
-	provider           operatorv1.Provider
-	status             status.StatusManager
-	clusterDomain      string
-	licenseAPIReady    *utils.ReadyFlag
-	policyWatchesReady *utils.ReadyFlag
-	usePSP             bool
+	client          client.Client
+	scheme          *runtime.Scheme
+	provider        operatorv1.Provider
+	status          status.StatusManager
+	clusterDomain   string
+	licenseAPIReady *utils.ReadyFlag
+	usePSP          bool
 }
 
 func GetCompliance(ctx context.Context, cli client.Client) (*operatorv1.Compliance, error) {
@@ -218,11 +215,6 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
 		return reconcile.Result{}, err
-	}
-
-	if !r.policyWatchesReady.IsReady() {
-		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -542,10 +542,6 @@ var _ = Describe("Compliance controller tests", func() {
 			}
 		})
 
-		It("should wait if API server is unavailable", func() {
-			utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
-		})
-
 		It("should wait if allow-tigera tier is unavailable", func() {
 			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
 		})

--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -89,13 +89,12 @@ var _ = Describe("Compliance controller tests", func() {
 		// Create an object we can use throughout the test to do the compliance reconcile loops.
 		// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 		r = ReconcileCompliance{
-			client:             c,
-			scheme:             scheme,
-			provider:           operatorv1.ProviderNone,
-			status:             mockStatus,
-			clusterDomain:      dns.DefaultClusterDomain,
-			licenseAPIReady:    &utils.ReadyFlag{},
-			policyWatchesReady: &utils.ReadyFlag{},
+			client:          c,
+			scheme:          scheme,
+			provider:        operatorv1.ProviderNone,
+			status:          mockStatus,
+			clusterDomain:   dns.DefaultClusterDomain,
+			licenseAPIReady: &utils.ReadyFlag{},
 		}
 
 		// We start off with a 'standard' installation, with nothing special
@@ -149,9 +148,8 @@ var _ = Describe("Compliance controller tests", func() {
 		cr = &operatorv1.Compliance{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}}
 		Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 
-		// mark that the watches were successful
+		// Mark that watches were successful.
 		r.licenseAPIReady.MarkAsReady()
-		r.policyWatchesReady.MarkAsReady()
 	})
 
 	It("should create resources for standalone clusters", func() {
@@ -522,42 +520,12 @@ var _ = Describe("Compliance controller tests", func() {
 		})
 	})
 
-	Context("allow-tigera reconciliation", func() {
-		var readyFlag *utils.ReadyFlag
+	It("should wait if allow-tigera tier is unavailable", func() {
+		mockStatus = &status.MockStatus{}
+		mockStatus.On("OnCRFound").Return()
+		r.status = mockStatus
 
-		BeforeEach(func() {
-			mockStatus = &status.MockStatus{}
-			mockStatus.On("OnCRFound").Return()
-
-			readyFlag = &utils.ReadyFlag{}
-			readyFlag.MarkAsReady()
-			r = ReconcileCompliance{
-				client:             c,
-				scheme:             scheme,
-				provider:           operatorv1.ProviderNone,
-				status:             mockStatus,
-				clusterDomain:      dns.DefaultClusterDomain,
-				licenseAPIReady:    readyFlag,
-				policyWatchesReady: readyFlag,
-			}
-		})
-
-		It("should wait if allow-tigera tier is unavailable", func() {
-			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
-		})
-
-		It("should wait if policy watches are not ready", func() {
-			r = ReconcileCompliance{
-				client:             c,
-				scheme:             scheme,
-				provider:           operatorv1.ProviderNone,
-				status:             mockStatus,
-				clusterDomain:      dns.DefaultClusterDomain,
-				licenseAPIReady:    readyFlag,
-				policyWatchesReady: &utils.ReadyFlag{},
-			}
-			utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
-		})
+		utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
 	})
 
 	Context("Feature compliance not active", func() {

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -27,6 +27,9 @@ import (
 	"strings"
 	"time"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 
 	apps "k8s.io/api/apps/v1"
@@ -1000,21 +1003,25 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			return reconcile.Result{}, err
 		}
 
-		// Successful reconciliation of non-NetworkPolicy resources in the core controller ensures that NetworkPolicy
-		// is reconcilable (by enabling the availability of the API server and the creation of containing Tier). Therefore,
-		// to prevent a chicken-and-egg scenario, we only reconcile NetworkPolicy resources once we can confirm that all
-		// requirements to reconcile NetworkPolicy have been met.
-		//
-		// utils.IsV3NetworkPolicyReconcilable does not verify API server availability, so we take extra precaution
-		// when rendering components below.
-		if utils.IsV3NetworkPolicyReconcilable(ctx, r.client, networkpolicy.TigeraComponentTierName) {
+		// Ensure the allow-tigera tier exists, before rendering any network policies within it.
+		if err := r.client.Get(ctx, client.ObjectKey{Name: networkpolicy.TigeraComponentTierName}, &v3.Tier{}); err != nil {
+			// The creation of the Tier depends on this controller to reconcile it's non-NetworkPolicy resources so that
+			// the API Server becomes available. Therefore, if we fail to query the Tier, we exclude NetworkPolicy from
+			// reconciliation and tolerate errors arising from the Tier not being created or the API server not being available.
+			if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+				log.Error(err, "Error querying allow-tigera tier")
+				r.status.SetDegraded("Error querying allow-tigera tier", err.Error())
+				return reconcile.Result{}, err
+			}
+		} else {
 			includeV3NetworkPolicy = true
 
+			// Use tier availability as a signal that we can validate watches, since this controller is a dependency for
+			// the API Server to become available and watches will not become available until the API Server is available.
 			if !r.tierWatchReady.IsReady() {
 				r.status.SetDegraded("Waiting for Tier watch to be established", "")
 				return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 			}
-
 			if !r.policyWatchesReady.IsReady() {
 				r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
 				return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -1316,8 +1323,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	// v3 NetworkPolicy will fail to reconcile if the API server deployment is unhealthy. In case the API Server
 	// deployment becomes unhealthy and reconciliation of non-NetworkPolicy resources in the core controller
 	// would resolve it, we render the network policies of components last to prevent a chicken-and-egg scenario.
-	//
-	// We take this precaution as utils.IsV3NetworkPolicyReconcilable is not sensitive to API server availability.
 	if includeV3NetworkPolicy {
 		components = append(components, kubecontrollers.NewCalicoKubeControllersPolicy(&kubeControllersCfg))
 	}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -149,7 +149,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		}
 
 		// Watch for changes to Tier, as its status is used as input to determine whether network policy should be reconciled by this controller.
-		go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log)
+		go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, nil)
 
 		go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
 			{Name: kubecontrollers.KubeControllerNetworkPolicyName, Namespace: common.CalicoNamespace}},

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -312,10 +312,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			}),
 	)
 
-	notReady := &utils.ReadyFlag{}
-	ready := &utils.ReadyFlag{}
-	ready.MarkAsReady()
-
 	Context("image reconciliation tests", func() {
 		var c client.Client
 		var cs *kfake.Clientset
@@ -396,8 +392,6 @@ var _ = Describe("Testing core-controller installation", func() {
 				amazonCRDExists:       true,
 				enterpriseCRDsExist:   true,
 				migrationChecked:      true,
-				tierWatchReady:        ready,
-				policyWatchesReady:    ready,
 			}
 
 			r.typhaAutoscaler.start(ctx)
@@ -767,8 +761,6 @@ var _ = Describe("Testing core-controller installation", func() {
 				enterpriseCRDsExist:   true,
 				migrationChecked:      true,
 				clusterDomain:         dns.DefaultClusterDomain,
-				tierWatchReady:        ready,
-				policyWatchesReady:    ready,
 			}
 			r.typhaAutoscaler.start(ctx)
 			r.calicoWindowsUpgrader.Start(ctx)
@@ -1007,8 +999,6 @@ var _ = Describe("Testing core-controller installation", func() {
 				amazonCRDExists:       true,
 				enterpriseCRDsExist:   true,
 				migrationChecked:      true,
-				tierWatchReady:        ready,
-				policyWatchesReady:    ready,
 			}
 
 			r.typhaAutoscaler.start(ctx)
@@ -1495,7 +1485,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(cr.Status.Conditions[2].ObservedGeneration).To(Equal(int64(2)))
 		})
 
-		It("should render allow-tigera policy when tier and policy watch are ready", func() {
+		It("should render allow-tigera policy when tier is ready", func() {
 			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 
 			_, err := r.Reconcile(ctx, reconcile.Request{})
@@ -1528,36 +1518,6 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
-
-			policies := v3.NetworkPolicyList{}
-			Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(0))
-		})
-
-		It("should degrade and wait if tier is ready but policy watch is not ready", func() {
-			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
-			r.policyWatchesReady = notReady
-			mockStatus = &status.MockStatus{}
-			mockStatus.On("OnCRFound").Return()
-			mockStatus.On("SetMetaData", mock.Anything).Return()
-			r.status = mockStatus
-
-			utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
-
-			policies := v3.NetworkPolicyList{}
-			Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(0))
-		})
-
-		It("should degrade and wait if tier is ready but tier watch is not ready", func() {
-			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
-			r.tierWatchReady = notReady
-			mockStatus = &status.MockStatus{}
-			mockStatus.On("OnCRFound").Return()
-			mockStatus.On("SetMetaData", mock.Anything).Return()
-			r.status = mockStatus
-
-			utils.ExpectWaitForTierWatch(ctx, &r, mockStatus)
 
 			policies := v3.NetworkPolicyList{}
 			Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -67,10 +67,9 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	licenseAPIReady := &utils.ReadyFlag{}
 	dpiAPIReady := &utils.ReadyFlag{}
-	policyWatchesReady := &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts, licenseAPIReady, dpiAPIReady, policyWatchesReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady, dpiAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("intrusiondetection-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -89,7 +88,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	go utils.WaitToAddResourceWatch(controller, k8sClient, log, dpiAPIReady,
 		[]client.Object{&v3.DeepPacketInspection{TypeMeta: metav1.TypeMeta{Kind: v3.KindDeepPacketInspection}}})
 
-	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, policyWatchesReady, []types.NamespacedName{
+	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, []types.NamespacedName{
 		{Name: render.IntrusionDetectionControllerPolicyName, Namespace: render.IntrusionDetectionNamespace},
 		{Name: render.IntrusionDetectionInstallerPolicyName, Namespace: render.IntrusionDetectionNamespace},
 		{Name: render.ADAPIPolicyName, Namespace: render.IntrusionDetectionNamespace},
@@ -102,17 +101,16 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag, dpiAPIReady *utils.ReadyFlag, policyWatchesReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag, dpiAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	r := &ReconcileIntrusionDetection{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		provider:           opts.DetectedProvider,
-		status:             status.New(mgr.GetClient(), "intrusion-detection", opts.KubernetesVersion),
-		clusterDomain:      opts.ClusterDomain,
-		licenseAPIReady:    licenseAPIReady,
-		dpiAPIReady:        dpiAPIReady,
-		policyWatchesReady: policyWatchesReady,
-		usePSP:             opts.UsePSP,
+		client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "intrusion-detection", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
+		licenseAPIReady: licenseAPIReady,
+		dpiAPIReady:     dpiAPIReady,
+		usePSP:          opts.UsePSP,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -206,15 +204,14 @@ var _ reconcile.Reconciler = &ReconcileIntrusionDetection{}
 type ReconcileIntrusionDetection struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client             client.Client
-	scheme             *runtime.Scheme
-	provider           operatorv1.Provider
-	status             status.StatusManager
-	clusterDomain      string
-	licenseAPIReady    *utils.ReadyFlag
-	dpiAPIReady        *utils.ReadyFlag
-	policyWatchesReady *utils.ReadyFlag
-	usePSP             bool
+	client          client.Client
+	scheme          *runtime.Scheme
+	provider        operatorv1.Provider
+	status          status.StatusManager
+	clusterDomain   string
+	licenseAPIReady *utils.ReadyFlag
+	dpiAPIReady     *utils.ReadyFlag
+	usePSP          bool
 }
 
 // Reconcile reads that state of the cluster for a IntrusionDetection object and makes changes based on the state read
@@ -255,11 +252,6 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
 		return reconcile.Result{}, err
-	}
-
-	if !r.policyWatchesReady.IsReady() {
-		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
@@ -440,10 +440,6 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 			}
 		})
 
-		It("should wait if API server is unavailable", func() {
-			utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
-		})
-
 		It("should wait if allow-tigera tier is unavailable", func() {
 			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
 		})

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -64,10 +64,9 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	licenseAPIReady := &utils.ReadyFlag{}
-	policyWatchesReady := &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts, licenseAPIReady, policyWatchesReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("logcollector-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -83,7 +82,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	go utils.WaitToAddLicenseKeyWatch(controller, k8sClient, log, licenseAPIReady)
 
-	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, policyWatchesReady, []types.NamespacedName{
+	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, []types.NamespacedName{
 		{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace},
 	})
 
@@ -91,16 +90,15 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag, policyWatchesReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	c := &ReconcileLogCollector{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		provider:           opts.DetectedProvider,
-		status:             status.New(mgr.GetClient(), "log-collector", opts.KubernetesVersion),
-		clusterDomain:      opts.ClusterDomain,
-		licenseAPIReady:    licenseAPIReady,
-		policyWatchesReady: policyWatchesReady,
-		usePSP:             opts.UsePSP,
+		client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "log-collector", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
+		licenseAPIReady: licenseAPIReady,
+		usePSP:          opts.UsePSP,
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -162,14 +160,13 @@ var _ reconcile.Reconciler = &ReconcileLogCollector{}
 type ReconcileLogCollector struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client             client.Client
-	scheme             *runtime.Scheme
-	provider           operatorv1.Provider
-	status             status.StatusManager
-	clusterDomain      string
-	licenseAPIReady    *utils.ReadyFlag
-	policyWatchesReady *utils.ReadyFlag
-	usePSP             bool
+	client          client.Client
+	scheme          *runtime.Scheme
+	provider        operatorv1.Provider
+	status          status.StatusManager
+	clusterDomain   string
+	licenseAPIReady *utils.ReadyFlag
+	usePSP          bool
 }
 
 // GetLogCollector returns the default LogCollector instance with defaults populated.
@@ -256,11 +253,6 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
 		return reconcile.Result{}, nil
-	}
-
-	if !r.policyWatchesReady.IsReady() {
-		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -554,10 +554,6 @@ var _ = Describe("LogCollector controller tests", func() {
 			}
 		})
 
-		It("should wait if API server is unavailable", func() {
-			utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
-		})
-
 		It("should wait if allow-tigera tier is unavailable", func() {
 			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
 		})

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -82,12 +82,11 @@ var _ = Describe("LogCollector controller tests", func() {
 		// Create an object we can use throughout the test to do the compliance reconcile loops.
 		// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 		r = ReconcileLogCollector{
-			client:             c,
-			scheme:             scheme,
-			provider:           operatorv1.ProviderNone,
-			status:             mockStatus,
-			licenseAPIReady:    &utils.ReadyFlag{},
-			policyWatchesReady: &utils.ReadyFlag{},
+			client:          c,
+			scheme:          scheme,
+			provider:        operatorv1.ProviderNone,
+			status:          mockStatus,
+			licenseAPIReady: &utils.ReadyFlag{},
 		}
 
 		// We start off with a 'standard' installation, with nothing special
@@ -142,9 +141,8 @@ var _ = Describe("LogCollector controller tests", func() {
 		Expect(c.Create(ctx, &operatorv1.LogCollector{
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})).NotTo(HaveOccurred())
 
-		// mark that the watches were successful
+		// Mark that watches were successful.
 		r.licenseAPIReady.MarkAsReady()
-		r.policyWatchesReady.MarkAsReady()
 	})
 
 	Context("image reconciliation", func() {
@@ -535,40 +533,12 @@ var _ = Describe("LogCollector controller tests", func() {
 		})
 	})
 
-	Context("allow-tigera reconciliation", func() {
-		var readyFlag *utils.ReadyFlag
+	It("should wait if allow-tigera tier is unavailable", func() {
+		mockStatus = &status.MockStatus{}
+		mockStatus.On("OnCRFound").Return()
+		r.status = mockStatus
 
-		BeforeEach(func() {
-			mockStatus = &status.MockStatus{}
-			mockStatus.On("OnCRFound").Return()
-
-			readyFlag = &utils.ReadyFlag{}
-			readyFlag.MarkAsReady()
-			r = ReconcileLogCollector{
-				client:             c,
-				scheme:             scheme,
-				provider:           operatorv1.ProviderNone,
-				status:             mockStatus,
-				licenseAPIReady:    readyFlag,
-				policyWatchesReady: readyFlag,
-			}
-		})
-
-		It("should wait if allow-tigera tier is unavailable", func() {
-			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
-		})
-
-		It("should wait if policy watches are not ready", func() {
-			r = ReconcileLogCollector{
-				client:             c,
-				scheme:             scheme,
-				provider:           operatorv1.ProviderNone,
-				status:             mockStatus,
-				licenseAPIReady:    readyFlag,
-				policyWatchesReady: &utils.ReadyFlag{},
-			}
-			utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
-		})
+		utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
 	})
 
 	Context("should test fillDefaults for logCollector", func() {

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -75,7 +75,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	// Create the reconciler
-	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage", opts.KubernetesVersion), opts, utils.NewElasticClient, &utils.ReadyFlag{})
+	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage", opts.KubernetesVersion), opts, utils.NewElasticClient)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return fmt.Errorf("log-storage-controller failed to establish a connection to k8s: %w", err)
 	}
 
-	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, r.policyWatchesReady, []types.NamespacedName{
+	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
 		{Name: render.ElasticsearchPolicyName, Namespace: render.ElasticsearchNamespace},
 		{Name: render.EsCuratorPolicyName, Namespace: render.ElasticsearchNamespace},
 		{Name: render.KibanaPolicyName, Namespace: render.KibanaNamespace},
@@ -108,16 +108,15 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(cli client.Client, schema *runtime.Scheme, statusMgr status.StatusManager, opts options.AddOptions, esCliCreator utils.ElasticsearchClientCreator, policyWatchesReady *utils.ReadyFlag) (*ReconcileLogStorage, error) {
+func newReconciler(cli client.Client, schema *runtime.Scheme, statusMgr status.StatusManager, opts options.AddOptions, esCliCreator utils.ElasticsearchClientCreator) (*ReconcileLogStorage, error) {
 	c := &ReconcileLogStorage{
-		client:             cli,
-		scheme:             schema,
-		status:             statusMgr,
-		provider:           opts.DetectedProvider,
-		esCliCreator:       esCliCreator,
-		clusterDomain:      opts.ClusterDomain,
-		policyWatchesReady: policyWatchesReady,
-		usePSP:             opts.UsePSP,
+		client:        cli,
+		scheme:        schema,
+		status:        statusMgr,
+		provider:      opts.DetectedProvider,
+		esCliCreator:  esCliCreator,
+		clusterDomain: opts.ClusterDomain,
+		usePSP:        opts.UsePSP,
 	}
 
 	c.status.Run(opts.ShutdownContext)
@@ -225,14 +224,13 @@ var _ reconcile.Reconciler = &ReconcileLogStorage{}
 type ReconcileLogStorage struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client             client.Client
-	scheme             *runtime.Scheme
-	status             status.StatusManager
-	provider           operatorv1.Provider
-	esCliCreator       utils.ElasticsearchClientCreator
-	clusterDomain      string
-	policyWatchesReady *utils.ReadyFlag
-	usePSP             bool
+	client        client.Client
+	scheme        *runtime.Scheme
+	status        status.StatusManager
+	provider      operatorv1.Provider
+	esCliCreator  utils.ElasticsearchClientCreator
+	clusterDomain string
+	usePSP        bool
 }
 
 // fillDefaults populates the default values onto an LogStorage object.
@@ -377,11 +375,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		}
 		r.status.SetDegraded("An error occurred while querying Installation", err.Error())
 		return reconcile.Result{}, err
-	}
-
-	if !r.policyWatchesReady.IsReady() {
-		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -379,12 +379,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	// Ensure the API Server is ready, before rendering any objects that utilize the V3 API.
-	if !utils.IsAPIServerReady(r.client, reqLogger) {
-		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
 	if !r.policyWatchesReady.IsReady() {
 		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -1359,10 +1359,6 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(err).ShouldNot(HaveOccurred())
 					})
 
-					It("should wait if API server is unavailable", func() {
-						utils.DeleteAPIServerAndExpectWait(ctx, cli, r, mockStatus)
-					})
-
 					It("should wait if allow-tigera tier is unavailable", func() {
 						utils.DeleteAllowTigeraTierAndExpectWait(ctx, cli, r, mockStatus)
 					})

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -254,7 +254,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("ReadyToMonitor")
 					})
 					DescribeTable("tests that the ExternalService is setup with the default service name", func(clusterDomain, expectedSvcName string) {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain, readyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 						_, err = r.Reconcile(ctx, reconcile.Request{})
 						Expect(err).ShouldNot(HaveOccurred())
@@ -278,7 +278,7 @@ var _ = Describe("LogStorage controller", func() {
 					})
 
 					It("returns an error if the LogStorage resource exists and is not marked for deletion", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", "LogStorage validation failed", "cluster type is managed but LogStorage CR still exists").Return()
 						result, err := r.Reconcile(ctx, reconcile.Request{})
@@ -297,7 +297,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("ClearDegraded", mock.Anything).Return()
 						mockStatus.On("ReadyToMonitor")
 
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						ls := &operatorv1.LogStorage{}
@@ -408,7 +408,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -528,7 +528,7 @@ var _ = Describe("LogStorage controller", func() {
 						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersEsSecreteName},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -653,7 +653,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Elasticsearch and kibana secrets are good.
@@ -692,7 +692,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -789,7 +789,7 @@ var _ = Describe("LogStorage controller", func() {
 						},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -831,7 +831,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(cli.Create(ctx, kbSecret)).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -905,7 +905,7 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
 					}
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for curator secrets to become available", "").Return()
@@ -985,7 +985,7 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
 					}
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for curator secrets to become available", "").Return()
@@ -1023,7 +1023,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -1091,7 +1091,7 @@ var _ = Describe("LogStorage controller", func() {
 						}
 					})
 					It("should use default images", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						esAdminUserSecret := &corev1.Secret{
@@ -1214,7 +1214,7 @@ var _ = Describe("LogStorage controller", func() {
 								},
 							},
 						})).ToNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						esAdminUserSecret := &corev1.Secret{
@@ -1324,38 +1324,52 @@ var _ = Describe("LogStorage controller", func() {
 					})
 				})
 
-				It("should wait if allow-tigera tier is unavailable", func() {
-					Expect(cli.Create(ctx, &storagev1.StorageClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: storageClassName,
-						},
-					})).ShouldNot(HaveOccurred())
-
-					Expect(cli.Create(ctx, &operatorv1.LogStorage{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "tigera-secure",
-						},
-						Spec: operatorv1.LogStorageSpec{
-							Nodes: &operatorv1.Nodes{
-								Count: int64(1),
+				Context("allow-tigera rendering", func() {
+					var r reconcile.Reconciler
+					BeforeEach(func() {
+						Expect(cli.Create(ctx, &storagev1.StorageClass{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: storageClassName,
 							},
-							StorageClassName: storageClassName,
-						},
-					})).ShouldNot(HaveOccurred())
+						})).ShouldNot(HaveOccurred())
 
-					Expect(cli.Create(ctx, &corev1.ConfigMap{
-						ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
-						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
-					})).ShouldNot(HaveOccurred())
+						Expect(cli.Create(ctx, &operatorv1.LogStorage{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "tigera-secure",
+							},
+							Spec: operatorv1.LogStorageSpec{
+								Nodes: &operatorv1.Nodes{
+									Count: int64(1),
+								},
+								StorageClassName: storageClassName,
+							},
+						})).ShouldNot(HaveOccurred())
 
-					mockStatus = &status.MockStatus{}
-					mockStatus.On("Run").Return()
-					mockStatus.On("OnCRFound").Return()
+						Expect(cli.Create(ctx, &corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
+							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
+						})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
-					Expect(err).ShouldNot(HaveOccurred())
+						mockStatus = &status.MockStatus{}
+						mockStatus.On("Run").Return()
+						mockStatus.On("OnCRFound").Return()
 
-					utils.DeleteAllowTigeraTierAndExpectWait(ctx, cli, r, mockStatus)
+						var err error
+						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						Expect(err).ShouldNot(HaveOccurred())
+					})
+
+					It("should wait if allow-tigera tier is unavailable", func() {
+						utils.DeleteAllowTigeraTierAndExpectWait(ctx, cli, r, mockStatus)
+					})
+
+					It("should wait if tier watch is not ready", func() {
+						var err error
+						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, &utils.ReadyFlag{})
+						Expect(err).ShouldNot(HaveOccurred())
+
+						utils.ExpectWaitForTierWatch(ctx, r, mockStatus)
+					})
 				})
 			})
 
@@ -1411,7 +1425,7 @@ var _ = Describe("LogStorage controller", func() {
 				})
 
 				It("deletes Elasticsearch and Kibana then removes the finalizers on the LogStorage CR", func() {
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					esAdminUserSecret := &corev1.Secret{

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -254,7 +254,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("ReadyToMonitor")
 					})
 					DescribeTable("tests that the ExternalService is setup with the default service name", func(clusterDomain, expectedSvcName string) {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 						_, err = r.Reconcile(ctx, reconcile.Request{})
 						Expect(err).ShouldNot(HaveOccurred())
@@ -278,7 +278,7 @@ var _ = Describe("LogStorage controller", func() {
 					})
 
 					It("returns an error if the LogStorage resource exists and is not marked for deletion", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", "LogStorage validation failed", "cluster type is managed but LogStorage CR still exists").Return()
 						result, err := r.Reconcile(ctx, reconcile.Request{})
@@ -297,7 +297,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("ClearDegraded", mock.Anything).Return()
 						mockStatus.On("ReadyToMonitor")
 
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						ls := &operatorv1.LogStorage{}
@@ -408,7 +408,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -528,7 +528,7 @@ var _ = Describe("LogStorage controller", func() {
 						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersEsSecreteName},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -653,7 +653,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Elasticsearch and kibana secrets are good.
@@ -692,7 +692,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -789,7 +789,7 @@ var _ = Describe("LogStorage controller", func() {
 						},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -831,7 +831,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(cli.Create(ctx, kbSecret)).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -905,7 +905,7 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
 					}
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for curator secrets to become available", "").Return()
@@ -985,7 +985,7 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
 					}
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for curator secrets to become available", "").Return()
@@ -1023,7 +1023,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", "Waiting for Elasticsearch cluster to be operational", "").Return()
@@ -1091,7 +1091,7 @@ var _ = Describe("LogStorage controller", func() {
 						}
 					})
 					It("should use default images", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						esAdminUserSecret := &corev1.Secret{
@@ -1214,7 +1214,7 @@ var _ = Describe("LogStorage controller", func() {
 								},
 							},
 						})).ToNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						esAdminUserSecret := &corev1.Secret{
@@ -1324,52 +1324,38 @@ var _ = Describe("LogStorage controller", func() {
 					})
 				})
 
-				Context("allow-tigera rendering", func() {
-					var r reconcile.Reconciler
-					BeforeEach(func() {
-						Expect(cli.Create(ctx, &storagev1.StorageClass{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: storageClassName,
+				It("should wait if allow-tigera tier is unavailable", func() {
+					Expect(cli.Create(ctx, &storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
+
+					Expect(cli.Create(ctx, &operatorv1.LogStorage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "tigera-secure",
+						},
+						Spec: operatorv1.LogStorageSpec{
+							Nodes: &operatorv1.Nodes{
+								Count: int64(1),
 							},
-						})).ShouldNot(HaveOccurred())
+							StorageClassName: storageClassName,
+						},
+					})).ShouldNot(HaveOccurred())
 
-						Expect(cli.Create(ctx, &operatorv1.LogStorage{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "tigera-secure",
-							},
-							Spec: operatorv1.LogStorageSpec{
-								Nodes: &operatorv1.Nodes{
-									Count: int64(1),
-								},
-								StorageClassName: storageClassName,
-							},
-						})).ShouldNot(HaveOccurred())
+					Expect(cli.Create(ctx, &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
+						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
+					})).ShouldNot(HaveOccurred())
 
-						Expect(cli.Create(ctx, &corev1.ConfigMap{
-							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
-							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
-						})).ShouldNot(HaveOccurred())
+					mockStatus = &status.MockStatus{}
+					mockStatus.On("Run").Return()
+					mockStatus.On("OnCRFound").Return()
 
-						mockStatus = &status.MockStatus{}
-						mockStatus.On("Run").Return()
-						mockStatus.On("OnCRFound").Return()
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
+					Expect(err).ShouldNot(HaveOccurred())
 
-						var err error
-						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
-						Expect(err).ShouldNot(HaveOccurred())
-					})
-
-					It("should wait if allow-tigera tier is unavailable", func() {
-						utils.DeleteAllowTigeraTierAndExpectWait(ctx, cli, r, mockStatus)
-					})
-
-					It("should wait if policy watches are not ready", func() {
-						var err error
-						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, &utils.ReadyFlag{})
-						Expect(err).ShouldNot(HaveOccurred())
-
-						utils.ExpectWaitForPolicyWatches(ctx, r, mockStatus)
-					})
+					utils.DeleteAllowTigeraTierAndExpectWait(ctx, cli, r, mockStatus)
 				})
 			})
 
@@ -1425,7 +1411,7 @@ var _ = Describe("LogStorage controller", func() {
 				})
 
 				It("deletes Elasticsearch and Kibana then removes the finalizers on the LogStorage CR", func() {
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					esAdminUserSecret := &corev1.Secret{

--- a/pkg/controller/logstorage/shim_test.go
+++ b/pkg/controller/logstorage/shim_test.go
@@ -33,7 +33,8 @@ func NewReconcilerWithShims(
 	status status.StatusManager,
 	provider operatorv1.Provider,
 	esCliCreator utils.ElasticsearchClientCreator,
-	clusterDomain string) (*ReconcileLogStorage, error) {
+	clusterDomain string,
+	tierWatchReady *utils.ReadyFlag) (*ReconcileLogStorage, error) {
 
 	opts := options.AddOptions{
 		DetectedProvider: provider,
@@ -41,5 +42,5 @@ func NewReconcilerWithShims(
 		ShutdownContext:  context.TODO(),
 	}
 
-	return newReconciler(cli, schema, status, opts, esCliCreator)
+	return newReconciler(cli, schema, status, opts, esCliCreator, tierWatchReady)
 }

--- a/pkg/controller/logstorage/shim_test.go
+++ b/pkg/controller/logstorage/shim_test.go
@@ -33,8 +33,7 @@ func NewReconcilerWithShims(
 	status status.StatusManager,
 	provider operatorv1.Provider,
 	esCliCreator utils.ElasticsearchClientCreator,
-	clusterDomain string,
-	policyWatchesReady *utils.ReadyFlag) (*ReconcileLogStorage, error) {
+	clusterDomain string) (*ReconcileLogStorage, error) {
 
 	opts := options.AddOptions{
 		DetectedProvider: provider,
@@ -42,5 +41,5 @@ func NewReconcilerWithShims(
 		ShutdownContext:  context.TODO(),
 	}
 
-	return newReconciler(cli, schema, status, opts, esCliCreator, policyWatchesReady)
+	return newReconciler(cli, schema, status, opts, esCliCreator)
 }

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -64,9 +64,10 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	licenseAPIReady := &utils.ReadyFlag{}
+	tierWatchReady := &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts, licenseAPIReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady, tierWatchReady)
 
 	// Create a new controller
 	controller, err := controller.New("cmanager-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -82,6 +83,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	go utils.WaitToAddLicenseKeyWatch(controller, k8sClient, log, licenseAPIReady)
 
+	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, controller, k8sClient, log, tierWatchReady)
 	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, []types.NamespacedName{
 		{Name: render.ManagerPolicyName, Namespace: render.ManagerNamespace},
 		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.ManagerNamespace},
@@ -91,7 +93,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag, tierWatchReady *utils.ReadyFlag) reconcile.Reconciler {
 	c := &ReconcileManager{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
@@ -99,6 +101,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady
 		status:          status.New(mgr.GetClient(), "manager", opts.KubernetesVersion),
 		clusterDomain:   opts.ClusterDomain,
 		licenseAPIReady: licenseAPIReady,
+		tierWatchReady:  tierWatchReady,
 		usePSP:          opts.UsePSP,
 	}
 	c.status.Run(opts.ShutdownContext)
@@ -195,6 +198,7 @@ type ReconcileManager struct {
 	status          status.StatusManager
 	clusterDomain   string
 	licenseAPIReady *utils.ReadyFlag
+	tierWatchReady  *utils.ReadyFlag
 	usePSP          bool
 }
 
@@ -238,6 +242,12 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
 		return reconcile.Result{}, nil
+	}
+
+	// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
+	if !r.tierWatchReady.IsReady() {
+		r.status.SetDegraded("Waiting for Tier watch to be established", "")
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -64,10 +64,9 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	licenseAPIReady := &utils.ReadyFlag{}
-	policyWatchesReady := &utils.ReadyFlag{}
 
 	// create the reconciler
-	reconciler := newReconciler(mgr, opts, licenseAPIReady, policyWatchesReady)
+	reconciler := newReconciler(mgr, opts, licenseAPIReady)
 
 	// Create a new controller
 	controller, err := controller.New("cmanager-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
@@ -83,7 +82,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	go utils.WaitToAddLicenseKeyWatch(controller, k8sClient, log, licenseAPIReady)
 
-	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, policyWatchesReady, []types.NamespacedName{
+	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, []types.NamespacedName{
 		{Name: render.ManagerPolicyName, Namespace: render.ManagerNamespace},
 		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.ManagerNamespace},
 	})
@@ -92,16 +91,15 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag, policyWatchesReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag) reconcile.Reconciler {
 	c := &ReconcileManager{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		provider:           opts.DetectedProvider,
-		status:             status.New(mgr.GetClient(), "manager", opts.KubernetesVersion),
-		clusterDomain:      opts.ClusterDomain,
-		licenseAPIReady:    licenseAPIReady,
-		policyWatchesReady: policyWatchesReady,
-		usePSP:             opts.UsePSP,
+		client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		provider:        opts.DetectedProvider,
+		status:          status.New(mgr.GetClient(), "manager", opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
+		licenseAPIReady: licenseAPIReady,
+		usePSP:          opts.UsePSP,
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -191,14 +189,13 @@ var _ reconcile.Reconciler = &ReconcileManager{}
 type ReconcileManager struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client             client.Client
-	scheme             *runtime.Scheme
-	provider           operatorv1.Provider
-	status             status.StatusManager
-	clusterDomain      string
-	licenseAPIReady    *utils.ReadyFlag
-	policyWatchesReady *utils.ReadyFlag
-	usePSP             bool
+	client          client.Client
+	scheme          *runtime.Scheme
+	provider        operatorv1.Provider
+	status          status.StatusManager
+	clusterDomain   string
+	licenseAPIReady *utils.ReadyFlag
+	usePSP          bool
 }
 
 // GetManager returns the default manager instance with defaults populated.
@@ -241,11 +238,6 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
 		return reconcile.Result{}, nil
-	}
-
-	if !r.policyWatchesReady.IsReady() {
-		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -499,10 +499,6 @@ var _ = Describe("Manager controller tests", func() {
 				}
 			})
 
-			It("should wait if API server is unavailable", func() {
-				utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
-			})
-
 			It("should wait if allow-tigera tier is unavailable", func() {
 				utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
 			})

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -107,13 +107,12 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
-				client:             c,
-				scheme:             scheme,
-				provider:           operatorv1.ProviderNone,
-				status:             mockStatus,
-				clusterDomain:      clusterDomain,
-				licenseAPIReady:    &utils.ReadyFlag{},
-				policyWatchesReady: &utils.ReadyFlag{},
+				client:          c,
+				scheme:          scheme,
+				provider:        operatorv1.ProviderNone,
+				status:          mockStatus,
+				clusterDomain:   clusterDomain,
+				licenseAPIReady: &utils.ReadyFlag{},
 			}
 
 			Expect(c.Create(ctx, &operatorv1.APIServer{
@@ -194,9 +193,8 @@ var _ = Describe("Manager controller tests", func() {
 			}
 			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 
-			// mark that the watches were successful
+			// Mark that watches were successful.
 			r.licenseAPIReady.MarkAsReady()
-			r.policyWatchesReady.MarkAsReady()
 		})
 
 		It("should reconcile if user supplied a manager TLS cert", func() {
@@ -312,12 +310,11 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
-				client:             c,
-				scheme:             scheme,
-				provider:           operatorv1.ProviderNone,
-				status:             mockStatus,
-				licenseAPIReady:    &utils.ReadyFlag{},
-				policyWatchesReady: &utils.ReadyFlag{},
+				client:          c,
+				scheme:          scheme,
+				provider:        operatorv1.ProviderNone,
+				status:          mockStatus,
+				licenseAPIReady: &utils.ReadyFlag{},
 			}
 
 			Expect(c.Create(ctx, &operatorv1.APIServer{
@@ -397,9 +394,8 @@ var _ = Describe("Manager controller tests", func() {
 				},
 			})).NotTo(HaveOccurred())
 
-			// mark that the watches were successful
+			// Mark that watches were successful.
 			r.licenseAPIReady.MarkAsReady()
-			r.policyWatchesReady.MarkAsReady()
 		})
 
 		Context("image reconciliation", func() {
@@ -481,39 +477,11 @@ var _ = Describe("Manager controller tests", func() {
 			})
 		})
 
-		Context("allow-tigera reconciliation", func() {
-			var readyFlag *utils.ReadyFlag
-			BeforeEach(func() {
-				mockStatus = &status.MockStatus{}
-				mockStatus.On("OnCRFound").Return()
-
-				readyFlag = &utils.ReadyFlag{}
-				readyFlag.MarkAsReady()
-				r = ReconcileManager{
-					client:             c,
-					scheme:             scheme,
-					provider:           operatorv1.ProviderNone,
-					status:             mockStatus,
-					licenseAPIReady:    readyFlag,
-					policyWatchesReady: readyFlag,
-				}
-			})
-
-			It("should wait if allow-tigera tier is unavailable", func() {
-				utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
-			})
-
-			It("should wait if policy watches are not ready", func() {
-				r = ReconcileManager{
-					client:             c,
-					scheme:             scheme,
-					provider:           operatorv1.ProviderNone,
-					status:             mockStatus,
-					licenseAPIReady:    readyFlag,
-					policyWatchesReady: &utils.ReadyFlag{},
-				}
-				utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
-			})
+		It("should wait if allow-tigera tier is unavailable", func() {
+			mockStatus = &status.MockStatus{}
+			mockStatus.On("OnCRFound").Return()
+			r.status = mockStatus
+			utils.DeleteAllowTigeraTierAndExpectWait(ctx, c, &r, mockStatus)
 		})
 	})
 })

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -352,14 +352,9 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	// v3 NetworkPolicy will fail to reconcile if the Tier is not created, which can only occur once a License is created.
-	// In managed clusters, the monitor controller is a dependency for the License to be created. In case the
-	// License is unavailable and reconciliation of non-NetworkPolicy resources in the monitor controller
-	// would resolve it, we render network policies last to prevent a chicken-and-egg scenario.
-
-	// v3 NetworkPolicy will fail to reconcile if the Tier is not created, which can only be created once a License
-	// is in place. In managed clusters, the monitor controller is a dependency for the License to be created. In case
-	// the License becomes unavailable and reconciliation of non-NetworkPolicy resources in the monitor controller
-	// would resolve it, we render the network policies of components last to prevent a chicken-and-egg scenario.
+	// In managed clusters, the monitor controller is a dependency for the License to be created. In case the License is
+	// unavailable and reconciliation of non-NetworkPolicy resources in the monitor controller would resolve it, we
+	// render network policies last to prevent a chicken-and-egg scenario.
 	if includeV3NetworkPolicy {
 		components = append(components, monitor.MonitorPolicy(monitorCfg))
 	}

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -64,9 +64,10 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	prometheusReady := &utils.ReadyFlag{}
+	tierWatchReady := &utils.ReadyFlag{}
 
 	// Create the reconciler
-	reconciler := newReconciler(mgr, opts, prometheusReady)
+	reconciler := newReconciler(mgr, opts, prometheusReady, tierWatchReady)
 
 	// Create a new controller
 	controller, err := controller.New("monitor-controller", mgr, controller.Options{Reconciler: reconciler})
@@ -90,7 +91,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	// Watch for changes to Tier, as its status is used as input to determine whether network policy should be reconciled by this controller.
-	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, controller, k8sClient, log)
+	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, controller, k8sClient, log, tierWatchReady)
 
 	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, policyNames)
 
@@ -99,13 +100,14 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	return add(mgr, controller)
 }
 
-func newReconciler(mgr manager.Manager, opts options.AddOptions, prometheusReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions, prometheusReady *utils.ReadyFlag, tierWatchReady *utils.ReadyFlag) reconcile.Reconciler {
 	r := &ReconcileMonitor{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
 		provider:        opts.DetectedProvider,
 		status:          status.New(mgr.GetClient(), "monitor", opts.KubernetesVersion),
 		prometheusReady: prometheusReady,
+		tierWatchReady:  tierWatchReady,
 		clusterDomain:   opts.ClusterDomain,
 	}
 
@@ -169,6 +171,7 @@ type ReconcileMonitor struct {
 	provider        operatorv1.Provider
 	status          status.StatusManager
 	prometheusReady *utils.ReadyFlag
+	tierWatchReady  *utils.ReadyFlag
 	clusterDomain   string
 }
 
@@ -286,6 +289,12 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		log.Error(err, "Failed to process the authentication CR.")
 		r.status.SetDegraded("Failed to process the authentication CR.", err.Error())
 		return reconcile.Result{}, err
+	}
+
+	// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
+	if !r.tierWatchReady.IsReady() {
+		r.status.SetDegraded("Waiting for Tier watch to be established", "")
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.

--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -50,10 +50,6 @@ var _ = Describe("Monitor controller tests", func() {
 	var scheme *runtime.Scheme
 	var installation *operatorv1.Installation
 
-	notReady := &utils.ReadyFlag{}
-	ready := &utils.ReadyFlag{}
-	ready.MarkAsReady()
-
 	BeforeEach(func() {
 		// The schema contains all objects that should be known to the fake client when the test runs.
 		scheme = runtime.NewScheme()
@@ -79,13 +75,11 @@ var _ = Describe("Monitor controller tests", func() {
 
 		// Create an object we can use throughout the test to do the monitor reconcile loops.
 		r = ReconcileMonitor{
-			client:             cli,
-			scheme:             scheme,
-			provider:           operatorv1.ProviderNone,
-			status:             mockStatus,
-			prometheusReady:    ready,
-			tierWatchReady:     ready,
-			policyWatchesReady: ready,
+			client:          cli,
+			scheme:          scheme,
+			provider:        operatorv1.ProviderNone,
+			status:          mockStatus,
+			prometheusReady: &utils.ReadyFlag{},
 		}
 
 		// We start off with a 'standard' installation, with nothing special
@@ -111,6 +105,9 @@ var _ = Describe("Monitor controller tests", func() {
 		})).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, render.CreateCertificateConfigMap("test", render.TyphaCAConfigMapName, common.OperatorNamespace()))).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
+
+		// Mark that watches were successful.
+		r.prometheusReady.MarkAsReady()
 	})
 
 	Context("controller reconciliation", func() {
@@ -164,34 +161,6 @@ var _ = Describe("Monitor controller tests", func() {
 
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
-
-			policies := v3.NetworkPolicyList{}
-			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(0))
-		})
-
-		It("should degrade and wait if tier is ready but policy watch is not ready", func() {
-			r.policyWatchesReady = notReady
-			mockStatus = &status.MockStatus{}
-			mockStatus.On("OnCRFound").Return()
-			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
-			r.status = mockStatus
-
-			utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
-
-			policies := v3.NetworkPolicyList{}
-			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(0))
-		})
-
-		It("should degrade and wait if tier is ready but tier watch is not ready", func() {
-			r.tierWatchReady = notReady
-			mockStatus = &status.MockStatus{}
-			mockStatus.On("OnCRFound").Return()
-			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
-			r.status = mockStatus
-
-			utils.ExpectWaitForTierWatch(ctx, &r, mockStatus)
 
 			policies := v3.NetworkPolicyList{}
 			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())

--- a/pkg/controller/tiers/tiers_controller.go
+++ b/pkg/controller/tiers/tiers_controller.go
@@ -66,7 +66,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return err
 	}
 
-	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log)
+	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, nil)
 
 	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
 		{Name: tiers.ClusterDNSPolicyName, Namespace: "openshift-dns"},

--- a/pkg/controller/tiers/tiers_controller.go
+++ b/pkg/controller/tiers/tiers_controller.go
@@ -53,10 +53,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return nil
 	}
 
-	tierWatchReady := &utils.ReadyFlag{}
-	policyWatchesReady := &utils.ReadyFlag{}
-
-	reconciler := newReconciler(mgr, opts, tierWatchReady, policyWatchesReady)
+	reconciler := newReconciler(mgr, opts)
 
 	c, err := controller.New("tiers-controller", mgr, controller.Options{Reconciler: reconciler})
 	if err != nil {
@@ -69,9 +66,9 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return err
 	}
 
-	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, tierWatchReady)
+	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log)
 
-	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, policyWatchesReady, []types.NamespacedName{
+	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
 		{Name: tiers.ClusterDNSPolicyName, Namespace: "openshift-dns"},
 		{Name: tiers.ClusterDNSPolicyName, Namespace: "kube-system"},
 	})
@@ -80,14 +77,12 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opts options.AddOptions, tierWatchReady *utils.ReadyFlag, policyWatchesReady *utils.ReadyFlag) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, opts options.AddOptions) reconcile.Reconciler {
 	r := &ReconcileTiers{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		provider:           opts.DetectedProvider,
-		status:             status.New(mgr.GetClient(), "tiers", opts.KubernetesVersion),
-		tierWatchReady:     tierWatchReady,
-		policyWatchesReady: policyWatchesReady,
+		client:   mgr.GetClient(),
+		scheme:   mgr.GetScheme(),
+		provider: opts.DetectedProvider,
+		status:   status.New(mgr.GetClient(), "tiers", opts.KubernetesVersion),
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -123,16 +118,6 @@ func (r *ReconcileTiers) Reconcile(ctx context.Context, request reconcile.Reques
 
 	if !utils.IsAPIServerReady(r.client, reqLogger) {
 		r.status.SetDegraded("Waiting for Tigera API server to be ready", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
-	if !r.tierWatchReady.IsReady() {
-		r.status.SetDegraded("Waiting for Tier watch to be established", "")
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
-	if !r.policyWatchesReady.IsReady() {
-		r.status.SetDegraded("Waiting for NetworkPolicy watches to be established", "")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 

--- a/pkg/controller/tiers/tiers_controller_test.go
+++ b/pkg/controller/tiers/tiers_controller_test.go
@@ -116,7 +116,10 @@ var _ = Describe("tier controller tests", func() {
 	})
 
 	It("waits for API server to be available before reconciling", func() {
+		err := c.Delete(ctx, &operatorv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})
+		Expect(err).ShouldNot(HaveOccurred())
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetDegraded", "Waiting for Tigera API server to be ready", "").Return()
 		r = ReconcileTiers{
 			client:             c,
 			scheme:             scheme,
@@ -125,7 +128,11 @@ var _ = Describe("tier controller tests", func() {
 			tierWatchReady:     readyFlag,
 			policyWatchesReady: readyFlag,
 		}
-		utils.DeleteAPIServerAndExpectWait(ctx, c, &r, mockStatus)
+
+		_, err = r.Reconcile(ctx, reconcile.Request{})
+
+		Expect(err).ShouldNot(HaveOccurred())
+		mockStatus.AssertExpectations(GinkgoT())
 	})
 
 	It("should wait if policy watches are not ready", func() {

--- a/pkg/controller/tiers/tiers_controller_test.go
+++ b/pkg/controller/tiers/tiers_controller_test.go
@@ -135,32 +135,6 @@ var _ = Describe("tier controller tests", func() {
 		mockStatus.AssertExpectations(GinkgoT())
 	})
 
-	It("should wait if policy watches are not ready", func() {
-		mockStatus = &status.MockStatus{}
-		r = ReconcileTiers{
-			client:             c,
-			scheme:             scheme,
-			provider:           operatorv1.ProviderNone,
-			status:             mockStatus,
-			tierWatchReady:     readyFlag,
-			policyWatchesReady: &utils.ReadyFlag{},
-		}
-		utils.ExpectWaitForPolicyWatches(ctx, &r, mockStatus)
-	})
-
-	It("should wait if tier watch is not ready", func() {
-		mockStatus = &status.MockStatus{}
-		r = ReconcileTiers{
-			client:             c,
-			scheme:             scheme,
-			provider:           operatorv1.ProviderNone,
-			status:             mockStatus,
-			tierWatchReady:     &utils.ReadyFlag{},
-			policyWatchesReady: readyFlag,
-		}
-		utils.ExpectWaitForTierWatch(ctx, &r, mockStatus)
-	})
-
 	It("should require license", func() {
 		Expect(c.Delete(ctx, &v3.LicenseKey{ObjectMeta: metav1.ObjectMeta{Name: "default"}})).ToNot(HaveOccurred())
 		mockStatus = &status.MockStatus{}

--- a/pkg/controller/utils/test_utils.go
+++ b/pkg/controller/utils/test_utils.go
@@ -20,26 +20,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-// DeleteAPIServerAndExpectWait deletes the API server resource and expects the Reconciler issues a degraded status, waiting for
-// the API server to become available before progressing its status further. Assumes that mockStatus has any required initial status
-// progression expectations set, and that the Reconciler utilizes the mockStatus object. Assumes the API server resource has been created.
-func DeleteAPIServerAndExpectWait(ctx context.Context, c client.Client, r reconcile.Reconciler, mockStatus *status.MockStatus) {
-	err := c.Delete(ctx, &operatorv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})
-	Expect(err).ShouldNot(HaveOccurred())
-
-	mockStatus.On("SetDegraded", "Waiting for Tigera API server to be ready", "").Return()
-
-	_, err = r.Reconcile(ctx, reconcile.Request{})
-	Expect(err).ShouldNot(HaveOccurred())
-	mockStatus.AssertExpectations(GinkgoT())
-}
 
 // DeleteAllowTigeraTierAndExpectWait deletes the tier resource and expects the Reconciler issues a degraded status, waiting for
 // the tier to become available before progressing its status further. Assumes that mockStatus has any required initial status

--- a/pkg/controller/utils/test_utils.go
+++ b/pkg/controller/utils/test_utils.go
@@ -39,3 +39,13 @@ func DeleteAllowTigeraTierAndExpectWait(ctx context.Context, c client.Client, r 
 	Expect(err).ShouldNot(HaveOccurred())
 	mockStatus.AssertExpectations(GinkgoT())
 }
+
+// ExpectWaitForTierWatch expects the Reconciler issues a degraded status, waiting for a Tier watch to be established.
+// Assumes that mockStatus has any required initial status progression expectations set, and that the Reconciler utilizes
+// the mockStatus object.
+func ExpectWaitForTierWatch(ctx context.Context, r reconcile.Reconciler, mockStatus *status.MockStatus) {
+	mockStatus.On("SetDegraded", "Waiting for Tier watch to be established", "").Return()
+	_, err := r.Reconcile(ctx, reconcile.Request{})
+	Expect(err).ShouldNot(HaveOccurred())
+	mockStatus.AssertExpectations(GinkgoT())
+}

--- a/pkg/controller/utils/test_utils.go
+++ b/pkg/controller/utils/test_utils.go
@@ -39,33 +39,3 @@ func DeleteAllowTigeraTierAndExpectWait(ctx context.Context, c client.Client, r 
 	Expect(err).ShouldNot(HaveOccurred())
 	mockStatus.AssertExpectations(GinkgoT())
 }
-
-// ExpectWaitForPolicyWatches expects the Reconciler issues a degraded status, waiting for NetworkPolicy watches to
-// be established. Assumes that mockStatus has any required initial status progression expectations set, and that
-// the Reconciler utilizes the mockStatus object.
-func ExpectWaitForPolicyWatches(ctx context.Context, r reconcile.Reconciler, mockStatus *status.MockStatus) {
-	mockStatus.On("SetDegraded", "Waiting for NetworkPolicy watches to be established", "").Return()
-	_, err := r.Reconcile(ctx, reconcile.Request{})
-	Expect(err).ShouldNot(HaveOccurred())
-	mockStatus.AssertExpectations(GinkgoT())
-}
-
-// ExpectWaitForTierWatch expects the Reconciler issues a degraded status, waiting for a Tier watch to be established.
-// Assumes that mockStatus has any required initial status progression expectations set, and that the Reconciler utilizes
-// the mockStatus object.
-func ExpectWaitForTierWatch(ctx context.Context, r reconcile.Reconciler, mockStatus *status.MockStatus) {
-	mockStatus.On("SetDegraded", "Waiting for Tier watch to be established", "").Return()
-	_, err := r.Reconcile(ctx, reconcile.Request{})
-	Expect(err).ShouldNot(HaveOccurred())
-	mockStatus.AssertExpectations(GinkgoT())
-}
-
-// ExpectWaitForLicenseWatch expects the Reconciler issues a degraded status, waiting for a License watch to be established.
-// Assumes that mockStatus has any required initial status progression expectations set, and that the Reconciler utilizes
-// the mockStatus object.
-func ExpectWaitForLicenseWatch(ctx context.Context, r reconcile.Reconciler, mockStatus *status.MockStatus) {
-	mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return()
-	_, err := r.Reconcile(ctx, reconcile.Request{})
-	Expect(err).ShouldNot(HaveOccurred())
-	mockStatus.AssertExpectations(GinkgoT())
-}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -137,15 +137,14 @@ func WaitToAddNetworkPolicyWatches(controller controller.Controller, c kubernete
 	WaitToAddResourceWatch(controller, c, log, nil, objs)
 }
 
-func WaitToAddTierWatch(tierName string, controller controller.Controller, c kubernetes.Interface, log logr.Logger) {
+func WaitToAddTierWatch(tierName string, controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {
 	obj := &v3.Tier{
 		TypeMeta:   metav1.TypeMeta{Kind: "Tier", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: tierName},
 	}
 
-	// The success of a Tier watch is not a dependency for resources to be installed or function correctly.
-	// Therefore, no ready flag is accepted or created for the watch.
-	WaitToAddResourceWatch(controller, c, log, nil, []client.Object{obj})
+	// The success of a Tier watch can be used as a signal that Tier queries will be resolved using the cache.
+	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{obj})
 }
 
 // AddNamespacedWatch creates a watch on the given object. If a name and namespace are provided, then it will

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -123,7 +123,7 @@ func WaitToAddLicenseKeyWatch(controller controller.Controller, c kubernetes.Int
 	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{&v3.LicenseKey{TypeMeta: metav1.TypeMeta{Kind: v3.KindLicenseKey}}})
 }
 
-func WaitToAddNetworkPolicyWatches(controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag, policies []types.NamespacedName) {
+func WaitToAddNetworkPolicyWatches(controller controller.Controller, c kubernetes.Interface, log logr.Logger, policies []types.NamespacedName) {
 	objs := []client.Object{}
 	for _, policy := range policies {
 		objs = append(objs, &v3.NetworkPolicy{
@@ -132,15 +132,20 @@ func WaitToAddNetworkPolicyWatches(controller controller.Controller, c kubernete
 		})
 	}
 
-	WaitToAddResourceWatch(controller, c, log, flag, objs)
+	// The success of a NetworkPolicy watch is not a dependency for resources to be installed or function correctly.
+	// Therefore, no ready flag is accepted or created for the watch.
+	WaitToAddResourceWatch(controller, c, log, nil, objs)
 }
 
-func WaitToAddTierWatch(tierName string, controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {
+func WaitToAddTierWatch(tierName string, controller controller.Controller, c kubernetes.Interface, log logr.Logger) {
 	obj := &v3.Tier{
 		TypeMeta:   metav1.TypeMeta{Kind: "Tier", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: tierName},
 	}
-	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{obj})
+
+	// The success of a Tier watch is not a dependency for resources to be installed or function correctly.
+	// Therefore, no ready flag is accepted or created for the watch.
+	WaitToAddResourceWatch(controller, c, log, nil, []client.Object{obj})
 }
 
 // AddNamespacedWatch creates a watch on the given object. If a name and namespace are provided, then it will
@@ -467,7 +472,9 @@ func WaitToAddResourceWatch(controller controller.Controller, c kubernetes.Inter
 		}
 
 		if len(resourcesToWatch) == 0 {
-			flag.MarkAsReady()
+			if flag != nil {
+				flag.MarkAsReady()
+			}
 			return
 		}
 	}

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -44,10 +44,7 @@ var _ = Describe("Rendering tests", func() {
 	var g render.Component
 	var resources []client.Object
 
-	guardianPolicy := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/guardian.json")
-	guardianPolicyForOCP := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/guardian_ocp.json")
-
-	renderGuardian := func(i operatorv1.InstallationSpec, includeNetworkPolicy bool, addr string, openshift bool) {
+	createGuardianConfig := func(i operatorv1.InstallationSpec, addr string, openshift bool) *render.GuardianConfiguration {
 		secret := &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -66,7 +63,7 @@ var _ = Describe("Rendering tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		bundle := certificateManager.CreateTrustedBundle()
 
-		cfg := &render.GuardianConfiguration{
+		return &render.GuardianConfiguration{
 			URL: addr,
 			PullSecrets: []*corev1.Secret{{
 				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
@@ -75,125 +72,128 @@ var _ = Describe("Rendering tests", func() {
 					Namespace: common.OperatorNamespace(),
 				},
 			}},
-			Installation:         &i,
-			TunnelSecret:         secret,
-			TrustedCertBundle:    bundle,
-			Openshift:            openshift,
-			IncludeNetworkPolicy: includeNetworkPolicy,
+			Installation:      &i,
+			TunnelSecret:      secret,
+			TrustedCertBundle: bundle,
+			Openshift:         openshift,
 		}
-		g = render.Guardian(cfg)
-		Expect(g.ResolveImages(nil)).To(BeNil())
-		resources, _ = g.Objects()
 	}
 
-	BeforeEach(func() {
-		renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"}, true, "127.0.0.1:1234", false)
-	})
-
-	It("should render all resources for a managed cluster", func() {
-		expectedResources := []struct {
-			name    string
-			ns      string
-			group   string
-			version string
-			kind    string
-		}{
-			{name: render.GuardianNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
-			{name: render.GuardianPolicyName, ns: render.GuardianNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-			{name: networkpolicy.TigeraComponentDefaultDenyPolicyName, ns: render.GuardianNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-			{name: "pull-secret", ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
-			{name: render.GuardianServiceAccountName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "ServiceAccount"},
-			{name: render.GuardianClusterRoleName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-			{name: render.GuardianClusterRoleBindingName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: render.GuardianDeploymentName, ns: render.GuardianNamespace, group: "apps", version: "v1", kind: "Deployment"},
-			{name: render.GuardianServiceName, ns: render.GuardianNamespace, group: "", version: "", kind: ""},
-			{name: render.GuardianSecretName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
-			{name: certificatemanagement.TrustedCertConfigMapName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "ConfigMap"},
-			{name: render.ManagerNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
-			{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
-			{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-			{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-			{name: render.ManagerClusterSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: render.ManagerUserSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
-			{name: render.ManagerClusterSettingsLayerTigera, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-			{name: render.ManagerClusterSettingsViewDefault, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
-		}
-		Expect(len(resources)).To(Equal(len(expectedResources)))
-		for i, expectedRes := range expectedResources {
-			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+	Context("Guardian component", func() {
+		renderGuardian := func(i operatorv1.InstallationSpec) {
+			cfg := createGuardianConfig(i, "127.0.0.1:1234", false)
+			g = render.Guardian(cfg)
+			Expect(g.ResolveImages(nil)).To(BeNil())
+			resources, _ = g.Objects()
 		}
 
-		deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-		Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("my-reg/tigera/guardian:" + components.ComponentGuardian.Version))
+		BeforeEach(func() {
+			renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"})
+		})
 
-		Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
-		Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
-		Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-		Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
-		Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(1001))
-
-		// Check the namespace.
-		ns := rtest.GetResource(resources, "tigera-guardian", "", "", "v1", "Namespace").(*corev1.Namespace)
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("restricted"))
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
-	})
-
-	It("should render controlPlaneTolerations", func() {
-		t := corev1.Toleration{
-			Key:      "foo",
-			Operator: corev1.TolerationOpEqual,
-			Value:    "bar",
-		}
-		renderGuardian(
-			operatorv1.InstallationSpec{
-				ControlPlaneTolerations: []corev1.Toleration{t},
-			},
-			true,
-			"127.0.0.1:1234",
-			false,
-		)
-		deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(deployment.Spec.Template.Spec.Tolerations).Should(ContainElements(t, rmeta.TolerateCriticalAddonsOnly, rmeta.TolerateMaster))
-	})
-
-	Context("allow-tigera rendering", func() {
-		policyName := types.NamespacedName{Name: "allow-tigera.guardian-access", Namespace: "tigera-guardian"}
-
-		getExpectedPolicy := func(name types.NamespacedName, scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
-			if name.Name == "allow-tigera.guardian-access" && scenario.ManagedCluster {
-				return testutils.SelectPolicyByProvider(scenario, guardianPolicy, guardianPolicyForOCP)
+		It("should render all resources for a managed cluster", func() {
+			expectedResources := []struct {
+				name    string
+				ns      string
+				group   string
+				version string
+				kind    string
+			}{
+				{name: render.GuardianNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+				{name: "pull-secret", ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
+				{name: render.GuardianServiceAccountName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+				{name: render.GuardianClusterRoleName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+				{name: render.GuardianClusterRoleBindingName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+				{name: render.GuardianDeploymentName, ns: render.GuardianNamespace, group: "apps", version: "v1", kind: "Deployment"},
+				{name: render.GuardianServiceName, ns: render.GuardianNamespace, group: "", version: "", kind: ""},
+				{name: render.GuardianSecretName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "Secret"},
+				{name: certificatemanagement.TrustedCertConfigMapName, ns: render.GuardianNamespace, group: "", version: "v1", kind: "ConfigMap"},
+				{name: render.ManagerNamespace, ns: "", group: "", version: "v1", kind: "Namespace"},
+				{name: render.ManagerServiceAccount, ns: render.ManagerNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+				{name: render.ManagerClusterRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+				{name: render.ManagerClusterRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+				{name: render.ManagerClusterSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+				{name: render.ManagerUserSettings, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettingsGroup"},
+				{name: render.ManagerClusterSettingsLayerTigera, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
+				{name: render.ManagerClusterSettingsViewDefault, ns: "", group: "projectcalico.org", version: "v3", kind: "UISettings"},
+			}
+			Expect(len(resources)).To(Equal(len(expectedResources)))
+			for i, expectedRes := range expectedResources {
+				rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 			}
 
-			return nil
+			deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(Equal("my-reg/tigera/guardian:" + components.ComponentGuardian.Version))
+
+			Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
+			Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
+			Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(*deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(1001))
+
+			// Check the namespace.
+			ns := rtest.GetResource(resources, "tigera-guardian", "", "", "v1", "Namespace").(*corev1.Namespace)
+			Expect(ns.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("restricted"))
+			Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
+		})
+
+		It("should render controlPlaneTolerations", func() {
+			t := corev1.Toleration{
+				Key:      "foo",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "bar",
+			}
+			renderGuardian(operatorv1.InstallationSpec{
+				ControlPlaneTolerations: []corev1.Toleration{t},
+			})
+			deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(deployment.Spec.Template.Spec.Tolerations).Should(ContainElements(t, rmeta.TolerateCriticalAddonsOnly, rmeta.TolerateMaster))
+		})
+	})
+
+	Context("GuardianPolicy component", func() {
+		guardianPolicy := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/guardian.json")
+		guardianPolicyForOCP := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/guardian_ocp.json")
+
+		renderGuardianPolicy := func(addr string, openshift bool) {
+			cfg := createGuardianConfig(operatorv1.InstallationSpec{Registry: "my-reg/"}, addr, openshift)
+			g, err := render.GuardianPolicy(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			resources, _ = g.Objects()
 		}
 
-		DescribeTable("should render allow-tigera policy",
-			func(scenario testutils.AllowTigeraScenario) {
-				// Validate policy is rendered when policy flag is set.
-				renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"}, true, "127.0.0.1:1234", scenario.Openshift)
-				policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
-				expectedPolicy := getExpectedPolicy(policyName, scenario)
-				Expect(policy).To(Equal(expectedPolicy))
+		Context("allow-tigera rendering", func() {
+			policyName := types.NamespacedName{Name: "allow-tigera.guardian-access", Namespace: "tigera-guardian"}
 
-				// Validate policy is not rendered when policy flag is not set.
-				renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"}, false, "127.0.0.1:1234", scenario.Openshift)
-				for _, obj := range resources {
-					Expect(obj.GetObjectKind().GroupVersionKind().Kind).ToNot(Equal("NetworkPolicy"))
+			getExpectedPolicy := func(name types.NamespacedName, scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+				if name.Name == "allow-tigera.guardian-access" && scenario.ManagedCluster {
+					return testutils.SelectPolicyByProvider(scenario, guardianPolicy, guardianPolicyForOCP)
 				}
-			},
-			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
-			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
-		)
 
-		// The test matrix above validates against an IP-based management cluster address.
-		// Validate policy adaptation for domain-based management cluster address here.
-		It("should adapt Guardian policy if ManagementClusterAddr is domain-based", func() {
-			renderGuardian(operatorv1.InstallationSpec{Registry: "my-reg/"}, true, "mydomain.io:8080", false)
-			policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
-			managementClusterEgressRule := policy.Spec.Egress[4]
-			Expect(managementClusterEgressRule.Destination.Domains).To(Equal([]string{"mydomain.io"}))
-			Expect(managementClusterEgressRule.Destination.Ports).To(Equal(networkpolicy.Ports(8080)))
+				return nil
+			}
+
+			DescribeTable("should render allow-tigera policy",
+				func(scenario testutils.AllowTigeraScenario) {
+					renderGuardianPolicy("127.0.0.1:1234", scenario.Openshift)
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+					expectedPolicy := getExpectedPolicy(policyName, scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				},
+				Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
+				Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
+			)
+
+			// The test matrix above validates against an IP-based management cluster address.
+			// Validate policy adaptation for domain-based management cluster address here.
+			It("should adapt Guardian policy if ManagementClusterAddr is domain-based", func() {
+				renderGuardianPolicy("mydomain.io:8080", false)
+				policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+				managementClusterEgressRule := policy.Spec.Egress[4]
+				Expect(managementClusterEgressRule.Destination.Domains).To(Equal([]string{"mydomain.io"}))
+				Expect(managementClusterEgressRule.Destination.Ports).To(Equal(networkpolicy.Ports(8080)))
+			})
 		})
 	})
 })

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -94,7 +94,6 @@ var _ = Describe("monitor rendering tests", func() {
 			AlertmanagerConfigSecret: defaultAlertmanagerConfigSecret,
 			ClusterDomain:            "example.org",
 			TrustedCertBundle:        bundle,
-			IncludeV3NetworkPolicy:   true,
 		}
 	})
 
@@ -112,12 +111,6 @@ var _ = Describe("monitor rendering tests", func() {
 			kind    string
 		}{
 			{"tigera-prometheus", "", "", "v1", "Namespace"},
-			{"allow-tigera.calico-node-alertmanager", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.calico-node-alertmanager-mesh", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.prometheus", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.tigera-prometheus-api", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.prometheus-operator", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.default-deny", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 			{"tigera-prometheus-role", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
 			{"tigera-prometheus-role-binding", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
@@ -391,12 +384,6 @@ var _ = Describe("monitor rendering tests", func() {
 			kind    string
 		}{
 			{"tigera-prometheus", "", "", "v1", "Namespace"},
-			{"allow-tigera.calico-node-alertmanager", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.calico-node-alertmanager-mesh", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.prometheus", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.tigera-prometheus-api", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.prometheus-operator", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
-			{"allow-tigera.default-deny", common.TigeraPrometheusNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 			{"tigera-prometheus-role", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
 			{"tigera-prometheus-role-binding", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
@@ -551,24 +538,13 @@ var _ = Describe("monitor rendering tests", func() {
 			func(scenario testutils.AllowTigeraScenario) {
 				cfg.Openshift = scenario.Openshift
 
-				// Validate policy is rendered when policy flag is set.
-				cfg.IncludeV3NetworkPolicy = true
-				component := monitor.Monitor(cfg)
+				component := monitor.MonitorPolicy(cfg)
 				resourcesToCreate, _ := component.Objects()
 
 				for _, policyName := range policyNames {
 					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resourcesToCreate)
 					expectedPolicy := getExpectedPolicy(policyName, scenario)
 					Expect(policy).To(Equal(expectedPolicy))
-				}
-
-				// Validate policy is not rendered when policy flag is not set.
-				cfg.IncludeV3NetworkPolicy = false
-				component = monitor.Monitor(cfg)
-				resourcesToCreate, _ = component.Objects()
-
-				for _, obj := range resourcesToCreate {
-					Expect(obj.GetObjectKind().GroupVersionKind().Kind).ToNot(Equal("NetworkPolicy"))
 				}
 			},
 			Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),


### PR DESCRIPTION
## Description
Addresses the 'immediate follow-up' items from #1970.
The bulk of the changes come from removing Reconcile waits for policy and tier watches, this is captured in it's own commit.

Items addressed:
* Removed use of reconcilability util function in favour of direct Tier Get()
* Ensured that controllers which impact policy reconcilability render policy last
* Removed waits for policy and tier watches
* Removed API server waits added in allow-tigera PR
 
## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
