### PR TITLE
Create, delete cluster scoped resources from EGW controller

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -309,7 +309,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 				if err == nil {
 					tunnelCASecret = certificatemanagement.NewKeyPair(tunnelSecret, nil, "")
 					// Creating the voltron tunnel secret is not (yet) supported by certificate mananger.
-					tunnelSecretPassthrough = render.NewPassthrough(tunnelCASecret.Secret(common.OperatorNamespace()))
+					tunnelSecretPassthrough = render.NewPassthrough(false, tunnelCASecret.Secret(common.OperatorNamespace()))
 				}
 			}
 			if err != nil {

--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -289,7 +289,7 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 	}
 
 	if passthroughModSecurityRuleSet {
-		err = ch.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(modSecurityRuleSet), r.status)
+		err = ch.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(false, modSecurityRuleSet), r.status)
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -327,7 +327,7 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 	// Reconcile all the EGWs
 	var errMsgs []string
 	for _, egw := range egwsToReconcile {
-		err = r.reconcileEgressGateway(ctx, &egw, reqLogger, variant, fc, pullSecrets, installation, getEGWNamespacedNames(egws))
+		err = r.reconcileEgressGateway(ctx, &egw, reqLogger, variant, fc, pullSecrets, installation, getEGWNamespaceAndNames(egws))
 		if err != nil {
 			reqLogger.Error(err, "Error reconciling egress gateway")
 			errMsgs = append(errMsgs, err.Error())
@@ -354,7 +354,7 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 
 func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw *operatorv1.EgressGateway, reqLogger logr.Logger,
 	variant operatorv1.ProductVariant, fc *crdv1.FelixConfiguration, pullSecrets []*v1.Secret,
-	installation *operatorv1.InstallationSpec, namespacedNames []string) error {
+	installation *operatorv1.InstallationSpec, namespaceAndNames []string) error {
 
 	preDefaultPatchFrom := client.MergeFrom(egw.DeepCopy())
 	// update the EGW resource with default values.
@@ -391,15 +391,15 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 
 	openshift := r.provider == operatorv1.ProviderOpenShift
 	config := &egressgateway.Config{
-		PullSecrets:     pullSecrets,
-		Installation:    installation,
-		OSType:          rmeta.OSTypeLinux,
-		EgressGW:        egw,
-		VXLANPort:       egwVXLANPort,
-		VXLANVNI:        egwVXLANVNI,
-		UsePSP:          r.usePSP,
-		OpenShift:       openshift,
-		NamespacedNames: namespacedNames,
+		PullSecrets:       pullSecrets,
+		Installation:      installation,
+		OSType:            rmeta.OSTypeLinux,
+		EgressGW:          egw,
+		VXLANPort:         egwVXLANPort,
+		VXLANVNI:          egwVXLANVNI,
+		UsePSP:            r.usePSP,
+		OpenShift:         openshift,
+		NamespaceAndNames: namespaceAndNames,
 	}
 
 	component := egressgateway.EgressGateway(config)
@@ -700,7 +700,7 @@ func getDegradedMsg(egw *operatorv1.EgressGateway) string {
 	return ""
 }
 
-func getEGWNamespacedNames(egws []operatorv1.EgressGateway) []string {
+func getEGWNamespaceAndNames(egws []operatorv1.EgressGateway) []string {
 	namespacedName := []string{}
 	for _, egw := range egws {
 		namespacedName = append(namespacedName, fmt.Sprintf("%s:%s", egw.Namespace, egw.Name))

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -507,13 +507,13 @@ func getEgressGateways(ctx context.Context, cli client.Client) ([]operatorv1.Egr
 }
 
 func getOpenShiftSCC(ctx context.Context, cli client.Client) (*ocsv1.SecurityContextConstraints, error) {
-	scc := &ocsv1.SecurityContextConstraints{}
+	scc := &ocsv1.SecurityContextConstraints{
+		TypeMeta:   metav1.TypeMeta{Kind: "SecurityContextConstraints", APIVersion: "security.openshift.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: egressgateway.OpenShiftSCCName},
+	}
 	err := cli.Get(ctx, client.ObjectKey{Name: egressgateway.OpenShiftSCCName}, scc)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, err
-		}
-		return egressgateway.SecurityContextConstraints(), nil
+		return nil, err
 	}
 	return scc, nil
 }

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	ocsv1 "github.com/openshift/api/security/v1"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 
@@ -159,13 +160,20 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// If there are no Egress Gateway resources, return.
+	ch := utils.NewComponentHandler(log, r.client, r.scheme, nil)
 	if len(egws) == 0 {
-		ch := utils.NewComponentHandler(log, r.client, r.scheme, nil)
 		objects := []client.Object{}
+		// If PSP is enabled, remove the Pod Security policy.
 		if r.usePSP {
 			psp := egressgateway.PodSecurityPolicy()
 			objects = append(objects, psp)
 		}
+		// If provider is openshift, remove the SCC
+		if r.provider == operatorv1.ProviderOpenShift {
+			scc := egressgateway.SecurityContextConstraints()
+			objects = append(objects, scc)
+		}
+
 		err := ch.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(true, objects...), r.status)
 		if err != nil {
 			reqLogger.Error(err, "error deleting cluster scoped resources")
@@ -197,6 +205,28 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 			reqLogger.Info("EgressGateway object not found")
 			// Since the EGW resource is not found, remove the deployment.
 			r.status.RemoveDeployments(types.NamespacedName{Name: request.Name, Namespace: request.Namespace})
+
+			// In case of openShift, we are using a single SCC.
+			// Whenever a EGW resource is deleted, remove the corresponding user from the SCC
+			// and update the resource.
+			if r.provider == operatorv1.ProviderOpenShift {
+				scc, err := getOpenShiftSCC(ctx, r.client)
+				if err != nil {
+					reqLogger.Error(err, "Error querying SecurityContextConstraints")
+				} else {
+					userString := fmt.Sprintf("system:serviceaccount:%s:%s", request.Namespace, request.Name)
+					for index, user := range scc.Users {
+						if user == userString {
+							scc.Users = append(scc.Users[:index], scc.Users[index+1:]...)
+							err := ch.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(false, scc), r.status)
+							if err != nil {
+								reqLogger.Error(err, "error updating security context constraints")
+							}
+							break
+						}
+					}
+				}
+			}
 			// Get the unready EGW. Let's say we have 2 EGW resources red and blue.
 			// Red has already degraded. When the user deletes Red, TigeraStatus should go back to available
 			// as Blue is healthy. If all the EGWs are ready, clear the degraded TigeraStatus.
@@ -365,26 +395,51 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 		EgressGW:     egw,
 		VXLANPort:    egwVXLANPort,
 		VXLANVNI:     egwVXLANVNI,
-		Openshift:    openshift,
 		UsePSP:       r.usePSP,
 	}
 
-	component := egressgateway.EgressGateway(config)
+	components := []render.Component{egressgateway.EgressGateway(config)}
+	// In case of openshift, we will use a single SCC and update the users for every EGW resource created, deleted.
+	// Get the current SCC, append the user string if not already present and update the SCC.
+	if openshift {
+		scc, err := getOpenShiftSCC(ctx, r.client)
+		if err != nil {
+			reqLogger.Error(err, "Error getting SecurityContextConstraints")
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "Error getting SecurityContextConstraints", err, reqLogger)
+			setDegraded(r.client, ctx, egw, reconcileErr, fmt.Sprintf("Error getting SecurityContextConstraints err = %s", err.Error()))
+			return err
+		}
+		found := false
+		userStr := fmt.Sprintf("system:serviceaccount:%s:%s", egw.Namespace, egw.Name)
+		for _, user := range scc.Users {
+			if user == userStr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			scc.Users = append(scc.Users, fmt.Sprintf("system:serviceaccount:%s:%s", egw.Namespace, egw.Name))
+		}
+		components = append(components, render.NewPassthrough(false, scc))
+	}
+
 	ch := utils.NewComponentHandler(log, r.client, r.scheme, egw)
 
-	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
+	if err = imageset.ApplyImageSet(ctx, r.client, variant, components...); err != nil {
 		reqLogger.Error(err, "Error with images from ImageSet")
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
 		setDegraded(r.client, ctx, egw, reconcileErr, fmt.Sprintf("Error with images from ImageSet err = %s", err.Error()))
 		return err
 	}
 
-	if err = ch.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
-		reqLogger.Error(err, fmt.Sprintf("Error creating / updating resource: Name = %s, Namespace = %s", egw.Name, egw.Namespace))
-		r.status.SetDegraded(operatorv1.ResourceUpdateError,
-			fmt.Sprintf("Error creating / updating resource: Name = %s, Namespace = %s", egw.Name, egw.Namespace), err, reqLogger)
-		setDegraded(r.client, ctx, egw, reconcileErr, fmt.Sprintf("Error creating / updating resource err = %s", err.Error()))
-		return err
+	for _, component := range components {
+		if err = ch.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
+			reqLogger.Error(err, fmt.Sprintf("Error creating / updating resource: Name = %s, Namespace = %s", egw.Name, egw.Namespace))
+			r.status.SetDegraded(operatorv1.ResourceUpdateError,
+				fmt.Sprintf("Error creating / updating resource: Name = %s, Namespace = %s", egw.Name, egw.Namespace), err, reqLogger)
+			setDegraded(r.client, ctx, egw, reconcileErr, fmt.Sprintf("Error creating / updating resource err = %s", err.Error()))
+			return err
+		}
 	}
 
 	// Update the status of this CR.
@@ -471,6 +526,18 @@ func getEgressGateways(ctx context.Context, cli client.Client) ([]operatorv1.Egr
 		return []operatorv1.EgressGateway{}, err
 	}
 	return instance.Items, nil
+}
+
+func getOpenShiftSCC(ctx context.Context, cli client.Client) (*ocsv1.SecurityContextConstraints, error) {
+	scc := &ocsv1.SecurityContextConstraints{}
+	err := cli.Get(ctx, client.ObjectKey{Name: egressgateway.OpenShiftSCCName}, scc)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+		return egressgateway.SecurityContextConstraints(), nil
+	}
+	return scc, nil
 }
 
 // fillDefaults sets the default values of the EGW resource.

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -157,16 +157,25 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, err
 	}
 
