### PR TITLE
CalicoVersion added to installation status

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -651,6 +651,11 @@ type InstallationStatus struct {
 	// Computed is the final installation including overlaid resources.
 	// +optional
 	Computed *InstallationSpec `json:"computed,omitempty"`
+
+	// CalicoVersion shows the current running version of calico.
+	// CalicoVersion along with Variant is needed to know the exact
+	// version deployed.
+	CalicoVersion string `json:"calicoVersion,omitempty"`
 
 	// Conditions represents the latest observed set of conditions for the component. A component may be one or more of
 	// Ready, Progressing, Degraded or other customer types.

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1115,6 +1115,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	// a non-default port, and use that value if they are.
 	nodeReporterMetricsPort := defaultNodeReporterPort
 	var nodePrometheusTLS certificatemanagement.KeyPairInterface
+	calicoVersion := components.CalicoRelease
 	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
 
 		// Determine the port to use for nodeReporter metrics.
@@ -1144,6 +1145,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		if prometheusClientCert != nil {
 			typhaNodeTLS.TrustedBundle.AddCertificates(prometheusClientCert)
 		}
+		calicoVersion = components.EnterpriseRelease
 	}
 
 	// Query the KubeControllersConfiguration object. We'll use this to help configure kube-controllers.
@@ -1440,7 +1442,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, errors.New("The MTU size should be between Max int32 (2147483647) and 0")
 	}
 	instance.Status.MTU = int32(statusMTU)
+	// Variant and CalicoVersion must be updated at the same time.
 	instance.Status.Variant = instance.Spec.Variant
+	instance.Status.CalicoVersion = calicoVersion
 	if imageSet == nil {
 		instance.Status.ImageSet = ""
 	} else {

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -626,6 +626,25 @@ var _ = Describe("Testing core-controller installation", func() {
 			}
 			Expect(test.GetResource(c, &inst)).To(BeNil())
 			Expect(inst.Status.ImageSet).To(Equal("enterprise-" + components.EnterpriseRelease))
+		})
+
+		It("should update version", func() {
+			instance := &operator.Installation{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, instance)).NotTo(HaveOccurred())
+			instance.Status.CalicoVersion = "v3.14"
+			Expect(c.Update(ctx, instance)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, instance)).NotTo(HaveOccurred())
+			Expect(instance.Status.CalicoVersion).To(Equal(components.EnterpriseRelease))
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, instance)).NotTo(HaveOccurred())
+			instance.Status.CalicoVersion = "v3.23"
+			instance.Spec.Variant = operator.Calico
+			Expect(c.Update(ctx, instance)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, instance)).NotTo(HaveOccurred())
+			Expect(instance.Status.CalicoVersion).To(Equal(components.CalicoRelease))
 		})
 	})
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -352,6 +352,16 @@ func GetAuthentication(ctx context.Context, cli client.Client) (*operatorv1.Auth
 	return authentication, nil
 }
 
+// GetInstallationStatus returns the current installation status, for use by other controllers.
+func GetInstallationStatus(ctx context.Context, client client.Client) (*operatorv1.InstallationStatus, error) {
+	// Fetch the Installation instance. We only support a single instance named "default".
+	instance := &operatorv1.Installation{}
+	if err := client.Get(ctx, DefaultInstanceKey, instance); err != nil {
+		return nil, err
+	}
+	return &instance.Status, nil
+}
+
 // GetInstallation returns the current installation, for use by other controllers. It accounts for overlays and
 // returns the variant according to status.Variant, which is leveraged by other controllers to know when it is safe to
 // launch enterprise-dependent components.

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -6104,6 +6104,11 @@ spec:
             description: Most recently observed state for the Calico or Calico Enterprise
               installation.
             properties:
+              calicoVersion:
+                description: CalicoVersion shows the current running version of calico.
+                  CalicoVersion along with Variant is needed to know the exact version
+                  deployed.
+                type: string
               computed:
                 description: Computed is the final installation including overlaid
                   resources.


### PR DESCRIPTION
## Description

Calico Version is added to the Installation Status object. A new API ```GetInstallationStatus()``` is added.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
