### PR TITLE
 Add syslog tls changes - EV-2481

### DIFF
--- a/api/v1/logcollector_types.go
+++ b/api/v1/logcollector_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,13 @@ type CollectProcessPathOption string
 const (
 	CollectProcessPathEnable  CollectProcessPathOption = "Enabled"
 	CollectProcessPathDisable CollectProcessPathOption = "Disabled"
+)
+
+type EncryptionOption string
+
+const (
+	EncryptionNone EncryptionOption = "None"
+	EncryptionTLS  EncryptionOption = "TLS"
 )
 
 type AdditionalLogStoreSpec struct {
@@ -128,6 +135,12 @@ type SyslogStoreSpec struct {
 	// LogTypes contains a list of types of logs to export to syslog. By default, if this field is
 	// omitted, it will be set to include all possible values.
 	LogTypes []SyslogLogType `json:"logTypes"`
+
+	// Encryption configures traffic encryption to the Syslog server.
+	// Default: None
+	// +optional
+	// +kubebuilder:validation:Enum=None;TLS
+	Encryption EncryptionOption `json:"encryption,omitempty"`
 }
 
 // SplunkStoreSpec defines configuration for exporting logs to splunk.

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -571,14 +571,14 @@ var _ = Describe("LogCollector controller tests", func() {
 			logCollector := operatorv1.LogCollector{Spec: operatorv1.LogCollectorSpec{AdditionalStores: &operatorv1.AdditionalLogStoreSpec{
 				Syslog: &operatorv1.SyslogStoreSpec{}}}}
 			modifiedFields := fillDefaults(&logCollector)
-			expectedFields := []string{"CollectProcessPath", "AdditionalStores.Syslog.LogTypes"}
+			expectedFields := []string{"CollectProcessPath", "AdditionalStores.Syslog.LogTypes", "AdditionalStores.Syslog.Encryption"}
 			expectedLogTypes := []operatorv1.SyslogLogType{
 				operatorv1.SyslogLogAudit,
 				operatorv1.SyslogLogDNS,
 				operatorv1.SyslogLogFlows,
 			}
 
-			Expect(len(modifiedFields)).To(Equal(2))
+			Expect(len(modifiedFields)).To(Equal(3))
 			Expect(modifiedFields).To(ConsistOf(expectedFields))
 			Expect(*logCollector.Spec.CollectProcessPath).To(Equal(operatorv1.CollectProcessPathEnable))
 			Expect(logCollector.Spec.AdditionalStores.Syslog.LogTypes).To(Equal(expectedLogTypes))
@@ -590,6 +590,7 @@ var _ = Describe("LogCollector controller tests", func() {
 			processPath := operatorv1.CollectProcessPathDisable
 			logCollector.Spec.CollectProcessPath = &processPath
 			logCollector.Spec.AdditionalStores.Syslog.LogTypes = []operatorv1.SyslogLogType{operatorv1.SyslogLogAudit}
+			logCollector.Spec.AdditionalStores.Syslog.Encryption = operatorv1.EncryptionNone
 			modifiedFields := fillDefaults(&logCollector)
 			Expect(*logCollector.Spec.CollectProcessPath).To(Equal(operatorv1.CollectProcessPathDisable))
 			expectedLogTypes := []operatorv1.SyslogLogType{

--- a/pkg/crds/operator/operator.tigera.io_logcollectors.yaml
+++ b/pkg/crds/operator/operator.tigera.io_logcollectors.yaml
@@ -105,6 +105,13 @@ spec:
                     description: If specified, enables exporting of flow, audit, and
                       DNS logs to syslog.
                     properties:
+                      encryption:
+                        description: 'Encryption configures traffic encryption to
+                          the Syslog server. Default: None'
+                        enum:
+                        - None
+                        - TLS
+                        type: string
                       endpoint:
                         description: 'Location of the syslog server. example: tcp://1.2.3.4:601'
                         type: string

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -478,46 +478,18 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 		envs := ds.Spec.Template.Spec.Containers[0].Env
 
-		expectedEnvs := []struct {
-			name       string
-			val        string
-			secretName string
-			secretKey  string
-		}{
-			{"SYSLOG_HOST", "1.2.3.4", "", ""},
-			{"SYSLOG_PORT", "80", "", ""},
-			{"SYSLOG_PROTOCOL", "tcp", "", ""},
-			{"SYSLOG_FLUSH_INTERVAL", "5s", "", ""},
-			{"SYSLOG_PACKET_SIZE", "180", "", ""},
-			{"SYSLOG_DNS_LOG", "true", "", ""},
-			{"SYSLOG_FLOW_LOG", "true", "", ""},
-			{"SYSLOG_IDS_EVENT_LOG", "true", "", ""},
-			{"SYSLOG_TLS", "true", "", ""},
-			{"SYSLOG_VERIFY_MODE", "1", "", ""},
-			{"SYSLOG_CA_FILE", cfg.TrustedBundle.MountPath(), "", ""},
-		}
-		for _, expected := range expectedEnvs {
-			if expected.val != "" {
-				Expect(envs).To(ContainElement(corev1.EnvVar{Name: expected.name, Value: expected.val}))
-			} else {
-				Expect(envs).To(ContainElement(corev1.EnvVar{
-					Name: expected.name,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
-							Key:                  expected.secretKey,
-						},
-					},
-				}))
-			}
-		}
-		Expect(envs).To(ContainElement(corev1.EnvVar{
-			Name: "SYSLOG_HOSTNAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "spec.nodeName",
-				},
-			},
+		Expect(envs).To(ContainElements([]corev1.EnvVar{
+			{Name: "SYSLOG_HOST", Value: "1.2.3.4", ValueFrom: nil},
+			{Name: "SYSLOG_PORT", Value: "80", ValueFrom: nil},
+			{Name: "SYSLOG_PROTOCOL", Value: "tcp", ValueFrom: nil},
+			{Name: "SYSLOG_FLUSH_INTERVAL", Value: "5s", ValueFrom: nil},
+			{Name: "SYSLOG_PACKET_SIZE", Value: "180", ValueFrom: nil},
+			{Name: "SYSLOG_DNS_LOG", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_FLOW_LOG", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_IDS_EVENT_LOG", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_TLS", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_VERIFY_MODE", Value: "1", ValueFrom: nil},
+			{Name: "SYSLOG_CA_FILE", Value: cfg.TrustedBundle.MountPath(), ValueFrom: nil},
 		}))
 	})
 	It("should render with Syslog configuration with TLS and Internet CA", func() {
@@ -544,46 +516,18 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 		envs := ds.Spec.Template.Spec.Containers[0].Env
 
-		expectedEnvs := []struct {
-			name       string
-			val        string
-			secretName string
-			secretKey  string
-		}{
-			{"SYSLOG_HOST", "1.2.3.4", "", ""},
-			{"SYSLOG_PORT", "80", "", ""},
-			{"SYSLOG_PROTOCOL", "tcp", "", ""},
-			{"SYSLOG_FLUSH_INTERVAL", "5s", "", ""},
-			{"SYSLOG_PACKET_SIZE", "180", "", ""},
-			{"SYSLOG_DNS_LOG", "true", "", ""},
-			{"SYSLOG_FLOW_LOG", "true", "", ""},
-			{"SYSLOG_IDS_EVENT_LOG", "true", "", ""},
-			{"SYSLOG_TLS", "true", "", ""},
-			{"SYSLOG_VERIFY_MODE", "1", "", ""},
-			{"SYSLOG_CA_FILE", render.SysLogPublicCAPath, "", ""},
-		}
-		for _, expected := range expectedEnvs {
-			if expected.val != "" {
-				Expect(envs).To(ContainElement(corev1.EnvVar{Name: expected.name, Value: expected.val}))
-			} else {
-				Expect(envs).To(ContainElement(corev1.EnvVar{
-					Name: expected.name,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
-							Key:                  expected.secretKey,
-						},
-					},
-				}))
-			}
-		}
-		Expect(envs).To(ContainElement(corev1.EnvVar{
-			Name: "SYSLOG_HOSTNAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "spec.nodeName",
-				},
-			},
+		Expect(envs).To(ContainElements([]corev1.EnvVar{
+			{Name: "SYSLOG_HOST", Value: "1.2.3.4", ValueFrom: nil},
+			{Name: "SYSLOG_PORT", Value: "80", ValueFrom: nil},
+			{Name: "SYSLOG_PROTOCOL", Value: "tcp", ValueFrom: nil},
+			{Name: "SYSLOG_FLUSH_INTERVAL", Value: "5s", ValueFrom: nil},
+			{Name: "SYSLOG_PACKET_SIZE", Value: "180", ValueFrom: nil},
+			{Name: "SYSLOG_DNS_LOG", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_FLOW_LOG", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_IDS_EVENT_LOG", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_TLS", Value: "true", ValueFrom: nil},
+			{Name: "SYSLOG_VERIFY_MODE", Value: "1", ValueFrom: nil},
+			{Name: "SYSLOG_CA_FILE", Value: render.SysLogPublicCAPath, ValueFrom: nil},
 		}))
 	})
 

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -448,6 +448,144 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			},
 		}))
 	})
