### PR TITLE
Automated cherry pick of #2138: Change audit api version to v1

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1725,7 +1725,7 @@ func (c *apiServerComponent) uiSettingsPassthruClusterRolebinding() *rbacv1.Clus
 //
 // Calico Enterprise only
 func (c *apiServerComponent) auditPolicyConfigMap() *corev1.ConfigMap {
-	const defaultAuditPolicy = `apiVersion: audit.k8s.io/v1beta1
+	const defaultAuditPolicy = `apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
 - level: RequestResponse


### PR DESCRIPTION
Cherry pick of #2138 on release-v1.28.

#2138: Change audit api version to v1