### PR TITLE
Add linseed component

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -33,6 +33,9 @@ components:
   es-proxy:
     image: tigera/es-proxy
     version: master
+  linseed:
+    image: tigera/linseed
+    version: master
   es-gateway:
     image: tigera/es-gateway
     version: master

--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -44,6 +44,7 @@ var defaultImages = map[string]string{
 	"key-cert-provisioner":       "tigera/key-cert-provisioner",
 	"calico/apiserver":           "calico/apiserver",
 	"calico/windows-upgrade":     "calico/windows-upgrade",
+	"tigera/linseed":             "tigera/linseed",
 }
 
 var ignoredImages = map[string]struct{}{

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -118,6 +118,12 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components "linseed" }}
+	ComponentLinseed = component{
+		Version: "{{ .Version }}",
+		Image:   "{{ .Image }}",
+	}
+{{- end }}
 {{ with .Components.fluentd }}
 	ComponentFluentd = component{
 		Version: "{{ .Version }}",

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -102,6 +102,11 @@ var (
 		Image:   "tigera/es-gateway",
 	}
 
+	ComponentLinseed = component{
+		Version: "master",
+		Image:   "tigera/linseed",
+	}
+
 	ComponentFluentd = component{
 		Version: "master",
 		Image:   "tigera/fluentd",

--- a/pkg/controller/logstorage/linseed.go
+++ b/pkg/controller/logstorage/linseed.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logstorage
+
+import (
+	"context"
+
+	"github.com/tigera/operator/pkg/render/logstorage/linseed"
+	"github.com/tigera/operator/pkg/render/monitor"
+
+	"github.com/go-logr/logr"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/dns"
+	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/controller/utils/imageset"
+	"github.com/tigera/operator/pkg/render"
+)
+
+func (r *ReconcileLogStorage) createLinseed(
+	install *operatorv1.InstallationSpec,
+	variant operatorv1.ProductVariant,
+	pullSecrets []*corev1.Secret,
+	hdler utils.ComponentHandler,
+	reqLogger logr.Logger,
+	ctx context.Context,
+	certificateManager certificatemanager.CertificateManager,
+) (reconcile.Result, bool, error) {
+	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
+	svcDNSNames = append(svcDNSNames, dns.GetServiceDNSNames(linseed.ServiceName, render.ElasticsearchNamespace, r.clusterDomain)...)
+
+	linseedKeyPair, err := certificateManager.GetOrCreateKeyPair(r.client, render.TigeraLinseedSecret, common.OperatorNamespace(), svcDNSNames)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating TLS certificate", err, reqLogger)
+		return reconcile.Result{}, false, err
+	}
+
+	prometheusCertificate, err := certificateManager.GetCertificate(r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, reqLogger)
+		return reconcile.Result{}, false, err
+	} else if prometheusCertificate == nil {
+		reqLogger.Info("Prometheus secrets are not available yet, waiting until they become available")
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Prometheus secrets are not available yet, waiting until they become available", nil, reqLogger)
+		return reconcile.Result{}, false, nil
+	}
+
+	esInternalCertificate, err := certificateManager.GetCertificate(r.client, render.TigeraElasticsearchInternalCertSecret, common.OperatorNamespace())
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch tls certificate secret", err, reqLogger)
+		return reconcile.Result{}, false, err
+	} else if esInternalCertificate == nil {
+		reqLogger.Info("Waiting for internal Elasticsearch tls certificate secret to be available")
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for internal Elasticsearch tls certificate secret to be available", nil, reqLogger)
+		return reconcile.Result{}, false, nil
+	}
+	trustedBundle := certificateManager.CreateTrustedBundle(esInternalCertificate, prometheusCertificate)
+
+	cfg := &linseed.Config{
+		Installation:  install,
+		PullSecrets:   pullSecrets,
+		TrustedBundle: trustedBundle,
+		ClusterDomain: r.clusterDomain,
+		KeyPair:       linseedKeyPair,
+	}
+
+	linseedComponent := linseed.Linseed(cfg)
+
+	if err = imageset.ApplyImageSet(ctx, r.client, variant, linseedComponent); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
+		return reconcile.Result{}, false, err
+	}
+
+	certificateComponent := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
+		Namespace:       render.ElasticsearchNamespace,
+		ServiceAccounts: []string{linseed.ServiceAccountName},
+		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+			rcertificatemanagement.NewKeyPairOption(linseedKeyPair, true, true),
+		},
+		TrustedBundle: trustedBundle,
+	})
+
+	for _, comp := range []render.Component{linseedComponent, certificateComponent} {
+		if err := hdler.CreateOrUpdateOrDelete(ctx, comp, r.status); err != nil {
+			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating / deleting resource", err, reqLogger)
+			return reconcile.Result{}, false, err
+		}
+	}
+	return reconcile.Result{}, true, nil
+}

