### PR TITLE
Add AssignIpv[46] in CalicoNetworkSpec

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -326,6 +326,16 @@ type CalicoNetworkSpec struct {
 	// +optional
 	IPPools []IPPool `json:"ipPools,omitempty"`
 
+	// AssignIpv4 configure whether ipv4 pools are enabled or disabled
+	// If omitted, its value will be derived from the presence of ipv4 ippools in IPPools
+	// +optional
+	AssignIpv4 *bool `json:"assignIpv4,omitempty"`
+
+	// AssignIpv6 configure whether ipv6 pools are enabled or disabled
+	// If omitted, its value will be derived from the presence of ipv6 ippools in IPPools
+	// +optional
+	AssignIpv6 *bool `json:"assignIpv6,omitempty"`
+
 	// MTU specifies the maximum transmission unit to use on the pod network.
 	// If not specified, Calico will perform MTU auto-detection based on the cluster network.
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -598,6 +598,16 @@ func (in *CalicoNetworkSpec) DeepCopyInto(out *CalicoNetworkSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AssignIpv4 != nil {
+		in, out := &in.AssignIpv4, &out.AssignIpv4
+		*out = new(bool)
+		**out = **in
+	}
+	if in.AssignIpv6 != nil {
+		in, out := &in.AssignIpv6, &out.AssignIpv6
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MTU != nil {
 		in, out := &in.MTU, &out.MTU
 		*out = new(int32)

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -43,6 +43,16 @@ spec:
                 description: CalicoNetwork specifies networking configuration options
                   for Calico.
                 properties:
+                  assignIpv4:
+                    description: AssignIpv4 configure whether ipv4 pools are enabled
+                      or disabled If omitted, its value will be derived from the presence
+                      of ipv4 ippools in IPPools
+                    type: boolean
+                  assignIpv6:
+                    description: AssignIpv6 configure whether ipv6 pools are enabled
+                      or disabled If omitted, its value will be derived from the presence
+                      of ipv6 ippools in IPPools
+                    type: boolean
                   bgp:
                     description: BGP configures whether or not to enable Calico's
                       BGP capabilities.
@@ -791,6 +801,16 @@ spec:
                     description: CalicoNetwork specifies networking configuration
                       options for Calico.
                     properties:
+                      assignIpv4:
+                        description: AssignIpv4 configure whether ipv4 pools are enabled
+                          or disabled If omitted, its value will be derived from the
+                          presence of ipv4 ippools in IPPools
+                        type: boolean
+                      assignIpv6:
+                        description: AssignIpv6 configure whether ipv6 pools are enabled
+                          or disabled If omitted, its value will be derived from the
+                          presence of ipv6 ippools in IPPools
+                        type: boolean
                       bgp:
                         description: BGP configures whether or not to enable Calico's
                           BGP capabilities.

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -585,19 +585,27 @@ func (c *nodeComponent) nodeCNIConfigMap() *corev1.ConfigMap {
 	}
 }
 
+func boolToStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
 func (c *nodeComponent) getCalicoIPAM() string {
 	// Determine what address families to enable.
 	var assign_ipv4 string
 	var assign_ipv6 string
-	if v4pool := GetIPv4Pool(c.cfg.Installation.CalicoNetwork.IPPools); v4pool != nil {
-		assign_ipv4 = "true"
+
+	if c.cfg.Installation.CalicoNetwork.AssignIpv4 == nil {
+		assign_ipv4 = boolToStr(GetIPv4Pool(c.cfg.Installation.CalicoNetwork.IPPools) != nil)
 	} else {
-		assign_ipv4 = "false"
+		assign_ipv4 = boolToStr(*c.cfg.Installation.CalicoNetwork.AssignIpv4)
 	}
-	if v6pool := GetIPv6Pool(c.cfg.Installation.CalicoNetwork.IPPools); v6pool != nil {
-		assign_ipv6 = "true"
+	if c.cfg.Installation.CalicoNetwork.AssignIpv6 == nil {
+		assign_ipv6 = boolToStr(GetIPv6Pool(c.cfg.Installation.CalicoNetwork.IPPools) != nil)
 	} else {
-		assign_ipv6 = "false"
+		assign_ipv6 = boolToStr(*c.cfg.Installation.CalicoNetwork.AssignIpv6)
 	}
 	return fmt.Sprintf(`{ "type": "calico-ipam", "assign_ipv4" : "%s", "assign_ipv6" : "%s"}`,
 		assign_ipv4, assign_ipv6,


### PR DESCRIPTION
## Description

This patchs adds two additional parameters to the CalicoNetworkSpec
allowing to force the value of assign_ipv4 / assign_ipv6 in the CNI
configuration. This is useful when the ippools are not created at
installation time but later on during provisionning.

If omitted, the previous behaviour will be preserved (deriving the
values from the presence of v4/v6 pools in the default ippools)

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
