### PR TITLE
Support Compliance CR omission

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -496,7 +496,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		ESLicenseType:           elasticLicenseType,
 		Replicas:                replicas,
 		Compliance:              complianceCR,
-		ComplianceFeatureActive: complianceLicenseFeatureActive,
+		ComplianceLicenseActive: complianceLicenseFeatureActive,
 		UsePSP:                  r.usePSP,
 	}
 

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -313,14 +313,14 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	complianceLicenseFeatureActive := utils.IsFeatureActive(license, common.ComplianceFeature)
 	complianceCR, err := compliance.GetCompliance(ctx, r.client)
 	if err != nil && !errors.IsNotFound(err) {
-		r.status.SetDegraded("Error querying compliance", err.Error())
+		r.status.SetDegraded(string(operatorv1.ResourceReadError), fmt.Sprintf("Error querying compliance: %s", err.Error()))
 		return reconcile.Result{}, err
 	}
 
 	if complianceLicenseFeatureActive && complianceCR != nil {
 		// Check that compliance is running.
 		if complianceCR.Status.State != operatorv1.TigeraStatusReady {
-			r.status.SetDegraded("Compliance is not ready", fmt.Sprintf("compliance status: %s", complianceCR.Status.State))
+			r.status.SetDegraded(string(operatorv1.ResourceNotReady), "Compliance is not ready")
 			return reconcile.Result{}, nil
 		}
 		trustedSecretNames = append(trustedSecretNames, render.ComplianceServerCertSecret)
@@ -481,23 +481,23 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	managerCfg := &render.ManagerConfiguration{
-		KeyValidatorConfig:             keyValidatorConfig,
-		ESSecrets:                      esSecrets,
-		TrustedCertBundle:              trustedBundle,
-		ESClusterConfig:                esClusterConfig,
-		TLSKeyPair:                     tlsSecret,
-		PullSecrets:                    pullSecrets,
-		Openshift:                      r.provider == operatorv1.ProviderOpenShift,
-		Installation:                   installation,
-		ManagementCluster:              managementCluster,
-		TunnelSecret:                   tunnelSecret,
-		InternalTrafficSecret:          internalTrafficSecret,
-		ClusterDomain:                  r.clusterDomain,
-		ESLicenseType:                  elasticLicenseType,
-		Replicas:                       replicas,
-		Compliance:                     complianceCR,
-		ComplianceLicenseFeatureActive: complianceLicenseFeatureActive,
-		UsePSP:                         r.usePSP,
+		KeyValidatorConfig:      keyValidatorConfig,
+		ESSecrets:               esSecrets,
+		TrustedCertBundle:       trustedBundle,
+		ESClusterConfig:         esClusterConfig,
+		TLSKeyPair:              tlsSecret,
+		PullSecrets:             pullSecrets,
+		Openshift:               r.provider == operatorv1.ProviderOpenShift,
+		Installation:            installation,
+		ManagementCluster:       managementCluster,
+		TunnelSecret:            tunnelSecret,
+		InternalTrafficSecret:   internalTrafficSecret,
+		ClusterDomain:           r.clusterDomain,
+		ESLicenseType:           elasticLicenseType,
+		Replicas:                replicas,
+		Compliance:              complianceCR,
+		ComplianceFeatureActive: complianceLicenseFeatureActive,
+		UsePSP:                  r.usePSP,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -309,20 +309,18 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	trustedSecretNames := []string{render.PacketCaptureCertSecret, render.PrometheusTLSSecretName, relasticsearch.PublicCertSecret}
-	installCompliance := utils.IsFeatureActive(license, common.ComplianceFeature)
-	if installCompliance {
+
+	complianceLicenseFeatureActive := utils.IsFeatureActive(license, common.ComplianceFeature)
+	complianceCR, err := compliance.GetCompliance(ctx, r.client)
+	if err != nil && !errors.IsNotFound(err) {
+		r.status.SetDegraded("Error querying compliance", err.Error())
+		return reconcile.Result{}, err
+	}
+
+	if complianceLicenseFeatureActive && complianceCR != nil {
 		// Check that compliance is running.
-		compliance, err := compliance.GetCompliance(ctx, r.client)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				r.status.SetDegraded("Compliance not found", err.Error())
-				return reconcile.Result{}, err
-			}
-			r.status.SetDegraded("Error querying compliance", err.Error())
-			return reconcile.Result{}, err
-		}
-		if compliance.Status.State != operatorv1.TigeraStatusReady {
-			r.status.SetDegraded("Compliance is not ready", fmt.Sprintf("compliance status: %s", compliance.Status.State))
+		if complianceCR.Status.State != operatorv1.TigeraStatusReady {
+			r.status.SetDegraded("Compliance is not ready", fmt.Sprintf("compliance status: %s", complianceCR.Status.State))
 			return reconcile.Result{}, nil
 		}
 		trustedSecretNames = append(trustedSecretNames, render.ComplianceServerCertSecret)
@@ -483,22 +481,23 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	managerCfg := &render.ManagerConfiguration{
-		KeyValidatorConfig:      keyValidatorConfig,
-		ESSecrets:               esSecrets,
-		TrustedCertBundle:       trustedBundle,
-		ESClusterConfig:         esClusterConfig,
-		TLSKeyPair:              tlsSecret,
-		PullSecrets:             pullSecrets,
-		Openshift:               r.provider == operatorv1.ProviderOpenShift,
-		Installation:            installation,
-		ManagementCluster:       managementCluster,
-		TunnelSecret:            tunnelSecret,
-		InternalTrafficSecret:   internalTrafficSecret,
-		ClusterDomain:           r.clusterDomain,
-		ESLicenseType:           elasticLicenseType,
-		Replicas:                replicas,
-		ComplianceFeatureActive: installCompliance,
-		UsePSP:                  r.usePSP,
+		KeyValidatorConfig:             keyValidatorConfig,
+		ESSecrets:                      esSecrets,
+		TrustedCertBundle:              trustedBundle,
+		ESClusterConfig:                esClusterConfig,
+		TLSKeyPair:                     tlsSecret,
+		PullSecrets:                    pullSecrets,
+		Openshift:                      r.provider == operatorv1.ProviderOpenShift,
+		Installation:                   installation,
+		ManagementCluster:              managementCluster,
+		TunnelSecret:                   tunnelSecret,
+		InternalTrafficSecret:          internalTrafficSecret,
+		ClusterDomain:                  r.clusterDomain,
+		ESLicenseType:                  elasticLicenseType,
+		Replicas:                       replicas,
+		Compliance:                     complianceCR,
+		ComplianceLicenseFeatureActive: complianceLicenseFeatureActive,
+		UsePSP:                         r.usePSP,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
@@ -295,6 +296,8 @@ var _ = Describe("Manager controller tests", func() {
 	Context("reconciliation", func() {
 		var r ReconcileManager
 		var mockStatus *status.MockStatus
+		var licenseKey *v3.LicenseKey
+		var compliance *operatorv1.Compliance
 
 		BeforeEach(func() {
 			// Create an object we can use throughout the test to do the compliance reconcile loops.
@@ -309,6 +312,7 @@ var _ = Describe("Manager controller tests", func() {
 			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
 			mockStatus.On("SetDegraded", "Waiting for secret 'calico-node-prometheus-tls' to become available", "").Return().Maybe()
 			mockStatus.On("SetDegraded", "Waiting for secret 'tigera-packetcapture-server-tls' to become available", "").Return().Maybe()
+			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
 			mockStatus.On("ReadyToMonitor")
 
 			r = ReconcileManager{
@@ -329,9 +333,15 @@ var _ = Describe("Manager controller tests", func() {
 			Expect(c.Create(ctx, &v3.Tier{
 				ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"},
 			})).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, &v3.LicenseKey{
+			licenseKey = &v3.LicenseKey{
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
-			})).NotTo(HaveOccurred())
+				Status: v3.LicenseKeyStatus{
+					Features: []string{
+						common.ComplianceFeature,
+					},
+				},
+			}
+			Expect(c.Create(ctx, licenseKey)).NotTo(HaveOccurred())
 			Expect(c.Create(
 				ctx,
 				&operatorv1.Installation{
@@ -351,12 +361,13 @@ var _ = Describe("Manager controller tests", func() {
 					},
 				},
 			)).NotTo(HaveOccurred())
-			Expect(c.Create(ctx, &operatorv1.Compliance{
+			compliance = &operatorv1.Compliance{
 				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
 				Status: operatorv1.ComplianceStatus{
 					State: operatorv1.TigeraStatusReady,
 				},
-			})).NotTo(HaveOccurred())
+			}
+			Expect(c.Create(ctx, compliance)).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: common.TigeraPrometheusNamespace},
 			})).NotTo(HaveOccurred())
@@ -507,6 +518,55 @@ var _ = Describe("Manager controller tests", func() {
 				r.tierWatchReady = &utils.ReadyFlag{}
 				utils.ExpectWaitForTierWatch(ctx, &r, mockStatus)
 			})
+		})
+
+		Context("compliance reconciliation", func() {
+			It("should degrade if license is not present", func() {
+				Expect(c.Delete(ctx, licenseKey)).NotTo(HaveOccurred())
+				mockStatus = &status.MockStatus{}
+				mockStatus.On("OnCRFound").Return()
+				mockStatus.On("SetDegraded", "License not found", "licensekeies.projectcalico.org \"default\" not found").Return()
+				r.status = mockStatus
+
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+
+				Expect(err).NotTo(HaveOccurred())
+				mockStatus.AssertExpectations(GinkgoT())
+			})
+
+			It("should degrade if compliance CR and compliance-enabled license is present, but compliance is not ready", func() {
+				compliance.Status.State = ""
+				Expect(c.Update(ctx, compliance)).NotTo(HaveOccurred())
+				mockStatus = &status.MockStatus{}
+				mockStatus.On("OnCRFound").Return()
+				mockStatus.On("SetDegraded", "Compliance is not ready", "compliance status: ").Return()
+				r.status = mockStatus
+
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+
+				Expect(err).NotTo(HaveOccurred())
+				mockStatus.AssertExpectations(GinkgoT())
+			})
+
+			DescribeTable("should not degrade when compliance CR or compliance license feature is not present/active", func(crPresent, licenseFeatureActive bool) {
+				if !crPresent {
+					Expect(c.Delete(ctx, compliance)).NotTo(HaveOccurred())
+				}
+				if !licenseFeatureActive {
+					licenseKey.Status.Features = []string{}
+					Expect(c.Update(ctx, licenseKey)).NotTo(HaveOccurred())
+				}
+
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+
+				// Expect no error, and no degraded status from compliance
+				Expect(err).NotTo(HaveOccurred())
+				mockStatus.AssertExpectations(GinkgoT())
+			},
+				Entry("CR and license feature not present/active", false, false),
+				Entry("CR not present, license feature active", false, true),
+				Entry("CR present, license feature inactive", true, false),
+			)
 		})
 	})
 })

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -539,7 +539,7 @@ var _ = Describe("Manager controller tests", func() {
 				Expect(c.Update(ctx, compliance)).NotTo(HaveOccurred())
 				mockStatus = &status.MockStatus{}
 				mockStatus.On("OnCRFound").Return()
-				mockStatus.On("SetDegraded", "Compliance is not ready", "compliance status: ").Return()
+				mockStatus.On("SetDegraded", "ResourceNotReady", "Compliance is not ready").Return()
 				r.status = mockStatus
 
 				_, err := r.Reconcile(ctx, reconcile.Request{})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -125,7 +125,7 @@ type ManagerConfiguration struct {
 	ESLicenseType           ElasticsearchLicenseType
 	Replicas                *int32
 	Compliance              *operatorv1.Compliance
-	ComplianceFeatureActive bool
+	ComplianceLicenseActive bool
 
 	// Whether or not the cluster supports pod security policies.
 	UsePSP bool
@@ -354,6 +354,9 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 		{Name: "ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		// Kibana does not have a FIPS compatible mode, therefore we disable the button in the UI.
 		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(!operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode))},
+		// The manager supports two states of a product feature being unavailable: the product feature being feature-flagged off,
+		// and the current license not enabling the feature. The compliance flag that we set on the manager container is a feature
+		// flag, which we should set purely based on whether the compliance CR is present, ignoring the license status.
 		{Name: "ENABLE_COMPLIANCE_REPORTS", Value: strconv.FormatBool(c.cfg.Compliance != nil)},
 	}
 
@@ -433,7 +436,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
 		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"},
-		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(c.cfg.Compliance != nil && c.cfg.ComplianceFeatureActive)},
+		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(c.cfg.Compliance != nil && c.cfg.ComplianceLicenseActive)},
 		{Name: "VOLTRON_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 	}
 

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -110,22 +110,22 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 
 // ManagerConfiguration contains all the config information needed to render the component.
 type ManagerConfiguration struct {
-	KeyValidatorConfig             authentication.KeyValidatorConfig
-	ESSecrets                      []*corev1.Secret
-	TrustedCertBundle              certificatemanagement.TrustedBundle
-	ESClusterConfig                *relasticsearch.ClusterConfig
-	TLSKeyPair                     certificatemanagement.KeyPairInterface
-	PullSecrets                    []*corev1.Secret
-	Openshift                      bool
-	Installation                   *operatorv1.InstallationSpec
-	ManagementCluster              *operatorv1.ManagementCluster
-	TunnelSecret                   certificatemanagement.KeyPairInterface
-	InternalTrafficSecret          certificatemanagement.KeyPairInterface
-	ClusterDomain                  string
-	ESLicenseType                  ElasticsearchLicenseType
-	Replicas                       *int32
-	Compliance                     *operatorv1.Compliance
-	ComplianceLicenseFeatureActive bool
+	KeyValidatorConfig      authentication.KeyValidatorConfig
+	ESSecrets               []*corev1.Secret
+	TrustedCertBundle       certificatemanagement.TrustedBundle
+	ESClusterConfig         *relasticsearch.ClusterConfig
+	TLSKeyPair              certificatemanagement.KeyPairInterface
+	PullSecrets             []*corev1.Secret
+	Openshift               bool
+	Installation            *operatorv1.InstallationSpec
+	ManagementCluster       *operatorv1.ManagementCluster
+	TunnelSecret            certificatemanagement.KeyPairInterface
+	InternalTrafficSecret   certificatemanagement.KeyPairInterface
+	ClusterDomain           string
+	ESLicenseType           ElasticsearchLicenseType
+	Replicas                *int32
+	Compliance              *operatorv1.Compliance
+	ComplianceFeatureActive bool
 
 	// Whether or not the cluster supports pod security policies.
 	UsePSP bool
@@ -433,7 +433,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
 		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"},
-		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(c.cfg.Compliance != nil && c.cfg.ComplianceLicenseFeatureActive)},
+		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(c.cfg.Compliance != nil && c.cfg.ComplianceFeatureActive)},
 		{Name: "VOLTRON_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 	}
 

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -110,21 +110,22 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 
 // ManagerConfiguration contains all the config information needed to render the component.
 type ManagerConfiguration struct {
-	KeyValidatorConfig      authentication.KeyValidatorConfig
-	ESSecrets               []*corev1.Secret
-	TrustedCertBundle       certificatemanagement.TrustedBundle
-	ESClusterConfig         *relasticsearch.ClusterConfig
-	TLSKeyPair              certificatemanagement.KeyPairInterface
-	PullSecrets             []*corev1.Secret
-	Openshift               bool
-	Installation            *operatorv1.InstallationSpec
-	ManagementCluster       *operatorv1.ManagementCluster
-	TunnelSecret            certificatemanagement.KeyPairInterface
-	InternalTrafficSecret   certificatemanagement.KeyPairInterface
-	ClusterDomain           string
-	ESLicenseType           ElasticsearchLicenseType
-	Replicas                *int32
-	ComplianceFeatureActive bool
+	KeyValidatorConfig             authentication.KeyValidatorConfig
+	ESSecrets                      []*corev1.Secret
+	TrustedCertBundle              certificatemanagement.TrustedBundle
+	ESClusterConfig                *relasticsearch.ClusterConfig
+	TLSKeyPair                     certificatemanagement.KeyPairInterface
+	PullSecrets                    []*corev1.Secret
+	Openshift                      bool
+	Installation                   *operatorv1.InstallationSpec
+	ManagementCluster              *operatorv1.ManagementCluster
+	TunnelSecret                   certificatemanagement.KeyPairInterface
+	InternalTrafficSecret          certificatemanagement.KeyPairInterface
+	ClusterDomain                  string
+	ESLicenseType                  ElasticsearchLicenseType
+	Replicas                       *int32
+	Compliance                     *operatorv1.Compliance
+	ComplianceLicenseFeatureActive bool
 
 	// Whether or not the cluster supports pod security policies.
 	UsePSP bool
@@ -353,6 +354,7 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 		{Name: "ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		// Kibana does not have a FIPS compatible mode, therefore we disable the button in the UI.
 		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(!operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode))},
+		{Name: "ENABLE_COMPLIANCE_REPORTS", Value: strconv.FormatBool(c.cfg.Compliance != nil)},
 	}
 
 	envs = append(envs, c.managerOAuth2EnvVars()...)
@@ -431,7 +433,7 @@ func (c *managerComponent) managerProxyContainer() corev1.Container {
 		{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
 		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"},
-		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: fmt.Sprintf("%v", c.cfg.ComplianceFeatureActive)},
+		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(c.cfg.Compliance != nil && c.cfg.ComplianceLicenseFeatureActive)},
 		{Name: "VOLTRON_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 	}
 

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -193,10 +193,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Entry("Both CR and license feature not present/active", false, false, managerComplianceExpectation{managerFlag: false, voltronFlag: false}),
 		Entry("CR not present, license feature active", false, true, managerComplianceExpectation{managerFlag: false, voltronFlag: false}),
 
-		// The manager supports two states of a product feature being unavailable: the product feature being feature-flagged off, and the current
-		// license not enabling the feature. The flag that we set on the manager container is a feature flag, which we should set purely based on
-		// whether the compliance CR is present, ignoring the license status. Therefore, when the CR is present but the license feature is not,
-		// we still expect that the manager feature flag should be set. The manager will render the insufficient license state appropriately.
+		// We expect the manager feature flag to be true in this case, since the CR is present. The manager will render an insufficient license state.
 		Entry("CR present, license feature not active", true, false, managerComplianceExpectation{managerFlag: true, voltronFlag: false}),
 	)
 
@@ -786,7 +783,7 @@ func renderObjects(roc renderConfig) []client.Object {
 		ESLicenseType:           render.ElasticsearchLicenseTypeEnterpriseTrial,
 		Replicas:                roc.installation.ControlPlaneReplicas,
 		Compliance:              roc.compliance,
-		ComplianceFeatureActive: roc.complianceFeatureActive,
+		ComplianceLicenseActive: roc.complianceFeatureActive,
 		Openshift:               roc.openshift,
 		UsePSP:                  true,
 	}

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -16,6 +16,7 @@ package render_test
 
 import (
 	"fmt"
+	"strconv"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -56,13 +57,14 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	}
 	var replicas int32 = 2
 	installation := &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas}
+	compliance := &operatorv1.Compliance{}
 	const expectedResourcesNumber = 13
 
 	expectedManagerPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/manager.json")
 	expectedManagerOpenshiftPolicy := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/manager_ocp.json")
 
 	It("should render all resources for a default configuration", func() {
-		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, complianceFeatureActive: true})
+		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, compliance: compliance, complianceFeatureActive: true})
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -118,6 +120,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(*manager.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
 		Expect(*manager.SecurityContext.RunAsNonRoot).To(BeTrue())
 		Expect(*manager.SecurityContext.RunAsUser).To(BeEquivalentTo(999))
+		Expect(manager.Env).Should(ContainElements(
+			corev1.EnvVar{Name: "ENABLE_COMPLIANCE_REPORTS", Value: "true"},
+		))
 
 		// es-proxy container
 		Expect(esProxy.Env).Should(ContainElements(
@@ -160,14 +165,43 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 	})
 
-	It("should not proxy compliance if the feature is not active", func() {
-		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, complianceFeatureActive: false})
-		voltron := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment).Spec.Template.Spec.Containers[2]
-		Expect(voltron.Env).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: "false"}))
-	})
+	type managerComplianceExpectation struct {
+		managerFlag bool
+		voltronFlag bool
+	}
+	DescribeTable("should set container env appropriately when compliance is not fully available",
+		func(crPresent bool, licenseFeatureActive bool, scenario managerComplianceExpectation) {
+			var complianceCR *operatorv1.Compliance
+			if crPresent {
+				complianceCR = &operatorv1.Compliance{}
+			}
+
+			resources := renderObjects(renderConfig{
+				oidc:                    false,
+				managementCluster:       nil,
+				installation:            installation,
+				compliance:              complianceCR,
+				complianceFeatureActive: licenseFeatureActive,
+			})
+
+			deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			manager := deployment.Spec.Template.Spec.Containers[0]
+			voltron := deployment.Spec.Template.Spec.Containers[2]
+			Expect(manager.Env).To(ContainElement(corev1.EnvVar{Name: "ENABLE_COMPLIANCE_REPORTS", Value: strconv.FormatBool(scenario.managerFlag)}))
+			Expect(voltron.Env).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(scenario.voltronFlag)}))
+		},
+		Entry("Both CR and license feature not present/active", false, false, managerComplianceExpectation{managerFlag: false, voltronFlag: false}),
+		Entry("CR not present, license feature active", false, true, managerComplianceExpectation{managerFlag: false, voltronFlag: false}),
+
+		// The manager supports two states of a product feature being unavailable: the product feature being feature-flagged off, and the current
+		// license not enabling the feature. The flag that we set on the manager container is a feature flag, which we should set purely based on
+		// whether the compliance CR is present, ignoring the license status. Therefore, when the CR is present but the license feature is not,
+		// we still expect that the manager feature flag should be set. The manager will render the insufficient license state appropriately.
+		Entry("CR present, license feature not active", true, false, managerComplianceExpectation{managerFlag: true, voltronFlag: false}),
+	)
 
 	It("should ensure cnx policy recommendation support is always set to true", func() {
-		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation})
+		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, compliance: compliance, complianceFeatureActive: true})
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 
 		// Should render the correct resource based on test case.
