### PR TITLE
Set the csi-node-driver DaemonSet PriorityClass to system-node-critical

### DIFF
--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -281,6 +281,8 @@ func (c *csiComponent) csiDaemonset() *appsv1.DaemonSet {
 		Template: c.csiTemplate(),
 	}
 
+	setNodeCriticalPod(&(dsSpec.Template))
+
 	return &appsv1.DaemonSet{
 		TypeMeta:   typeMeta,
 		ObjectMeta: dsMeta,

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -17,6 +17,9 @@ package render_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/render"
@@ -81,5 +84,11 @@ var _ = Describe("CSI rendering tests", func() {
 		for i, expectedRes := range expectedDelObjs {
 			rtest.ExpectResource(delObjs[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
+	})
+
+	It("should set priority class to system-node-critical", func() {
+		resources, _ := render.CSI(&cfg).Objects()
+		ds := rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal("system-node-critical"))
 	})
 })


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

It should be set the csi-node-driver DaemonSet PriorityClass to `system-node-critical`.

When I updated the tigera-oprator Helm chart (quay.io/tigera/operator:v1.27.1 -> v1.28.0), some csi-node-driver pods were stack in pending because they couldn't be scheduled to a node. I'd like to set the PriorityClass to `system-node-critical`, like the calico-node DaemonSet.
ref. https://github.com/tigera/operator/pull/1473

## For PR author

- [x] Tests for change.
- [ ] ~If changing pkg/apis/, run `make gen-files`~
- [ ] ~If changing versions, run `make gen-versions`~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