--- a/pkg/controller/logstorage/logstorage.go
+++ b/pkg/controller/logstorage/logstorage.go
@@ -333,6 +333,8 @@ func addLogStorageWatches(c controller.Controller) error {
 		return fmt.Errorf("log-storage-controller failed to watch primary resource: %w", err)
 	}
 
+	//TODO(Alina): Add watch for TenantID
+
 	for _, name := range []string{
 		render.OIDCUsersConfigMapName, render.OIDCUsersEsSecreteName,
 		render.ElasticsearchAdminUserSecret,

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/tigera/operator/pkg/render/logstorage/linseed"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -81,6 +83,7 @@ var (
 
 	esDNSNames         = dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
 	esGatewayDNSNmes   = dns.GetServiceDNSNames(esgateway.ServiceName, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
+	linseedDNSNmes     = dns.GetServiceDNSNames(linseed.ServiceName, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
 	kbDNSNames         = dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, dns.DefaultClusterDomain)
 	kbInternalDNSNames = dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, dns.DefaultClusterDomain)
 )
@@ -1499,6 +1502,7 @@ var _ = Describe("LogStorage controller", func() {
 									{Image: "tigera/es-curator", Digest: "sha256:escuratorhash"},
 									{Image: "tigera/elasticsearch-metrics", Digest: "sha256:esmetricshash"},
 									{Image: "tigera/es-gateway", Digest: "sha256:esgatewayhash"},
+									{Image: "tigera/linseed", Digest: "sha256:linseedhash"},
 								},
 							},
 						})).ToNot(HaveOccurred())
@@ -1609,6 +1613,23 @@ var _ = Describe("LogStorage controller", func() {
 							fmt.Sprintf("some.registry.org/%s@%s",
 								components.ComponentESGateway.Image,
 								"sha256:esgatewayhash")))