@@ -279,7 +313,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		oidcEnvVar.Value = authority
 
 		// Should render the correct resource based on test case.
-		resources := renderObjects(renderConfig{oidc: true, managementCluster: nil, installation: installation})
+		resources := renderObjects(renderConfig{oidc: true, managementCluster: nil, installation: installation, compliance: compliance, complianceFeatureActive: true})
 		Expect(len(resources)).To(Equal(expectedResourcesNumber))
 		d := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		// tigera-manager volumes/volumeMounts checks.
@@ -345,7 +379,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	})
 
 	It("should render multicluster settings properly", func() {
-		resources := renderObjects(renderConfig{oidc: false, managementCluster: &operatorv1.ManagementCluster{}, installation: installation})
+		resources := renderObjects(renderConfig{oidc: false, managementCluster: &operatorv1.ManagementCluster{}, installation: installation, compliance: compliance, complianceFeatureActive: true})
 
 		// Should render the correct resources.
 		expectedResources := []struct {
@@ -569,9 +603,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		ca, _ := tls.MakeCA(rmeta.DefaultOperatorCASignerName())
 		cert, _, _ := ca.Config.GetPEMBytes()
 		resources := renderObjects(renderConfig{
-			oidc:              false,
-			managementCluster: nil,
-			installation:      &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{CACert: cert}, ControlPlaneReplicas: &replicas},
+			oidc:                    false,
+			managementCluster:       nil,
+			installation:            &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{CACert: cert}, ControlPlaneReplicas: &replicas},
+			compliance:              compliance,
+			complianceFeatureActive: true,
 		})
 
 		// Should render the correct resources.
@@ -619,9 +655,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		installation.ControlPlaneReplicas = &replicas
 
 		resources := renderObjects(renderConfig{
-			oidc:              false,
-			managementCluster: nil,
-			installation:      &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas},
+			oidc:                    false,
+			managementCluster:       nil,
+			installation:            &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas},
+			compliance:              compliance,
+			complianceFeatureActive: true,
 		})
 		deploy, ok := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
