### PR TITLE
add gen-files and fix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -91,7 +91,7 @@ blocks:
           execution_time_limit:
             minutes: 15
           commands:
-            - make format-check validate-gen-versions fmt test-crds
+            - make format-check validate-gen-versions fmt test-crds gen-files fix
             - make dirty-check
             - make vet
             - make static-checks

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ foss-checks:
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: clean format-check validate-gen-versions static-checks image-all test dirty-check test-crds
+ci: clean format-check validate-gen-versions static-checks image-all test gen-files fix dirty-check test-crds
 
 validate-gen-versions:
 	make gen-versions


### PR DESCRIPTION
Semaphore now runs gen-files and fix before checking for dirty on static checks job.

Makefile::ci now also includes these goals.