### PR TITLE
Support rolling updates during upgrades by preserving legacy fields in tls secrets

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -265,6 +265,7 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 		Name:           secretName,
 		PrivateKeyPEM:  keyPEM,
 		CertificatePEM: certPEM,
+		OriginalSecret: secret,
 	}, x509Cert, nil
 
 }

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -52,9 +52,11 @@ import (
 var _ = Describe("Test CertificateManagement suite", func() {
 
 	const (
-		appSecretName  = "my-app-tls"
-		appSecretName2 = "my-app-tls-2"
-		appNs          = "my-app"
+		appSecretName       = "my-app-tls"
+		appSecretName2      = "my-app-tls-2"
+		appNs               = "my-app"
+		legacyKeyFieldName  = "key"
+		legacyCertFieldName = "cert"
 	)
 
 	var (
@@ -93,7 +95,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 		cm = &operatorv1.CertificateManagement{CACert: keyPair.GetCertificatePEM()}
 
 		// Create a legacy secret (how certs were before v1.24) with non-standardized legacy key and cert name.
-		legacySecret, err = secret.CreateTLSSecret(nil, appSecretName, appNs, "key", "cert", time.Hour, nil, appSecretName)
+		legacySecret, err = secret.CreateTLSSecret(nil, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, time.Hour, nil, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create a byo secret with non-standardized legacy key and cert name (like our docs for felix/typha).
@@ -106,14 +108,13 @@ var _ = Describe("Test CertificateManagement suite", func() {
 
 		legacyCryptoCA, err := tls.MakeCA(rmeta.TigeraOperatorCAIssuerPrefix + "@some-hash")
 		Expect(err).NotTo(HaveOccurred())
-		expiredLegacySecret, err = secret.CreateTLSSecret(legacyCryptoCA, appSecretName, appNs, "key", "cert", -time.Hour, nil, appSecretName)
+		expiredLegacySecret, err = secret.CreateTLSSecret(legacyCryptoCA, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, -time.Hour, nil, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
 
 		ca, err := crypto.GetCAFromBytes(certificateManager.KeyPair().GetCertificatePEM(), certificateManager.KeyPair().Secret("").Data[corev1.TLSPrivateKeyKey])
 		Expect(err).NotTo(HaveOccurred())
-		expiredSecret, err = secret.CreateTLSSecret(ca, appSecretName, appNs, "key", "cert", -time.Hour, nil, appSecretName)
+		expiredSecret, err = secret.CreateTLSSecret(ca, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, -time.Hour, nil, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
-
 	})
 
 	Describe("test CertificateManager interface", func() {
@@ -420,6 +421,10 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			By("verifying that the non-standard secret fields have been standardized")
 			Expect(keyPair.Secret(appNs).Data[corev1.TLSPrivateKeyKey]).NotTo(BeNil())
 			Expect(keyPair.Secret(appNs).Data[corev1.TLSCertKey]).NotTo(BeNil())
+
+			By("verifying that the legacy fields have been preserved for certain edge-cases in cluster upgrades")
+			Expect(keyPair.Secret(appNs).Data[legacyKeyFieldName]).NotTo(BeNil())
+			Expect(keyPair.Secret(appNs).Data[legacyCertFieldName]).NotTo(BeNil())
 		})
 	})
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1156,6 +1156,20 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	}
 
+	components = append(components,
+		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
+			Namespace:       common.CalicoNamespace,
+			ServiceAccounts: []string{render.CalicoNodeObjectName, render.TyphaServiceAccountName},
+			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+				// this controller is responsible for rendering the tigera-ca-private secret.
+				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
+				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
+				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
+			},
+			TrustedBundle: typhaNodeTLS.TrustedBundle,
+		}))
 	// Build a configuration for rendering calico/typha.
 	typhaCfg := render.TyphaConfiguration{
 		K8sServiceEp:           k8sapi.Endpoint,
@@ -1217,21 +1231,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		BindMode:                bgpConfiguration.Spec.BindMode,
 	}
 	components = append(components, render.Node(&nodeCfg))
-
-	components = append(components,
-		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       common.CalicoNamespace,
-			ServiceAccounts: []string{render.CalicoNodeObjectName, render.TyphaServiceAccountName},
-			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
-				// this controller is responsible for rendering the tigera-ca-private secret.
-				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
-				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
-				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
-				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, true, true),
-				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
-			},
-			TrustedBundle: typhaNodeTLS.TrustedBundle,
-		}))
 
 	// Build a configuration for rendering calico/kube-controllers.
 	kubeControllersCfg := kubecontrollers.KubeControllersConfiguration{

--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -1,3 +1,20 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This renderer is responsible for all resources related to a Guardian Deployment in a
+// multicluster setup.
+
 package certificatemanagement
 
 import (
@@ -25,6 +42,9 @@ type KeyPair struct {
 	*operatorv1.CertificateManagement
 	DNSNames []string
 	Issuer   KeyPairInterface
+
+	// OriginalSecret maintains a copy of the secret that the KeyPair was created from.
+	OriginalSecret *corev1.Secret
 }
 
 func (k *KeyPair) GetCertificatePEM() []byte {
@@ -46,13 +66,20 @@ func (k *KeyPair) BYO() bool {
 }
 
 func (k *KeyPair) Secret(namespace string) *corev1.Secret {
+	var data map[string][]byte
+	if k.OriginalSecret == nil {
+		data = make(map[string][]byte)
+	} else {
+		// Preserve original fields, such as uri-san, common-name or legacy names for tls.key and tls.crt.
+		// This is necessary for example to support rolling calico-node updates of larger clusters from older versions.
+		data = k.OriginalSecret.Data
+	}
+	data[corev1.TLSPrivateKeyKey] = k.PrivateKeyPEM
+	data[corev1.TLSCertKey] = k.CertificatePEM
 	return &corev1.Secret{
 		TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: k.GetName(), Namespace: namespace},
-		Data: map[string][]byte{
-			corev1.TLSPrivateKeyKey: k.PrivateKeyPEM,
-			corev1.TLSCertKey:       k.CertificatePEM,
-		},
+		Data:       data,
 	}
 }
 

--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This renderer is responsible for all resources related to a Guardian Deployment in a
-// multicluster setup.
-
 package certificatemanagement
 
 import (


### PR DESCRIPTION
Support rolling updates during upgrades by preserving legacy fields in tls secrets