### PR TITLE
[Cherry-pick #2243 to v1.27] prevent operator lockup when unused apiservices are down

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -436,7 +436,7 @@ func WaitToAddResourceWatch(controller controller.Controller, client kubernetes.
 			duration = maxDuration
 		}
 		ticker.Reset(duration)
-		if isResourceReady(client, obj.GetObjectKind().GroupVersionKind().Kind) {
+		if isCalicoResourceReady(client, obj.GetObjectKind().GroupVersionKind().Kind) {
 			err := controller.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{})
 			if err != nil {
 				log.Info("failed to watch %s resource: %v. Will retry to add watch", obj.GetObjectKind().GroupVersionKind().Kind, err)
@@ -448,18 +448,14 @@ func WaitToAddResourceWatch(controller controller.Controller, client kubernetes.
 	}
 }
 
-func isResourceReady(client kubernetes.Interface, resourceKind string) bool {
-	_, res, err := client.Discovery().ServerGroupsAndResources()
+func isCalicoResourceReady(client kubernetes.Interface, resourceKind string) bool {
+	res, err := client.Discovery().ServerResourcesForGroupVersion(v3.GroupVersionCurrent)
 	if err != nil {
 		return false
 	}
-	for _, group := range res {
-		if group.GroupVersion == v3.GroupVersionCurrent {
-			for _, r := range group.APIResources {
-				if r.Kind == resourceKind {
-					return true
-				}
-			}
+	for _, r := range res.APIResources {
+		if resourceKind == r.Kind {
+			return true
 		}
 	}
 	return false

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -105,27 +105,22 @@ var _ = Describe("Tigera License polling test", func() {
 	})
 
 	It("should be able to verify that the LicenseKey is ready", func() {
-		discovery.On("ServerGroupsAndResources").Return(nil, []*metav1.APIResourceList{
-			{
-				GroupVersion: "projectcalico.org/v3",
-				APIResources: []metav1.APIResource{
-					{Kind: "LicenseKey"},
-				},
-			},
+		discovery.On("ServerResourcesForGroupVersion", v3.GroupVersionCurrent).Return(&metav1.APIResourceList{
+			APIResources: []metav1.APIResource{{
+				Kind: "LicenseKey",
+			}},
 		})
-		Expect(isResourceReady(client, v3.KindLicenseKey)).To(BeTrue())
+		Expect(isCalicoResourceReady(client, v3.KindLicenseKey)).To(BeTrue())
 		discovery.AssertExpectations(GinkgoT())
 	})
+
 	It("should be able to verify that the LicenseKey is not ready", func() {
-		discovery.On("ServerGroupsAndResources").Return(nil, []*metav1.APIResourceList{
-			{
-				GroupVersion: "apps/v1",
-				APIResources: []metav1.APIResource{
-					{Kind: "Deployment"},
-				},
-			},
+		discovery.On("ServerResourcesForGroupVersion", v3.GroupVersionCurrent).Return(&metav1.APIResourceList{
+			APIResources: []metav1.APIResource{{
+				Kind: "Deployment",
+			}},
 		})
-		Expect(isResourceReady(client, v3.KindLicenseKey)).To(BeFalse())
+		Expect(isCalicoResourceReady(client, v3.KindLicenseKey)).To(BeFalse())
 		discovery.AssertExpectations(GinkgoT())
 	})
 })
@@ -197,7 +192,7 @@ func (m fakeClient) Discovery() discovery.DiscoveryInterface {
 	return m.discovery
 }
 
-func (m *fakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	args := m.Called()
-	return nil, args.Get(1).([]*metav1.APIResourceList), nil
+func (m *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	args := m.Called(groupVersion)
+	return args.Get(0).(*metav1.APIResourceList), nil
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