@@ -633,9 +671,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		installation.ControlPlaneReplicas = &replicas
 
 		resources := renderObjects(renderConfig{
-			oidc:              false,
-			managementCluster: nil,
-			installation:      &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas},
+			oidc:                    false,
+			managementCluster:       nil,
+			installation:            &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas},
+			compliance:              compliance,
+			complianceFeatureActive: true,
 		})
 		deploy, ok := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
@@ -646,7 +686,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 	It("should set the right env when FIPS is enabled", func() {
 		fipsEnabled := operatorv1.FIPSModeEnabled
 		installation.FIPSMode = &fipsEnabled
-		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, complianceFeatureActive: true})
+		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: installation, compliance: compliance, complianceFeatureActive: true})
 		Expect(resources).To(HaveLen(expectedResourcesNumber))
 		deploy, ok := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
@@ -677,6 +717,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 					oidc:                    false,
 					managementCluster:       nil,
 					installation:            installation,
+					compliance:              compliance,
 					complianceFeatureActive: true,
 				})
 
@@ -695,6 +736,7 @@ type renderConfig struct {
 	oidc                    bool
 	managementCluster       *operatorv1.ManagementCluster
 	installation            *operatorv1.InstallationSpec
+	compliance              *operatorv1.Compliance
 	complianceFeatureActive bool
 	openshift               bool
 }
