### PR TITLE
chore(AutoDiscoverProvider): implements conflicts discovery

### DIFF
--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -124,10 +124,15 @@ func AutoDiscoverProvider(ctx context.Context, clientset kubernetes.Interface) (
 		detectedProviders = append(detectedProviders, operatorv1.ProviderRKE2)
 	}
 
+	// More than one provider was detected. Can't be sure which one is correct.
 	if len(detectedProviders) > 1 {
 		return operatorv1.ProviderNone, fmt.Errorf(
-			"Failed to assert provider caused by detection of more than one provider. Detected providers: %s",
+			"Failed to assert provider caused by detection of more than one. Detected providers: %s",
 			detectedProviders)
+	}
+	// Only one provider was detected.
+	if len(detectedProviders) == 1 {
+		return detectedProviders[0], nil
 	}
 
 	// Couldn't detect any specific platform.


### PR DESCRIPTION
## Description

I recently went through a scenario where using an RKE2 cluster it was necessary to create the `GKEBackendConfig` to maintain compatibility during the migration of some services. Because of this, the `networking.gke.io/v1` group was created in the cluster and this caused the tigera/operator to erroneously infer the `kubernetesProvider` field and lead us to a failure scenario.
Considering this scenario and other similar ones, this MR implements the detection of conflicts during the inference of the Kubernetes Provider, generating an error if more than one provider is detected.

## For PR author

- [X] Tests for change.
- [X] If changing pkg/apis/, run `make gen-files`
- [X] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
