### PR TITLE
Allow IP forwarding during manifest-to-operator migration

### DIFF
--- a/pkg/controller/migration/convert/network.go
+++ b/pkg/controller/migration/convert/network.go
@@ -221,12 +221,10 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 			fix:       "disable 'IpAddrsNoIpam' in the CNI configuration",
 		}
 	}
+
 	if c.cni.CalicoConfig.ContainerSettings.AllowIPForwarding {
-		return ErrIncompatibleCluster{
-			err:       "AllowIPForwarding not supported",
-			component: ComponentCNIConfig,
-			fix:       "disable 'AllowIPForwarding' in the CNI configuration",
-		}
+		containerIPForward := v1.ContainerIPForwardingEnabled
+		install.Spec.CalicoNetwork.ContainerIPForwarding = &containerIPForward
 	}
 
 	return nil


### PR DESCRIPTION
## Description
This PR will allow for successful migration from manifest-based installs to operator-based installs while "allow_ip_forwarding" is configured under "container_settings" in the calico-config ConfigMap resource. This was a specific customer ask to implement this behaviour.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- ~~[ ] If changing pkg/apis/, run `make gen-files`~~
- ~~[ ] If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
