### PR TITLE
prevent operator lockup when unused apiservices are down

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -460,7 +460,7 @@ func WaitToAddResourceWatch(controller controller.Controller, c kubernetes.Inter
 		for obj := range resourcesToWatch {
 			objLog := resourcesToWatch[obj].logger
 			predicateFn := resourcesToWatch[obj].predicate
-			if ok, err := isResourceReady(c, obj.GetObjectKind().GroupVersionKind().Kind); err != nil {
+			if ok, err := isCalicoResourceReady(c, obj.GetObjectKind().GroupVersionKind().Kind); err != nil {
 				objLog.WithValues("Error", err).Info("Failed to check if resource is ready - will retry")
 			} else if !ok {
 				objLog.Info("Waiting for resource to be ready - will retry")
@@ -481,18 +481,18 @@ func WaitToAddResourceWatch(controller controller.Controller, c kubernetes.Inter
 	}
 }
 
-func isResourceReady(client kubernetes.Interface, resourceKind string) (bool, error) {
-	_, res, err := client.Discovery().ServerGroupsAndResources()
+// isCalicoResourceReady checks if the specified resourceKind is available.
+// the resourceKind must be of the calico resource group.
+func isCalicoResourceReady(client kubernetes.Interface, resourceKind string) (bool, error) {
+	// Only get the resources for the groupVersion we care about so that we are resilient to other
+	// apiservices being down.
+	res, err := client.Discovery().ServerResourcesForGroupVersion(v3.GroupVersionCurrent)
 	if err != nil {
 		return false, err
 	}
-	for _, group := range res {
-		if group.GroupVersion == v3.GroupVersionCurrent {
-			for _, r := range group.APIResources {
-				if r.Kind == resourceKind {
-					return true, nil
-				}
-			}
+	for _, r := range res.APIResources {
+		if resourceKind == r.Kind {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -105,27 +105,22 @@ var _ = Describe("Tigera License polling test", func() {
 	})
 
 	It("should be able to verify that the LicenseKey is ready", func() {
-		discovery.On("ServerGroupsAndResources").Return(nil, []*metav1.APIResourceList{
-			{
-				GroupVersion: "projectcalico.org/v3",
-				APIResources: []metav1.APIResource{
-					{Kind: "LicenseKey"},
-				},
-			},
+		discovery.On("ServerResourcesForGroupVersion", v3.GroupVersionCurrent).Return(&metav1.APIResourceList{
+			APIResources: []metav1.APIResource{{
+				Kind: "LicenseKey",
+			}},
 		})
-		Expect(isResourceReady(client, v3.KindLicenseKey)).To(BeTrue())
+		Expect(isCalicoResourceReady(client, v3.KindLicenseKey)).To(BeTrue())
 		discovery.AssertExpectations(GinkgoT())
 	})
+
 	It("should be able to verify that the LicenseKey is not ready", func() {
-		discovery.On("ServerGroupsAndResources").Return(nil, []*metav1.APIResourceList{
-			{
-				GroupVersion: "apps/v1",
-				APIResources: []metav1.APIResource{
-					{Kind: "Deployment"},
-				},
-			},
+		discovery.On("ServerResourcesForGroupVersion", v3.GroupVersionCurrent).Return(&metav1.APIResourceList{
+			APIResources: []metav1.APIResource{{
+				Kind: "Deployment",
+			}},
 		})
-		Expect(isResourceReady(client, v3.KindLicenseKey)).To(BeFalse())
+		Expect(isCalicoResourceReady(client, v3.KindLicenseKey)).To(BeFalse())
 		discovery.AssertExpectations(GinkgoT())
 	})
 })
@@ -216,7 +211,7 @@ func (m fakeClient) Discovery() discovery.DiscoveryInterface {
 	return m.discovery
 }
 
-func (m *fakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	args := m.Called()
-	return nil, args.Get(1).([]*metav1.APIResourceList), nil
+func (m *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	args := m.Called(groupVersion)
+	return args.Get(0).(*metav1.APIResourceList), nil
 }


### PR DESCRIPTION
## Description

This resolves a bug where any APIService in an unhealthy state will cause several TigeraStatuses to enter a `Degraded=true Progressing=false` state with the error `Waiting for LicenseKeyAPI to be ready`. Note this only impacts a few of the Enterprise tigerastatuses, i.e. `compliance`, `intrusion-detection`, `log-collector`, and `manager`

You can reproduce the issue by getting an APIService into `Available=False` . I achieved this by installing the 'metrics-server' on a kind cluster using helm. 
```
$ k get deployment,pod
NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/metrics-server   0/1     1            0           4h2m

NAME                                  READY   STATUS    RESTARTS   AGE
pod/metrics-server-7d76b744cd-fpw6m   0/1     Running   0          4h2m

$ k get apiservice v1beta1.metrics.k8s.io
NAME                     SERVICE                  AVAILABLE                  AGE
v1beta1.metrics.k8s.io   default/metrics-server   False (MissingEndpoints)   4h3m
```

With that in place, tigerastatuses will enter a degraded state.

You can also trigger the same API failure the Operator is hitting by running `kubectl api-resources`, and alongside the working API's, you'll see an error that says:
```
error: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request
```

The reason for this failure is that Operator uses the Discovery API to call `ServerPreferredResources` which first gets all API Groups, and then connects to each one individually to get the list of APIs it is hosting. Since the metrics API is down, it can't respond, and our call will fail. A special error which details which ones failed if any of them are unavailable: https://github.com/kubernetes/client-go/blob/v0.25.3/discovery/discovery_client.go#L334

One solution would be to parse that error type and ignore the ones we don't care about, but this PR instead switches to a different discovery API which specifically requests only the API's that we need.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
