### PR TITLE
Automated cherry pick of #2417: Remove max-tls-flag. It is no longer necessary for FIPS mode

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -970,10 +970,6 @@ func (c *apiServerComponent) startUpArgs() []string {
 		fmt.Sprintf("--secure-port=%d", APIServerPort),
 		fmt.Sprintf("--tls-private-key-file=%s", c.cfg.TLSKeyPair.VolumeMountKeyFilePath()),
 		fmt.Sprintf("--tls-cert-file=%s", c.cfg.TLSKeyPair.VolumeMountCertificateFilePath()),
-	}
-
-	if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-		args = append(args, "--tls-max-version=VersionTLS12")
 	}
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -326,14 +326,13 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		}
 	})
 
-	It("should render the env variable for queryserver and arg for apiserver when FIPS is enabled", func() {
+	It("should render the env variable for queryserver when FIPS is enabled", func() {
 		fipsEnabled := operatorv1.FIPSModeEnabled
 		cfg.Installation.FIPSMode = &fipsEnabled
 		component, err := render.APIServer(cfg)
 		Expect(err).NotTo(HaveOccurred())
 		resources, _ := component.Objects()
 		d := rtest.GetResource(resources, "tigera-apiserver", "tigera-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(d.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tls-max-version=VersionTLS12"))
 		Expect(d.Spec.Template.Spec.Containers[1].Name).To(Equal("tigera-queryserver"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
 	})


### PR DESCRIPTION
Cherry pick of #2417 on release-v1.29.

#2417: Remove max-tls-flag. It is no longer necessary for FIPS mode