+	egwDeleteResources := func() {
+		if r.usePSP {
+			obj := egressgateway.EGWPodSecurityPolicy(request.Name, request.Namespace)
+			if err := r.deleteResources(ctx, obj); err != nil {
+				reqLogger.Info("error deleting pod security policy")
+			}
+		}
+		if r.provider == operatorv1.ProviderOpenShift {
+			obj := egressgateway.EGWSecurityContextConstraints(request.Name, request.Namespace)
+			if err = r.deleteResources(ctx, obj); err != nil {
+				reqLogger.Info("error deleting security context")
+			}
+		}
+	}
+
 	// If there are no Egress Gateway resources, return.
 	if len(egws) == 0 {
 		if request.Namespace != "" {
-			r.status.RemoveDeployments(types.NamespacedName{Name: request.Name, Namespace: request.Namespace})
-			if r.usePSP {
-				obj := egressgateway.EGWPodSecurityPolicy(request.Name, request.Namespace)
-				if err := r.deleteClusterWideResources(ctx, obj); err != nil {
-					reqLogger.Info("error deleting pod security policy")
-				}
-			}
+			egwDeleteResources()
 		}
 		r.status.OnCRNotFound()
 		return reconcile.Result{}, nil
@@ -195,12 +204,7 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 			reqLogger.Info("EgressGateway object not found")
 			// Since the EGW resource is not found, remove the deployment.
 			r.status.RemoveDeployments(types.NamespacedName{Name: request.Name, Namespace: request.Namespace})
-			if r.usePSP {
-				obj := egressgateway.EGWPodSecurityPolicy(request.Name, request.Namespace)
-				if err := r.deleteClusterWideResources(ctx, obj); err != nil {
-					reqLogger.Info("error deleting pod security policy")
-				}
-			}
+			egwDeleteResources()
 			// Get the unready EGW. Let's say we have 2 EGW resources red and blue.
 			// Red has already degraded. When the user deletes Red, TigeraStatus should go back to available
 			// as Blue is healthy. If all the EGWs are ready, clear the degraded TigeraStatus.
@@ -369,7 +373,6 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 		EgressGW:     egw,
 		VXLANPort:    egwVXLANPort,
 		VXLANVNI:     egwVXLANVNI,
-		Openshift:    openshift,
 		UsePSP:       r.usePSP,
 	}
 