+
+						linseedDp := appsv1.Deployment{
+							TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      linseed.DeploymentName,
+								Namespace: render.ElasticsearchNamespace,
+							},
+						}
+						Expect(test.GetResource(cli, &linseedDp)).To(BeNil())
+						Expect(linseedDp.Spec.Template.Spec.Containers).To(HaveLen(1))
+						linseed := test.GetContainer(linseedDp.Spec.Template.Spec.Containers, linseed.DeploymentName)
+						Expect(linseed).ToNot(BeNil())
+						Expect(linseed.Image).To(Equal(
+							fmt.Sprintf("some.registry.org/%s@%s",
+								components.ComponentLinseed.Image,
+								"sha256:linseedhash")))
+
 					})
 				})
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -66,6 +66,10 @@ const (
 
 	ElasticsearchNamespace = "tigera-elasticsearch"
 
+	// TigeraLinseedSecret is the TLS key pair that is mounted into Linseed, used in mTLS establishment
+	// with its clients.
+	TigeraLinseedSecret = "tigera-secure-linseed-cert"
+
 	// TigeraElasticsearchGatewaySecret is the TLS key pair that is mounted by Elasticsearch gateway.
 	TigeraElasticsearchGatewaySecret = "tigera-secure-elasticsearch-cert"
 	// TigeraElasticsearchInternalCertSecret is the TLS key pair that is mounted by the Elasticsearch pods.
@@ -155,21 +159,27 @@ const (
 	caVolumeName = "elasticsearch-certs"
 )
 
-var ElasticsearchSelector = fmt.Sprintf("elasticsearch.k8s.elastic.co/cluster-name == '%s'", ElasticsearchName)
-var ElasticsearchEntityRule = v3.EntityRule{
-	NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
-	Selector:          ElasticsearchSelector,
-	Ports:             []numorstring.Port{{MinPort: ElasticsearchDefaultPort, MaxPort: ElasticsearchDefaultPort}},
-}
+var (
+	ElasticsearchSelector   = fmt.Sprintf("elasticsearch.k8s.elastic.co/cluster-name == '%s'", ElasticsearchName)
+	ElasticsearchEntityRule = v3.EntityRule{
+		NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
+		Selector:          ElasticsearchSelector,
+		Ports:             []numorstring.Port{{MinPort: ElasticsearchDefaultPort, MaxPort: ElasticsearchDefaultPort}},
+	}
+)
+
 var InternalElasticsearchEntityRule = v3.EntityRule{
 	NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
 	Selector:          ElasticsearchSelector,
 	Ports:             []numorstring.Port{{MinPort: ElasticsearchInternalPort, MaxPort: ElasticsearchInternalPort}},
 }
-var KibanaEntityRule = networkpolicy.CreateEntityRule(KibanaNamespace, KibanaName, KibanaPort)
-var KibanaSourceEntityRule = networkpolicy.CreateSourceEntityRule(KibanaNamespace, KibanaName)
-var ECKOperatorSourceEntityRule = networkpolicy.CreateSourceEntityRule(ECKOperatorNamespace, ECKOperatorName)
-var ESCuratorSourceEntityRule = networkpolicy.CreateSourceEntityRule(ElasticsearchNamespace, EsCuratorName)
+
+var (
+	KibanaEntityRule            = networkpolicy.CreateEntityRule(KibanaNamespace, KibanaName, KibanaPort)
+	KibanaSourceEntityRule      = networkpolicy.CreateSourceEntityRule(KibanaNamespace, KibanaName)
+	ECKOperatorSourceEntityRule = networkpolicy.CreateSourceEntityRule(ECKOperatorNamespace, ECKOperatorName)
+	ESCuratorSourceEntityRule   = networkpolicy.CreateSourceEntityRule(ElasticsearchNamespace, EsCuratorName)
+)
 
 var log = logf.Log.WithName("render")
 
@@ -543,7 +553,6 @@ func (es elasticsearchComponent) javaOpts() string {
 			"-Djavax.net.ssl.trustStoreType=BCFKS "+
 			"-Djavax.net.ssl.trustStorePassword=%s "+
 			"-Dorg.bouncycastle.fips.approved_only=true", javaOpts, es.cfg.KeyStoreSecret.Data[ElasticsearchKeystoreEnvName])
-
 	}
 	return javaOpts
 }