+	It("should render with Syslog configuration with TLS and user's corporate CA", func() {
+		cfg.UseSyslogCertificate = true
+		var ps int32 = 180
+		cfg.LogCollector.Spec.AdditionalStores = &operatorv1.AdditionalLogStoreSpec{
+			Syslog: &operatorv1.SyslogStoreSpec{
+				Endpoint:   "tcp://1.2.3.4:80",
+				Encryption: operatorv1.EncryptionTLS,
+				PacketSize: &ps,
+				LogTypes: []operatorv1.SyslogLogType{
+					operatorv1.SyslogLogDNS,
+					operatorv1.SyslogLogFlows,
+					operatorv1.SyslogLogIDSEvents,
+				},
+			},
+		}
+		component := render.Fluentd(cfg)
+		resources, _ := component.Objects()
+
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(3))
+
+		var volnames []string
+		for _, vol := range ds.Spec.Template.Spec.Volumes {
+			volnames = append(volnames, vol.Name)
+		}
+		Expect(volnames).To(ContainElement("tigera-ca-bundle"))
+
+		envs := ds.Spec.Template.Spec.Containers[0].Env
+
+		expectedEnvs := []struct {
+			name       string
+			val        string
+			secretName string
+			secretKey  string
+		}{
+			{"SYSLOG_HOST", "1.2.3.4", "", ""},
+			{"SYSLOG_PORT", "80", "", ""},
+			{"SYSLOG_PROTOCOL", "tcp", "", ""},
+			{"SYSLOG_FLUSH_INTERVAL", "5s", "", ""},
+			{"SYSLOG_PACKET_SIZE", "180", "", ""},
+			{"SYSLOG_DNS_LOG", "true", "", ""},
+			{"SYSLOG_FLOW_LOG", "true", "", ""},
+			{"SYSLOG_IDS_EVENT_LOG", "true", "", ""},
+			{"SYSLOG_TLS", "true", "", ""},
+			{"SYSLOG_VERIFY_MODE", "1", "", ""},
+			{"SYSLOG_CA_FILE", cfg.TrustedBundle.MountPath(), "", ""},
+		}
+		for _, expected := range expectedEnvs {
+			if expected.val != "" {
+				Expect(envs).To(ContainElement(corev1.EnvVar{Name: expected.name, Value: expected.val}))
+			} else {
+				Expect(envs).To(ContainElement(corev1.EnvVar{
+					Name: expected.name,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
+							Key:                  expected.secretKey,
+						},
+					},
+				}))
+			}
+		}
+		Expect(envs).To(ContainElement(corev1.EnvVar{
+			Name: "SYSLOG_HOSTNAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		}))
+	})
+	It("should render with Syslog configuration with TLS and Internet CA", func() {
+		cfg.UseSyslogCertificate = false
+		var ps int32 = 180
+		cfg.LogCollector.Spec.AdditionalStores = &operatorv1.AdditionalLogStoreSpec{
+			Syslog: &operatorv1.SyslogStoreSpec{
+				Endpoint:   "tcp://1.2.3.4:80",
+				Encryption: operatorv1.EncryptionTLS,
+				PacketSize: &ps,
+				LogTypes: []operatorv1.SyslogLogType{
+					operatorv1.SyslogLogDNS,
+					operatorv1.SyslogLogFlows,
+					operatorv1.SyslogLogIDSEvents,
+				},
+			},
+		}
+		component := render.Fluentd(cfg)
+		resources, _ := component.Objects()
+
+		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(3))
+
+		envs := ds.Spec.Template.Spec.Containers[0].Env
+
+		expectedEnvs := []struct {
+			name       string
+			val        string
+			secretName string
+			secretKey  string
+		}{
+			{"SYSLOG_HOST", "1.2.3.4", "", ""},
+			{"SYSLOG_PORT", "80", "", ""},
+			{"SYSLOG_PROTOCOL", "tcp", "", ""},
+			{"SYSLOG_FLUSH_INTERVAL", "5s", "", ""},
+			{"SYSLOG_PACKET_SIZE", "180", "", ""},
+			{"SYSLOG_DNS_LOG", "true", "", ""},
+			{"SYSLOG_FLOW_LOG", "true", "", ""},
+			{"SYSLOG_IDS_EVENT_LOG", "true", "", ""},
+			{"SYSLOG_TLS", "true", "", ""},
+			{"SYSLOG_VERIFY_MODE", "1", "", ""},
+			{"SYSLOG_CA_FILE", render.SysLogPublicCAPath, "", ""},
+		}
+		for _, expected := range expectedEnvs {
+			if expected.val != "" {
+				Expect(envs).To(ContainElement(corev1.EnvVar{Name: expected.name, Value: expected.val}))
+			} else {
+				Expect(envs).To(ContainElement(corev1.EnvVar{
+					Name: expected.name,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: expected.secretName},
+							Key:                  expected.secretKey,
+						},
+					},
+				}))
+			}
+		}
+		Expect(envs).To(ContainElement(corev1.EnvVar{
+			Name: "SYSLOG_HOSTNAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		}))
+	})
 
 	It("should render with splunk configuration with ca", func() {
 		cfg.SplkCredential = &render.SplunkCredential{

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 									"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
 									"--web.telemetry-path=/metrics", "--tls.key=/tigera-ee-elasticsearch-metrics-tls/tls.key",
 									"--tls.crt=/tigera-ee-elasticsearch-metrics-tls/tls.crt",
-									"--ca.crt=/etc/pki/tls/certs/tigera-ca-bundle.crt"},
+									"--ca.crt=/tigera-ca-bundle/tigera-ca-bundle.crt"},
 								Env: []corev1.EnvVar{
 									{Name: "FIPS_MODE_ENABLED", Value: "false"},
 									{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: "true"},
 			{Name: "VOLTRON_QUERYSERVER_ENDPOINT", Value: "https://tigera-api.tigera-system.svc:8080"},
 			{Name: "VOLTRON_QUERYSERVER_BASE_PATH", Value: "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy/"},
-			{Name: "VOLTRON_QUERYSERVER_CA_BUNDLE_PATH", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
+			{Name: "VOLTRON_QUERYSERVER_CA_BUNDLE_PATH", Value: "/tigera-ca-bundle/tigera-ca-bundle.crt"},
 		}))
 
 		Expect(voltron.VolumeMounts).To(HaveLen(2))

--- a/pkg/tls/certificatemanagement/interface.go
+++ b/pkg/tls/certificatemanagement/interface.go
@@ -23,10 +23,10 @@ const (
 	CASecretName                      = "tigera-ca-private"
 	TrustedCertConfigMapName          = "tigera-ca-bundle"
 	TrustedCertConfigMapKeyName       = "tigera-ca-bundle.crt"
-	TrustedCertVolumeMountPath        = "/etc/pki/tls/certs/"
-	TrustedCertVolumeMountPathWindows = "c:/etc/pki/tls/certs/"
-	TrustedCertBundleMountPath        = "/etc/pki/tls/certs/tigera-ca-bundle.crt"
-	TrustedCertBundleMountPathWindows = "c:/etc/pki/tls/certs/tigera-ca-bundle.crt"
+	TrustedCertVolumeMountPath        = "/tigera-ca-bundle/"
+	TrustedCertVolumeMountPathWindows = "c:/tigera-ca-bundle/"
+	TrustedCertBundleMountPath        = "/tigera-ca-bundle/tigera-ca-bundle.crt"
+	TrustedCertBundleMountPathWindows = "c:/tigera-ca-bundle/tigera-ca-bundle.crt"
 )
 
 // KeyPairInterface wraps a Secret object that contains a private key and a certificate. Whether CertificateManagement is


### PR DESCRIPTION
## Description

This PR has 2 changes.
1) Provide option to enable TLS for syslog forwarding.
2) Update the tigera-ca-bundle fluentd  specific paths (details below).

