### PR TITLE
Fix that operator could not remove a ClusterIP.

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -137,7 +137,9 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 				return err
 			}
 
-			if err := c.client.Create(ctx, obj); err != nil {
+			// Do the Create() with the merged object so that we preserve external labels/annotations.
+			resetMetadataForCreate(mobj)
+			if err := c.client.Create(ctx, mobj); err != nil {
 				return err
 			}
 			return nil
@@ -152,8 +154,10 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 					logCtx.WithValues("key", key).Info("Failed to delete secret for recreation.")
 					return err
 				}
-				obj.SetResourceVersion("")
-				if err := c.client.Create(ctx, obj); err != nil {
+
+				// Do the Create() with the merged object so that we preserve external labels/annotations.
+				resetMetadataForCreate(mobj)
+				if err := c.client.Create(ctx, mobj); err != nil {
 					return err
 				}
 				return nil
@@ -169,8 +173,11 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 					logCtx.WithValues("key", key).Error(err, "Failed to delete Service for recreation.")
 					return err
 				}
-				if err := c.client.Create(ctx, obj); err != nil {
-					logCtx.WithValues("key", key).Error(err, "Failed to recreatae service.", "obj", obj)
+
+				// Do the Create() with the merged object so that we preserve external labels/annotations.
+				resetMetadataForCreate(mobj)
+				if err := c.client.Create(ctx, mobj); err != nil {
+					logCtx.WithValues("key", key).Error(err, "Failed to recreate service.", "obj", obj)
 					return err
 				}
 				return nil
@@ -182,6 +189,12 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 		}
 	}
 	return nil
+}
+
+func resetMetadataForCreate(obj client.Object) {
+	obj.SetResourceVersion("")
+	obj.SetUID("")
+	obj.SetCreationTimestamp(metav1.Time{})
 }
 
 func (c componentHandler) CreateOrUpdateOrDelete(ctx context.Context, component render.Component, status status.StatusManager) error {

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -140,6 +140,7 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 			if err := c.client.Create(ctx, obj); err != nil {
 				return err
 			}
+			return nil
 		case *v1.Secret:
 			objSecret := obj.(*v1.Secret)
 			curSecret := cur.(*v1.Secret)
@@ -155,17 +156,29 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 				if err := c.client.Create(ctx, obj); err != nil {
 					return err
 				}
-			} else {
-				if err := c.client.Update(ctx, mobj); err != nil {
-					logCtx.WithValues("key", key).Info("Failed to update object.")
+				return nil
+			}
+		case *v1.Service:
+			objService := obj.(*v1.Service)
+			curService := cur.(*v1.Service)
+			if objService.Spec.ClusterIP == "None" && curService.Spec.ClusterIP != "None" {
+				// We don't want this service to have a cluster IP, but it has got one already.  Need to recreate
+				// the service to remove it.
+				logCtx.WithValues("key", key).Info("Service already exists and has unwanted ClusterIP, recreating service.")
+				if err := c.client.Delete(ctx, obj); err != nil {
+					logCtx.WithValues("key", key).Error(err, "Failed to delete Service for recreation.")
 					return err
 				}
+				if err := c.client.Create(ctx, obj); err != nil {
+					logCtx.WithValues("key", key).Error(err, "Failed to recreatae service.", "obj", obj)
+					return err
+				}
+				return nil
 			}
-		default:
-			if err := c.client.Update(ctx, mobj); err != nil {
-				logCtx.WithValues("key", key).Info("Failed to update object.")
-				return err
-			}
+		}
+		if err := c.client.Update(ctx, mobj); err != nil {
+			logCtx.WithValues("key", key).Info("Failed to update object.")
+			return err
 		}
 	}
 	return nil
