### PR TITLE
[RS-707] - Allow tigera-ui-user to view WAF config

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1467,13 +1467,14 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Verbs:         []string{"*"},
 			ResourceNames: []string{"user-settings"},
 		},
-		// Allow the user to read applicationlayers and services to view WAF configuration.
+		// Allow the user to read applicationlayers to detect if WAF is enabled/disabled.
 		{
 			APIGroups:     []string{"operator.tigera.io"},
 			Resources:     []string{"applicationlayers"},
 			Verbs:         []string{"get"},
 			ResourceNames: []string{"tigera-secure"},
 		},
+		// Allow the user to read services to view WAF configuration.
 		{
 			APIGroups: []string{""},
 			Resources: []string{"services"},
@@ -1621,13 +1622,14 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			Verbs:         []string{"*"},
 			ResourceNames: []string{"cluster-settings", "user-settings"},
 		},
-		// Allow the user to read and write applicationlayers and services to configure WAF.
+		// Allow the user to read and write applicationlayers to enable/disable WAF.
 		{
 			APIGroups:     []string{"operator.tigera.io"},
 			Resources:     []string{"applicationlayers"},
 			ResourceNames: []string{"tigera-secure"},
 			Verbs:         []string{"get", "update", "patch", "create"},
 		},
+		// Allow the user to read services to view WAF configuration.
 		{
 			APIGroups: []string{""},
 			Resources: []string{"services"},

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1467,7 +1467,13 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Verbs:         []string{"*"},
 			ResourceNames: []string{"user-settings"},
 		},
-		// Allow the user to read services to configure WAF.
+		// Allow the user to read applicationlayers and services to view WAF configuration.
+		{
+			APIGroups:     []string{"operator.tigera.io"},
+			Resources:     []string{"applicationlayers"},
+			Verbs:         []string{"get"},
+			ResourceNames: []string{"tigera-secure"},
+		},
 		{
 			APIGroups: []string{""},
 			Resources: []string{"services"},
@@ -1615,14 +1621,13 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			Verbs:         []string{"*"},
 			ResourceNames: []string{"cluster-settings", "user-settings"},
 		},
-		// Allow the user to read and write the applicationlayers resource to enable/disable WAF.
+		// Allow the user to read and write applicationlayers and services to configure WAF.
 		{
 			APIGroups:     []string{"operator.tigera.io"},
 			Resources:     []string{"applicationlayers"},
 			ResourceNames: []string{"tigera-secure"},
 			Verbs:         []string{"get", "update", "patch", "create"},
 		},
-		// Allow the user to read services to configure WAF.
 		{
 			APIGroups: []string{""},
 			Resources: []string{"services"},

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1329,6 +1329,12 @@ var (
 				"flows", "audit*", "l7", "events", "dns", "kibana_login",
 			},
 			Verbs: []string{"get"},
+		},
+		{
+			APIGroups:     []string{"operator.tigera.io"},
+			Resources:     []string{"applicationlayers"},
+			Verbs:         []string{"get"},
+			ResourceNames: []string{"tigera-secure"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
## Description

This PR fixes a [bug](https://tigera.atlassian.net/browse/RS-707) where users with the `tigera-ui-user` ClusterRole were unable to view the WAF config screen. The missing permision they need is to `get` the `tigera-secure` `applicationlayers` resource, which this PR adds.

This is needed for 3.16 so a cherrypick will follow for that.

I tested this change on a 3.16 Calient cluster, and confirmed the `tigera-ui-user` ClusterRole is created as expected.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
