### PR TITLE
Update versions for CE v3.15

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -97,7 +97,7 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v2.32.0
+    version: v2.32.1
   prometheus:
     image: tigera/prometheus
     version: release-calient-v3.15

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -173,7 +173,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = component{
-		Version: "v2.32.0",
+		Version: "v2.32.1",
 	}
 
 	ComponentPrometheus = component{


### PR DESCRIPTION
Update prometheus version to reflect version tracked by prometheus-docker

Pairs with changes in Calico CE versions (see referenced PR)