### PR TITLE
Let the pcap server trust dex by mounting the ca-bundle

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -408,6 +408,19 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			return reconcile.Result{}, err
 		}
 
+		var certificates []certificatemanagement.CertificateInterface
+		if keyValidatorConfig != nil {
+			dexSecret, err := certificateManager.GetCertificate(r.client, render.DexTLSSecretName, common.OperatorNamespace())
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("failed to retrieve %s", render.DexTLSSecretName))
+				r.status.SetDegraded(fmt.Sprintf("Failed to retrieve %s", render.DexTLSSecretName), err.Error())
+				return reconcile.Result{}, err
+			} else if dexSecret != nil {
+				certificates = append(certificates, dexSecret)
+			}
+		}
+		trustedBundle := certificateManager.CreateTrustedBundle(certificates...)
+
 		packetCaptureApiCfg := &render.PacketCaptureApiConfiguration{
 			PullSecrets:                 pullSecrets,
 			Openshift:                   r.provider == operatorv1.ProviderOpenShift,
@@ -416,6 +429,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			ServerCertSecret:            packetCaptureCertSecret,
 			ClusterDomain:               r.clusterDomain,
 			ManagementClusterConnection: managementClusterConnection,
+			TrustedBundle:               trustedBundle,
 		}
 		pc := render.PacketCaptureAPI(packetCaptureApiCfg)
 		pcPolicy = render.PacketCaptureAPIPolicy(packetCaptureApiCfg)
@@ -426,6 +440,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 				KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 					rcertificatemanagement.NewKeyPairOption(packetCaptureCertSecret, true, true),
 				},
+				TrustedBundle: trustedBundle,
 			}),
 		)
 		certificateManager.AddToStatusManager(r.status, render.PacketCaptureNamespace)

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tigera/operator/pkg/controller/utils"
-
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	netv1 "k8s.io/api/networking/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -109,6 +109,26 @@ var _ = Describe("apiserver controller tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		packetCaptureSecret, err = secret.CreateTLSSecret(cryptoCA, render.PacketCaptureCertSecret, common.OperatorNamespace(), "key.key", "cert.crt", time.Hour, nil, dns.GetServiceDNSNames(render.PacketCaptureServiceName, render.PacketCaptureNamespace, dns.DefaultClusterDomain)...)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(cli.Create(ctx, &operatorv1.Authentication{
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			Spec: operatorv1.AuthenticationSpec{
+				ManagerDomain: "https://localhost:9443",
+				OIDC: &operatorv1.AuthenticationOIDC{
+					IssuerURL: "https://localhost:9443/dex",
+				},
+			},
+		})).ToNot(HaveOccurred())
+		dexSecret, err := secret.CreateTLSSecret(cryptoCA, render.DexTLSSecretName, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey, time.Hour, nil, dns.GetServiceDNSNames(render.DexTLSSecretName, render.DexNamespace, dns.DefaultClusterDomain)...)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cli.Create(ctx, dexSecret)).ToNot(HaveOccurred())
+		Expect(cli.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-oidc-credentials", Namespace: common.OperatorNamespace()},
+			Data: map[string][]byte{
+				render.ClientIDSecretField:     []byte("a"),
+				render.ClientSecretSecretField: []byte("a"),
+				render.RootCASecretField:       []byte("a"),
+			},
+		})).ToNot(HaveOccurred())
 
 		// Set up a mock status
 		mockStatus = &status.MockStatus{}
@@ -185,6 +205,18 @@ var _ = Describe("apiserver controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentPacketCapture.Image,
 					components.ComponentPacketCapture.Version)))
+			Expect(pcContainer.VolumeMounts).To(ConsistOf([]corev1.VolumeMount{
+				{
+					Name:      packetCaptureSecret.Name,
+					ReadOnly:  true,
+					MountPath: fmt.Sprintf("/%s", packetCaptureSecret.Name),
+				},
+				{
+					Name:      certificatemanagement.TrustedCertConfigMapName,
+					ReadOnly:  true,
+					MountPath: certificatemanagement.TrustedCertVolumeMountPath,
+				},
+			}))
 			csrinitContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.InitContainers, "tigera-packetcapture-server-tls-key-cert-provisioner")
 			Expect(csrinitContainer).ToNot(BeNil())
 			Expect(csrinitContainer.Image).To(Equal(


### PR DESCRIPTION
Currently, no volume mount is present in master and v1.27.x for pcap as the bundle is not added to the configuration for the render object.

When you use oidc and make a request to the packetcapture service, it will try to authenticate the bearer token (which is a JWT) on the request.
This token contains the issuer:
https://tigera-dex.tigera-dex.svc.cluster.local:5556/dex
The authentication code that is imported in some of our servers, including pcap will understand that this token issuer is the issuer it has been configured with (Dex). It will use the oidc standard to validate the signature of the JWT. In order to find the public key to validate this with, it will make a call to the /keys endpoint of the issuer to see what the public keys are that can sign this issuer. To make this request, it needs to trust the TLS certificate that Dex presents.
Currently, it does not look like packetcapture is configured to trust Dex at all. This issue should surface in master, and 3.14.