@@ -393,11 +396,22 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 
 	if r.usePSP {
 		obj := egressgateway.EGWPodSecurityPolicy(egw.Name, egw.Namespace)
-		if err = r.createClusterWideResources(ctx, obj); err != nil {
+		if err = r.createResources(ctx, obj); err != nil {
 			reqLogger.Error(err, fmt.Sprintf("Error creating pod security policy Name = %s, Namespace = %s", egw.Name, egw.Namespace))
 			r.status.SetDegraded(operatorv1.ResourceUpdateError,
 				fmt.Sprintf("Error creating pod security policy: Name = %s, Namespace = %s", egw.Name, egw.Namespace), err, reqLogger)
 			setDegraded(r.client, ctx, egw, reconcileErr, fmt.Sprintf("Error creating pod security policy err = %s", err.Error()))
+			return err
+		}
+	}
+
+	if openshift {
+		obj := egressgateway.EGWSecurityContextConstraints(egw.Name, egw.Namespace)
+		if err = r.createResources(ctx, obj); err != nil {
+			reqLogger.Error(err, fmt.Sprintf("Error creating security context Name = %s, Namespace = %s", egw.Name, egw.Namespace))
+			r.status.SetDegraded(operatorv1.ResourceUpdateError,
+				fmt.Sprintf("Error creating security context: Name = %s, Namespace = %s", egw.Name, egw.Namespace), err, reqLogger)
+			setDegraded(r.client, ctx, egw, reconcileErr, fmt.Sprintf("Error creating security context err = %s", err.Error()))
 			return err
 		}
 	}
@@ -408,7 +422,7 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 	return nil
 }
 
