### PR TITLE
Add expiry to kb session

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1324,7 +1324,8 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 
 	config := map[string]interface{}{
 		"elasticsearch.ssl.certificateAuthorities": []string{"/usr/share/kibana/config/elasticsearch-certs/tls.crt"},
-		"server": server,
+		"server":                          server,
+		"xpack.security.session.lifespan": "24h",
 		"tigera": map[string]interface{}{
 			"enabled":        true,
 			"licenseEdition": "enterpriseEdition",


### PR DESCRIPTION
I have set the default session lifespan setting to 24h  according to https://www.elastic.co/guide/en/kibana/master/security-settings-kb.html#security-session-and-cookie-settings

I have verified that the setting is in the kibana.yml inside the pod.

I was unable to find any UI  page or API that would let me validate this setting is present. I assume it must be working.