### PR TITLE
Configure dnsTrustedServers correctly for RKE2

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1480,6 +1480,11 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 			// We also need to configure a non-default trusted DNS server, since there's no kube-dns.
 			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"})
 		}
+	case operatorv1.ProviderRKE2:
+		// For RKE2, configure a non-default trusted DNS server, as the DNS service is not named "kube-dns".
+		if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
+			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:kube-system/rke2-coredns-rke2-coredns"})
+		}
 	// For AKS/AzureVNET and EKS/VPCCNI, we must explicitly ask felix to add host IP's to wireguard ifaces
 	case operatorv1.ProviderAKS:
 		if c.cfg.Installation.CNI.Type == operatorv1.PluginAzureVNET {


### PR DESCRIPTION
The default for dnsTrustedServers assumes that the DNS service is named `kube-dns`.  On RKE2 a different name is used.  Note, we already have a similar special case for OpenShift.

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