-func (r *ReconcileEgressGateway) createClusterWideResources(ctx context.Context, obj client.Object) error {
+func (r *ReconcileEgressGateway) createResources(ctx context.Context, obj client.Object) error {
 	_, ok := obj.(metav1.ObjectMetaAccessor)
 	if !ok {
 		return fmt.Errorf("Object is not ObjectMetaAccessor")
@@ -430,12 +444,11 @@ func (r *ReconcileEgressGateway) createClusterWideResources(ctx context.Context,
 		if err != nil {
 			return err
 		}
-		return nil
 	}
 	return nil
 }
 
-func (r *ReconcileEgressGateway) deleteClusterWideResources(ctx context.Context, obj client.Object) error {
+func (r *ReconcileEgressGateway) deleteResources(ctx context.Context, obj client.Object) error {
 	err := r.client.Delete(ctx, obj)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("error deleting object %v", obj)

--- a/pkg/controller/egressgateway/egressgateway_controller_test.go
+++ b/pkg/controller/egressgateway/egressgateway_controller_test.go
@@ -38,6 +38,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -93,6 +94,7 @@ var _ = Describe("Egress Gateway controller tests", func() {
 				scheme:          scheme,
 				status:          mockStatus,
 				licenseAPIReady: &utils.ReadyFlag{},
+				usePSP:          true,
 			}
 
 			Expect(c.Create(ctx, &crdv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "ippool-1"}, Spec: crdv1.IPPoolSpec{
@@ -312,6 +314,72 @@ var _ = Describe("Egress Gateway controller tests", func() {
 				Expect(initContainer.Env).To(ContainElement(elem))
 				Expect(initContainer_blue.Env).To(ContainElement(elem))
 			}
+		})
+
+		It("should use a single psp when EGW is created with on a psp cluster", func() {
+			mockStatus.On("AddDaemonsets", mock.Anything).Return()
+			mockStatus.On("AddDeployments", mock.Anything).Return()
+			mockStatus.On("IsAvailable").Return(true)
+			mockStatus.On("AddStatefulSets", mock.Anything).Return()
+			mockStatus.On("AddCronJobs", mock.Anything)
+			mockStatus.On("OnCRNotFound").Return()
+			mockStatus.On("ClearDegraded")
+			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+			mockStatus.On("ReadyToMonitor")
+			Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+			logSeverity := operatorv1.LogLevelInfo
+			egw_red := &operatorv1.EgressGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "calico-red", Namespace: "calico-egress"},
+				Spec: operatorv1.EgressGatewaySpec{
+					LogSeverity: &logSeverity,
+					IPPools: []operatorv1.EgressGatewayIPPool{
+						{Name: "ippool-1", CIDR: ""},
+						{Name: "", CIDR: "1.2.4.0/24"},
+					},
+					ExternalNetworks: []string{"one", "two"},
+				},
+				Status: operatorv1.EgressGatewayStatus{
+					State: operatorv1.TigeraStatusReady,
+				},
+			}
+			Expect(c.Create(ctx, egw_red)).NotTo(HaveOccurred())
+
+			egw_blue := &operatorv1.EgressGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "calico-blue", Namespace: "calico-egress"},
+				Spec: operatorv1.EgressGatewaySpec{
+					LogSeverity: &logSeverity,
+					IPPools: []operatorv1.EgressGatewayIPPool{
+						{Name: "ippool-1", CIDR: ""},
+						{Name: "", CIDR: "1.2.4.0/24"},
+					},
+					ExternalNetworks: []string{"one", "two"},
+				},
+				Status: operatorv1.EgressGatewayStatus{
+					State: operatorv1.TigeraStatusReady,
+				},
+			}
+			Expect(c.Create(ctx, egw_blue)).NotTo(HaveOccurred())
+
+			r.usePSP = true
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			psp := policyv1beta1.PodSecurityPolicy{
+				TypeMeta: metav1.TypeMeta{Kind: "PodSecurityPolicy", APIVersion: "policy/v1beta1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "tigera-egressgateway",
+				},
+			}
+			Expect(test.GetResource(c, &psp)).To(BeNil())
+
+			Expect(c.Delete(ctx, egw_red)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &psp)).To(BeNil())
+
+			Expect(c.Delete(ctx, egw_blue)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &psp)).NotTo(BeNil())
 		})
 
 		It("Should throw an error when ippool is not present", func() {

--- a/pkg/controller/egressgateway/egressgateway_controller_test.go
+++ b/pkg/controller/egressgateway/egressgateway_controller_test.go
@@ -17,6 +17,7 @@ package egressgateway
 import (
 	"context"
 	"fmt"
+
 	"sync"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
+	ocsv1 "github.com/openshift/api/security/v1"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
@@ -94,7 +96,6 @@ var _ = Describe("Egress Gateway controller tests", func() {
 				scheme:          scheme,
 				status:          mockStatus,
 				licenseAPIReady: &utils.ReadyFlag{},
-				usePSP:          true,
 			}
 
 			Expect(c.Create(ctx, &crdv1.IPPool{ObjectMeta: metav1.ObjectMeta{Name: "ippool-1"}, Spec: crdv1.IPPoolSpec{
@@ -380,6 +381,84 @@ var _ = Describe("Egress Gateway controller tests", func() {
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(test.GetResource(c, &psp)).NotTo(BeNil())
+		})
+
+		It("should use a single scc when EGW is created in openshift", func() {
+			mockStatus.On("AddDaemonsets", mock.Anything).Return()
+			mockStatus.On("AddDeployments", mock.Anything).Return()
+			mockStatus.On("RemoveDeployments", mock.Anything).Return()
+			mockStatus.On("IsAvailable").Return(true)
+			mockStatus.On("AddStatefulSets", mock.Anything).Return()
+			mockStatus.On("AddCronJobs", mock.Anything)
+			mockStatus.On("OnCRNotFound").Return()
+			mockStatus.On("ClearDegraded")
+			mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+			mockStatus.On("ReadyToMonitor")
+			Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+
+			r.provider = operatorv1.ProviderOpenShift
+			logSeverity := operatorv1.LogLevelInfo
+			egw_red := &operatorv1.EgressGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "calico-red", Namespace: "calico-egress"},
+				Spec: operatorv1.EgressGatewaySpec{
+					LogSeverity: &logSeverity,
+					IPPools: []operatorv1.EgressGatewayIPPool{
+						{Name: "ippool-1", CIDR: ""},
+						{Name: "", CIDR: "1.2.4.0/24"},
+					},
+					ExternalNetworks: []string{"one", "two"},
+				},
+				Status: operatorv1.EgressGatewayStatus{
+					State: operatorv1.TigeraStatusReady,
+				},
+			}
+
+			egw_blue := &operatorv1.EgressGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: "calico-blue", Namespace: "calico-egress"},
+				Spec: operatorv1.EgressGatewaySpec{
+					LogSeverity: &logSeverity,
+					IPPools: []operatorv1.EgressGatewayIPPool{
+						{Name: "ippool-1", CIDR: ""},
+						{Name: "", CIDR: "1.2.4.0/24"},
+					},
+					ExternalNetworks: []string{"one", "two"},
+				},
+				Status: operatorv1.EgressGatewayStatus{
+					State: operatorv1.TigeraStatusReady,
+				},
+			}
+			scc := ocsv1.SecurityContextConstraints{
+				TypeMeta: metav1.TypeMeta{Kind: "SecurityContextConstraints", APIVersion: "security.openshift.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "tigera-egressgateway",
+				},
+			}
+
+			Expect(c.Create(ctx, egw_red)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &scc)).To(BeNil())
+			Expect(len(scc.Users)).To(Equal(1))
+			Expect(scc.Users[0]).To(Equal("system:serviceaccount:calico-egress:calico-red"))
+
+			Expect(c.Create(ctx, egw_blue)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &scc)).To(BeNil())
+			Expect(len(scc.Users)).To(Equal(2))
+			Expect(scc.Users[1]).To(Equal("system:serviceaccount:calico-egress:calico-blue"))
+
+			Expect(c.Delete(ctx, egw_red)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{types.NamespacedName{Name: "calico-red", Namespace: "calico-egress"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &scc)).To(BeNil())
+			Expect(len(scc.Users)).To(Equal(1))
+			Expect(scc.Users[0]).To(Equal("system:serviceaccount:calico-egress:calico-blue"))
+
+			Expect(c.Delete(ctx, egw_blue)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &scc)).NotTo(BeNil())
 		})
 
 		It("Should throw an error when ippool is not present", func() {

--- a/pkg/controller/egressgateway/egressgateway_controller_test.go
+++ b/pkg/controller/egressgateway/egressgateway_controller_test.go
@@ -449,7 +449,7 @@ var _ = Describe("Egress Gateway controller tests", func() {
 			Expect(scc.Users[1]).To(Equal("system:serviceaccount:calico-egress:calico-blue"))
 
 			Expect(c.Delete(ctx, egw_red)).NotTo(HaveOccurred())
-			_, err = r.Reconcile(ctx, reconcile.Request{types.NamespacedName{Name: "calico-red", Namespace: "calico-egress"}})
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "calico-red", Namespace: "calico-egress"}})
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(test.GetResource(c, &scc)).To(BeNil())
 			Expect(len(scc.Users)).To(Equal(1))

--- a/pkg/controller/egressgateway/egressgateway_controller_test.go
+++ b/pkg/controller/egressgateway/egressgateway_controller_test.go
@@ -446,7 +446,8 @@ var _ = Describe("Egress Gateway controller tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(test.GetResource(c, &scc)).To(BeNil())
 			Expect(len(scc.Users)).To(Equal(2))
-			Expect(scc.Users[1]).To(Equal("system:serviceaccount:calico-egress:calico-blue"))
+			Expect(scc.Users[0]).To(Equal("system:serviceaccount:calico-egress:calico-blue"))
+			Expect(scc.Users[1]).To(Equal("system:serviceaccount:calico-egress:calico-red"))
 
 			Expect(c.Delete(ctx, egw_red)).NotTo(HaveOccurred())
 			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "calico-red", Namespace: "calico-egress"}})

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1190,7 +1190,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	if newActiveCM != nil && !terminating {
 		log.Info("adding active configmap")
-		components = append(components, render.NewPassthrough(newActiveCM))
+		components = append(components, render.NewPassthrough(false, newActiveCM))
 	}
 
 	// If we're on OpenShift on AWS render a Job (and needed resources) to
@@ -1218,7 +1218,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		criticalPriorityClasses := []string{render.NodePriorityClassName, render.ClusterPriorityClassName}
 		resourceQuotaObj := resourcequota.ResourceQuotaForPriorityClassScope(resourcequota.CalicoCriticalResourceQuotaName,
 			common.CalicoNamespace, criticalPriorityClasses)
-		resourceQuotaComponent := render.NewPassthrough(resourceQuotaObj)
+		resourceQuotaComponent := render.NewPassthrough(false, resourceQuotaObj)
 		components = append(components, resourceQuotaComponent)
 
 	}
