### PR TITLE
fix(render/ids): render ad api with privilege user if persistent storage is used

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -61,10 +61,17 @@ const (
 	IntrusionDetectionControllerPolicyName = networkpolicy.TigeraComponentPolicyPrefix + IntrusionDetectionControllerName
 	IntrusionDetectionInstallerPolicyName  = networkpolicy.TigeraComponentPolicyPrefix + "intrusion-detection-elastic"
 
+	ADAPIObjectName          = "anomaly-detection-api"
+	ADAPIObjectPortName      = "anomaly-detection-api-https"
+	ADAPITLSSecretName       = "anomaly-detection-api-tls"
+	ADAPIExpectedServiceName = "anomaly-detection-api.tigera-intrusion-detection.svc"
+	ADAPIPolicyName          = networkpolicy.TigeraComponentPolicyPrefix + ADAPIObjectName
+	adAPIPort                = 8080
+
 	ADPersistentVolumeClaimName            = "tigera-anomaly-detection"
 	DefaultAnomalyDetectionPVRequestSizeGi = "10Gi"
 	adAPIStorageVolumeName                 = "volume-storage"
-	adAPIVolumePath                        = "/storage"
+	adAPIStoragePath                       = "/mnt/" + ADAPIObjectName + "/storage"
 	ADJobPodTemplateBaseName               = "tigera.io.detectors"
 	adDetectorPrefixName                   = "tigera.io.detector."
 	adDetectorName                         = "anomaly-detectors"
@@ -73,13 +80,6 @@ const (
 	ADResourceGroup                        = "detectors.tigera.io"
 	ADDetectorsModelResourceName           = "models"
 	ADLogTypeMetaDataResourceName          = "metadata"
-
-	ADAPIObjectName          = "anomaly-detection-api"
-	ADAPIObjectPortName      = "anomaly-detection-api-https"
-	ADAPITLSSecretName       = "anomaly-detection-api-tls"
-	ADAPIExpectedServiceName = "anomaly-detection-api.tigera-intrusion-detection.svc"
-	ADAPIPolicyName          = networkpolicy.TigeraComponentPolicyPrefix + ADAPIObjectName
-	adAPIPort                = 8080
 )
 
 var adAPIReplicas int32 = 1
@@ -174,9 +174,10 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 	// Configure pod security standard. If syslog forwarding is enabled, we
 	// need hostpath volumes which require a privileged PSS.
 	pss := PSSBaseline
-	if c.syslogForwardingIsEnabled() {
+	if c.syslogForwardingIsEnabled() || c.adAPIPersistentStorageEnabled() {
 		pss = PSSPrivileged
 	}
+
 	objs := []client.Object{
 		// In order to switch to a restricted policy, we need to set the following on all containers in the namespace:
 		// - securityContext.allowPrivilegeEscalation=false)
@@ -217,7 +218,7 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 			c.adAPIAccessRoleBinding(),
 		)
 
-		shouldConfigureADStorage := len(c.cfg.IntrusionDetection.Spec.AnomalyDetection.StorageClassName) > 0
+		shouldConfigureADStorage := c.adAPIPersistentStorageEnabled()
 
 		if shouldConfigureADStorage && c.cfg.ShouldRenderADPVC {
 			adObjs = append(adObjs, c.adPersistentVolumeClaim())
@@ -225,7 +226,7 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 
 		adObjs = append(adObjs,
 			c.adAPIService(),
-			c.adAPIDeployment(shouldConfigureADStorage),
+			c.adAPIDeployment(),
 		)
 
 		// RBAC for AD Detector Pods
@@ -689,6 +690,10 @@ func (c *intrusionDetectionComponent) syslogForwardingIsEnabled() bool {
 		}
 	}
 	return false
+}
+
+func (c *intrusionDetectionComponent) adAPIPersistentStorageEnabled() bool {
+	return len(c.cfg.IntrusionDetection.Spec.AnomalyDetection.StorageClassName) > 0
 }
 
 func syslogEventsForwardingVolumeMount() corev1.VolumeMount {
@@ -1408,20 +1413,27 @@ func (c *intrusionDetectionComponent) adPersistentVolumeClaim() *corev1.Persiste
 	return &adPVC
 }
 
-func (c *intrusionDetectionComponent) adAPIDeployment(configureADStorage bool) *appsv1.Deployment {
+func (c *intrusionDetectionComponent) adAPIDeployment() *appsv1.Deployment {
 	var adModelVolumeSource corev1.VolumeSource
-	if configureADStorage {
+	sc := securitycontext.NewBaseContext(securitycontext.RunAsUserID, securitycontext.RunAsGroupID)
+
+	if c.adAPIPersistentStorageEnabled() {
 		adStorageClassName := c.cfg.IntrusionDetection.Spec.AnomalyDetection.StorageClassName
 		adModelVolumeSource = corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: adStorageClassName,
 			},
 		}
+
+		// When Persistent Storage is configured for AD API, it will use the host path of /mnt/anomaly-detection-api
+		// where it requires root privileges to write to
+		sc.RunAsGroup = ptr.Int64ToPtr(0)
+		sc.RunAsUser = ptr.Int64ToPtr(0)
+		sc.RunAsNonRoot = ptr.BoolToPtr(false)
 	} else {
 		adModelVolumeSource = corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		}
-
 	}
 
 	var initContainers []corev1.Container
@@ -1467,11 +1479,12 @@ func (c *intrusionDetectionComponent) adAPIDeployment(configureADStorage bool) *
 							Image: c.adAPIImage,
 							Env: []corev1.EnvVar{
 								{Name: "LOG_LEVEL", Value: "info"},
-								{Name: "STORAGE_PATH", Value: adAPIVolumePath},
+								{Name: "STORAGE_PATH", Value: adAPIStoragePath},
 								{Name: "TLS_KEY", Value: c.cfg.ADAPIServerCertSecret.VolumeMountKeyFilePath()},
 								{Name: "TLS_CERT", Value: c.cfg.ADAPIServerCertSecret.VolumeMountCertificateFilePath()},
 								{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 							},
+							SecurityContext: sc,
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -1495,7 +1508,7 @@ func (c *intrusionDetectionComponent) adAPIDeployment(configureADStorage bool) *
 								c.cfg.TrustedCertBundle.VolumeMount(c.SupportedOSType()),
 								c.cfg.ADAPIServerCertSecret.VolumeMount(c.SupportedOSType()),
 								{
-									MountPath: adAPIVolumePath,
+									MountPath: adAPIStoragePath,
 									Name:      adAPIStorageVolumeName,
 									ReadOnly:  false,
 								},

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -233,6 +233,13 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			},
 		))
 
+		// check non-privileged container is used
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(Equal(false))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(Equal(false))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(Equal(true))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(Equal(int64(10001)))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(int64(10001)))
+
 		// Check all Role for respective AD API SAs
 		detectorsSecret := rtest.GetResource(resources, "anomaly-detectors", render.IntrusionDetectionNamespace, "", "v1", "Secret").(*corev1.Secret)
 		Expect(detectorsSecret.Type).To(Equal(corev1.SecretTypeServiceAccountToken))
@@ -321,6 +328,12 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 				},
 			},
 		))
+
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(Equal(false))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(Equal(false))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(Equal(false))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(Equal(int64(0)))
+		Expect(*adAPIDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(int64(0)))
 	})
 
 	It("should not render a persistentVolume claim if indicated that the AD StorageClassName is provided but an existing PVC already exists", func() {


### PR DESCRIPTION
Since we require  AD API Pods to write to certain static paths in the volume storage, because of the unprivileged PSS, we now need to use a privileged user

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
