### PR TITLE
Add PSP for Guardian for RKE2 CIS -Hardened clusters

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -107,6 +107,7 @@ func newReconciler(
 		status:         statusMgr,
 		clusterDomain:  opts.ClusterDomain,
 		tierWatchReady: tierWatchReady,
+		usePSP:         opts.UsePSP,
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -166,6 +167,7 @@ type ReconcileConnection struct {
 	status         status.StatusManager
 	clusterDomain  string
 	tierWatchReady *utils.ReadyFlag
+	usePSP         bool
 }
 
 // Reconcile reads that state of the cluster for a ManagementClusterConnection object and makes changes based on the
@@ -309,6 +311,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		Installation:      instl,
 		TunnelSecret:      tunnelSecret,
 		TrustedCertBundle: trustedCertBundle,
+		UsePSP:            r.usePSP,
 	}
 
 	components := []render.Component{render.Guardian(guardianCfg)}

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -23,13 +23,16 @@ import (
 	"github.com/tigera/api/pkg/lib/numorstring"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/ptr"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -44,6 +47,7 @@ const (
 	GuardianClusterRoleName        = GuardianName
 	GuardianClusterRoleBindingName = GuardianName
 	GuardianDeploymentName         = GuardianName
+	GuardianPodSecurityPolicyName  = GuardianName
 	GuardianServiceName            = "tigera-guardian"
 	GuardianVolumeName             = "tigera-guardian-certs"
 	GuardianSecretName             = "tigera-managed-cluster-connection"
@@ -82,6 +86,9 @@ type GuardianConfiguration struct {
 	TunnelSecret      *corev1.Secret
 	TrustedCertBundle certificatemanagement.TrustedBundle
 	TunnelCAType      operatorv1.CAType
+
+	// Whether or not the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type GuardianComponent struct {
@@ -126,6 +133,10 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		managerClusterWideTigeraLayer(),
 		managerClusterWideDefaultView(),
 	)
+
+	if !c.cfg.Openshift && c.cfg.UsePSP {
+		objs = append(objs, c.podsecuritypolicy())
+	}
 
 	return objs, nil
 }
@@ -175,19 +186,41 @@ func (c *GuardianComponent) serviceAccount() client.Object {
 	}
 }
 
+func (c *GuardianComponent) podsecuritypolicy() client.Object {
+	psp := podsecuritypolicy.NewBasePolicy()
+	psp.GetObjectMeta().SetName(GuardianPodSecurityPolicyName)
+	psp.Spec.Privileged = false
+	psp.Spec.AllowPrivilegeEscalation = ptr.BoolToPtr(false)
+	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyMustRunAsNonRoot
+
+	return psp
+}
+
 func (c *GuardianComponent) clusterRole() client.Object {
+	policyRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"users", "groups", "serviceaccounts"},
+			Verbs:     []string{"impersonate"},
+		},
+	}
+
+	if !c.cfg.Openshift && c.cfg.UsePSP {
+		// Allow access to the pod security policy in case this is enforced on the cluster
+		policyRules = append(policyRules, rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{GuardianPodSecurityPolicyName},
+		})
+	}
+
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: GuardianClusterRoleName,
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"users", "groups", "serviceaccounts"},
-				Verbs:     []string{"impersonate"},
-			},
-		},
+		Rules: policyRules,
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Since the `tigera-guardian` namespace is annotated by the PSS tag `pod-security.kubernetes.io/enforce=restricted`, seccompProfile field required to be set in `tigera-guardian`  to `RuntimeDefault`.  This is disallowed in RKE2 CIS hardened cluster since it deploys PSPs that blocks setting seccompProfile - this PR deploys a PSP for tigera-guardian to allow the profile setting 

 
## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
