### PR TITLE
Fix race condition where trusted bundle is rendered twice with differ…

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -68,7 +68,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration"
 	"github.com/tigera/operator/pkg/controller/migration/convert"
-	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -1147,14 +1146,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			typhaNodeTLS.TrustedBundle.AddCertificates(prometheusClientCert)
 		}
 		calicoVersion = components.EnterpriseRelease
-		esgwCertificate, err := certificateManager.GetCertificate(r.client, relasticsearch.PublicCertSecret, common.OperatorNamespace())
-		if err != nil {
-			r.status.SetDegraded(operator.ResourceReadError, fmt.Sprintf("Failed to retrieve / validate  %s", relasticsearch.PublicCertSecret), err, reqLogger)
-			return reconcile.Result{}, err
-		}
-		if esgwCertificate != nil {
-			typhaNodeTLS.TrustedBundle.AddCertificates(esgwCertificate)
-		}
 	}
 
 	// Query the KubeControllersConfiguration object. We'll use this to help configure kube-controllers.

--- a/pkg/controller/logstorage/esgateway.go
+++ b/pkg/controller/logstorage/esgateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/dns"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
+	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -43,13 +44,13 @@ func (r *ReconcileLogStorage) createEsGateway(
 	reqLogger logr.Logger,
 	ctx context.Context,
 	certificateManager certificatemanager.CertificateManager,
-) (reconcile.Result, bool, error) {
+) (reconcile.Result, certificatemanagement.TrustedBundle, bool, error) {
 	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
 	svcDNSNames = append(svcDNSNames, dns.GetServiceDNSNames(esgateway.ServiceName, render.ElasticsearchNamespace, r.clusterDomain)...)
 	gatewayKeyPair, err := certificateManager.GetOrCreateKeyPair(r.client, render.TigeraElasticsearchGatewaySecret, common.OperatorNamespace(), svcDNSNames)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating TLS certificate", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	}
 
 	var kibanaCertificate certificatemanagement.CertificateInterface
@@ -57,27 +58,37 @@ func (r *ReconcileLogStorage) createEsGateway(
 		kibanaCertificate, err = certificateManager.GetCertificate(r.client, render.TigeraKibanaCertSecret, common.OperatorNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Kibana tls certificate secret", err, reqLogger)
-			return reconcile.Result{}, false, err
+			return reconcile.Result{}, nil, false, err
 		} else if kibanaCertificate == nil {
 			r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for internal Kibana tls certificate secret to be available", nil, reqLogger)
-			return reconcile.Result{}, false, nil
+			return reconcile.Result{}, nil, false, nil
 		}
 	}
 	esInternalCertificate, err := certificateManager.GetCertificate(r.client, render.TigeraElasticsearchInternalCertSecret, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch tls certificate secret", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	} else if esInternalCertificate == nil {
 		reqLogger.Info("Waiting for internal Elasticsearch tls certificate secret to be available")
 		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for internal Elasticsearch tls certificate secret to be available", nil, reqLogger)
-		return reconcile.Result{}, false, nil
+		return reconcile.Result{}, nil, false, nil
 	}
-	trustedBundle := certificateManager.CreateTrustedBundle(esInternalCertificate, kibanaCertificate)
+
+	prometheusCertificate, err := certificateManager.GetCertificate(r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, reqLogger)
+		return reconcile.Result{}, nil, false, err
+	} else if prometheusCertificate == nil {
+		reqLogger.Info("Prometheus secrets are not available yet, waiting until they become available")
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Prometheus secrets are not available yet, waiting until they become available", nil, reqLogger)
+		return reconcile.Result{}, nil, false, nil
+	}
+	trustedBundle := certificateManager.CreateTrustedBundle(esInternalCertificate, kibanaCertificate, prometheusCertificate, gatewayKeyPair)
 
 	// This secret should only ever contain one key.
 	if len(esAdminUserSecret.Data) != 1 {
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "Elasticsearch admin user secret contains too many entries", nil, reqLogger)
-		return reconcile.Result{}, false, nil
+		return reconcile.Result{}, nil, false, nil
 	}
 
 	var esAdminUserName string
