### PR TITLE
CSI - AutomountServiceAccountToken false when using default service account 

### DIFF
--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -268,6 +268,10 @@ func (c *csiComponent) csiTemplate() corev1.PodTemplateSpec {
 		AutomountServiceAccountToken: ptr.BoolToPtr(false),
 	}
 
+	// SA is only used as part of associating PSP.
+	// If PSP is not on then SA is not created.
+	// Default SA will be used and token will not be mounted
+	// as it is not needed.
 	if !c.cfg.Openshift && c.cfg.UsePSP {
 		templateSpec.ServiceAccountName = CSIDaemonSetName
 		templateSpec.AutomountServiceAccountToken = ptr.BoolToPtr(true)

--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -261,14 +261,16 @@ func (c *csiComponent) csiTemplate() corev1.PodTemplateSpec {
 		Labels: templateLabels,
 	}
 	templateSpec := corev1.PodSpec{
-		Tolerations:      c.csiTolerations(),
-		Containers:       c.csiContainers(),
-		ImagePullSecrets: c.cfg.Installation.ImagePullSecrets,
-		Volumes:          c.csiVolumes(),
+		Tolerations:                  c.csiTolerations(),
+		Containers:                   c.csiContainers(),
+		ImagePullSecrets:             c.cfg.Installation.ImagePullSecrets,
+		Volumes:                      c.csiVolumes(),
+		AutomountServiceAccountToken: ptr.BoolToPtr(false),
 	}
 
 	if !c.cfg.Openshift && c.cfg.UsePSP {
 		templateSpec.ServiceAccountName = CSIDaemonSetName
+		templateSpec.AutomountServiceAccountToken = ptr.BoolToPtr(true)
 	}
 
 	return corev1.PodTemplateSpec{

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -158,6 +158,7 @@ var _ = Describe("CSI rendering tests", func() {
 
 		ds := rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
+		Expect(*ds.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 
 		cfg.Openshift = true
 		cfg.UsePSP = true
@@ -166,6 +167,7 @@ var _ = Describe("CSI rendering tests", func() {
 
 		ds = rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
+		Expect(*ds.Spec.Template.Spec.AutomountServiceAccountToken).To(BeFalse())
 	})
 	Context("With csi-node-driver DaemonSet overrides", func() {
 		It("should handle csiNodeDriverDaemonSet overrides", func() {

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -123,6 +123,9 @@ var _ = Describe("CSI rendering tests", func() {
 		serviceAccount := rtest.GetResource(resources, render.CSIDaemonSetName, render.CSIDaemonSetNamespace, "", "v1", "ServiceAccount")
 		Expect(serviceAccount).ToNot(BeNil())
 
+		ds := rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(*ds.Spec.Template.Spec.AutomountServiceAccountToken).To(BeTrue())
+
 		psp := rtest.GetResource(resources, render.CSIDaemonSetName, "", "policy", "v1beta1", "PodSecurityPolicy").(*policyv1beta1.PodSecurityPolicy)
 		Expect(psp).ToNot(BeNil())
 		Expect(psp.Spec.Privileged).To(BeTrue())


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
### Background
Hello, 

First time that I've tried to contribute to an operator but it's one of the things I want to learn about this year. Happy to make any changes if I've missed anything conventional 'cus there could be all sorts i've overlooked. Thank you for your time :slightly_smiling_face: :peace_symbol:.

### Overview
Currently when not using OpenShift and using PSPs then for the CSI DaemonSet a new Service Account is created with RBAC which is used. When this is not the case then no Service Account is explicitly set for the DS pods. This means that the namespace default service account is set. In this circumstance the CIS K8s benchmark fails for "5.1.6 Ensure that Service Account Tokens are only mounted where necessary (Manual)" (at time of writing).

This little change should make it such that in the case the default SA is used for CSI then the token wouldn't be mounted and the benchmark check passes.

### Realsies
I understand that default service account tokens (given RBAC hasn't been added) can not do anything. And so there is realistically very little risk in mounting a token that couldn't access anything if used. However CIS is influential and this rule is / will be baked into all sorts of scanning and policy software. So, given there is little or no downside, this type of change is more to make life easier for teams to operate calico in environments that have all of these reviews, scans and policy things constantly. Mostly big ol' enterprises aha. So the value is there even if you aren't buying the security aspect of the change. 

### Future
This change would make the benchmark technically pass for CSI which it doesn't now. But also in the spirit of being pragmatic it would be nice if I / we could go on to always use a unique Service Account for CSI even in the case where it's not needed. And in this scenario we just don't create the RBAC elements.

The logic here being that a short hand policy implementation that is widely used in the industry to cover the benchmark is that the default token should never be used and pods which have no SA config fail these types of scan. Even though a default token that is not mounted is technically sufficient to cover the benchmark. Again, this just ends up reducing headaches for users in these types of environments.


## Tags
Improvement, Security, UX (Ops Experience).


## Issues
* https://github.com/tigera/operator/issues/2224


## For PR author
- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files` - n/a.
- [x] If changing versions, run `make gen-versions` - n/a.


## For PR reviewers
A note for code reviewers - all pull requests must have the following:
- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
