### PR TITLE
Add functionality to include system root certs into the tigera-ca-bundle

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -70,6 +70,8 @@ type CertificateManager interface {
 	GetCertificate(cli client.Client, secretName, secretNamespace string) (certificatemanagement.CertificateInterface, error)
 	// CreateTrustedBundle creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
 	CreateTrustedBundle(certificates ...certificatemanagement.CertificateInterface) certificatemanagement.TrustedBundle
+	// CreateTrustedBundleWithSystemRootCertificates creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
+	CreateTrustedBundleWithSystemRootCertificates(certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error)
 	// AddToStatusManager lets the status manager monitor pending CSRs if the certificate management is enabled.
 	AddToStatusManager(manager status.StatusManager, namespace string)
 	// KeyPair Returns the CA KeyPairInterface, so it can be rendered in the operator namespace.
@@ -337,4 +339,9 @@ func HasExpectedDNSNames(secretName, secretNamespace string, cert *x509.Certific
 // CreateTrustedBundle creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
 func (cm *certificateManager) CreateTrustedBundle(certificates ...certificatemanagement.CertificateInterface) certificatemanagement.TrustedBundle {
 	return certificatemanagement.CreateTrustedBundle(append([]certificatemanagement.CertificateInterface{cm.keyPair}, certificates...)...)
+}
+
+// CreateTrustedBundleWithSystemRootCertificates creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
+func (cm *certificateManager) CreateTrustedBundleWithSystemRootCertificates(certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error) {
+	return certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(append([]certificatemanagement.CertificateInterface{cm.keyPair}, certificates...)...)
 }

--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -69,8 +69,13 @@ type CertificateManager interface {
 	// GetCertificate returns a Certificate. If the certificate is not found, nil is returned.
 	GetCertificate(cli client.Client, secretName, secretNamespace string) (certificatemanagement.CertificateInterface, error)
 	// CreateTrustedBundle creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
+	// It will include:
+	// - A bundle with Calico's root certificates + any user supplied certificates in /etc/pki/tls/certs/tigera-ca-bundle.crt.
 	CreateTrustedBundle(certificates ...certificatemanagement.CertificateInterface) certificatemanagement.TrustedBundle
 	// CreateTrustedBundleWithSystemRootCertificates creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
+	// It will include:
+	// - A bundle with Calico's root certificates + any user supplied certificates in /etc/pki/tls/certs/tigera-ca-bundle.crt.
+	// - A system root certificate bundle in /etc/pki/tls/certs/ca-bundle.crt.
 	CreateTrustedBundleWithSystemRootCertificates(certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error)
 	// AddToStatusManager lets the status manager monitor pending CSRs if the certificate management is enabled.
 	AddToStatusManager(manager status.StatusManager, namespace string)
@@ -337,11 +342,16 @@ func HasExpectedDNSNames(secretName, secretNamespace string, cert *x509.Certific
 }
 
 // CreateTrustedBundle creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
+// It will include:
+// - A bundle with Calico's root certificates + any user supplied certificates in /etc/pki/tls/certs/tigera-ca-bundle.crt.
 func (cm *certificateManager) CreateTrustedBundle(certificates ...certificatemanagement.CertificateInterface) certificatemanagement.TrustedBundle {
 	return certificatemanagement.CreateTrustedBundle(append([]certificatemanagement.CertificateInterface{cm.keyPair}, certificates...)...)
 }
 
 // CreateTrustedBundleWithSystemRootCertificates creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.
+// It will include:
+// - A bundle with Calico's root certificates + any user supplied certificates in /etc/pki/tls/certs/tigera-ca-bundle.crt.
+// - A system root certificate bundle in /etc/pki/tls/certs/ca-bundle.crt.
 func (cm *certificateManager) CreateTrustedBundleWithSystemRootCertificates(certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error) {
 	return certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(append([]certificatemanagement.CertificateInterface{cm.keyPair}, certificates...)...)
 }

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 		})
 		It("should load the system certificates into the bundle", func() {
 			if runtime.GOOS != "linux" {
-				Skip("Skip for users that run tests on different systems.")
+				Skip("Skip for users that run this test outside of a container on incompatible systems.")
 			}
 			trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates()
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -19,31 +19,32 @@ package certificatemanager_test
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"time"
 
-	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/controller/utils/imageset"
-
-	"github.com/openshift/library-go/pkg/crypto"
-	"github.com/tigera/operator/pkg/controller/certificatemanager"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-	"github.com/tigera/operator/pkg/tls"
-	"github.com/tigera/operator/pkg/tls/certificatemanagement"
-	"github.com/tigera/operator/test"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/library-go/pkg/crypto"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/controller/utils/imageset"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/tls"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/test"
+
 	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -58,7 +59,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 
 	var (
 		cli                 client.Client
-		scheme              *runtime.Scheme
+		scheme              *k8sruntime.Scheme
 		installation        *operatorv1.InstallationSpec
 		cm                  *operatorv1.CertificateManagement
 		clusterDomain       = "cluster.local"
@@ -73,7 +74,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 	)
 	BeforeEach(func() {
 		// Create a Kubernetes client.
-		scheme = runtime.NewScheme()
+		scheme = k8sruntime.NewScheme()
 		err := apis.AddToScheme(scheme)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -484,6 +485,20 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			Expect(trustedBundle.HashAnnotations()).To(HaveKey("hash.operator.tigera.io/tigera-ca-private"))
 			Expect(trustedBundle.HashAnnotations()).To(HaveKey("hash.operator.tigera.io/byo-secret"))
 			Expect(trustedBundle.HashAnnotations()).To(HaveKey("hash.operator.tigera.io/legacy-secret"))
+		})
+		It("should load the system certificates into the bundle", func() {
+			if runtime.GOOS != "linux" {
+				Skip("Skip for users that run tests on different systems.")
+			}
+			trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates()
+			Expect(err).NotTo(HaveOccurred())
+			configMap := trustedBundle.ConfigMap(appNs)
+			Expect(configMap.ObjectMeta).To(Equal(metav1.ObjectMeta{Name: certificatemanagement.TrustedCertConfigMapName, Namespace: appNs}))
+			Expect(configMap.TypeMeta).To(Equal(metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}))
+			By("counting the number of pem blocks in the configmap")
+			bundle := configMap.Data[certificatemanagement.RHELRootCertificateBundleName]
+			numBlocks := strings.Count(bundle, "-----BEGIN CERTIFICATE-----")
+			Expect(numBlocks > 1).To(BeTrue()) // We expect tens of them most likely.
 		})
 	})
 })

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -460,7 +460,11 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	}
 
 	var esLicenseType render.ElasticsearchLicenseType
