### PR TITLE
Propagate imagePullSecrets from Installation resource th...

### DIFF
--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -255,9 +255,10 @@ func (c *csiComponent) csiTemplate() corev1.PodTemplateSpec {
 		Labels: templateLabels,
 	}
 	templateSpec := corev1.PodSpec{
-		Tolerations: c.csiTolerations(),
-		Containers:  c.csiContainers(),
-		Volumes:     c.csiVolumes(),
+		Tolerations:      c.csiTolerations(),
+		Containers:       c.csiContainers(),
+		ImagePullSecrets: c.cfg.Installation.ImagePullSecrets,
+		Volumes:          c.csiVolumes(),
 	}
 	return corev1.PodTemplateSpec{
 		ObjectMeta: templateMeta,


### PR DESCRIPTION
…rough to CSI daemonset

## Description

CSI daemonset was not using the `imagePullSecrets` field configured via the `Installation` resource as described here: https://projectcalico.docs.tigera.io/reference/installation/api

This fix corrects this behaviour to be consistent with the other daemonsets.

Verified via newly introduced UT as well as manually on a kind cluster.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

fixes [6750](https://github.com/projectcalico/calico/issues/6750)

## For PR author

- [x] Tests for change.
- ~~[ ] If changing pkg/apis/, run `make gen-files`~~
- ~~[ ] If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
