### PR TITLE
Cherry pick 2257 into release v1.28

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -611,6 +611,11 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 			},
 			{
 				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
 				Verbs:     []string{"list"},
 			},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -278,6 +278,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
 				Verbs:     []string{"list"},
 			},
@@ -503,6 +508,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				APIGroups: []string{"networking.k8s.io"},
 				Resources: []string{"networkpolicies"},
 				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"get"},
 			},
 			{
 				APIGroups: []string{""},


### PR DESCRIPTION
## Description

Add `{ApiGroups: v1 Resources: namespaces, Verbs: get}` to `tigera-manager-role` ClusterRole. 
The new `tigera-manager-role` clusterrole definition is used by the policy recommendation component to verify that the namespace exists.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
