### PR TITLE
Automated cherry pick of #2357: Support rolling updates during upgrades by preserving

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -272,6 +272,7 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 		Name:           secretName,
 		PrivateKeyPEM:  keyPEM,
 		CertificatePEM: certPEM,
+		OriginalSecret: secret,
 	}, x509Cert, nil
 
 }

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1214,6 +1214,20 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	}
 
+	components = append(components,
+		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
+			Namespace:       common.CalicoNamespace,
+			ServiceAccounts: []string{render.CalicoNodeObjectName, render.TyphaServiceAccountName},
+			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+				// this controller is responsible for rendering the tigera-ca-private secret.
+				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
+				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
+				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
+			},
+			TrustedBundle: typhaNodeTLS.TrustedBundle,
+		}))
 	// Build a configuration for rendering calico/typha.
 	typhaCfg := render.TyphaConfiguration{
 		K8sServiceEp:           k8sapi.Endpoint,
@@ -1285,21 +1299,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		UsePSP:       r.usePSP,
 	}
 	components = append(components, render.CSI(&csiCfg))
-
-	components = append(components,
-		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       common.CalicoNamespace,
-			ServiceAccounts: []string{render.CalicoNodeObjectName, render.TyphaServiceAccountName},
-			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
-				// this controller is responsible for rendering the tigera-ca-private secret.
-				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
-				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
-				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
-				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, true, true),
-				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
-			},
-			TrustedBundle: typhaNodeTLS.TrustedBundle,
-		}))
 
 	// Build a configuration for rendering calico/kube-controllers.
 	kubeControllersCfg := kubecontrollers.KubeControllersConfiguration{

--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -39,6 +39,9 @@ type KeyPair struct {
 	*operatorv1.CertificateManagement
 	DNSNames []string
 	Issuer   KeyPairInterface
+
+	// OriginalSecret maintains a copy of the secret that the KeyPair was created from.
+	OriginalSecret *corev1.Secret
 }
 
 func (k *KeyPair) GetCertificatePEM() []byte {
@@ -60,13 +63,20 @@ func (k *KeyPair) BYO() bool {
 }
 
 func (k *KeyPair) Secret(namespace string) *corev1.Secret {
+	var data map[string][]byte
+	if k.OriginalSecret == nil {
+		data = make(map[string][]byte)
+	} else {
+		// Preserve original fields, such as uri-san, common-name or legacy names for tls.key and tls.crt.
+		// This is necessary for example to support rolling calico-node updates of larger clusters from older versions.
+		data = k.OriginalSecret.Data
+	}
+	data[corev1.TLSPrivateKeyKey] = k.PrivateKeyPEM
+	data[corev1.TLSCertKey] = k.CertificatePEM
 	return &corev1.Secret{
 		TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: k.GetName(), Namespace: namespace},
-		Data: map[string][]byte{
-			corev1.TLSPrivateKeyKey: k.PrivateKeyPEM,
-			corev1.TLSCertKey:       k.CertificatePEM,
-		},
+		Data:       data,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #2357 on release-v1.28.

#2357: Support rolling updates during upgrades by preserving