### PR TITLE
Fix: incompatible job spec caused controller to fail

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -292,7 +292,7 @@ func (c *intrusionDetectionComponent) intrusionDetectionElasticsearchJob() *batc
 		Spec: corev1.PodSpec{
 			Tolerations:      c.cfg.Installation.ControlPlaneTolerations,
 			NodeSelector:     c.cfg.Installation.ControlPlaneNodeSelector,
-			RestartPolicy:    corev1.RestartPolicyOnFailure,
+			RestartPolicy:    corev1.RestartPolicyNever,
 			ImagePullSecrets: secret.GetReferenceList(c.cfg.PullSecrets),
 			Containers: []corev1.Container{
 				relasticsearch.ContainerDecorate(c.intrusionDetectionJobContainer(), c.cfg.ESClusterConfig.ClusterName(),

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -290,8 +290,9 @@ func (c *intrusionDetectionComponent) intrusionDetectionElasticsearchJob() *batc
 			Labels: map[string]string{"job-name": IntrusionDetectionInstallerJobName},
 		},
 		Spec: corev1.PodSpec{
-			Tolerations:      c.cfg.Installation.ControlPlaneTolerations,
-			NodeSelector:     c.cfg.Installation.ControlPlaneNodeSelector,
+			Tolerations:  c.cfg.Installation.ControlPlaneTolerations,
+			NodeSelector: c.cfg.Installation.ControlPlaneNodeSelector,
+			// This value needs to be set to never. The PodFailurePolicy will still ensure that this job will run until completion.
 			RestartPolicy:    corev1.RestartPolicyNever,
 			ImagePullSecrets: secret.GetReferenceList(c.cfg.PullSecrets),
 			Containers: []corev1.Container{


### PR DESCRIPTION
Issue was caused by: #2382

Restart policy OnFailure is not allowed in combination with PodFailurePolicyRule. Setting it to Never fixes it. This is a repro where the job fails initially, but successfully restarts until it completes:

```
$ k get po
NAME                                             READY   STATUS      RESTARTS   AGE
anomaly-detection-api-6ccf6b9468-tr5gs           1/1     Running     0          93m
intrusion-detection-controller-647b9f89d-vpz7j   1/1     Running     0          81m
intrusion-detection-es-job-installer-6vfr9       0/1     Error       0          81m
intrusion-detection-es-job-installer-8q5fp       0/1     Error       0          84m
intrusion-detection-es-job-installer-9cgvk       0/1     Error       0          81m
intrusion-detection-es-job-installer-9hbhh       0/1     Error       0          81m
intrusion-detection-es-job-installer-cncln       0/1     Error       0          81m
intrusion-detection-es-job-installer-cvsjg       0/1     Error       0          81m
intrusion-detection-es-job-installer-cxj7p       0/1     Error       0          85m
intrusion-detection-es-job-installer-gbcfs       0/1     Error       0          81m
intrusion-detection-es-job-installer-lcxf5       0/1     Completed   0          81m
intrusion-detection-es-job-installer-lrv46       0/1     Error       0          81m
intrusion-detection-es-job-installer-nxkgr       0/1     Completed   0          81m
intrusion-detection-es-job-installer-shw2t       0/1     Error       0          86m

$ k get job
NAME                                   COMPLETIONS   DURATION   AGE
intrusion-detection-es-job-installer   1/1           18s        81m

$ k logs intrusion-detection-es-job-installer-lcxf5
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/config/7.6.2 - 200 OK

$ k logs intrusion-detection-es-job-installer-nxkgr
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/_bulk_create - 200 OK
POST api/saved_objects/config/7.6.2 failed with 409, attempting PUT
PUT api/saved_objects/config/7.6.2 - 200 OK <= successful retry
POST api/saved_objects/_bulk_create - 200 OK
```