### PR TITLE
Change audit api version to v1

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1725,7 +1725,7 @@ func (c *apiServerComponent) uiSettingsPassthruClusterRolebinding() *rbacv1.Clus
 //
 // Calico Enterprise only
 func (c *apiServerComponent) auditPolicyConfigMap() *corev1.ConfigMap {
-	const defaultAuditPolicy = `apiVersion: audit.k8s.io/v1beta1
+	const defaultAuditPolicy = `apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
 - level: RequestResponse


### PR DESCRIPTION
The operator [mounts a Policy](https://github.com/tigera/operator/blob/master/pkg/render/apiserver.go#L1728) in the apiserver spec of apiVersion: http://audit.k8s.io/v1beta1 leading to a crash with Fatal log:
F0823 21:38:57.471971       1 server.go:71] error running server (loading audit policy file: failed decoding: no kind "Policy" is registered for version "audit.k8s.io/v1beta1" in scheme "pkg/runtime/scheme.go:100": from file /etc/tigera/audit/policy.conf)

Upon closer examination, the audit v1 has been around since apiserver v1.12. The code has maintained  conversion functions for v1alpha1 and v1beta1 up until v0.23.0. But we recently upgraded to v0.24, which dropped the support.
This is not an api for k8s that you would find in kubectl api-resources, but a model that exists in the [k8s.io/apiserver](http://k8s.io/apiserver).

I verified the configs are compatible using code. I did not add a test as to not bring in more dependencies:
![image](https://user-images.githubusercontent.com/15924949/186468925-14efed38-27be-4978-b185-38a8edbd9d1e.png)


