### PR TITLE
Remove unconditional ServiceAccountName on CSI daemonset

### DIFF
--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -260,11 +260,10 @@ func (c *csiComponent) csiTemplate() corev1.PodTemplateSpec {
 		Labels: templateLabels,
 	}
 	templateSpec := corev1.PodSpec{
-		Tolerations:        c.csiTolerations(),
-		Containers:         c.csiContainers(),
-		ImagePullSecrets:   c.cfg.Installation.ImagePullSecrets,
-		Volumes:            c.csiVolumes(),
-		ServiceAccountName: CSIDaemonSetName,
+		Tolerations:      c.csiTolerations(),
+		Containers:       c.csiContainers(),
+		ImagePullSecrets: c.cfg.Installation.ImagePullSecrets,
+		Volumes:          c.csiVolumes(),
 	}
 
 	if !c.cfg.Openshift && c.cfg.UsePSP {

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -150,4 +150,22 @@ var _ = Describe("CSI rendering tests", func() {
 			},
 		))
 	})
+
+	It("should not add ServiceAccountName field when UsePSP is false or not on Openshift", func() {
+		cfg.Openshift = false
+		cfg.UsePSP = false
+
+		resources, _ := render.CSI(&cfg).Objects()
+
+		ds := rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
+
+		cfg.Openshift = true
+		cfg.UsePSP = true
+
+		resources, _ = render.CSI(&cfg).Objects()
+
+		ds = rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
A recent change to introduce PSPs for CSI daemonset introduced a bug where a ServiceAccountName could be set without the corresponding ServiceAccount also being created. This change corrects the errored state.

This is a cherry-pick of [PR 2281](https://github.com/tigera/operator/pull/2281)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- ~~[ ] If changing pkg/apis/, run `make gen-files`~~
- ~~[ ] If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