@@ -1365,7 +1374,6 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 
 		initContainers = append(initContainers, csrInitContainer)
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-
 			Name:      csrVolumeNameHTTP,
 			MountPath: "/mnt/elastic-internal/http-certs/",
 		})

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -1,0 +1,416 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linseed
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tigera/operator/pkg/render/intrusiondetection/dpi"
+	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
+	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+const (
+	DeploymentName             = "linseed"
+	ServiceAccountName         = "linseed"
+	RoleName                   = "linseed"
+	ServiceName                = "linseed"
+	PolicyName                 = networkpolicy.TigeraComponentPolicyPrefix + "es-gateway-access"
+	PortName                   = "https"
+	Port                       = 443
+	ElasticsearchHTTPSEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
+)
+
+func Linseed(c *Config) render.Component {
+	return &linseed{
+		cfg:       c,
+		namespace: render.ElasticsearchNamespace,
+	}
+}
+
+type linseed struct {
+	linseedImage string
+	csrImage     string
+	cfg          *Config
+
+	// Namespace in which to provision namespaced resources.
+	namespace string
+}
+
+// Config contains all the information needed to render the Linseed component.
+type Config struct {
+	// CustomResources provided by the user.
+	Installation *operatorv1.InstallationSpec
+
+	// Pull secrets provided by the user.
+	PullSecrets []*corev1.Secret
+
+	// Keypair to use for asserting Linseed's identity.
+	KeyPair certificatemanagement.KeyPairInterface
+
+	// Trusted bundle to use when validating client certificates.
+	TrustedBundle certificatemanagement.TrustedBundle
+
+	// ClusterDomain to use when building service URLs.
+	ClusterDomain string
+}
+
+func (e *linseed) ResolveImages(is *operatorv1.ImageSet) error {
+	reg := e.cfg.Installation.Registry
+	path := e.cfg.Installation.ImagePath
+	prefix := e.cfg.Installation.ImagePrefix
+	var err error
+	errMsgs := []string{}
+
+	// Calculate the image(s) to use for Linseed, given user registry configuration.
+	e.linseedImage, err = components.GetReference(components.ComponentLinseed, reg, path, prefix, is)
+	if err != nil {
+		errMsgs = append(errMsgs, err.Error())
+	}
+
+	if e.cfg.Installation.CertificateManagement != nil {
+		e.csrImage, err = certificatemanagement.ResolveCSRInitImage(e.cfg.Installation, is)
+		if err != nil {
+			errMsgs = append(errMsgs, err.Error())
+		}
+	}
+	if len(errMsgs) != 0 {
+		return fmt.Errorf(strings.Join(errMsgs, ","))
+	}
+	return nil
+}
+
+func (e *linseed) Objects() (toCreate, toDelete []client.Object) {
+	toCreate = append(toCreate, e.linseedAllowTigeraPolicy())
+	toCreate = append(toCreate, e.linseedService())
+	toCreate = append(toCreate, e.linseedRole())
+	toCreate = append(toCreate, e.linseedRoleBinding())
+	toCreate = append(toCreate, e.linseedServiceAccount())
+	toCreate = append(toCreate, e.linseedDeployment())
+	return toCreate, toDelete
+}
+
+func (e *linseed) Ready() bool {
+	return true
+}
+
+func (e *linseed) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeLinux
+}
+
+func (e linseed) linseedRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: e.namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				// Linseed uses subject access review to perform authorization of clients.
+				APIGroups:     []string{"authorization.k8s.io"},
+				Resources:     []string{"subjectaccessreview"},
+				ResourceNames: []string{},
+				Verbs:         []string{"create"},
+			},
+		},
+	}
+}
+
+func (e linseed) linseedRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: e.namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     RoleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      ServiceAccountName,
+				Namespace: e.namespace,
+			},
+		},
+	}
+}
+
+func (e linseed) linseedDeployment() *appsv1.Deployment {
+	envVars := []corev1.EnvVar{
+		{Name: "LINSEED_LOG_LEVEL", Value: "INFO"},
+
+		// Configuration for linseed API.
+		{Name: "LINSEED_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(e.cfg.Installation.FIPSMode)},
+		{Name: "LINSEED_HTTPS_CERT", Value: e.cfg.KeyPair.VolumeMountCertificateFilePath()},
+		{Name: "LINSEED_HTTPS_KEY", Value: e.cfg.KeyPair.VolumeMountKeyFilePath()},
+
+		// Configuration for connection to Elasticsearch.
+		{Name: "LINSEED_ELASTIC_ENDPOINT", Value: ElasticsearchHTTPSEndpoint},
+	}
+
+	var initContainers []corev1.Container
+	if e.cfg.KeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, e.cfg.KeyPair.InitContainer(e.namespace))
+	}
+
+	volumes := []corev1.Volume{
+		e.cfg.KeyPair.Volume(),
+		e.cfg.TrustedBundle.Volume(),
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		e.cfg.KeyPair.VolumeMount(e.SupportedOSType()),
+		e.cfg.TrustedBundle.VolumeMount(e.SupportedOSType()),
+	}
+
+	annotations := e.cfg.TrustedBundle.HashAnnotations()
+	annotations[e.cfg.KeyPair.HashAnnotationKey()] = e.cfg.KeyPair.HashAnnotationValue()
+	podTemplate := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        DeploymentName,
+			Namespace:   e.namespace,
+			Annotations: annotations,
+		},
+		Spec: corev1.PodSpec{
+			Tolerations:        e.cfg.Installation.ControlPlaneTolerations,
+			NodeSelector:       e.cfg.Installation.ControlPlaneNodeSelector,
+			ServiceAccountName: ServiceAccountName,
+			ImagePullSecrets:   secret.GetReferenceList(e.cfg.PullSecrets),
+			Volumes:            volumes,
+			InitContainers:     initContainers,
+			Containers: []corev1.Container{
+				{
+					Name:         DeploymentName,
+					Image:        e.linseedImage,
+					Env:          envVars,
+					VolumeMounts: volumeMounts,
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/health",
+								Port:   intstr.FromInt(Port),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       5,
+					},
+				},
+			},
+		},
+	}
+
+	if e.cfg.Installation.ControlPlaneReplicas != nil && *e.cfg.Installation.ControlPlaneReplicas > 1 {
+		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity(DeploymentName, e.namespace)
+	}
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: e.namespace,
+			Labels: map[string]string{
+				"k8s-app": DeploymentName,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+			Template: *podTemplate,
+			Replicas: e.cfg.Installation.ControlPlaneReplicas,
+		},
+	}
+}
+
+func (e linseed) linseedServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceAccountName,
+			Namespace: e.namespace,
+		},
+	}
+}
+
+func (e linseed) linseedService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName,
+			Namespace: e.namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"k8s-app": DeploymentName},
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       PortName,
+					Port:       int32(Port),
+					TargetPort: intstr.FromInt(Port),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}
+
+// Allow access to Linseed from components that need it.
+func (e *linseed) linseedAllowTigeraPolicy() *v3.NetworkPolicy {
+	// Egress needs to be allowed to:
+	// - Kubernetes API
+	// - Cluster DNS
+	// - Elasticsearch
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, e.cfg.Installation.KubernetesProvider == operatorv1.ProviderOpenShift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerServiceSelectorEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.ElasticsearchEntityRule,
+		},
+	}...)
+
+	// Ingress needs to be allowed from all clients.
+	esgatewayIngressDestinationEntityRule := v3.EntityRule{
+		Ports: networkpolicy.Ports(Port),
+	}
+	return &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PolicyName,
+			Namespace: e.namespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.TigeraComponentTierName,
+			Selector: networkpolicy.KubernetesAppSelector(DeploymentName),
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
+			Ingress: []v3.Rule{
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.FluentdSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.EKSLogForwarderEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.IntrusionDetectionInstallerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ESCuratorSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ManagerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceBenchmarkerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceControllerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceServerSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceSnapshotterSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ComplianceReporterSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.IntrusionDetectionSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      render.ECKOperatorSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      esmetrics.ESMetricsSourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      dpi.DPISourceEntityRule,
+					Destination: esgatewayIngressDestinationEntityRule,
+				},
+			},
+			Egress: egressRules,
+		},
+	}
+}

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -45,7 +45,7 @@ const (
 	ServiceAccountName         = "linseed"
 	RoleName                   = "linseed"
 	ServiceName                = "linseed"
-	PolicyName                 = networkpolicy.TigeraComponentPolicyPrefix + "es-gateway-access"
+	PolicyName                 = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
 	PortName                   = "https"
 	Port                       = 443
 	ElasticsearchHTTPSEndpoint = "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200"
@@ -310,7 +310,7 @@ func (e *linseed) linseedAllowTigeraPolicy() *v3.NetworkPolicy {
 	}...)
 
 	// Ingress needs to be allowed from all clients.
