### PR TITLE
Hide anomaly detection when FIPS is enabled

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -352,6 +352,8 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 		{Name: "ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		// Kibana does not have a FIPS compatible mode, therefore we disable the button in the UI.
 		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(!operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode))},
+		// Currently, we do not support anomaly detection when FIPS mode is enabled, therefore we disable the button in the UI.
+		{Name: "ENABLE_ANOMALY_DETECTION", Value: strconv.FormatBool(!operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode))},
 		// The manager supports two states of a product feature being unavailable: the product feature being feature-flagged off,
 		// and the current license not enabling the feature. The compliance flag that we set on the manager container is a feature
 		// flag, which we should set purely based on whether the compliance CR is present, ignoring the license status.

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -691,6 +691,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deploy.Spec.Template.Spec.Containers[1].Name).To(Equal("tigera-es-proxy"))
 		Expect(deploy.Spec.Template.Spec.Containers[2].Name).To(Equal("tigera-voltron"))
 		Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "ENABLE_KIBANA", Value: "false"}))
+		Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "ENABLE_ANOMALY_DETECTION", Value: "false"}))
 		Expect(deploy.Spec.Template.Spec.Containers[1].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
 		Expect(deploy.Spec.Template.Spec.Containers[2].Env).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_FIPS_MODE_ENABLED", Value: "true"}))
 	})


### PR DESCRIPTION
Since anomaly detection is disabled when FIPS is enabled, it is nicer to hide the page in the UI as well. This feature flag lets the manager UI do that.