### PR TITLE
[Release 28] Update base image (cherry-pick 2275)

### DIFF
--- a/build/Dockerfile.amd64
+++ b/build/Dockerfile.amd64
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 AS ubi
 
 # Update base packages to get security updates.
 RUN microdnf update

--- a/build/Dockerfile.arm64
+++ b/build/Dockerfile.arm64
@@ -15,10 +15,10 @@
 # important in cross compiling
 ARG UBI_DIGEST=sha256:0aeb0f23d012ee735e4469fd6ff736d3d42be6326aeeb8118b1fec98d9209f8d
 # go-build latest not available for arm64
-ARG QEMU_IMAGE=calico/go-build:v0.63-arm64
+ARG QEMU_IMAGE=calico/go-build:v0.76-arm64
 
 FROM ${QEMU_IMAGE} as qemu
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 AS ubi
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG QEMU_IMAGE=calico/go-build:v0.73-ppc64le
+ARG QEMU_IMAGE=calico/go-build:v0.76-ppc64le
 FROM ${QEMU_IMAGE} as qemu
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 AS ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 AS ubi
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!


### PR DESCRIPTION
## Description
Update base to UBI 8.7 for all architectures
Update golang (go-build) in arm64 and ppc64le
Cherry-pick https://github.com/tigera/operator/pull/2275
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