@@ -732,20 +774,21 @@ func renderObjects(roc renderConfig) []client.Object {
 
 	esConfigMap := relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
 	cfg := &render.ManagerConfiguration{
-		KeyValidatorConfig:      dexCfg,
-		TrustedCertBundle:       bundle,
-		ESClusterConfig:         esConfigMap,
-		TLSKeyPair:              managerTLS,
-		Installation:            roc.installation,
-		ManagementCluster:       roc.managementCluster,
-		TunnelSecret:            tunnelSecret,
-		InternalTrafficSecret:   internalTraffic,
-		ClusterDomain:           dns.DefaultClusterDomain,
-		ESLicenseType:           render.ElasticsearchLicenseTypeEnterpriseTrial,
-		Replicas:                roc.installation.ControlPlaneReplicas,
-		ComplianceFeatureActive: roc.complianceFeatureActive,
-		Openshift:               roc.openshift,
-		UsePSP:                  true,
+		KeyValidatorConfig:             dexCfg,
+		TrustedCertBundle:              bundle,
+		ESClusterConfig:                esConfigMap,
+		TLSKeyPair:                     managerTLS,
+		Installation:                   roc.installation,
+		ManagementCluster:              roc.managementCluster,
+		TunnelSecret:                   tunnelSecret,
+		InternalTrafficSecret:          internalTraffic,
+		ClusterDomain:                  dns.DefaultClusterDomain,
+		ESLicenseType:                  render.ElasticsearchLicenseTypeEnterpriseTrial,
+		Replicas:                       roc.installation.ControlPlaneReplicas,
+		Compliance:                     roc.compliance,
+		ComplianceLicenseFeatureActive: roc.complianceFeatureActive,
+		Openshift:                      roc.openshift,
+		UsePSP:                         true,
 	}
 	component, err := render.Manager(cfg)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -774,21 +774,21 @@ func renderObjects(roc renderConfig) []client.Object {
 
 	esConfigMap := relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
 	cfg := &render.ManagerConfiguration{
-		KeyValidatorConfig:             dexCfg,
-		TrustedCertBundle:              bundle,
-		ESClusterConfig:                esConfigMap,
-		TLSKeyPair:                     managerTLS,
-		Installation:                   roc.installation,
-		ManagementCluster:              roc.managementCluster,
-		TunnelSecret:                   tunnelSecret,
-		InternalTrafficSecret:          internalTraffic,
-		ClusterDomain:                  dns.DefaultClusterDomain,
-		ESLicenseType:                  render.ElasticsearchLicenseTypeEnterpriseTrial,
-		Replicas:                       roc.installation.ControlPlaneReplicas,
-		Compliance:                     roc.compliance,
-		ComplianceLicenseFeatureActive: roc.complianceFeatureActive,
-		Openshift:                      roc.openshift,
-		UsePSP:                         true,
+		KeyValidatorConfig:      dexCfg,
+		TrustedCertBundle:       bundle,
+		ESClusterConfig:         esConfigMap,
+		TLSKeyPair:              managerTLS,
+		Installation:            roc.installation,
+		ManagementCluster:       roc.managementCluster,
+		TunnelSecret:            tunnelSecret,
+		InternalTrafficSecret:   internalTraffic,
+		ClusterDomain:           dns.DefaultClusterDomain,
+		ESLicenseType:           render.ElasticsearchLicenseTypeEnterpriseTrial,
+		Replicas:                roc.installation.ControlPlaneReplicas,
+		Compliance:              roc.compliance,
+		ComplianceFeatureActive: roc.complianceFeatureActive,
+		Openshift:               roc.openshift,
+		UsePSP:                  true,
 	}
 	component, err := render.Manager(cfg)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)


### PR DESCRIPTION
## Description
Allow for the Compliance CR to be omitted by
- Only enforcing the Manager dependency on Compliance when both Compliance CR and license feature are present (previously only license feature)
- Setting the new feature-flag environment variable on the Manager container to disable Compliance in the Manager UI when the Compliance CR is not present.

I've validated that CE install (standalone) progresses with Compliance CR omitted, and that Compliance and Manager both transition to available after creating the Compliance CR.

This mitigates CI-1021 and pairs with EV-2392.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
