### PR TITLE
Add support for Typha graceful shutdown

### DIFF
--- a/api/v1/apiserver_types.go
+++ b/api/v1/apiserver_types.go
@@ -18,6 +18,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -284,5 +285,13 @@ func (c *APIServerDeployment) GetTolerations() []v1.Toleration {
 			}
 		}
 	}
+	return nil
+}
+
+func (c *APIServerDeployment) GetTerminationGracePeriodSeconds() *int64 {
+	return nil
+}
+
+func (c *APIServerDeployment) GetDeploymentStrategy() *appsv1.DeploymentStrategy {
 	return nil
 }

--- a/api/v1/calico_kubecontrollers_types.go
+++ b/api/v1/calico_kubecontrollers_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -190,5 +191,13 @@ func (c *CalicoKubeControllersDeployment) GetTolerations() []v1.Toleration {
 			}
 		}
 	}
+	return nil
+}
+
+func (c *CalicoKubeControllersDeployment) GetTerminationGracePeriodSeconds() *int64 {
+	return nil
+}
+
+func (c *CalicoKubeControllersDeployment) GetDeploymentStrategy() *appsv1.DeploymentStrategy {
 	return nil
 }

--- a/api/v1/calico_node_types.go
+++ b/api/v1/calico_node_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -223,5 +224,13 @@ func (c *CalicoNodeDaemonSet) GetTolerations() []v1.Toleration {
 			}
 		}
 	}
+	return nil
+}
+
+func (c *CalicoNodeDaemonSet) GetTerminationGracePeriodSeconds() *int64 {
+	return nil
+}
+
+func (c *CalicoNodeDaemonSet) GetDeploymentStrategy() *appsv1.DeploymentStrategy {
 	return nil
 }

--- a/api/v1/windows_upgrade_types.go
+++ b/api/v1/windows_upgrade_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -185,5 +186,13 @@ func (c *CalicoWindowsUpgradeDaemonSet) GetTolerations() []v1.Toleration {
 			}
 		}
 	}