@@ -263,6 +276,10 @@ func (c componentHandler) CreateOrUpdateOrDelete(ctx context.Context, component 
 
 // mergeState returns the object to pass to Update given the current and desired object states.
 func mergeState(desired client.Object, current runtime.Object) client.Object {
+	// Take a copy of the desired object, so we can merge values into it without
+	// adjusting the caller's copy.
+	desired = desired.DeepCopyObject().(client.Object)
+
 	currentMeta := current.(metav1.ObjectMetaAccessor).GetObjectMeta()
 	desiredMeta := desired.(metav1.ObjectMetaAccessor).GetObjectMeta()
 
@@ -297,7 +314,10 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 		// and we need to maintain them on updates.
 		cs := current.(*v1.Service)
 		ds := desired.(*v1.Service)
-		ds.Spec.ClusterIP = cs.Spec.ClusterIP
+		if ds.Spec.ClusterIP != "None" {
+			// We want this service to keep its cluster IP.
+			ds.Spec.ClusterIP = cs.Spec.ClusterIP
+		}
 		return ds
 	case *batchv1.Job:
 		cj := current.(*batchv1.Job)

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -1026,6 +1026,57 @@ var _ = Describe("Component handler tests", func() {
 		},
 	)
 
+	It("recreates a service if its ClusterIP is removed", func() {
+		// Simulate creation of a service by earlier version of operator that includes a ClusterIP.
+		svcWithIP := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-service"},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.96.0.1",
+			},
+		}
+		fc := &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs: []client.Object{
+				svcWithIP,
+			},
+		}
+		err := handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcWithIP)).NotTo(HaveOccurred())
+		Expect(svcWithIP.Spec.ClusterIP).To(Equal("10.96.0.1"))
+
+		// Now pretend we're the new operator version, wanting to remove the cluster IP.
+		svcNoIP := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-service"},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "None",
+			},
+		}
+		fc = &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs: []client.Object{
+				svcNoIP,
+			},
+		}
+		err = handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcNoIP)).NotTo(HaveOccurred())
+		Expect(svcNoIP.Spec.ClusterIP).To(Equal("None"))
+
+		// The fake client resets the resource version to 1 on create.
+		Expect(svcNoIP.ObjectMeta.ResourceVersion).To(Equal("1"),
+			"Expected recreation of Service to reset resourceVersion to 1")
+
+		// Finally, make a normal change, this should result in an update.
+		svcNoIP.Labels = map[string]string{"foo": "bar"}
+		err = handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcNoIP)).NotTo(HaveOccurred())
+		Expect(svcNoIP.Labels).To(Equal(map[string]string{"foo": "bar"}))
+		Expect(svcNoIP.ObjectMeta.ResourceVersion).To(Equal("2"),
+			"Expected update to rev ResourceVersion")
+	})
+
 	It("allows you to replace a secret if the types change", func() {
 		// Please note that a fake client does not behave exactly as it would on K8s:
 		// - A secret without a type in a real cluster automatically becomes type Opaque

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -1029,7 +1029,12 @@ var _ = Describe("Component handler tests", func() {
 	It("recreates a service if its ClusterIP is removed", func() {
 		// Simulate creation of a service by earlier version of operator that includes a ClusterIP.
 		svcWithIP := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{Name: "my-service"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-service",
+				Labels: map[string]string{
+					"old": "should-be-preserved",
+				},
+			},
 			Spec: corev1.ServiceSpec{
 				ClusterIP: "10.96.0.1",
 			},
@@ -1044,10 +1049,18 @@ var _ = Describe("Component handler tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcWithIP)).NotTo(HaveOccurred())
 		Expect(svcWithIP.Spec.ClusterIP).To(Equal("10.96.0.1"))
+		Expect(svcWithIP.Labels).To(Equal(map[string]string{
+			"old": "should-be-preserved",
+		}))
 
 		// Now pretend we're the new operator version, wanting to remove the cluster IP.
 		svcNoIP := &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{Name: "my-service"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-service",
+				Labels: map[string]string{
+					"new": "should-be-added",
+				},
+			},
 			Spec: corev1.ServiceSpec{
 				ClusterIP: "None",
 			},
@@ -1062,17 +1075,25 @@ var _ = Describe("Component handler tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcNoIP)).NotTo(HaveOccurred())
 		Expect(svcNoIP.Spec.ClusterIP).To(Equal("None"))
+		Expect(svcNoIP.Labels).To(Equal(map[string]string{
+			"old": "should-be-preserved",
+			"new": "should-be-added",
+		}))
 
 		// The fake client resets the resource version to 1 on create.
 		Expect(svcNoIP.ObjectMeta.ResourceVersion).To(Equal("1"),
 			"Expected recreation of Service to reset resourceVersion to 1")
 
 		// Finally, make a normal change, this should result in an update.
-		svcNoIP.Labels = map[string]string{"foo": "bar"}
+		svcNoIP.Labels = map[string]string{"newer": "should-be-added"}
 		err = handler.CreateOrUpdateOrDelete(ctx, fc, sm)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcNoIP)).NotTo(HaveOccurred())
-		Expect(svcNoIP.Labels).To(Equal(map[string]string{"foo": "bar"}))
+		Expect(svcNoIP.Labels).To(Equal(map[string]string{
+			"old":   "should-be-preserved",
+			"new":   "should-be-added",
+			"newer": "should-be-added",
+		}))
 		Expect(svcNoIP.ObjectMeta.ResourceVersion).To(Equal("2"),
 			"Expected update to rev ResourceVersion")
 	})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

A recent fix removed ClusterIPs from our metrics services to make them headless.  That change cannot be applied via update, the service must be recreated.

- Add special case to `createOrUpdateObject` to handle services, modelled on similar logic for secrets/jobs. 
- Change `mergeState` to operate on a copy, otherwise it updates the resource version on the desired object, which makes `Create()` fail.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
