### PR TITLE
Fix kibana certificate in esgateway trusted bundle EV-2686

### DIFF
--- a/pkg/controller/logstorage/esgateway.go
+++ b/pkg/controller/logstorage/esgateway.go
@@ -54,7 +54,7 @@ func (r *ReconcileLogStorage) createEsGateway(
 	}
 	var kibanaCertificate certificatemanagement.CertificateInterface
 	if !operatorv1.IsFIPSModeEnabled(install.FIPSMode) {
-		kibanaCertificate, err := certificateManager.GetCertificate(r.client, render.TigeraKibanaCertSecret, common.OperatorNamespace())
+		kibanaCertificate, err = certificateManager.GetCertificate(r.client, render.TigeraKibanaCertSecret, common.OperatorNamespace())
 		if err != nil {
 			reqLogger.Error(err, "failed to get Kibana tls certificate secret")
 			r.status.SetDegraded("Failed to get Kibana tls certificate secret", err.Error())


### PR DESCRIPTION
## Description

Issue:
https://tigera.atlassian.net/browse/EV-2686

esgateway pod  does not have kibanacertificates in the trusted bundle when FIPS mode is not enabled.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