@@ -89,7 +100,7 @@ func (r *ReconcileLogStorage) createEsGateway(
 	kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, err := lscommon.CreateKubeControllersSecrets(ctx, esAdminUserSecret, esAdminUserName, r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Failed to create kube-controllers secrets for Elasticsearch gateway", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	}
 
 	cfg := &esgateway.Config{
@@ -106,7 +117,7 @@ func (r *ReconcileLogStorage) createEsGateway(
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, esGatewayComponent); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	}
 
 	certificateComponent := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
@@ -121,8 +132,8 @@ func (r *ReconcileLogStorage) createEsGateway(
 	for _, comp := range []render.Component{esGatewayComponent, certificateComponent} {
 		if err := hdler.CreateOrUpdateOrDelete(ctx, comp, r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating / deleting resource", err, reqLogger)
-			return reconcile.Result{}, false, err
+			return reconcile.Result{}, nil, false, err
 		}
 	}
-	return reconcile.Result{}, true, nil
+	return reconcile.Result{}, trustedBundle, true, nil
 }

--- a/pkg/controller/logstorage/esmetrics.go
+++ b/pkg/controller/logstorage/esmetrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@ package logstorage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -33,7 +33,6 @@ import (
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
-	"github.com/tigera/operator/pkg/render/monitor"
 )
 
 func (r *ReconcileLogStorage) createEsMetrics(
@@ -45,6 +44,7 @@ func (r *ReconcileLogStorage) createEsMetrics(
 	ctx context.Context,
 	hdler utils.ComponentHandler,
 	clusterDomain string,
+	trustedBundle certificatemanagement.TrustedBundle,
 ) (reconcile.Result, bool, error) {
 	esMetricsSecret, err := utils.GetSecret(context.Background(), r.client, esmetrics.ElasticsearchMetricsSecret, common.OperatorNamespace())
 	if err != nil {
@@ -61,25 +61,6 @@ func (r *ReconcileLogStorage) createEsMetrics(
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, false, err
 	}
-	prometheusCertificate, err := certificateManager.GetCertificate(r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, reqLogger)
-		return reconcile.Result{}, false, err
-	} else if prometheusCertificate == nil {
-		reqLogger.Info("Prometheus secrets are not available yet, waiting until they become available")
-		r.status.SetDegraded(operatorv1.ResourceNotReady, "Prometheus secrets are not available yet, waiting until they become available", nil, reqLogger)
-		return reconcile.Result{}, false, nil
-	}
-	esgwCertificate, err := certificateManager.GetCertificate(r.client, relasticsearch.PublicCertSecret, common.OperatorNamespace())
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve / validate  %s", relasticsearch.PublicCertSecret), err, reqLogger)
-		return reconcile.Result{}, false, err
-	} else if esgwCertificate == nil {
-		log.Info("Elasticsearch gateway certificate is not available yet, waiting until they become available")
-		r.status.SetDegraded(operatorv1.ResourceNotReady, "Elasticsearch gateway certificate are not available yet, waiting until they become available", nil, reqLogger)
-		return reconcile.Result{}, false, nil
-	}
-	trustedBundle := certificateManager.CreateTrustedBundle(prometheusCertificate, esgwCertificate)
 
 	serverTLS, err := certificateManager.GetOrCreateKeyPair(
 		r.client,
@@ -108,7 +89,7 @@ func (r *ReconcileLogStorage) createEsMetrics(
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(serverTLS, true, true),
 			},
-			TrustedBundle: trustedBundle,
+			TrustedBundle: nil, // The trusted bundle should have already been rendered by the logstorage_controller.go for es-gateway.
 		}),
 	}
 

--- a/pkg/controller/logstorage/esmetrics.go
+++ b/pkg/controller/logstorage/esmetrics.go
@@ -89,7 +89,9 @@ func (r *ReconcileLogStorage) createEsMetrics(
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(serverTLS, true, true),
 			},
-			TrustedBundle: nil, // The trusted bundle should have already been rendered by the logstorage_controller.go for es-gateway.
+			// The trusted bundle should have already been rendered by the logstorage_controller.go for es-gateway.
+			// It already includes the certificates for es gateway and prometheus server, which es-metrics relies upon.
+			TrustedBundle: nil,
 		}),
 	}
 

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/kubecontrollers"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	"k8s.io/client-go/kubernetes"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -609,8 +610,8 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		if err != nil || !proceed {
 			return result, err
 		}
-
-		result, proceed, err = r.createEsGateway(
+		var trustedBundle certificatemanagement.TrustedBundle
+		result, trustedBundle, proceed, err = r.createEsGateway(
 			install,
 			variant,
 			pullSecrets,
@@ -643,6 +644,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			ctx,
 			hdler,
 			r.clusterDomain,
+			trustedBundle,
 		)
 		if err != nil || !proceed {
 			return result, err


### PR DESCRIPTION
The trusted bundle is rendered twice in the elasticsearch namespace. Since all the required certificates for esmetrics should already be rendered before the esgw is rendered, we can simply refrain from re-rendering it.