### PR TITLE
Add option for Persistent Storage for AD API

### DIFF
--- a/api/v1/intrusiondetection_types.go
+++ b/api/v1/intrusiondetection_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020, 2022 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,39 @@ type IntrusionDetectionSpec struct {
 	// Only DeepPacketInspection is supported for this spec.
 	// +optional
 	ComponentResources []IntrusionDetectionComponentResource `json:"componentResources,omitempty"`
+
+	// AnomalyDetectionSpec provides configuration for running AnomalyDetection Component within
+	// IntrusionDetection
+	AnomalyDetectionSpec *AnomalyDetectionSpec `json:"anomalyDetectionSpec,omitempty"`
 }
+
+type AnomalyDetectionSpec struct {
+	// StorageType Sets the type of storage to use for storing Anomaly Detection Models. By default it will use the ephemeral
+	// emptyDir on the node AD will be deployed to. This field sets precedent for all AD Storage related fields and will only
+	// take into effect on Management and Standalone clusters.
+	// default: Ephemeral
+	StorageType StorageType `json:"storageType,omitempty"`
+
+	// StorageClassName will populate the PersistentVolumeClaim.StorageClassName that is used to provision disks for the
+	// Anomaly Detection API pod for model storage. The StorageClassName should only be modified when no LogStorage is currently
+	// active. We recommend choosing a storage class dedicated to Tigera LogStorage only. Otherwise, model retention
+	// cannot be guaranteed during upgrades. See https://docs.tigera.io/maintenance/upgrading for up-to-date instructions.
+	// Default: tigera-anomaly-detection-storage
+	// +optional
+	StorageClassName string `json:"storageClassName,omitempty"`
+}
+
+// StorageType is sets the type of storage to be used for the specified component.
+type StorageType string
+
+const (
+	// Ephermeal storage type sets the ephermeal emptyDir() to be used by the component. Data created in this storage type will
+	// follow the Pod's lifetime and get created and deleted along with the Pod.
+	EphermealStorageType StorageType = "Ephermeal"
+	// Persistent storage type sets the will attempt to query for the StorageClass specified by StorageClassName created for
+	// the component. It will utilize the provided StorageClass for the componenet's Volume.
+	PersistentStorageType StorageType = "Persistent"
+)
 
 // IntrusionDetectionStatus defines the observed state of Tigera intrusion detection capabilities.
 type IntrusionDetectionStatus struct {

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -41,6 +41,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,7 +76,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	// Create a new controller
 	controller, err := controller.New("intrusiondetection-controller", mgr, controller.Options{Reconciler: reconcile.Reconciler(reconciler)})
 	if err != nil {
-		return fmt.Errorf("Failed to create intrusiondetection-controller: %v", err)
+		return fmt.Errorf("failed to create intrusiondetection-controller: %v", err)
 	}
 
 	k8sClient, err := kubernetes.NewForConfig(mgr.GetConfig())
@@ -149,6 +150,11 @@ func add(mgr manager.Manager, c controller.Controller) error {
 
 	if err = imageset.AddImageSetWatch(c); err != nil {
 		return fmt.Errorf("intrusiondetection-controller failed to watch ImageSet: %w", err)
+	}
+
+	// Watch for changes in storage classes to queue changes if new storage classes may be made available for AD API.
+	if err = c.Watch(&source.Kind{Type: &storagev1.StorageClass{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("intrusiondetection-controller failed to watch StorageClass resource: %w", err)
 	}
 
 	if err = utils.AddAPIServerWatch(c); err != nil {
@@ -308,6 +314,29 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 
+	// Query for StorageClass for AD API if provided
+	if instance.Spec.AnomalyDetectionSpec.StorageType == operatorv1.PersistentStorageType {
+		// validate to degrade early if the storage class name is not valid
+		if err = utils.ValidateResourceNameIsQualified(instance.Spec.AnomalyDetectionSpec.StorageClassName); err != nil {
+			errMessage := "invalid AD Storage Class name provided"
+			log.Error(err, errMessage)
+			r.status.SetDegraded("Error retrieving pull secrets", err.Error())
+			return reconcile.Result{}, err
+		}
+
+		if err = r.client.Get(ctx, client.ObjectKey{Name: instance.Spec.AnomalyDetectionSpec.StorageClassName}, &storagev1.StorageClass{}); err != nil {
+			if errors.IsNotFound(err) {
+				log.Error(err, "Anomaly Detection Storage Class not found")
+				r.status.SetDegraded("Failed to get storage class for anomaly detection", err.Error())
+				return reconcile.Result{}, err
+			} else {
+				reqLogger.Error(err, "Failed to query for Anomaly Detection Storage Class")
+				r.status.SetDegraded("Failed to get storage class for anomaly detection", err.Error())
+				return reconcile.Result{}, err
+			}
+		}
+	}
+
 	// Query for the LogCollector instance. We need this to determine whether or not
 	// to forward IDS event logs. Since this is optional, we don't need to degrade or
 	// change status if LogCollector is not found.
@@ -420,6 +449,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	// Render the desired objects from the CRD and create or update them.
 	hasNoLicense := !utils.IsFeatureActive(license, common.ThreatDefenseFeature)
 	intrusionDetectionCfg := &render.IntrusionDetectionConfiguration{
+		IntrusionDetction:     instance,
 		LogCollector:          lc,
 		ESSecrets:             esSecrets,
 		Installation:          network,
@@ -529,7 +559,8 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	return reconcile.Result{}, nil
 }
 
-// setDefaultsOnIntrusionDetection updates the IntrusionDetection resource with defaults if ComponentResources is not populated.
+// setDefaultsOnIntrusionDetection updates the IntrusionDetection resource with defaults if
+// ComponentResources and AnomalyDetectionSpec are not populated.
 func (r *ReconcileIntrusionDetection) setDefaultsOnIntrusionDetection(ctx context.Context, ids *operatorv1.IntrusionDetection) error {
 	if ids.Spec.ComponentResources == nil {
 		ids.Spec.ComponentResources = []operatorv1.IntrusionDetectionComponentResource{
@@ -546,6 +577,16 @@ func (r *ReconcileIntrusionDetection) setDefaultsOnIntrusionDetection(ctx contex
 					},
 				},
 			},
+		}
+
+		if ids.Spec.AnomalyDetectionSpec == nil {
+			ids.Spec.AnomalyDetectionSpec = &operatorv1.AnomalyDetectionSpec{
+				StorageType: operatorv1.EphermealStorageType,
+			}
+		} else {
+			if ids.Spec.AnomalyDetectionSpec.StorageType == operatorv1.PersistentStorageType && len(ids.Spec.AnomalyDetectionSpec.StorageClassName) == 0 {
+				ids.Spec.AnomalyDetectionSpec.StorageClassName = render.DefaultADStorageClassName
+			}
 		}
 
 		if err := r.client.Update(ctx, ids); err != nil {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -561,6 +561,8 @@ func createPredicateForObject(objMeta metav1.Object) predicate.Predicate {
 	}
 }
 
+// ValidateResourceNameIsQualified returns a compiled list of errors which states which rule the name
+// did not respect. Returns nil if it's a valid name.
 func ValidateResourceNameIsQualified(name string) error {
 	errors := validation.IsQualifiedName(name)
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -557,4 +559,14 @@ func createPredicateForObject(objMeta metav1.Object) predicate.Predicate {
 			return e.Object.GetNamespace() == objMeta.GetNamespace()
 		},
 	}
+}
+
+func ValidateResourceNameIsQualified(name string) error {
+	errors := validation.IsQualifiedName(name)
+
+	if len(errors) > 0 {
+		return fmt.Errorf("%s is not a qualified resource name with errors: %s", name, strings.Join(errors[:], ", "))
+	}
+
+	return nil
 }

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -183,6 +183,25 @@ var _ = Describe("Utils APIServer type tests", func() {
 	)
 })
 
+var _ = Describe("ValidateResourceNameIsQualified", func() {
+
+	It("returns nil for a compliant kubernetes name.", func() {
+		qualifiedName := "proper-resource-name"
+
+		err := ValidateResourceNameIsQualified(qualifiedName)
+
+		Expect(err).To(BeNil())
+	})
+
+	It("returns nil for an invalid resource name", func() {
+		invalidName := "inproper_resource_name"
+
+		err := ValidateResourceNameIsQualified(invalidName)
+
+		Expect(err).ToNot(BeNil())
+	})
+})
+
 type fakeClient struct {
 	discovery discovery.DiscoveryInterface
 	kubernetes.Interface

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -1320,7 +1320,7 @@ func (c *intrusionDetectionComponent) adPersistentVolume() *corev1.PersistentVol
 		Spec: corev1.PersistentVolumeSpec{
 			StorageClassName: adStorageClassName,
 			Capacity: corev1.ResourceList{
-				"storage": resource.MustParse(fmt.Sprintf("%dGi", DefaultAnomalyDetectionPVRequestSizeGi)),
+				corev1.ResourceStorage: resource.MustParse(fmt.Sprintf("%dGi", DefaultAnomalyDetectionPVRequestSizeGi)),
 			},
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
@@ -1346,7 +1346,7 @@ func (c *intrusionDetectionComponent) adPersistentVolumeClaim() *corev1.Persiste
 			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					"storage": resource.MustParse(fmt.Sprintf("%dGi", DefaultAnomalyDetectionPVRequestSizeGi)),
+					corev1.ResourceStorage: resource.MustParse(fmt.Sprintf("%dGi", DefaultAnomalyDetectionPVRequestSizeGi)),
 				},
 			},
 		},

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -15,6 +15,7 @@
 package render_test
 
 import (
+	"fmt"
 	"strconv"
 
 	. "github.com/onsi/ginkgo"
@@ -220,6 +221,12 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		Expect(adAPIDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal(bundle.VolumeMount(rmeta.OSTypeLinux).MountPath))
 		Expect(adAPIDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(adAPIKeyPair.VolumeMount(rmeta.OSTypeLinux).Name))
 		Expect(adAPIDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal(adAPIKeyPair.VolumeMount(rmeta.OSTypeLinux).MountPath))
+		// emptyDir is expected as the default volume
+		Expect(adAPIDeployment.Spec.Template.Spec.Volumes).To(ContainElement(
+			corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		))
 
 		// Check all Role for respective AD API SAs
 		detectorsSecret := rtest.GetResource(resources, "anomaly-detectors", render.IntrusionDetectionNamespace, "", "v1", "Secret").(*corev1.Secret)
@@ -276,6 +283,41 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			Name:      render.ADAPIObjectName,
 			Namespace: render.IntrusionDetectionNamespace,
 		}))
