### PR TITLE
Bump elasticsearch version to v7.17.6

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -45,7 +45,7 @@ components:
     image: tigera/kibana
     version: master
   eck-elasticsearch:
-    version: 7.17.5
+    version: 7.17.6
   elasticsearch:
     image: tigera/elasticsearch
     version: master

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -56,7 +56,7 @@ var (
 	}
 
 	ComponentEckElasticsearch = component{
-		Version: "7.17.5",
+		Version: "7.17.6",
 	}
 
 	ComponentEckKibana = component{


### PR DESCRIPTION
## Description

Bump Elasticsearch engine to v7.17.6.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
