### PR TITLE
Cherry-pick #2284 Update doc for syslog possible values (EV-2821,EV-2822)

### DIFF
--- a/api/v1/logcollector_types.go
+++ b/api/v1/logcollector_types.go
@@ -45,6 +45,9 @@ const (
 	CollectProcessPathDisable CollectProcessPathOption = "Disabled"
 )
 
+// EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.
+//
+// One of: None, TLS
 type EncryptionOption string
 
 const (
@@ -132,8 +135,8 @@ type SyslogStoreSpec struct {
 	// +optional
 	PacketSize *int32 `json:"packetSize,omitempty"`
 
-	// LogTypes contains a list of types of logs to export to syslog. By default, if this field is
-	// omitted, it will be set to include all possible values.
+	// If no values are provided, the list will be updated to include log types Audit, DNS and Flows.
+	// Default: Audit, DNS, Flows
 	LogTypes []SyslogLogType `json:"logTypes"`
 
 	// Encryption configures traffic encryption to the Syslog server.

--- a/pkg/crds/operator/operator.tigera.io_logcollectors.yaml
+++ b/pkg/crds/operator/operator.tigera.io_logcollectors.yaml
@@ -116,9 +116,9 @@ spec:
                         description: 'Location of the syslog server. example: tcp://1.2.3.4:601'
                         type: string
                       logTypes:
-                        description: LogTypes contains a list of types of logs to
-                          export to syslog. By default, if this field is omitted,
-                          it will be set to include all possible values.
+                        description: 'If no values are provided, the list will be
+                          updated to include log types Audit, DNS and Flows. Default:
+                          Audit, DNS, Flows'
                         items:
                           description: SyslogLogType represents the allowable log
                             types for syslog. Allowable values are Audit, DNS, Flows


### PR DESCRIPTION
## Description

cherry pick - https://github.com/tigera/operator/pull/2284

Add 2 doc change for syslog

Added possible values for EncryptionOption in command to generated in docs.
Updated the commands for existing logtypes since it was misleading from the actual behaviour.
Actual behavior:
When empty list is set, it will prepopulated with DNS,Audit and flow logs.
More details in the https://github.com/tigera/operator/blob/master/pkg/controller/logcollector/logcollector_controller.go#L213

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
