### PR TITLE
[v1.27] Fix that operator could not remove a ClusterIP.

### DIFF
--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -984,6 +984,78 @@ var _ = Describe("Component handler tests", func() {
 		},
 	)
 
+	It("recreates a service if its ClusterIP is removed", func() {
+		// Simulate creation of a service by earlier version of operator that includes a ClusterIP.
+		svcWithIP := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-service",
+				Labels: map[string]string{
+					"old": "should-be-preserved",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.96.0.1",
+			},
+		}
+		fc := &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs: []client.Object{
+				svcWithIP,
+			},
+		}
+		err := handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcWithIP)).NotTo(HaveOccurred())
+		Expect(svcWithIP.Spec.ClusterIP).To(Equal("10.96.0.1"))
+		Expect(svcWithIP.Labels).To(Equal(map[string]string{
+			"old": "should-be-preserved",
+		}))
+
+		// Now pretend we're the new operator version, wanting to remove the cluster IP.
+		svcNoIP := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-service",
+				Labels: map[string]string{
+					"new": "should-be-added",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "None",
+			},
+		}
+		fc = &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs: []client.Object{
+				svcNoIP,
+			},
+		}
+		err = handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcNoIP)).NotTo(HaveOccurred())
+		Expect(svcNoIP.Spec.ClusterIP).To(Equal("None"))
+		Expect(svcNoIP.Labels).To(Equal(map[string]string{
+			"old": "should-be-preserved",
+			"new": "should-be-added",
+		}))
+
+		// The fake client resets the resource version to 1 on create.
+		Expect(svcNoIP.ObjectMeta.ResourceVersion).To(Equal("1"),
+			"Expected recreation of Service to reset resourceVersion to 1")
+
+		// Finally, make a normal change, this should result in an update.
+		svcNoIP.Labels = map[string]string{"newer": "should-be-added"}
+		err = handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: "my-service"}, svcNoIP)).NotTo(HaveOccurred())
+		Expect(svcNoIP.Labels).To(Equal(map[string]string{
+			"old":   "should-be-preserved",
+			"new":   "should-be-added",
+			"newer": "should-be-added",
+		}))
+		Expect(svcNoIP.ObjectMeta.ResourceVersion).To(Equal("2"),
+			"Expected update to rev ResourceVersion")
+	})
+
 	It("allows you to replace a secret if the types change", func() {
 		// Please note that a fake client does not behave exactly as it would on K8s:
 		// - A secret without a type in a real cluster automatically becomes type Opaque


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
A recent fix removed ClusterIPs from our metrics services to make them headless.  That change cannot be applied via update, the service must be recreated.

Backport of #2353 
## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