@@ -1668,7 +1668,7 @@ func (r *ReconcileInstallation) updateCRDs(ctx context.Context, variant operator
 	if !r.manageCRDs {
 		return nil
 	}
-	crdComponent := render.NewPassthrough(crds.ToRuntimeObjects(crds.GetCRDs(variant)...)...)
+	crdComponent := render.NewPassthrough(false, crds.ToRuntimeObjects(crds.GetCRDs(variant)...)...)
 	// Specify nil for the CR so no ownership is put on the CRDs. We do this so removing the
 	// Installation CR will not remove the CRDs.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, nil)

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -360,7 +360,7 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	if createInOperatorNamespace {
-		components = append(components, render.NewPassthrough(alertmanagerConfigSecret))
+		components = append(components, render.NewPassthrough(false, alertmanagerConfigSecret))
 	}
 
 	// v3 NetworkPolicy will fail to reconcile if the Tier is not created, which can only occur once a License is created.

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -59,6 +59,13 @@ spec:
                   connections.  The only reason to disable it is for debugging purposes.  [Default:
                   true]'
                 type: boolean
+              bpfDSROptoutCIDRs:
+                description: BPFDSROptoutCIDRs is a list of CIDRs which are excluded
+                  from DSR. That is, clients in those CIDRs will accesses nodeports
+                  as if BPFExternalServiceMode was set to Tunnel.
+                items:
+                  type: string
+                type: array
               bpfDataIfacePattern:
                 description: BPFDataIfacePattern is a regular expression that controls
                   which interfaces Felix should attach BPF programs to in order to

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -101,7 +101,7 @@ func APIServer(cfg *APIServerConfiguration) (Component, error) {
 }
 
 func APIServerPolicy(cfg *APIServerConfiguration) Component {
-	return NewPassthrough(allowTigeraAPIServerPolicy(cfg))
+	return NewPassthrough(false, allowTigeraAPIServerPolicy(cfg))
 }
 
 // APIServerConfiguration contains all the config information needed to render the component.

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -75,8 +75,8 @@ type Config struct {
 
 	OpenShift bool
 	// Whether or not the cluster supports pod security policies.
-	UsePSP          bool
-	NamespacedNames []string
+	UsePSP            bool
+	NamespaceAndNames []string
 }
 
 func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
@@ -454,8 +454,8 @@ func (c *component) getHealthTimeoutDs() string {
 
 func (c *component) getSecurityContextConstraints() *ocsv1.SecurityContextConstraints {
 	scc := SecurityContextConstraints()
-	sort.Strings(c.config.NamespacedNames)
-	for _, egwNames := range c.config.NamespacedNames {
+	sort.Strings(c.config.NamespaceAndNames)
+	for _, egwNames := range c.config.NamespaceAndNames {
 		scc.Users = append(scc.Users, fmt.Sprintf("system:serviceaccount:%s", egwNames))
 	}
 	return scc

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -44,8 +44,8 @@ const (
 	DefaultVXLANPort      int   = 4790
 	DefaultVXLANVNI       int   = 4097
 	DefaultHealthPort     int32 = 8080
-	PodSecurityPolicyName       = "tigera-egressgateway"
 	OpenShiftSCCName            = "tigera-egressgateway"
+	podSecurityPolicyName       = "tigera-egressgateway"
 )
 
 var log = logf.Log.WithName("render")
@@ -293,7 +293,7 @@ func (c *component) egwInitEnvVars() []corev1.EnvVar {
 func PodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
 	boolTrue := true
 	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(PodSecurityPolicyName)
+	psp.GetObjectMeta().SetName(podSecurityPolicyName)
 	psp.Spec.AllowedCapabilities = []corev1.Capability{
 		corev1.Capability("NET_ADMIN"),
 	}

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			version string
 			kind    string
 		}{
+			{"tigera-egressgateway", "", "policy", "v1beta1", "PodSecurityPolicy"},
 			{"egress-test", "test-ns", rbac, "v1", "Role"},
 			{"egress-test", "test-ns", rbac, "v1", "RoleBinding"},
 		}
@@ -244,6 +245,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		}{
 			{"egress-test", "test-ns", "", "v1", "ServiceAccount"},
 			{"egress-test", "test-ns", "apps", "v1", "Deployment"},
+			{"tigera-egressgateway", "", "policy", "v1beta1", "PodSecurityPolicy"},
 			{"egress-test", "test-ns", rbac, "v1", "Role"},
 			{"egress-test", "test-ns", rbac, "v1", "RoleBinding"},
 		}

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -107,8 +107,8 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			version string
 			kind    string
 		}{
-			{"test-ns-egress-test", "", rbac, "v1", "ClusterRole"},
-			{"test-ns-egress-test", "", rbac, "v1", "ClusterRoleBinding"},
+			{"egress-test", "test-ns", rbac, "v1", "Role"},
+			{"egress-test", "test-ns", rbac, "v1", "RoleBinding"},
 		}
 
 		component := egressgateway.EgressGateway(&egressgateway.Config{
@@ -234,7 +234,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		Expect(elasticIPAnnotation).To(Equal("[\"1.2.3.4\",\"5.6.7.8\"]"))
 	})
 
-	It("should create service account, clusterrole, clusterrolebinding and psp if platform uses psp", func() {
+	It("should create service account, role, rolebinding if platform uses psp", func() {
 		expectedResources := []struct {
 			name    string
 			ns      string
@@ -244,9 +244,8 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		}{
 			{"egress-test", "test-ns", "", "v1", "ServiceAccount"},
 			{"egress-test", "test-ns", "apps", "v1", "Deployment"},
-			{"test-ns-egress-test", "", "policy", "v1beta1", "PodSecurityPolicy"},
-			{"test-ns-egress-test", "", rbac, "v1", "ClusterRole"},
-			{"test-ns-egress-test", "", rbac, "v1", "ClusterRoleBinding"},
+			{"egress-test", "test-ns", rbac, "v1", "Role"},
+			{"egress-test", "test-ns", rbac, "v1", "RoleBinding"},
 		}
 
 		component := egressgateway.EgressGateway(&egressgateway.Config{
@@ -264,67 +263,4 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 	})
-
-	It("should create security context if platform is openshift", func() {
-		expectedResources := []struct {
-			name    string
-			ns      string
-			group   string
-			version string
-			kind    string
-		}{
-			{"egress-test", "test-ns", "", "v1", "ServiceAccount"},
-			{"egress-test", "test-ns", "apps", "v1", "Deployment"},
-			{"test-ns-egress-test", "", "security.openshift.io", "v1", "SecurityContextConstraints"},
-		}
-
-		component := egressgateway.EgressGateway(&egressgateway.Config{
-			PullSecrets:  nil,
-			Installation: installation,
-			OSType:       rmeta.OSTypeLinux,
-			EgressGW:     egw,
-			VXLANVNI:     4097,
-			VXLANPort:    4790,
-			Openshift:    true,
-		})
-		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(len(expectedResources)))
-		for i, expectedRes := range expectedResources {
-			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-		}
-	})
-
-	It("Test with long string lengths for ns and name", func() {
-		egw.Namespace = "test-nsabcdefghijklmnopqrstuvwxyz1234567890abcdefg"
-		egw.Name = "egress-testabcdefghijklmnopqrstuvwxyz1234567890abc"
-		component := egressgateway.EgressGateway(&egressgateway.Config{
-			PullSecrets:  nil,
-			Installation: installation,
-			OSType:       rmeta.OSTypeLinux,
-			EgressGW:     egw,
-			VXLANVNI:     4097,
-			VXLANPort:    4790,
-			UsePSP:       true,
-		})
-
-		expectedResources := []struct {
-			name    string
-			ns      string
-			group   string
-			version string
-			kind    string
-		}{
-			{"egress-testabcdefghijklmnopqrstuvwxyz1234567890abc", "test-nsabcdefghijklmnopqrstuvwxyz1234567890abcdefg", "", "v1", "ServiceAccount"},
-			{"egress-testabcdefghijklmnopqrstuvwxyz1234567890abc", "test-nsabcdefghijklmnopqrstuvwxyz1234567890abcdefg", "apps", "v1", "Deployment"},
-			{"test-nsabcdefghijklmnopqrstuvwxyz1234567890abcdefg-egress-testabcdefghijklmnopqrstuvwxyz1234567890abc", "", "policy", "v1beta1", "PodSecurityPolicy"},
-			{"test-nsabcdefghijklmnopqrstuvwxyz1234567890abcdefg-egress-testabcdefghijklmnopqrstuvwxyz1234567890abc", "", rbac, "v1", "ClusterRole"},
-			{"test-nsabcdefghijklmnopqrstuvwxyz1234567890abcdefg-egress-testabcdefghijklmnopqrstuvwxyz1234567890abc", "", rbac, "v1", "ClusterRoleBinding"},
-		}
-		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(len(expectedResources)))
-		for i, expectedRes := range expectedResources {
-			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-		}
-	})
-
 })

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -265,4 +265,34 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 	})
+
+	It("should create security context if platform is openshift", func() {
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{"egress-test", "test-ns", "", "v1", "ServiceAccount"},
+			{"egress-test", "test-ns", "apps", "v1", "Deployment"},
+			{"tigera-egressgateway", "", "security.openshift.io", "v1", "SecurityContextConstraints"},
+		}
+
+		component := egressgateway.EgressGateway(&egressgateway.Config{
+			PullSecrets:  nil,
+			Installation: installation,
+			OSType:       rmeta.OSTypeLinux,
+			EgressGW:     egw,
+			VXLANVNI:     4097,
+			VXLANPort:    4790,
+			OpenShift:    true,
+		})
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+		for i, expectedRes := range expectedResources {
+			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+		}
+	})
+
 })

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -72,6 +72,7 @@ func GuardianPolicy(cfg *GuardianConfiguration) (Component, error) {
 	}
 
 	return NewPassthrough(
+		false,
 		guardianAccessPolicy,
 		networkpolicy.AllowTigeraDefaultDeny(GuardianNamespace),
 	), nil

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -132,7 +132,7 @@ func NewCalicoKubeControllers(cfg *KubeControllersConfiguration) *kubeController
 }
 
 func NewCalicoKubeControllersPolicy(cfg *KubeControllersConfiguration) render.Component {
-	return render.NewPassthrough(kubeControllersAllowTigeraPolicy(cfg))
+	return render.NewPassthrough(false, kubeControllersAllowTigeraPolicy(cfg))
 }
 
 func NewElasticsearchKubeControllers(cfg *KubeControllersConfiguration) *kubeControllersComponent {

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -91,6 +91,7 @@ func Monitor(cfg *Config) render.Component {
 
 func MonitorPolicy(cfg *Config) render.Component {
 	return render.NewPassthrough(
+		false,
 		allowTigeraAlertManagerPolicy(cfg),
 		allowTigeraAlertManagerMeshPolicy(cfg),
 		allowTigeraPrometheusPolicy(cfg),

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -78,7 +78,7 @@ func PacketCaptureAPI(cfg *PacketCaptureApiConfiguration) Component {
 }
 
 func PacketCaptureAPIPolicy(cfg *PacketCaptureApiConfiguration) Component {
-	return NewPassthrough(allowTigeraPolicy(cfg))
+	return NewPassthrough(false, allowTigeraPolicy(cfg))
 }
 
 func (pc *packetCaptureApiComponent) ResolveImages(is *operatorv1.ImageSet) error {

--- a/pkg/render/passthru.go
+++ b/pkg/render/passthru.go
@@ -6,14 +6,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewPassthrough(objs ...client.Object) Component {
-	return &passthroughComponent{objs: objs}
+func NewPassthrough(isDelete bool, objs ...client.Object) Component {
+	return &passthroughComponent{isDelete: isDelete, objs: objs}
 }
 
 // passthroughComponent is an implementation of a Component that simply passes back
 // the objects it was given unmodified.
 type passthroughComponent struct {
-	objs []client.Object
+	isDelete bool
+	objs     []client.Object
 }
 
 // ResolveImages should call components.GetReference for all images that the Component
@@ -35,6 +36,9 @@ func (p *passthroughComponent) Objects() (objsToCreate []client.Object, objsToDe
 			continue
 		}
 		objs = append(objs, o)
+	}
+	if p.isDelete {
+		return nil, objs
 	}
 	return objs, nil
 }

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -74,7 +74,7 @@ func allCalicoComponents(
 	if bgpLayout != nil {
 		objs = append(objs, bgpLayout)
 	}
-	secretsAndConfigMaps := render.NewPassthrough(objs...)
+	secretsAndConfigMaps := render.NewPassthrough(false, objs...)
 
 	nodeCfg := &render.NodeConfiguration{
 		K8sServiceEp:            k8sServiceEp,


### PR DESCRIPTION
## Description

When creating cluster scoped resources from EGW controller, controller-runtime throws an error that cluster scoped resources cannot have namespace scoped owners. Hence to avoid this

1. When PSP is enabled, create Role, Rolebindings instead of clusterrole, clusterrolebinding
2. When PSP is enabled, create the pod security policy from the controller. When the CR is deleted, delete the pod security policy.
3. When running in openShift, create or delete the securitycontext from the controller. 
## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
