### PR TITLE
[release-v1.28] IDS controller use root when syslog forwarding is enabled

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -637,8 +637,14 @@ func (c *intrusionDetectionComponent) intrusionDetectionControllerContainer() co
 			corev1.EnvVar{Name: "IDS_ENABLE_EVENT_FORWARDING", Value: "true"},
 		)
 		volumeMounts = append(volumeMounts, syslogEventsForwardingVolumeMount())
+		// When syslog forwarding is enabled, IDS controller mounts host volume /var/log/calico
+		// and writes events to it. This host path is owned by root user and group so we have to
+		// use privileged UID/GID 0.
+		sc.RunAsGroup = ptr.Int64ToPtr(0)
+		sc.RunAsNonRoot = ptr.BoolToPtr(false)
+		sc.RunAsUser = ptr.Int64ToPtr(0)
 		// On OpenShift, if we need the volume mount to hostpath volume for syslog forwarding,
-		// then ID controller needs privileged access to write event logs to that volume
+		// then IDS controller needs privileged access to write event logs to that volume
 		if c.cfg.Openshift {
 			sc.Privileged = ptr.BoolToPtr(true)
 		}

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -466,6 +466,12 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		Expect(idc.Spec.Template.Spec.Volumes[1].Name).To(Equal("var-log-calico"))
 		Expect(idc.Spec.Template.Spec.Volumes[1].VolumeSource.HostPath.Path).To(Equal("/var/log/calico"))
 
+		Expect(*idc.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+		Expect(*idc.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
+		Expect(*idc.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
+		Expect(*idc.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeFalse())
+		Expect(*idc.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(0))
+
 		// expect AD PodTemplate EnvVars
 		expectedADEnvs := []expectedEnvVar{
 			{"ELASTIC_HOST", dns.GetServiceDNSNames(render.ESGatewayServiceName, render.ElasticsearchNamespace, cfg.ClusterDomain)[2], "", ""},


### PR DESCRIPTION
## Description

Pick https://github.com/tigera/operator/pull/2294 into release v1.28 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