+	return nil
+}
+
+func (c *CalicoWindowsUpgradeDaemonSet) GetTerminationGracePeriodSeconds() *int64 {
+	return nil
+}
+
+func (c *CalicoWindowsUpgradeDaemonSet) GetDeploymentStrategy() *appsv1.DeploymentStrategy {
 	return nil
 }

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -3012,6 +3013,11 @@ func (in *TyphaDeploymentPodSpec) DeepCopyInto(out *TyphaDeploymentPodSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.TopologySpreadConstraints != nil {
 		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
 		*out = make([]corev1.TopologySpreadConstraint, len(*in))
@@ -3074,6 +3080,11 @@ func (in *TyphaDeploymentSpec) DeepCopyInto(out *TyphaDeploymentSpec) {
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
 		*out = new(TyphaDeploymentPodTemplateSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(appsv1.DeploymentStrategy)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/pkg/common/validation/overrides.go
+++ b/pkg/common/validation/overrides.go
@@ -87,6 +87,17 @@ func ValidateReplicatedPodResourceOverrides(overrides components.ReplicatedPodRe
 		}
 	}
 
+	tgp := overrides.GetTerminationGracePeriodSeconds()
+	if tgp != nil && *tgp < 0 {
+		return fmt.Errorf("spec.Template.Spec.TerminationGracePeriodSeconds is invalid: cannot be negative")
+	}
+
+	if st := overrides.GetDeploymentStrategy(); st != nil {
+		if err := k8svalidation.ValidateDeploymentStrategy(st, field.NewPath("spec", "strategy")); err.ToAggregate() != nil {
+			return fmt.Errorf("spec.Strategy is invalid: %w", err.ToAggregate())
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/common/validation/overrides_test.go
+++ b/pkg/common/validation/overrides_test.go
@@ -15,9 +15,15 @@
 package validation
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	typha "github.com/tigera/operator/pkg/common/validation/typha"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	opv1 "github.com/tigera/operator/api/v1"
 	node "github.com/tigera/operator/pkg/common/validation/calico-node"
@@ -146,13 +152,113 @@ var _ = Describe("Test overrides validation (TyphaDeployment)", func() {
 		}
 	})
 
+	It("should accept terminationGracePeriod=0", func() {
+		tgp := int64(0)
+		overrides.Spec.Template.Spec.TerminationGracePeriodSeconds = &tgp
+		err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should accept terminationGracePeriod=1", func() {
+		tgp := int64(1)
+		overrides.Spec.Template.Spec.TerminationGracePeriodSeconds = &tgp
+		err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should reject terminationGracePeriod=-1", func() {
+		tgp := int64(-1)
+		overrides.Spec.Template.Spec.TerminationGracePeriodSeconds = &tgp
+		err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).Should(HavePrefix("spec.Template.Spec.TerminationGracePeriodSeconds is invalid: cannot be negative"))
+	})
+
+	intOrStr := func(v string) *intstr.IntOrString {
+		if v == "" {
+			return nil
+		}
+		ios := intstr.Parse(v)
+		return &ios
+	}
+
+	rollingUpdateEntry := func(maxUnav, maxSurge string) TableEntry {
+		return Entry(fmt.Sprintf("maxUnav=%s, maxSurge=%s", maxUnav, maxSurge), appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDeployment{
+				MaxUnavailable: intOrStr(maxUnav),
+				MaxSurge:       intOrStr(maxSurge),
+			},
+		})
+	}
+
+	DescribeTable(
+		"should accept valid deployment strategies",
+		func(s appsv1.DeploymentStrategy) {
+			overrides.Spec.Strategy = &s
+			err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+			Expect(err).NotTo(HaveOccurred())
+		},
+		rollingUpdateEntry("1", "1"),
+		rollingUpdateEntry("0", "1"),
+		rollingUpdateEntry("1", "0"),
+		rollingUpdateEntry("10%", "10%"),
+		rollingUpdateEntry("0", "100%"),
+		rollingUpdateEntry("1", "100%"),
+		rollingUpdateEntry("0", "10%"),
+		rollingUpdateEntry("10%", "0"),
+	)
+
+	DescribeTable(
+		"should reject invalid deployment strategies",
+		func(s appsv1.DeploymentStrategy, expectedErr string) {
+			overrides.Spec.Strategy = &s
+			err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(expectedErr))
+		},
+		Entry("invalid type",
+			appsv1.DeploymentStrategy{
+				Type: "foo",
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: intOrStr("1"),
+					MaxSurge:       intOrStr("1"),
+				},
+			},
+			"invalid: spec.strategy: Unsupported value",
+		),
+		Entry("rolling update, both zero",
+			appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: intOrStr("0"),
+					MaxSurge:       intOrStr("0"),
+				},
+			},
+			"may not be 0 when `maxSurge` is 0",
+		),
+		Entry("rolling update, nil treated as zeros",
+			appsv1.DeploymentStrategy{
+				Type:          appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{},
+			},
+			"may not be 0 when `maxSurge` is 0",
+		),
+		Entry("rolling update, nil RollingUpdate",
+			appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+			"spec.Strategy is invalid: spec.strategy.rollingUpdate: Required value: this should be defaulted and never be nil",
+		),
+	)
+
 	It("should accept a valid topology spread constraint", func() {
 		s := metav1.LabelSelector{MatchLabels: map[string]string{"brick": "mortar"}}
 		overrides.Spec.Template.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 			{MaxSkew: 1, TopologyKey: "realm", WhenUnsatisfiable: corev1.DoNotSchedule, LabelSelector: &s},
 		}
-		err := ValidateReplicatedPodResourceOverrides(overrides, node.ValidateCalicoNodeDaemonSetContainer, node.ValidateCalicoNodeDaemonSetInitContainer)
-		Expect(err).To(BeNil())
+		err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an error if there are duplicate topology spread constraints", func() {
@@ -161,8 +267,8 @@ var _ = Describe("Test overrides validation (TyphaDeployment)", func() {
 			{MaxSkew: 1, TopologyKey: "dominion", WhenUnsatisfiable: corev1.DoNotSchedule, LabelSelector: &s},
 			{MaxSkew: 1, TopologyKey: "dominion", WhenUnsatisfiable: corev1.DoNotSchedule, LabelSelector: &s},
 		}
-		err := ValidateReplicatedPodResourceOverrides(overrides, node.ValidateCalicoNodeDaemonSetContainer, node.ValidateCalicoNodeDaemonSetInitContainer)
-		Expect(err).NotTo(BeNil())
+		err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).Should(HavePrefix("spec.Template.Spec.TopologySpreadConstraints is invalid: spec.template.spec.topologySpreadConstraints[0].{topologyKey, whenUnsatisfiable}: Duplicate value: \"{dominion, DoNotSchedule}\""))
 	})
 
@@ -171,8 +277,8 @@ var _ = Describe("Test overrides validation (TyphaDeployment)", func() {
 		overrides.Spec.Template.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 			{MaxSkew: 1, WhenUnsatisfiable: corev1.DoNotSchedule, LabelSelector: &s},
 		}
-		err := ValidateReplicatedPodResourceOverrides(overrides, node.ValidateCalicoNodeDaemonSetContainer, node.ValidateCalicoNodeDaemonSetInitContainer)
-		Expect(err).NotTo(BeNil())
+		err := ValidateReplicatedPodResourceOverrides(overrides, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).Should(HavePrefix("spec.Template.Spec.TopologySpreadConstraints is invalid: spec.template.spec.topologySpreadConstraints[0].topologyKey: Required value: can not be empty"))
 	})
 })

--- a/pkg/components/overrides.go
+++ b/pkg/components/overrides.go
@@ -16,7 +16,7 @@ package components
 
 import (
 	opv1 "github.com/tigera/operator/api/v1"
-
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -50,4 +50,8 @@ type ReplicatedPodResourceOverrides interface {
 
 	// GetTolerations returns the value used to override a DaemonSet/Deployment's tolerations.
 	GetTolerations() []corev1.Toleration
+
+	GetTerminationGracePeriodSeconds() *int64
+
+	GetDeploymentStrategy() *appsv1.DeploymentStrategy
 }

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -382,8 +382,8 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 	}
 
 	// Verify the CalicoKubeControllersDeployment overrides, if specified, is valid.
