### PR TITLE
load system certs for manager, and use correct location

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -267,7 +267,6 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 func (c *managerComponent) managerVolumeMounts() []corev1.VolumeMount {
 	if c.cfg.KeyValidatorConfig != nil {
 		trustedVolumeMount := c.cfg.TrustedCertBundle.VolumeMount(c.SupportedOSType())
-		trustedVolumeMount.MountPath = "/etc/ssl/certs/"
 		return append(c.cfg.KeyValidatorConfig.RequiredVolumeMounts(), trustedVolumeMount)
 	}
 	return []corev1.VolumeMount{}


### PR DESCRIPTION
## Description

Recent changes made to operator remove the root ca bundle from enterprise components docker images and instead [volume mount them into pods at runtime using tigera-ca-bundle](https://github.com/tigera/operator/pull/2312). In cases where root certs are needed they're included, but if they're not needed, they're left out.

In Enterprise with Dex, the oidc provider is internal and thus public ca bundles aren't needed. However, when using `oidc.type=tigera`, voltron directly connects to the external OIDC provider. As such, this PR has been updated to include root ca bundles in Manager when Tigera is used as the oidc connector. 

Note: It is possible that a customer uses Tigera as an OIDC connector to a CA that is running inside the cluster, in which case public ca bundle is not needed. But this code ignores that corner case since there's no known customer use cases where that is true, and even if it is, loading the public bundle does no harm.

Additionally, this PR fixes a bug in Manager where the ca bundle directory + filename combination is not correct. This combination is dictated by the OS. See [combinations here](https://github.com/tigera/operator/blob/e87b1c867a00c9a538c545f46870f2f2bb6afc2a/pkg/tls/certificatemanagement/certificatebundle.go#L186-L193). Since we're using a ca bundle file of `ca-bundle.crt`, the only place it can be read from with that name is `/etc/pki/tls/certs`


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
