### PR TITLE
[Issue #2006] Add {get,list,watch}/secrets permissions to calico-node rbac.

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -316,6 +316,12 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"watch", "list", "get"},
 			},
 			{
+				// This permission is needed to get bgp password for BGPPeer resource.
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
 				// Some information is stored on the node status.
 				APIGroups: []string{""},
 				Resources: []string{"nodes/status"},


### PR DESCRIPTION
Hi,
We faced with issue that calico-node couldn't read bgp password from secrets since there is no appropriate permissions for this role [1]. This PR adds {get, list, watch}/secrets permissions to calico-node rbac. Also i have created PR to calico helm chart too. [2]

Thanks!
[1] https://projectcalico.docs.tigera.io/reference/resources/bgppeer#bgppassword
[2] https://github.com/projectcalico/calico/pull/6475