### PR TITLE
Fix EGW upgrade and crd comments for doc

### DIFF
--- a/api/v1/egressgateway_types.go
+++ b/api/v1/egressgateway_types.go
@@ -150,7 +150,7 @@ type EgressGatewayMetadata struct {
 	// Labels is a map of string keys and values that may match replica set and
 	// service selectors. Each of these key/value pairs are added to the
 	// object's labels provided the key does not already exist in the object's labels.
-	// If not specified will default to projectcalico.org/egw:<name>, where <name> is
+	// If not specified will default to projectcalico.org/egw:[name], where [name] is
 	// the name of the Egress Gateway resource.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -480,9 +480,7 @@ func fillDefaults(egw *operatorv1.EgressGateway, installation *operatorv1.Instal
 		if egw.Spec.Template.Metadata == nil {
 			egw.Spec.Template.Metadata = &operatorv1.EgressGatewayMetadata{Labels: defLabel}
 		} else {
-			if len(egw.Spec.Template.Metadata.Labels) > 0 {
-				egw.Spec.Template.Metadata.Labels["projectcalico.org/egw"] = egw.Name
-			} else {
+			if len(egw.Spec.Template.Metadata.Labels) == 0 {
 				egw.Spec.Template.Metadata.Labels = defLabel
 			}
 		}

--- a/pkg/crds/operator/operator.tigera.io_egressgateways.yaml
+++ b/pkg/crds/operator/operator.tigera.io_egressgateways.yaml
@@ -201,8 +201,8 @@ spec:
                           may match replica set and service selectors. Each of these
                           key/value pairs are added to the object's labels provided
                           the key does not already exist in the object's labels. If
-                          not specified will default to projectcalico.org/egw:<name>,
-                          where <name> is the name of the Egress Gateway resource.
+                          not specified will default to projectcalico.org/egw:[name],
+                          where [name] is the name of the Egress Gateway resource.
                         type: object
                     type: object
                   spec:


### PR DESCRIPTION
## Description

When upgrading from 3.15 to 3.16, users are required to create an EGW CR similar to their current deployment. Once this is created, the operator overwrites the existing deployment with the new image. 

When creating the EGW deployment, the operator was adding additional labels on top of the specified ones. This results in a change in the selector of the existing deployment, which is immutable. As a result, upgrade fails. 

Fix - Not adding the default label if labels are specified. 

CRD changes - <name> was used in the comments of a field. This gets interpreted as html tags when building API reference docs. Changing this to [name]. 

## For PR author

- [ ] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
