### PR TITLE
Create node trustedbundle with root certificates.

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1524,11 +1524,17 @@ func GetOrCreateTyphaNodeTLSConfig(cli client.Client, certificateManager certifi
 		if len(configMap.Data[render.TyphaCABundleName]) == 0 {
 			errMsgs = append(errMsgs, fmt.Sprintf("ConfigMap %q does not have a field named %q", render.TyphaCAConfigMapName, render.TyphaCABundleName))
 		} else {
-			trustedBundle = certificateManager.CreateTrustedBundle(node, typha,
+			trustedBundle, err = certificateManager.CreateTrustedBundleWithSystemRootCertificates(node, typha,
 				certificatemanagement.NewCertificate(render.TyphaCAConfigMapName, []byte(configMap.Data[render.TyphaCABundleName]), nil))
+			if err != nil {
+				errMsgs = append(errMsgs, fmt.Sprintf("Error creating trusted bundle %s", err))
+			}
 		}
 	} else {
-		trustedBundle = certificateManager.CreateTrustedBundle(node, typha)
+		trustedBundle, err = certificateManager.CreateTrustedBundleWithSystemRootCertificates(node, typha)
+		if err != nil {
+			errMsgs = append(errMsgs, fmt.Sprintf("Error creating trusted bundle %s", err))
+		}
 	}
 	if len(errMsgs) != 0 {
 		return nil, fmt.Errorf(strings.Join(errMsgs, ";"))


### PR DESCRIPTION
## Description

When using EGWs in AWS, felix uses Ec2 APIs to read/set instances, IPs. These API calls started failing as these need to be signed with root certificate. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