-	trustedBundle := certificateManager.CreateTrustedBundle(esgwCertificate)
+	trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates(esgwCertificate)
+	if err != nil {
+		r.status.SetDegraded("Unable to create tigera-ca-bundle configmap", err.Error())
+		return reconcile.Result{}, err
+	}
 
 	if !isManagedCluster {
 		if esLicenseType, err = utils.GetElasticLicenseType(ctx, r.client, reqLogger); err != nil {

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -459,13 +459,15 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	var esLicenseType render.ElasticsearchLicenseType
+	// Intrusion detection controller sometimes needs to make requests to outside sources. Therefore, we include
+	// the system root certificate bundle.
 	trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates(esgwCertificate)
 	if err != nil {
 		r.status.SetDegraded("Unable to create tigera-ca-bundle configmap", err.Error())
 		return reconcile.Result{}, err
 	}
 
+	var esLicenseType render.ElasticsearchLicenseType
 	if !isManagedCluster {
 		if esLicenseType, err = utils.GetElasticLicenseType(ctx, r.client, reqLogger); err != nil {
 			r.status.SetDegraded("Failed to get Elasticsearch license", err.Error())

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -17,8 +17,6 @@ package render_test
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/render/testutils"
 
@@ -41,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -1021,6 +1021,7 @@ func trustedBundleVolume(bundle certificatemanagement.TrustedBundle) corev1.Volu
 	volume.ConfigMap.Items = []corev1.KeyToPath{
 		{Key: certificatemanagement.TrustedCertConfigMapKeyName, Path: certificatemanagement.TrustedCertConfigMapKeyName},
 		{Key: certificatemanagement.TrustedCertConfigMapKeyName, Path: SplunkFluentdSecretCertificateKey},
+		{Key: certificatemanagement.RHELRootCertificateBundleName, Path: certificatemanagement.RHELRootCertificateBundleName},
 	}
 	return volume
 }

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 									"--es.timeout=30s", "--es.ca=$(ELASTIC_CA)", "--web.listen-address=:9081",
 									"--web.telemetry-path=/metrics", "--tls.key=/tigera-ee-elasticsearch-metrics-tls/tls.key",
 									"--tls.crt=/tigera-ee-elasticsearch-metrics-tls/tls.crt",
-									"--ca.crt=/etc/pki/tigera/tigera-ca-bundle.crt"},
+									"--ca.crt=/etc/pki/tls/certs/tigera-ca-bundle.crt"},
 								Env: []corev1.EnvVar{
 									{Name: "FIPS_MODE_ENABLED", Value: "false"},
 									{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: "true"},
 			{Name: "VOLTRON_QUERYSERVER_ENDPOINT", Value: "https://tigera-api.tigera-system.svc:8080"},
 			{Name: "VOLTRON_QUERYSERVER_BASE_PATH", Value: "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy/"},
-			{Name: "VOLTRON_QUERYSERVER_CA_BUNDLE_PATH", Value: "/etc/pki/tigera/tigera-ca-bundle.crt"},
+			{Name: "VOLTRON_QUERYSERVER_CA_BUNDLE_PATH", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
 		}))
 
 		Expect(voltron.VolumeMounts).To(HaveLen(2))

