### PR TITLE
Render PSPs for CSI driver pods 

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1281,6 +1281,8 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	csiCfg := render.CSIConfiguration{
 		Installation: &instance.Spec,
 		Terminating:  terminating,
+		Openshift:    r.autoDetectedProvider == operator.ProviderOpenShift,
+		UsePSP:       r.usePSP,
 	}
 	components = append(components, render.CSI(&csiCfg))
 

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
@@ -52,6 +54,7 @@ var _ = Describe("CSI rendering tests", func() {
 			{name: "csi.tigera.io", ns: "", group: "storage", version: "v1", kind: "CSIDriver"},
 			{name: "csi-node-driver", ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
 		}
+
 		comp := render.CSI(&cfg)
 		Expect(comp.ResolveImages(nil)).To(BeNil())
 		createObjs, delObjs := comp.Objects()
@@ -109,5 +112,41 @@ var _ = Describe("CSI rendering tests", func() {
 		for _, container := range ds.Spec.Template.Spec.Containers {
 			Expect(strings.HasPrefix(container.Image, privateRegistry))
 		}
+	})
+
+	It("should render CSI's PSP and the corresponding clusterroles when UsePSP is set true", func() {
+		cfg.Openshift = false
+		cfg.UsePSP = true
+
+		resources, _ := render.CSI(&cfg).Objects()
+
+		serviceAccount := rtest.GetResource(resources, render.CSIDaemonSetName, render.CSIDaemonSetNamespace, "", "v1", "ServiceAccount")
+		Expect(serviceAccount).ToNot(BeNil())
+
+		psp := rtest.GetResource(resources, render.CSIDaemonSetName, "", "policy", "v1beta1", "PodSecurityPolicy").(*policyv1beta1.PodSecurityPolicy)
+		Expect(psp).ToNot(BeNil())
+		Expect(psp.Spec.Privileged).To(BeTrue())
+		Expect(*psp.Spec.AllowPrivilegeEscalation).To(BeTrue())
+		Expect(psp.Spec.RunAsUser.Rule).To(Equal(policyv1beta1.RunAsUserStrategyRunAsAny))
+
+		role := rtest.GetResource(resources, render.CSIDaemonSetName, render.CSIDaemonSetNamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
+		Expect(role).ToNot(BeNil())
+		Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{render.CSIDaemonSetName},
+		}))
+
+		roleBinding := rtest.GetResource(resources, render.CSIDaemonSetName, render.CSIDaemonSetNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+		Expect(roleBinding).ToNot(BeNil())
+		Expect(roleBinding.Subjects).To(HaveLen(1))
+		Expect(roleBinding.Subjects).To(ContainElement(
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      render.CSIDaemonSetName,
+				Namespace: render.CSIDaemonSetNamespace,
+			},
+		))
 	})
 })


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

CSI Drivers are missing PSPs to be rendered in  the restricted RKE2 CIS Hardened environment where their PSPs override the PSS tigera-operator sets in the calico-system namespace 

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
