### PR TITLE
cherry-pick #2273  Update tigera-ca-bundle path to /etc/pki/tigera

### DIFF
--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -316,6 +316,7 @@ func (c *GuardianComponent) container() []corev1.Container {
 				{Name: "GUARDIAN_VOLTRON_CA_TYPE", Value: string(c.cfg.TunnelCAType)},
 				{Name: "GUARDIAN_PACKET_CAPTURE_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
 				{Name: "GUARDIAN_PROMETHEUS_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
+				{Name: "GUARDIAN_QUERYSERVER_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
 				{Name: "GUARDIAN_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 			},
 			VolumeMounts: c.volumeMounts(),

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 									"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
 									"--web.telemetry-path=/metrics", "--tls.key=/tigera-ee-elasticsearch-metrics-tls/tls.key",
 									"--tls.crt=/tigera-ee-elasticsearch-metrics-tls/tls.crt",
-									"--ca.crt=/tigera-ca-bundle/tigera-ca-bundle.crt"},
+									"--ca.crt=/etc/pki/tigera/tigera-ca-bundle.crt"},
 								Env: []corev1.EnvVar{
 									{Name: "FIPS_MODE_ENABLED", Value: "false"},
 									{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: "true"},
 			{Name: "VOLTRON_QUERYSERVER_ENDPOINT", Value: "https://tigera-api.tigera-system.svc:8080"},
 			{Name: "VOLTRON_QUERYSERVER_BASE_PATH", Value: "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy/"},
-			{Name: "VOLTRON_QUERYSERVER_CA_BUNDLE_PATH", Value: "/tigera-ca-bundle/tigera-ca-bundle.crt"},
+			{Name: "VOLTRON_QUERYSERVER_CA_BUNDLE_PATH", Value: "/etc/pki/tigera/tigera-ca-bundle.crt"},
 		}))
 
 		Expect(voltron.VolumeMounts).To(HaveLen(2))

--- a/pkg/tls/certificatemanagement/interface.go
+++ b/pkg/tls/certificatemanagement/interface.go
@@ -23,10 +23,10 @@ const (
 	CASecretName                      = "tigera-ca-private"
 	TrustedCertConfigMapName          = "tigera-ca-bundle"
 	TrustedCertConfigMapKeyName       = "tigera-ca-bundle.crt"
-	TrustedCertVolumeMountPath        = "/tigera-ca-bundle/"
-	TrustedCertVolumeMountPathWindows = "c:/tigera-ca-bundle/"
-	TrustedCertBundleMountPath        = "/tigera-ca-bundle/tigera-ca-bundle.crt"
-	TrustedCertBundleMountPathWindows = "c:/tigera-ca-bundle/tigera-ca-bundle.crt"
+	TrustedCertVolumeMountPath        = "/etc/pki/tigera/"
+	TrustedCertVolumeMountPathWindows = "c:/etc/pki/tigera/"
+	TrustedCertBundleMountPath        = "/etc/pki/tigera/tigera-ca-bundle.crt"
+	TrustedCertBundleMountPathWindows = "c:/etc/pki/tigera/tigera-ca-bundle.crt"
 )
 
 // KeyPairInterface wraps a Secret object that contains a private key and a certificate. Whether CertificateManagement is


### PR DESCRIPTION
Cherry-picked from:
https://github.com/tigera/operator/pull/2273

Must be merged with https://github.com/tigera/fluentd-docker/pull/296

Updating the tigera-ca-bundle path as suggested in https://tigera.slack.com/archives/C03QHUBTEGP/p1668014386298799
from /tigera-ca-bundle/ to /etc/pki/tls/certs/

Background:
While mounting on "/etc/pki/tls/certs/" existing Internet ca-bundle.crt which was bundle as part of [tigera fluentd docker image ](https://github.com/tigera/fluentd-docker/blob/master/Dockerfile#L29)is overwritten.

Hence replacing all the tigera-ca-bundle reference to /etc/pki/tigera/

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
