### PR TITLE
[v1.27] Work around upgrade bug from versions that don't support TPROXY.

### DIFF
--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -449,6 +449,20 @@ func (r *ReconcileApplicationLayer) patchFelixTproxyMode(ctx context.Context, al
 	if al != nil && (r.isLogsCollectionEnabled(al.Spec.LogCollection) || r.isWAFEnabled(&al.Spec)) {
 		tproxyMode = crdv1.TPROXYModeOptionEnabled
 	} else {
+		if fc.Spec.TPROXYMode == nil {
+			// Workaround: we'd like to always force the value to be the correct one, matching the operator's
+			// configuration.  However, during an upgrade from a version that predates the TPROXYMode option,
+			// Felix hits a bug and gets confused by the new config parameter, which in turn triggers a restart.
+			// Work around that by relying on Disabled being the default value for the field instead.
+			//
+			// The felix bug was fixed in v3.16, v3.15.1 and v3.14.4; it should be safe to set new config fields
+			// once we know we're only upgrading from those versions and above.
+			return nil
+		}
+
+		// If the mode is already set, fall through to the normal logic, it's safe to force-set the field now.
+		// This also avoids churning the config if a previous version of the operator set it to Disabled already,
+		// we avoid setting it back to nil.
 		tproxyMode = crdv1.TPROXYModeOptionDisabled
 	}
 	// If tproxy mode is already set to desired state return nil.

--- a/pkg/controller/applicationlayer/applicationlayer_controller_test.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller_test.go
@@ -111,6 +111,24 @@ var _ = Describe("Application layer controller tests", func() {
 			r.licenseAPIReady.MarkAsReady()
 		})
 
+		It("should leave TPROXYMode as nil if log collection is disabled", func() {
+			// This test verifies a workaround for upgrade from versions that don't support TPROXY to versions
+			// that do.  Setting an unknown felix config field causes older versions of felix to cyclicly restart,
+			// which causes a disruptive upgrade.
+			By("reconciling before without an app layer resource")
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("ensuring that felix configuration TPROXYMode is nil")
+			fc := crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			}
+			Expect(test.GetResource(c, &fc)).To(BeNil())
+			Expect(fc.Spec.TPROXYMode).To(BeNil())
+		})
+
 		It("should render accurate resources for for log collection", func() {
 
 			By("applying the ApplicationLayer CR to the fake cluster")
@@ -166,6 +184,11 @@ var _ = Describe("Application layer controller tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("ensuring that felix configuration updated to disabled")
+			fc = crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			}
 			Expect(test.GetResource(c, &fc)).To(BeNil())
 			Expect(*fc.Spec.TPROXYMode).To(Equal(crdv1.TPROXYModeOptionDisabled))
 		})


### PR DESCRIPTION
## Description

Set the TPROXYMode to nil instead of "Disabled" to avoid confusing older felix versions that don't understand the new config field.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