-	if ds := instance.Spec.CalicoKubeControllersDeployment; ds != nil {
-		err := validation.ValidateReplicatedPodResourceOverrides(ds, kubecontrollers.ValidateCalicoKubeControllersDeploymentContainer, validation.NoContainersDefined)
+	if deploy := instance.Spec.CalicoKubeControllersDeployment; deploy != nil {
+		err := validation.ValidateReplicatedPodResourceOverrides(deploy, kubecontrollers.ValidateCalicoKubeControllersDeploymentContainer, validation.NoContainersDefined)
 		if err != nil {
 			return fmt.Errorf("Installation spec.CalicoKubeControllersDeployment is not valid: %w", err)
 
@@ -391,13 +391,13 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 	}
 
 	// Verify the TyphaDeployment overrides, if specified, is valid.
-	if ds := instance.Spec.TyphaDeployment; ds != nil {
-		err := validation.ValidateReplicatedPodResourceOverrides(ds, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
+	if deploy := instance.Spec.TyphaDeployment; deploy != nil {
+		err := validation.ValidateReplicatedPodResourceOverrides(deploy, typha.ValidateTyphaDeploymentContainer, typha.ValidateTyphaDeploymentInitContainer)
 		if err != nil {
 			return fmt.Errorf("Installation spec.TyphaDeployment is not valid: %w", err)
-
 		}
 	}
+
 	// Verify the CalicoWindowsUpgradeDaemonSet overrides, if specified, is valid.
 	if ds := instance.Spec.CalicoWindowsUpgradeDaemonSet; ds != nil {
 		err := validation.ValidateReplicatedPodResourceOverrides(ds, windowsupgrade.ValidateCalicoWindowsUpgradeDaemonSetContainer, validation.NoContainersDefined)

--- a/pkg/controller/utils/merge.go
+++ b/pkg/controller/utils/merge.go
@@ -497,6 +497,11 @@ func mergeTyphaDeployment(cfg, override *operatorv1.TyphaDeployment) *operatorv1
 			out.NodeSelector = override.NodeSelector
 		}
 
+		switch compareFields(out.TerminationGracePeriodSeconds, override.TerminationGracePeriodSeconds) {
+		case BOnlySet, Different:
+			out.TerminationGracePeriodSeconds = override.TerminationGracePeriodSeconds
+		}
+
 		switch compareFields(out.Tolerations, override.Tolerations) {
 		case BOnlySet, Different:
 			out.Tolerations = override.Tolerations
@@ -535,6 +540,11 @@ func mergeTyphaDeployment(cfg, override *operatorv1.TyphaDeployment) *operatorv1
 			out.Template = override.Template.DeepCopy()
 		case Different:
 			out.Template = mergeTemplateSpec(out.Template, override.Template)
+		}
+
+		switch compareFields(out.Strategy, override.Strategy) {
+		case BOnlySet, Different:
+			out.Strategy = override.Strategy.DeepCopy()
 		}
 
 		return out

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -384,7 +384,7 @@ spec:
                 type: string
               iptablesBackend:
                 description: IptablesBackend specifies which backend of iptables will
-                  be used. The default is legacy.
+                  be used. The default is Auto.
                 type: string
               iptablesFilterAllowAction:
                 type: string

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -4573,6 +4573,59 @@ spec:
                         maximum: 2147483647
                         minimum: 0
                         type: integer
+                      strategy:
+                        description: The deployment strategy to use to replace existing
+                          pods with new ones.
+                        properties:
+                          rollingUpdate:
+                            description: 'Rolling update config params. Present only
+                              if DeploymentStrategyType = RollingUpdate. --- TODO:
+                              Update this to follow our convention for oneOf, whatever
+                              we decide it to be.'
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can
+                                  be scheduled above the desired number of pods. Value
+                                  can be an absolute number (ex: 5) or a percentage
+                                  of desired pods (ex: 10%). This can not be 0 if
+                                  MaxUnavailable is 0. Absolute number is calculated
+                                  from percentage by rounding up. Defaults to 25%.
+                                  Example: when this is set to 30%, the new ReplicaSet
+                                  can be scaled up immediately when the rolling update
+                                  starts, such that the total number of old and new
+                                  pods do not exceed 130% of desired pods. Once old
+                                  pods have been killed, new ReplicaSet can be scaled
+                                  up further, ensuring that total number of pods running
+                                  at any time during the update is at most 130% of
+                                  desired pods.'
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can
+                                  be unavailable during the update. Value can be an
+                                  absolute number (ex: 5) or a percentage of desired
+                                  pods (ex: 10%). Absolute number is calculated from
+                                  percentage by rounding down. This can not be 0 if
+                                  MaxSurge is 0. Defaults to 25%. Example: when this
+                                  is set to 30%, the old ReplicaSet can be scaled
+                                  down to 70% of desired pods immediately when the
+                                  rolling update starts. Once new pods are ready,
+                                  old ReplicaSet can be scaled down further, followed
+                                  by scaling up the new ReplicaSet, ensuring that
+                                  the total number of pods available at all times
+                                  during the update is at least 70% of desired pods.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
                       template:
                         description: Template describes the typha Deployment pod that
                           will be created.
@@ -5759,6 +5812,21 @@ spec:
                                   WARNING: Please note that this field will modify
                                   the default calico-typha Deployment nodeSelector.'
                                 type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully. May be decreased
+                                  in delete request. Value must be non-negative integer.
+                                  The value zero indicates stop immediately via the
+                                  kill signal (no opportunity to shut down). If this
+                                  value is nil, the default grace period will be used
+                                  instead. The grace period is the duration in seconds
+                                  after the processes running in the pod are sent
+                                  a termination signal and the time when the processes
+                                  are forcibly halted with a kill signal. Set this
+                                  value longer than the expected cleanup time for
+                                  your process. Defaults to 30 seconds.
+                                format: int64
+                                type: integer
                               tolerations:
                                 description: 'Tolerations is the typha pod''s tolerations.
                                   If specified, this overrides any tolerations that
@@ -10907,6 +10975,61 @@ spec:
                             maximum: 2147483647
                             minimum: 0
                             type: integer
+                          strategy:
+                            description: The deployment strategy to use to replace
+                              existing pods with new ones.
+                            properties:
+                              rollingUpdate:
+                                description: 'Rolling update config params. Present
+                                  only if DeploymentStrategyType = RollingUpdate.
+                                  --- TODO: Update this to follow our convention for
+                                  oneOf, whatever we decide it to be.'
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that
+                                      can be scheduled above the desired number of
+                                      pods. Value can be an absolute number (ex: 5)
+                                      or a percentage of desired pods (ex: 10%). This
+                                      can not be 0 if MaxUnavailable is 0. Absolute
+                                      number is calculated from percentage by rounding
+                                      up. Defaults to 25%. Example: when this is set
+                                      to 30%, the new ReplicaSet can be scaled up
+                                      immediately when the rolling update starts,
+                                      such that the total number of old and new pods
+                                      do not exceed 130% of desired pods. Once old
+                                      pods have been killed, new ReplicaSet can be
+                                      scaled up further, ensuring that total number
+                                      of pods running at any time during the update
+                                      is at most 130% of desired pods.'
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that
+                                      can be unavailable during the update. Value
+                                      can be an absolute number (ex: 5) or a percentage
+                                      of desired pods (ex: 10%). Absolute number is
+                                      calculated from percentage by rounding down.
+                                      This can not be 0 if MaxSurge is 0. Defaults
+                                      to 25%. Example: when this is set to 30%, the
+                                      old ReplicaSet can be scaled down to 70% of
+                                      desired pods immediately when the rolling update
+                                      starts. Once new pods are ready, old ReplicaSet
+                                      can be scaled down further, followed by scaling
+                                      up the new ReplicaSet, ensuring that the total
+                                      number of pods available at all times during
+                                      the update is at least 70% of desired pods.'
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: Type of deployment. Can be "Recreate"
+                                  or "RollingUpdate". Default is RollingUpdate.
+                                type: string
+                            type: object
                           template:
                             description: Template describes the typha Deployment pod
                               that will be created.
@@ -12191,6 +12314,22 @@ spec:
                                       WARNING: Please note that this field will modify
                                       the default calico-typha Deployment nodeSelector.'
                                     type: object
+                                  terminationGracePeriodSeconds:
+                                    description: Optional duration in seconds the
+                                      pod needs to terminate gracefully. May be decreased
+                                      in delete request. Value must be non-negative
+                                      integer. The value zero indicates stop immediately
+                                      via the kill signal (no opportunity to shut
+                                      down). If this value is nil, the default grace
+                                      period will be used instead. The grace period
+                                      is the duration in seconds after the processes
+                                      running in the pod are sent a termination signal
+                                      and the time when the processes are forcibly
+                                      halted with a kill signal. Set this value longer
+                                      than the expected cleanup time for your process.
+                                      Defaults to 30 seconds.
+                                    format: int64
+                                    type: integer
                                   tolerations:
                                     description: 'Tolerations is the typha pod''s
                                       tolerations. If specified, this overrides any

--- a/pkg/ptr/conversion.go
+++ b/pkg/ptr/conversion.go
@@ -14,6 +14,10 @@
 
 package ptr
 
+import (
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
 func BoolToPtr(b bool) *bool {
 	return &b
 }
@@ -24,4 +28,9 @@ func Int64ToPtr(i int64) *int64 {
 
 func Int32ToPtr(i int32) *int32 {
 	return &i
+}
+
+func IntOrStrPtr(v string) *intstr.IntOrString {
+	ios := intstr.Parse(v)
+	return &ios
 }

--- a/pkg/render/common/components/components_suite_test.go
+++ b/pkg/render/common/components/components_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package components_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestComponents(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../../report/components_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/render/common/components Suite", []Reporter{junitReporter})
+}

--- a/pkg/render/common/components/components_test.go
+++ b/pkg/render/common/components/components_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "github.com/tigera/operator/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -555,7 +556,521 @@ var _ = Describe("Common components render tests", func() {
 				Expect(result).To(Equal(expected))
 			}),
 	)
+
+	DescribeTable("test ApplyDeploymentOverrides",
+		func(original func() appsv1.Deployment, override func() *v1.TyphaDeployment, expectations func(set appsv1.Deployment)) {
+			orig := original()
+			template := override()
+			ApplyDeploymentOverrides(&orig, template)
+			expectations(orig)
+		},
+		Entry("empty",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{}
+			},
+			func(result appsv1.Deployment) {
+				Expect(result).To(Equal(defaultedDeployment()))
+			}),
+		Entry("empty labels and annotations",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						Labels:      map[string]string{},
+						Annotations: nil,
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				Expect(result).To(Equal(defaultedDeployment()))
+			}),
+		Entry("empty labels and annotations, empty spec",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
+					},
+					Spec: &v1.TyphaDeploymentSpec{},
+				}
+			},
+			func(result appsv1.Deployment) {
+				Expect(result).To(Equal(defaultedDeployment()))
+			}),
+		Entry("labels and annotations",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						Labels:      map[string]string{"test-label": "label1"},
+						Annotations: map[string]string{"test-annot": "annot1"},
+					},
+					Spec: nil,
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Labels["test-label"] = "label1"
+				expected.Annotations["test-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("labels only",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						Labels: map[string]string{"test-label": "label1"},
+					},
+					Spec: nil,
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Labels["test-label"] = "label1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("annotations only",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						Annotations: map[string]string{"test-annot": "annot1"},
+					},
+					Spec: nil,
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Annotations["test-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("labels and annotations that are already defined",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						// "not-zero" label and annotation keys exist in the defaulted calico node.
+						Labels: map[string]string{
+							"test-label": "label1",
+							"not-zero":   "not-zero",
+						},
+						Annotations: map[string]string{
+							"not-zero":   "not-zero",
+							"test-annot": "annot1",
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				// Only the labels and annotations that don't clobber existing keys are added.
+				expected.Labels["test-label"] = "label1"
+				expected.Annotations["test-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("labels that are already defined",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						// "not-zero" label keys exist in the defaulted calico node.
+						Labels: map[string]string{
+							"test-label": "label1",
+							"not-zero":   "not-zero",
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				// Only the labels that don't clobber existing keys are added.
+				expected.Labels["test-label"] = "label1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("annotations that are already defined",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Metadata: &v1.Metadata{
+						// "not-zero" annotation keys exist in the defaulted calico node.
+						Annotations: map[string]string{
+							"not-zero":   "not-zero",
+							"test-annot": "annot1",
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				// Only the annotations that don't clobber existing keys are added.
+				expected.Annotations["test-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("minReadySeconds",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						MinReadySeconds: &three,
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.MinReadySeconds = three
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("pod template labels and annotations",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Metadata: &v1.Metadata{
+								Labels:      map[string]string{"test-pod-label": "label1"},
+								Annotations: map[string]string{"test-pod-annot": "annot1"},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Labels["test-pod-label"] = "label1"
+				expected.Spec.Template.Annotations["test-pod-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("pod template labels only",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Metadata: &v1.Metadata{
+								Labels: map[string]string{"test-pod-label": "label1"},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Labels["test-pod-label"] = "label1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("pod template annotations only",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Metadata: &v1.Metadata{
+								Annotations: map[string]string{"test-pod-annot": "annot1"},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Annotations["test-pod-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("pod labels and annotations that are already defined",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Metadata: &v1.Metadata{
+								Labels: map[string]string{
+									"test-pod-label": "label1",
+									"not-zero":       "wont-work",
+								},
+								Annotations: map[string]string{
+									"not-zero":       "wont-work",
+									"test-pod-annot": "annot1",
+								},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Labels["test-pod-label"] = "label1"
+				expected.Spec.Template.Annotations["test-pod-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("pod labels that are already defined",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Metadata: &v1.Metadata{
+								Labels: map[string]string{
+									"test-pod-label": "label1",
+									"not-zero":       "wont-work",
+								},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Labels["test-pod-label"] = "label1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("pod annotations that are already defined",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Metadata: &v1.Metadata{
+								Annotations: map[string]string{
+									"not-zero":       "wont-work",
+									"test-pod-annot": "annot1",
+								},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Annotations["test-pod-annot"] = "annot1"
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("init containers",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								InitContainers: []v1.TyphaDeploymentInitContainer{
+									{
+										Name:      "not-zero1",
+										Resources: &resources1,
+									},
+									// Invalid init container. Should be caught by CRD validation.
+									{
+										Name:      "does-not-exist",
+										Resources: &resources3,
+									},
+									{
+										Name:      "not-zero2",
+										Resources: &resources2,
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				Expect(expected.Spec.Template.Spec.InitContainers).To(HaveLen(2))
+
+				expected.Spec.Template.Spec.InitContainers[0].Resources = resources1
+				expected.Spec.Template.Spec.InitContainers[1].Resources = resources2
+				Expect(result.Spec.Template.Spec.InitContainers).To(ContainElements(expected.Spec.Template.Spec.InitContainers))
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("empty init containers",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								InitContainers: []v1.TyphaDeploymentInitContainer{},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				Expect(expected.Spec.Template.Spec.InitContainers).To(HaveLen(2))
+				Expect(result.Spec.Template.Spec.InitContainers).To(ContainElements(expected.Spec.Template.Spec.InitContainers))
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("containers",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								Containers: []v1.TyphaDeploymentContainer{
+									// Invalid container. Should be caught by CRD validation.
+									{
+										Name:      "does-not-exist",
+										Resources: &resources3,
+									},
+									{
+										Name:      "not-zero1",
+										Resources: &resources1,
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				Expect(expected.Spec.Template.Spec.Containers).To(HaveLen(2))
+				expected.Spec.Template.Spec.Containers[0].Resources = resources1
+				Expect(result.Spec.Template.Spec.Containers).To(ContainElements(expected.Spec.Template.Spec.Containers))
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("empty containers",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								Containers: []v1.TyphaDeploymentContainer{},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				Expect(expected.Spec.Template.Spec.Containers).To(HaveLen(2))
+				Expect(result.Spec.Template.Spec.Containers).To(ContainElements(expected.Spec.Template.Spec.Containers))
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("empty tolerations",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								Tolerations: []corev1.Toleration{},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
+				Expect(result.Spec.Template.Spec.Tolerations).To(Equal(expected.Spec.Template.Spec.Tolerations))
+				Expect(result).To(Equal(expected))
+			}),
+		Entry("empty nodeSelector",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								NodeSelector: map[string]string{},
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				Expect(result.Spec.Template.Spec.NodeSelector).To(Equal(expected.Spec.Template.Spec.NodeSelector))
+				Expect(result).To(Equal(expected))
+			}),
+
+		Entry("affinity, nodeSelector, and tolerations",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								Affinity:     &affinity,
+								NodeSelector: nodeSelector,
+								Tolerations:  tolerations,
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				expected := defaultedDeployment()
+				expected.Spec.Template.Spec.Affinity = &affinity
+				// only keys that don't already exist in the nodeSelector are added
+				for k, v := range nodeSelector {
+					if _, ok := expected.Spec.Template.Spec.NodeSelector[k]; !ok {
+						expected.Spec.Template.Spec.NodeSelector[k] = v
+					}
+				}
+				expected.Spec.Template.Spec.Tolerations = tolerations
+				Expect(result.Spec.Template.Spec.Affinity).To(Equal(expected.Spec.Template.Spec.Affinity))
+				Expect(result.Spec.Template.Spec.NodeSelector).To(Equal(expected.Spec.Template.Spec.NodeSelector))
+				Expect(result.Spec.Template.Spec.Tolerations).To(Equal(expected.Spec.Template.Spec.Tolerations))
+				Expect(result).To(Equal(expected))
+			}),
+
+		Entry("terminationGracePeriod",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Template: &v1.TyphaDeploymentPodTemplateSpec{
+							Spec: &v1.TyphaDeploymentPodSpec{
+								TerminationGracePeriodSeconds: int64Ptr(3),
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				Expect(*result.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(int64(3)))
+			}),
+
+		Entry("strategy",
+			defaultedDeployment,
+			func() *v1.TyphaDeployment {
+				return &v1.TyphaDeployment{
+					Spec: &v1.TyphaDeploymentSpec{
+						Strategy: &appsv1.DeploymentStrategy{
+							Type: appsv1.RollingUpdateDeploymentStrategyType,
+							RollingUpdate: &appsv1.RollingUpdateDeployment{
+								MaxUnavailable: intOrStrPtr("0"),
+								MaxSurge:       intOrStrPtr("100%"),
+							},
+						},
+					},
+				}
+			},
+			func(result appsv1.Deployment) {
+				Expect(result.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: intOrStrPtr("0"),
+						MaxSurge:       intOrStrPtr("100%"),
+					},
+				}))
+			}),
+	)
 })
+
+func intOrStrPtr(v string) *intstr.IntOrString {
+	ios := intstr.Parse(v)
+	return &ios
+}
+
+func int64Ptr(n int64) *int64 {
+	return &n
+}
 
 func addContainer(cs []corev1.Container) []corev1.Container {
 	// Add another container and rename them to "not-zero1" and "not-zero2".
@@ -576,6 +1091,17 @@ func addContainer(cs []corev1.Container) []corev1.Container {
 // defaultedDaemonSet returns a DaemonSet with its fields populated.
 func defaultedDaemonSet() appsv1.DaemonSet {
 	var ds appsv1.DaemonSet
+	defaulter := test.NewNonZeroStructDefaulter()
+	Expect(defaulter.SetDefault(&ds)).ToNot(HaveOccurred())
+
+	ds.Spec.Template.Spec.Containers = addContainer(ds.Spec.Template.Spec.Containers)
+	ds.Spec.Template.Spec.InitContainers = addContainer(ds.Spec.Template.Spec.InitContainers)
+	return ds
+}
+
+// defaultedDeployment returns a Deployment with its fields populated.
+func defaultedDeployment() appsv1.Deployment {
+	var ds appsv1.Deployment
 	defaulter := test.NewNonZeroStructDefaulter()
 	Expect(defaulter.SetDefault(&ds)).ToNot(HaveOccurred())
 

--- a/pkg/render/common/components/components_test.go
+++ b/pkg/render/common/components/components_test.go
@@ -18,9 +18,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	v1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/ptr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1026,7 +1025,7 @@ var _ = Describe("Common components render tests", func() {
 					Spec: &v1.TyphaDeploymentSpec{
 						Template: &v1.TyphaDeploymentPodTemplateSpec{
 							Spec: &v1.TyphaDeploymentPodSpec{
-								TerminationGracePeriodSeconds: int64Ptr(3),
+								TerminationGracePeriodSeconds: ptr.Int64ToPtr(3),
 							},
 						},
 					},
@@ -1044,8 +1043,8 @@ var _ = Describe("Common components render tests", func() {
 						Strategy: &appsv1.DeploymentStrategy{
 							Type: appsv1.RollingUpdateDeploymentStrategyType,
 							RollingUpdate: &appsv1.RollingUpdateDeployment{
-								MaxUnavailable: intOrStrPtr("0"),
-								MaxSurge:       intOrStrPtr("100%"),
+								MaxUnavailable: ptr.IntOrStrPtr("0"),
+								MaxSurge:       ptr.IntOrStrPtr("100%"),
 							},
 						},
 					},
@@ -1055,22 +1054,13 @@ var _ = Describe("Common components render tests", func() {
 				Expect(result.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{
 					Type: appsv1.RollingUpdateDeploymentStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateDeployment{
-						MaxUnavailable: intOrStrPtr("0"),
-						MaxSurge:       intOrStrPtr("100%"),
+						MaxUnavailable: ptr.IntOrStrPtr("0"),
+						MaxSurge:       ptr.IntOrStrPtr("100%"),
 					},
 				}))
 			}),
 	)
 })
-
-func intOrStrPtr(v string) *intstr.IntOrString {
-	ios := intstr.Parse(v)
-	return &ios
-}
-
-func int64Ptr(n int64) *int64 {
-	return &n
-}
 
 func addContainer(cs []corev1.Container) []corev1.Container {
 	// Add another container and rename them to "not-zero1" and "not-zero2".

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -45,6 +45,9 @@ const (
 	TyphaPort               int32 = 5473
 
 	TyphaContainerName = "calico-typha"
+
+	defaultTyphaTerminationGracePeriod = 300
+	shutdownTimeoutEnvVar              = "TYPHA_SHUTDOWNTIMEOUTSECS"
 )
 
 var (
@@ -346,10 +349,23 @@ func (c *typhaComponent) typhaRole() *rbacv1.ClusterRole {
 
 // typhaDeployment creates the typha deployment.
 func (c *typhaComponent) typhaDeployment() *appsv1.Deployment {
-	var terminationGracePeriod int64 = 0
+	// We set a fairly long grace period by default. Typha sheds load during the grace period rather than
+	// disconnecting all clients at once.
+	var terminationGracePeriod int64 = defaultTyphaTerminationGracePeriod
 	var revisionHistoryLimit int32 = 2
+	// Allowing 1 unavailable Typha by default ensures that we make progress in a cluster with constrained scheduling.
 	maxUnavailable := intstr.FromInt(1)
-	maxSurge := intstr.FromString("25%")
+	// Allowing 100% surge allows a complete replacement fleet of Typha instances to start during an upgrade. When
+	// combined with Typha's graceful shutdown, we get nice emergenet behavior:
+	// - All up-level Typhas start if there's room available.
+	// - Back-level Typhas shed load slowly over the termination grace period.
+	// - Clients that are shed end up connecting to up-level Typhas (because all the back-level Typhas are marked
+	//   as terminating once all the up-level Typhas are ready).  This tends to avoid bouncing a client multiple
+	//   times during an upgrade.
+	// - If there's any sort of version skew issue where a back-level client can't understand an up-level Typha,
+	//   it'll go non-ready and Kubernetes will upgrade it.  This is rate limited by Typha's load-shedding rate,
+	//   so we shouldn't get a "thundering herd".
+	maxSurge := intstr.FromString("100%")
 
 	annotations := c.cfg.TLS.TrustedBundle.HashAnnotations()
 	annotations[c.cfg.TLS.TyphaSecret.HashAnnotationKey()] = c.cfg.TLS.TyphaSecret.HashAnnotationValue()
@@ -411,7 +427,42 @@ func (c *typhaComponent) typhaDeployment() *appsv1.Deployment {
 	if overrides := c.cfg.Installation.TyphaDeployment; overrides != nil {
 		rcomp.ApplyDeploymentOverrides(&d, overrides)
 	}
+
+	// ApplyDeploymentOverrides patches some fields that have consistency requirements elsewhere in the spec.
+	// fix up the other places.
+	c.applyPostOverrideFixUps(&d)
+
 	return &d
+}
+
+func (c *typhaComponent) applyPostOverrideFixUps(d *appsv1.Deployment) {
+	// The deployment overrides may update the termination grace period and typha needs to know what the grace
+	// period is in order to calculate its shutdown disconnection rate.  Copy that over to an env var.
+	terminationGracePeriod := *d.Spec.Template.Spec.TerminationGracePeriodSeconds
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name != TyphaContainerName {
+			continue
+		}
+		for i, e := range c.Env {
+			if e.Name != shutdownTimeoutEnvVar {
+				continue
+			}
+			c.Env[i].Value = fmt.Sprint(terminationGracePeriod)
+			break
+		}
+		break
+	}
+
+	// If the termination grace period has been set to a very high value, make sure the Deployment's progress
+	// deadline takes account of that.
+	minProgressDeadline := int32(terminationGracePeriod * 120 / 100)
+	if minProgressDeadline < 600 {
+		// 600 is the Kubernetes default so let's not go below that.
+		minProgressDeadline = 600
+	}
+	if d.Spec.ProgressDeadlineSeconds == nil || *d.Spec.ProgressDeadlineSeconds < minProgressDeadline {
+		d.Spec.ProgressDeadlineSeconds = &minProgressDeadline
+	}
 }
 
 // volumes creates the typha's volumes.
@@ -476,6 +527,7 @@ func (c *typhaComponent) typhaEnvVars() []corev1.EnvVar {
 		{Name: "TYPHA_SERVERCERTFILE", Value: c.cfg.TLS.TyphaSecret.VolumeMountCertificateFilePath()},
 		{Name: "TYPHA_SERVERKEYFILE", Value: c.cfg.TLS.TyphaSecret.VolumeMountKeyFilePath()},
 		{Name: "TYPHA_FIPSMODEENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
+		{Name: shutdownTimeoutEnvVar, Value: fmt.Sprint(defaultTyphaTerminationGracePeriod)}, // May get overridden later.
 	}
 	// We need at least the CN or URISAN set, we depend on the validation
 	// done by the core_controller that the Secret will have one.

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -356,7 +356,7 @@ func (c *typhaComponent) typhaDeployment() *appsv1.Deployment {
 	// Allowing 1 unavailable Typha by default ensures that we make progress in a cluster with constrained scheduling.
 	maxUnavailable := intstr.FromInt(1)
 	// Allowing 100% surge allows a complete replacement fleet of Typha instances to start during an upgrade. When
-	// combined with Typha's graceful shutdown, we get nice emergenet behavior:
+	// combined with Typha's graceful shutdown, we get nice emergent behavior:
 	// - All up-level Typhas start if there's room available.
 	// - Back-level Typhas shed load slowly over the termination grace period.
 	// - Clients that are shed end up connecting to up-level Typhas (because all the back-level Typhas are marked

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/onsi/gomega/gstruct"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/ptr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -168,8 +168,8 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(d.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{
 			Type: appsv1.RollingUpdateDeploymentStrategyType,
 			RollingUpdate: &appsv1.RollingUpdateDeployment{
-				MaxSurge:       intOrStrPtr("100%"),
-				MaxUnavailable: intOrStrPtr("1"),
+				MaxSurge:       ptr.IntOrStrPtr("100%"),
+				MaxUnavailable: ptr.IntOrStrPtr("1"),
 			},
 		}))
 	})
@@ -493,8 +493,8 @@ var _ = Describe("Typha rendering tests", func() {
 					Strategy: &appsv1.DeploymentStrategy{
 						Type: appsv1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateDeployment{
-							MaxSurge:       intOrStrPtr("2"),
-							MaxUnavailable: intOrStrPtr("0"),
+							MaxSurge:       ptr.IntOrStrPtr("2"),
+							MaxUnavailable: ptr.IntOrStrPtr("0"),
 						},
 					},
 					Template: &operatorv1.TyphaDeploymentPodTemplateSpec{
@@ -543,8 +543,8 @@ var _ = Describe("Typha rendering tests", func() {
 			Expect(d.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxSurge:       intOrStrPtr("2"),
-					MaxUnavailable: intOrStrPtr("0"),
+					MaxSurge:       ptr.IntOrStrPtr("2"),
+					MaxUnavailable: ptr.IntOrStrPtr("0"),
 				},
 			}))
 
@@ -687,8 +687,3 @@ var _ = Describe("Typha rendering tests", func() {
 		})
 	})
 })
-
-func intOrStrPtr(v string) *intstr.IntOrString {
-	ios := intstr.Parse(v)
-	return &ios
-}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Change default Typha terminationGracePeriodSeconds and deployment strategy to allow for graceful shutdown.
- Allow override of both of the above.

These changes expose the Typha change here: https://github.com/projectcalico/calico/pull/6973

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
