### PR TITLE
Add delete permissions to the kubecontrollers (EE) for secrets, confi…

### DIFF
--- a/pkg/controller/logstorage/eskubecontrollers.go
+++ b/pkg/controller/logstorage/eskubecontrollers.go
@@ -49,12 +49,6 @@ func (r *ReconcileLogStorage) createEsKubeControllers(
 		return reconcile.Result{}, false, err
 	}
 
-	enableESOIDCWorkaround := false
-	if (authentication != nil && authentication.Spec.OIDC != nil && authentication.Spec.OIDC.Type == operatorv1.OIDCTypeTigera) ||
-		esLicenseType == render.ElasticsearchLicenseTypeBasic {
-		enableESOIDCWorkaround = true
-	}
-
 	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain)
 	if err != nil {
 		log.Error(err, "unable to create the Tigera CA")
@@ -85,7 +79,6 @@ func (r *ReconcileLogStorage) createEsKubeControllers(
 		ManagementCluster:            managementCluster,
 		ClusterDomain:                r.clusterDomain,
 		ManagerInternalSecret:        managerInternalTLSSecret,
-		EnabledESOIDCWorkaround:      enableESOIDCWorkaround,
 		Authentication:               authentication,
 		KubeControllersGatewaySecret: kubeControllersUserSecret,
 		LogStorageExists:             true,

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -75,9 +75,8 @@ type KubeControllersConfiguration struct {
 	// Whether or not the LogStorage CRD is present in the cluster.
 	LogStorageExists bool
 
-	EnabledESOIDCWorkaround bool
-	ClusterDomain           string
-	MetricsPort             int
+	ClusterDomain string
+	MetricsPort   int
 
 	// For details on why this is needed see 'Node and Installation finalizer' in the core_controller.
 	Terminating bool
@@ -415,9 +414,10 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		if c.kubeControllerName == EsKubeController {
-			if c.cfg.EnabledESOIDCWorkaround {
-				env = append(env, corev1.EnvVar{Name: "ENABLE_ELASTICSEARCH_OIDC_WORKAROUND", Value: "true"})
-			}
+			// What started as a workaround is now the default behaviour. This feature uses our backend in order to
+			// log into Kibana for users from external identity providers, rather than configuring an authn realm
+			// in the Elastic stack.
+			env = append(env, corev1.EnvVar{Name: "ENABLE_ELASTICSEARCH_OIDC_WORKAROUND", Value: "true"})
 
 			if c.cfg.Authentication != nil {
 				env = append(env,

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -147,11 +147,6 @@ func NewElasticsearchKubeControllers(cfg *KubeControllersConfiguration) *kubeCon
 				Verbs:     []string{"watch", "get", "list"},
 			},
 			rbacv1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"watch", "list", "get", "update", "create"},
-			},
-			rbacv1.PolicyRule{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},
 				Verbs:     []string{"watch", "list", "get"},
@@ -334,8 +329,8 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
-			Resources: []string{"configmaps"},
-			Verbs:     []string{"watch", "list", "get", "update", "create"},
+			Resources: []string{"configmaps", "secrets"},
+			Verbs:     []string{"watch", "list", "get", "update", "create", "delete"},
 		},
 		{
 			// Needed to validate the license
@@ -377,16 +372,6 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 			rbacv1.PolicyRule{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"licensekeys"},
-				Verbs:     []string{"get", "create", "update", "list", "watch"},
-			},
-			rbacv1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "create", "update", "list", "watch"},
-			},
-			rbacv1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"configmaps"},
 				Verbs:     []string{"get", "create", "update", "list", "watch"},
 			},
 		)

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -277,7 +277,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
 		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
-		cfg.EnabledESOIDCWorkaround = true
 
 		component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())
@@ -402,7 +401,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
 		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
-		cfg.EnabledESOIDCWorkaround = true
 
 		component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())
@@ -544,7 +542,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
 		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
-		cfg.EnabledESOIDCWorkaround = true
 		cfg.Authentication = &operatorv1.Authentication{Spec: operatorv1.AuthenticationSpec{
 			UsernamePrefix: "uOIDC:",
 			GroupsPrefix:   "gOIDC:",
@@ -794,7 +791,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
 			cfg.ManagerInternalSecret = internalManagerTLSSecret
 			cfg.MetricsPort = 9094
-			cfg.EnabledESOIDCWorkaround = true
 			component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 			resources, _ := component.Objects()
 
@@ -912,7 +908,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				cfg.LogStorageExists = true
 				cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
 				cfg.ManagerInternalSecret = internalManagerTLSSecret
-				cfg.EnabledESOIDCWorkaround = true
 
 				component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 				resources, _ := component.Objects()

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -314,7 +314,13 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[1].ConfigMap.Name).To(Equal(certificatemanagement.TrustedCertConfigMapName))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(20))
+		Expect(len(clusterRole.Rules)).To(Equal(19))
+		Expect(clusterRole.Rules).To(ContainElement(
+			rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps", "secrets"},
+				Verbs:     []string{"watch", "list", "get", "update", "create", "delete"},
+			}))
 	})
 
 	It("should render all calico-kube-controllers resources for a default configuration using TigeraSecureEnterprise and ClusterType is Management", func() {
@@ -434,7 +440,13 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(clusterRole.Rules)).To(Equal(20))
+		Expect(len(clusterRole.Rules)).To(Equal(19))
+		Expect(clusterRole.Rules).To(ContainElement(
+			rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps", "secrets"},
+				Verbs:     []string{"watch", "list", "get", "update", "create", "delete"},
+			}))
 	})
 
 	It("should include a ControlPlaneNodeSelector when specified", func() {


### PR DESCRIPTION
If your cluster is not working on a basic license, the operator would configure the kube controllers such that Tigera's SSO would not be active. This code flow leads to missing permission errors for the kube controllers, resulting into a panic (which will be addressed separately). 

This code enables the workaround regardless of the current elastic license and adds permissions to kubecontrollers that are missing (even if not used).