+	})
+
+	It("should render a persistent volume and the persistentVolume claim if indicated that the AnomalyDetection Storage spec type is Persistent", func() {
+		testADStorageClassName := "test-storage-class-name"
+		cfg.IntrusionDetction = &operatorv1.IntrusionDetection{
+			Spec: operatorv1.IntrusionDetectionSpec{
+				AnomalyDetectionSpec: &operatorv1.AnomalyDetectionSpec{
+					StorageType:      operatorv1.PersistentStorageType,
+					StorageClassName: testADStorageClassName,
+				},
+			},
+		}
+		cfg.Openshift = notOpenshift
+		cfg.ManagedCluster = false
+
+		component := render.IntrusionDetection(cfg)
+		resources, _ := component.Objects()
+
+		adAPIPV := rtest.GetResource(resources, testADStorageClassName, render.IntrusionDetectionNamespace, "", "v1", "PersistentVolume").(*corev1.PersistentVolume)
+		Expect(adAPIPV.Spec.StorageClassName).To(Equal(testADStorageClassName))
+		Expect(adAPIPV.Spec.Capacity[corev1.ResourceStorage]).To(Equal(fmt.Sprintf("%dGi", render.DefaultAnomalyDetectionPVRequestSizeGi)))
+		Expect(adAPIPV.Spec.PersistentVolumeSource.HostPath.Path).To(Equal("/storage"))
+
+		adAPIPVC := rtest.GetResource(resources, testADStorageClassName, render.IntrusionDetectionNamespace, "", "v1", "PersistentVolumeClaim").(*corev1.PersistentVolumeClaim)
+		Expect(adAPIPVC.Spec.StorageClassName).To(Equal(testADStorageClassName))
+		Expect(adAPIPVC.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(fmt.Sprintf("%dGi", render.DefaultAnomalyDetectionPVRequestSizeGi)))
+
+		adAPIDeployment := rtest.GetResource(resources, render.ADAPIObjectName, render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(adAPIDeployment.Spec.Template.Spec.Volumes).To(ContainElement(
+			corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: testADStorageClassName,
+				},
+			},
+		))
 	})
 
 	It("should render finalizers rbac resources in the IDS ClusterRole for an Openshift management/standalone cluster", func() {


### PR DESCRIPTION
feat(ids): set api for AD storageclass and render PVs PVCs

feat(ids_controller): add watcher for storageclasses in ids + config ad deployment to set storageclass volume

feat(ids): validation for AD storageclass name

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