-	esgatewayIngressDestinationEntityRule := v3.EntityRule{
+	linseedIngressDestinationEntityRule := v3.EntityRule{
 		Ports: networkpolicy.Ports(Port),
 	}
 	return &v3.NetworkPolicy{
@@ -329,85 +329,85 @@ func (e *linseed) linseedAllowTigeraPolicy() *v3.NetworkPolicy {
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.FluentdSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.EKSLogForwarderEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.IntrusionDetectionInstallerSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ESCuratorSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ManagerSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ComplianceBenchmarkerSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ComplianceControllerSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ComplianceServerSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ComplianceSnapshotterSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ComplianceReporterSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.IntrusionDetectionSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      render.ECKOperatorSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      esmetrics.ESMetricsSourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      dpi.DPISourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
+					Destination: linseedIngressDestinationEntityRule,
 				},
 			},
 			Egress: egressRules,

--- a/pkg/render/logstorage/linseed/linseed_suite_test.go
+++ b/pkg/render/logstorage/linseed/linseed_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linseed
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestRender(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../../report/linseed_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/logstorage/linseed Suite", []Reporter{junitReporter})
+}

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linseed
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/render/testutils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
+	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/kubecontrollers"
+)
+
+type resourceTestObj struct {
+	name string
+	ns   string
+	typ  runtime.Object
+	f    func(resource runtime.Object)
+}
+
+var _ = Describe("ES Gateway rendering tests", func() {
+	Context("ES Gateway deployment", func() {
+		var installation *operatorv1.InstallationSpec
+		var replicas int32
+		var cfg *Config
+		clusterDomain := "cluster.local"
+		expectedPolicy := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/es-gateway.json")
+		expectedPolicyForOpenshift := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/es-gateway_ocp.json")
+
+		BeforeEach(func() {
+			installation = &operatorv1.InstallationSpec{
+				ControlPlaneReplicas: &replicas,
+				KubernetesProvider:   operatorv1.ProviderNone,
+				Registry:             "testregistry.com/",
+			}
+			replicas = 2
+			kp, bundle := getTLS(installation)
+			cfg = &Config{
+				Installation: installation,
+				PullSecrets: []*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
+				},
+				ESGatewayKeyPair: kp,
+				TrustedBundle:    bundle,
+				KubeControllersUserSecrets: []*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
+					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
+				},
+				ClusterDomain:   clusterDomain,
+				EsAdminUserName: "elastic",
+			}
+		})
+
+		It("should render an ES Gateway deployment and all supporting resources", func() {
+			expectedResources := []resourceTestObj{
+				{PolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersUserSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{ServiceName, render.ElasticsearchNamespace, &corev1.Service{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
+				{ServiceAccountName, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
+				{DeploymentName, render.ElasticsearchNamespace, &appsv1.Deployment{}, nil},
+				{relasticsearch.PublicCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
+			}
+
+			component := EsGateway(cfg)
+
+			createResources, _ := component.Objects()
+			compareResources(createResources, expectedResources)
+		})
+
+		It("should render an ES Gateway deployment and all supporting resources when CertificateManagement is enabled", func() {
+			secret, err := certificatemanagement.CreateSelfSignedSecret("", "", "", nil)
+			Expect(err).NotTo(HaveOccurred())
+			installation.CertificateManagement = &operatorv1.CertificateManagement{CACert: secret.Data[corev1.TLSCertKey]}
+			expectedResources := []resourceTestObj{
+				{PolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersUserSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
+				{ServiceName, render.ElasticsearchNamespace, &corev1.Service{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
+				{RoleName, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
+				{ServiceAccountName, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
+				{DeploymentName, render.ElasticsearchNamespace, &appsv1.Deployment{}, nil},
+				{relasticsearch.PublicCertSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
+			}
+
+			component := EsGateway(cfg)
+
+			createResources, _ := component.Objects()
+			compareResources(createResources, expectedResources)
+		})
+
+		It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {
+			var replicas int32 = 1
+			installation.ControlPlaneReplicas = &replicas
+
+			component := EsGateway(cfg)
+
+			resources, _ := component.Objects()
+			deploy, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(deploy.Spec.Template.Spec.Affinity).To(BeNil())
+		})
+
+		It("should render PodAffinity when ControlPlaneReplicas is greater than 1", func() {
+			var replicas int32 = 2
+			installation.ControlPlaneReplicas = &replicas
+
+			component := EsGateway(cfg)
+
+			resources, _ := component.Objects()
+			deploy, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
+			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, render.ElasticsearchNamespace)))
+		})
+
+		It("should apply controlPlaneNodeSelector correctly", func() {
+			installation.ControlPlaneNodeSelector = map[string]string{"foo": "bar"}
+
+			component := EsGateway(cfg)
+
+			resources, _ := component.Objects()
+			d, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(d.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
+		})
+
+		It("should apply controlPlaneTolerations correctly", func() {
+			t := corev1.Toleration{
+				Key:      "foo",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "bar",
+			}
+
+			installation.ControlPlaneTolerations = []corev1.Toleration{t}
+			component := EsGateway(cfg)
+
+			resources, _ := component.Objects()
+			d, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
+		})
+
+		Context("allow-tigera rendering", func() {
+			policyName := types.NamespacedName{Name: "allow-tigera.es-gateway-access", Namespace: "tigera-elasticsearch"}
+
+			getExpectedPolicy := func(scenario testutils.AllowTigeraScenario) *v3.NetworkPolicy {
+				if scenario.ManagedCluster {
+					return nil
+				}
+
+				return testutils.SelectPolicyByProvider(scenario, expectedPolicy, expectedPolicyForOpenshift)
+			}
+
+			DescribeTable("should render allow-tigera policy",
+				func(scenario testutils.AllowTigeraScenario) {
+					if scenario.Openshift {
+						cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+					} else {
+						cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
+					}
+					component := EsGateway(cfg)
+					resources, _ := component.Objects()
+
+					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+					expectedPolicy := getExpectedPolicy(scenario)
+					Expect(policy).To(Equal(expectedPolicy))
+				},
+				// ES Gateway only renders in the presence of an LogStorage CR and absence of a ManagementClusterConnection CR, therefore
+				// does not have a config option for managed clusters.
+				Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+				Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+			)
+		})
+		It("should set the right env when FIPS mode is enabled", func() {
+			kp, bundle := getTLS(installation)
+			enabled := operatorv1.FIPSModeEnabled
+			installation.FIPSMode = &enabled
+			component := EsGateway(&Config{
+				Installation: installation,
+				PullSecrets: []*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
+				},
+				ESGatewayKeyPair: kp,
+				TrustedBundle:    bundle,
+				KubeControllersUserSecrets: []*corev1.Secret{
+					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
+					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
+					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
+				},
+				ClusterDomain:   clusterDomain,
+				EsAdminUserName: "elastic",
+			})
+
+			resources, _ := component.Objects()
+			d, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "ES_GATEWAY_FIPS_MODE_ENABLED", Value: "true"}))
+		})
+	})
+})
+
+func getTLS(installation *operatorv1.InstallationSpec) (certificatemanagement.KeyPairInterface, certificatemanagement.TrustedBundle) {
+	scheme := runtime.NewScheme()
+	Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	certificateManager, err := certificatemanager.Create(cli, installation, dns.DefaultClusterDomain)
+	Expect(err).NotTo(HaveOccurred())
+	esDNSNames := dns.GetServiceDNSNames(render.TigeraElasticsearchGatewaySecret, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
+	gwKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TigeraElasticsearchGatewaySecret, render.ElasticsearchNamespace, esDNSNames)
+	Expect(err).NotTo(HaveOccurred())
+	trustedBundle := certificateManager.CreateTrustedBundle(gwKeyPair)
+	Expect(cli.Create(context.Background(), certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+	return gwKeyPair, trustedBundle
+}
+
+func compareResources(resources []client.Object, expectedResources []resourceTestObj) {
+	Expect(len(resources)).To(Equal(len(expectedResources)))
+	for i, expectedResource := range expectedResources {
+		resource := resources[i]
+		actualName := resource.(metav1.ObjectMetaAccessor).GetObjectMeta().GetName()
+		actualNS := resource.(metav1.ObjectMetaAccessor).GetObjectMeta().GetNamespace()
+
+		Expect(actualName).To(Equal(expectedResource.name), fmt.Sprintf("Rendered resource has wrong name (position %d, name %s, namespace %s)", i, actualName, actualNS))
+		Expect(actualNS).To(Equal(expectedResource.ns), fmt.Sprintf("Rendered resource has wrong namespace (position %d, name %s, namespace %s)", i, actualName, actualNS))
+		Expect(resource).Should(BeAssignableToTypeOf(expectedResource.typ))
+		if expectedResource.f != nil {
+			expectedResource.f(resource)
+		}
+	}
+}

--- a/pkg/render/testutils/expected_policies/linseed.json
+++ b/pkg/render/testutils/expected_policies/linseed.json
@@ -1,0 +1,235 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.linseed-access",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'linseed'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'eks-log-forwarder'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "job-name == 'intrusion-detection-es-job-installer'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-curator'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-benchmarker'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-controller'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-server'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-snapshotter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-reporter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'intrusion-detection-controller'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-dpi'",
+          "namespaceSelector": "name == 'tigera-dpi'"
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "kubernetes",
+            "namespace": "default"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "ports": [
+            9200
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/linseed_ocp.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp.json
@@ -1,0 +1,246 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "allow-tigera.linseed-access",
+    "namespace": "tigera-elasticsearch"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "allow-tigera",
+    "selector": "k8s-app == 'linseed'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'fluentd-node' || k8s-app == 'fluentd-node-windows'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'eks-log-forwarder'",
+          "namespaceSelector": "name == 'tigera-fluentd'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "job-name == 'intrusion-detection-es-job-installer'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-curator'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-manager'",
+          "namespaceSelector": "name == 'tigera-manager'"
+        },
+        "destination": {
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-benchmarker'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-controller'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-server'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-snapshotter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'compliance-reporter'",
+          "namespaceSelector": "name == 'tigera-compliance'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'intrusion-detection-controller'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'elastic-operator'",
+          "namespaceSelector": "name == 'tigera-eck-operator'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            443
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-dpi'",
+          "namespaceSelector": "name == 'tigera-dpi'"
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "kubernetes",
+            "namespace": "default"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
+          "ports": [
+            9200
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

The initial Linseed implementation can be implemented in the tigera/operator alongside the existing es-gateway logic in the log storage controller and render packages. This will be refactored when we introduce multi-tenancy to other components as part of a later effort.

Linseed should be provided its own x509 certificate and trusted certificate bundle by the operator for use in mTLS.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
