### PR TITLE
Add system root ca in order to trust external identities providers

### DIFF
--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -266,6 +266,13 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, err
 	}
 
+	// Dex needs to trust a public CA, so we mount all the system certificates.
+	trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates()
+	if err != nil {
+		r.status.SetDegraded("Unable to create tigera-ca-bundle configmap", err.Error())
+		return reconcile.Result{}, err
+	}
+
 	// Dex will be configured with the contents of this secret, such as clientID and clientSecret.
 	idpSecret, err := utils.GetIdpSecret(ctx, r.client, authentication)
 	if err != nil {
@@ -312,6 +319,7 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		ClusterDomain: r.clusterDomain,
 		DeleteDex:     disableDex,
 		TLSKeyPair:    tlsKeyPair,
+		TrustedBundle: trustedBundle,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -17,6 +17,9 @@ package render_test
 import (
 	"fmt"
 
+	"github.com/tigera/operator/pkg/ptr"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -63,6 +66,57 @@ var _ = Describe("dex rendering tests", func() {
 			replicas       int32
 			cfg            *render.DexComponentConfiguration
 		)
+
+		var expectedVolumeMounts = []corev1.VolumeMount{
+			{Name: "config", MountPath: "/etc/dex/baseCfg", ReadOnly: true},
+			{Name: "secrets", MountPath: "/etc/dex/secrets", ReadOnly: true},
+			{Name: "tigera-dex-tls", MountPath: "/tigera-dex-tls", ReadOnly: true},
+			{Name: "tigera-ca-bundle", MountPath: "/etc/pki/tls/certs/", ReadOnly: true},
+		}
+
+		var expectedVolumes = []corev1.Volume{
+			{Name: "config",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "tigera-dex",
+						},
+						Items: []corev1.KeyToPath{
+							{Key: "config.yaml", Path: "config.yaml"},
+						},
+					},
+				}},
+			{Name: "secrets",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "tigera-oidc-credentials",
+						Items: []corev1.KeyToPath{
+							{Key: "serviceAccountSecret", Path: "google-groups.json"},
+						},
+						DefaultMode: ptr.Int32ToPtr(420),
+					},
+				}},
+			{Name: "tigera-dex-tls",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  "tigera-dex-tls",
+						DefaultMode: ptr.Int32ToPtr(420),
+					},
+				}},
+			{Name: "tigera-ca-bundle",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "tigera-ca-bundle",
+						},
+						Items: []corev1.KeyToPath{
+							{Key: certificatemanagement.TrustedCertConfigMapKeyName, Path: certificatemanagement.TrustedCertConfigMapKeyName},
+							{Key: certificatemanagement.TrustedCertConfigMapKeyName, Path: "ca.pem"},
+							{Key: certificatemanagement.RHELRootCertificateBundleName, Path: certificatemanagement.RHELRootCertificateBundleName},
+						},
+					},
+				}},
+		}
 
 		BeforeEach(func() {
 			scheme := runtime.NewScheme()
@@ -115,6 +169,8 @@ var _ = Describe("dex rendering tests", func() {
 			replicas = 2
 
 			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, dexSecret, idpSecret, clusterName)
+			trustedCaBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates()
+			Expect(err).NotTo(HaveOccurred())
 
 			cfg = &render.DexComponentConfiguration{
 				PullSecrets:   pullSecrets,
@@ -122,6 +178,7 @@ var _ = Describe("dex rendering tests", func() {
 				DexConfig:     dexCfg,
 				ClusterDomain: clusterName,
 				TLSKeyPair:    tlsKeyPair,
+				TrustedBundle: trustedCaBundle,
 			}
 		})
 
@@ -174,6 +231,12 @@ var _ = Describe("dex rendering tests", func() {
 				corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				}))
+
+			for k, v := range cfg.TrustedBundle.HashAnnotations() {
+				Expect(d.Spec.Template.Annotations).To(HaveKeyWithValue(k, v))
+			}
+			Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(expectedVolumeMounts))
+			Expect(d.Spec.Template.Spec.Volumes).To(BeEquivalentTo(expectedVolumes))
 		})
 
 		DescribeTable("should render the cluster name properly in the validator", func(clusterDomain string) {


### PR DESCRIPTION
## Description

Add tigera-dex bundle to dex, as we need to trust external sources when configuring OIDC providers. Since Dex image no longer adds certificates at build time, we will need to mount the certificates when `tigera-dex` are created. 

## For PR author

- [ x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