--- a/pkg/tls/certificatemanagement/certificatebundle.go
+++ b/pkg/tls/certificatemanagement/certificatebundle.go
@@ -106,6 +106,9 @@ func (t *trustedBundle) HashAnnotations() map[string]string {
 	for hash, cert := range t.certificates {
 		annotations[fmt.Sprintf("hash.operator.tigera.io/%s", cert.GetName())] = hash
 	}
+	if len(t.systemCertificates) > 0 {
+		annotations["hash.operator.tigera.io/system"] = rmeta.AnnotationHash(t.systemCertificates)
+	}
 	return annotations
 }
 

--- a/pkg/tls/certificatemanagement/interface.go
+++ b/pkg/tls/certificatemanagement/interface.go
@@ -47,7 +47,7 @@ type KeyPairInterface interface {
 	CertificateInterface
 }
 
-// Certificate wraps the certificate. Combine this with a TrustedBundle, to mount a trusted certificate bundle to a pod.
+// CertificateInterface wraps the certificate. Combine this with a TrustedBundle, to mount a trusted certificate bundle to a pod.
 type CertificateInterface interface {
 	GetIssuer() CertificateInterface
 	GetCertificatePEM() []byte

--- a/pkg/tls/certificatemanagement/interface.go
+++ b/pkg/tls/certificatemanagement/interface.go
@@ -23,10 +23,10 @@ const (
 	CASecretName                      = "tigera-ca-private"
 	TrustedCertConfigMapName          = "tigera-ca-bundle"
 	TrustedCertConfigMapKeyName       = "tigera-ca-bundle.crt"
-	TrustedCertVolumeMountPath        = "/etc/pki/tigera/"
-	TrustedCertVolumeMountPathWindows = "c:/etc/pki/tigera/"
-	TrustedCertBundleMountPath        = "/etc/pki/tigera/tigera-ca-bundle.crt"
-	TrustedCertBundleMountPathWindows = "c:/etc/pki/tigera/tigera-ca-bundle.crt"
+	TrustedCertVolumeMountPath        = "/etc/pki/tls/certs/"
+	TrustedCertVolumeMountPathWindows = "c:/etc/pki/tls/certs/"
+	TrustedCertBundleMountPath        = "/etc/pki/tls/certs/tigera-ca-bundle.crt"
+	TrustedCertBundleMountPathWindows = "c:/etc/pki/tls/certs/tigera-ca-bundle.crt"
 )
 
 // KeyPairInterface wraps a Secret object that contains a private key and a certificate. Whether CertificateManagement is


### PR DESCRIPTION
There is a private doc motivating this change, please reach out to me.

In short, we want the ability to include system root ca's into the tigera-ca-bundle cm. This PR introduces a new function that - in addition to tigera-ca-bundle.crt - also includes ca-bundle.crt, which is copied from the operator's UBI base image.

This way it is possible to mount everything in /etc/pki/tls/certs/ without overriding and removing the system certs.


