### PR TITLE
[pick 2421 r1.28] Move guardian hash annotation to podTemplate

### DIFF
--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -251,9 +251,8 @@ func (c *GuardianComponent) deployment() client.Object {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        GuardianDeploymentName,
-			Namespace:   GuardianNamespace,
-			Annotations: c.annotations(),
+			Name:      GuardianDeploymentName,
+			Namespace: GuardianNamespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -262,8 +261,9 @@ func (c *GuardianComponent) deployment() client.Object {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      GuardianDeploymentName,
-					Namespace: ManagerNamespace,
+					Name:        GuardianDeploymentName,
+					Namespace:   ManagerNamespace,
+					Annotations: c.annotations(),
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,


### PR DESCRIPTION
The hash is added so that pods will be updated if any secrets or configmaps are updated, like the CA bundle, if it is on the deployment the annotation is updated with no pod update but with it on the podTemplate then the pod will be redeployed so it will pick up the changes.

Picking #2421 

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
