### PR TITLE
Modify L7 logging and WAF to use CSI volume instead of flexvolume volume

### DIFF
--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -337,8 +337,8 @@ func (c *component) volumes() []corev1.Volume {
 	volumes = append(volumes, corev1.Volume{
 		Name: FelixSync,
 		VolumeSource: corev1.VolumeSource{
-			FlexVolume: &corev1.FlexVolumeSource{
-				Driver: "nodeagent/uds",
+			CSI: &corev1.CSIVolumeSource{
+				Driver: "csi.tigera.io",
 			},
 		},
 	})

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,8 +95,8 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 			{
 				Name: applicationlayer.FelixSync,
 				VolumeSource: corev1.VolumeSource{
-					FlexVolume: &corev1.FlexVolumeSource{
-						Driver: "nodeagent/uds",
+					CSI: &corev1.CSIVolumeSource{
+						Driver: "csi.tigera.io",
 					},
 				},
 			},


### PR DESCRIPTION
as part of transition away from deprecated flexvolume volumes

## Description
FlexVolumes are being deprecated in upstream Kubernetes so we need to transition to using CSI volumes instead.

Verified using both existing UT and manually by following L7 logging and WAF documentation pages.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- ~~[ ] If changing pkg/apis/, run `make gen-files`~~
- ~~[ ] If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