**Enable TLS option for rsyslog.**
Design Doc : https://docs.google.com/document/d/16xxQEbZXRM-7U52LFvLmm589GIypUyaS/edit#heading=h.gjdgxs
Story: https://tigera.atlassian.net/browse/EV-2481

Testing:
1. Create a Rsyslog server (We can clone a existing [rene micro server](https://docs.google.com/document/d/1XRJoxXYGRVdDQUn28iAwBAezB0VKeg0Qqo2kv_Jyuxg/edit#heading=h.7kalzx4f89n6) using "create similar" option in GCP ). This creates a new micro server with rsyslog installed.
2. Follow Syslog step in [rene's doc](https://docs.google.com/document/d/1XRJoxXYGRVdDQUn28iAwBAezB0VKeg0Qqo2kv_Jyuxg/edit#heading=h.7kalzx4f89n6) to set up the Syslog fowarding using TCP. Update the your box's configuration /etc/rsyslog.conf by mimic the one from rene's box.
3. To Test TLS, apply the below yaml to your cluster
```
apiVersion: operator.tigera.io/v1
kind: LogCollector
metadata:
  name: tigera-secure
spec:
  additionalStores:
    syslog:
      endpoint: tcp://hostname:port  // hostname -I in server box to find the IP , port is anything configured (eg:6514)
      encryption: TLS
      logTypes: 
        - Flows
        - DNS
        - Audit
        - IDSEvents
  collectProcessPath: Enabled
```
4. Install gnutls-bin and rsyslog-gnutls.
     sudo apt-get install gnutls-bin
    sudo apt-get install  rsyslog-gnutls

5. Create self signed CA, key, cert in rsyslog server using certtool. Copy the CA to cluster by creating a secret.
    copy CA into tls.crt file in the cluster and create configmap in operator namespace.
   ``` k create configmap syslog-ca --from-file=tls.crt -n tigera-operator  ```

6. Update the rsyslog server "/etc/rsyslog.conf" with below values.
```
# comment the exiting TCP lines and the below

# provides TCP syslog reception
module(load="imtcp"
        StreamDriver.Name="gtls"
        StreamDriver.Mode="1"
        StreamDriver.Authmode="anon"
)
input(type="imtcp" port="6514")

$DefaultNetstreamDriver gtls
$DefaultNetstreamDriverCAFile /etc/path_to_cert/ca.pem
$DefaultNetstreamDriverCertFile /etc/path_to_cert/server-cert.pem
$DefaultNetstreamDriverKeyFile /etc/path_to_cert/server-key.pem

```
7) Restart and watch for logs.
sudo systemctl restart rsyslog
sudo systemctl status rsyslog
tail -n 1 -f /var/log/syslog


**Update the tigera-ca-bundle fluentd  specific paths.**
Today tigera-ca-bundle is mounted at 2 places

[/etc/fluentd/elastic](https://github.com/tigera/operator/blob/4ba68f436cd2c79311272f72e4a8a41bf7f37845/pkg/render/fluentd.go#L487)
[/etc/pki/tls/certs/](https://github.com/tigera/operator/blob/4ba68f436cd2c79311272f72e4a8a41bf7f37845/pkg/render/fluentd.go#L516)
While mounting on "/etc/pki/tls/certs/" existing Internet ca-bundle.crt which was bundle as part of [tigera fluentd docker image ](https://github.com/tigera/fluentd-docker/blob/master/Dockerfile#L29)is overwritten.

Hence replacing all the tigera-ca-bundle reference to new /etc/fluentd/elastic

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

Need to be merged along with https://github.com/tigera/fluentd-docker/pull/293

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
