### PR TITLE
[release-v1.28] Allow query server talk to Prometheus

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import (
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
@@ -61,7 +62,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	c, err := controller.New("apiserver-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
-		return fmt.Errorf("Failed to create apiserver-controller: %v", err)
+		return fmt.Errorf("failed to create apiserver-controller: %w", err)
 	}
 
 	// Established deferred watches against the v3 API that should succeed after the Enterprise API Server becomes available.
@@ -155,7 +156,7 @@ func add(c controller.Controller, r *ReconcileAPIServer) error {
 
 	for _, secretName := range []string{
 		"calico-apiserver-certs", "tigera-apiserver-certs", render.PacketCaptureCertSecret,
-		certificatemanagement.CASecretName, render.DexTLSSecretName,
+		certificatemanagement.CASecretName, render.DexTLSSecretName, monitor.PrometheusClientTLSSecretName,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
@@ -260,6 +261,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 
 	// Query enterprise-only data.
 	var tunnelCASecret certificatemanagement.KeyPairInterface
+	var trustedBundle certificatemanagement.TrustedBundle
 	var amazon *operatorv1.AmazonCloudIntegration
 	var managementCluster *operatorv1.ManagementCluster
 	var managementClusterConnection *operatorv1.ManagementClusterConnection
@@ -332,6 +334,15 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 				includeV3NetworkPolicy = true
 			}
 		}
+
+		prometheusCertificate, err := certificateManager.GetCertificate(r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
+		if err != nil {
+			log.Error(err, "Failed to get certificate")
+			r.status.SetDegraded("Failed to get certificate", err.Error())
+			return reconcile.Result{}, err
+		} else if prometheusCertificate != nil {
+			trustedBundle = certificatemanagement.CreateTrustedBundle(prometheusCertificate)
+		}
 	}
 
 	err = utils.GetK8sServiceEndPoint(r.client)
@@ -358,6 +369,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		PullSecrets:                 pullSecrets,
 		Openshift:                   r.provider == operatorv1.ProviderOpenShift,
 		TunnelCASecret:              tunnelCASecret,
+		TrustedBundle:               trustedBundle,
 		UsePSP:                      r.usePSP,
 	}
 
@@ -376,6 +388,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 				rcertificatemanagement.NewKeyPairOption(tlsSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(tunnelCASecret, true, true),
 			},
+			TrustedBundle: trustedBundle,
 		}),
 	}
 	if tunnelSecretPassthrough != nil {

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -117,6 +117,7 @@ type APIServerConfiguration struct {
 	PullSecrets                 []*corev1.Secret
 	Openshift                   bool
 	TunnelCASecret              certificatemanagement.KeyPairInterface
+	TrustedBundle               certificatemanagement.TrustedBundle
 
 	// Whether or not the cluster supports pod security policies.
 	UsePSP bool
@@ -229,6 +230,9 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	// Namespaced enterprise-only objects.
 	namespacedEnterpriseObjects := []client.Object{
 		c.auditPolicyConfigMap(),
+	}
+	if c.cfg.TrustedBundle != nil {
+		namespacedEnterpriseObjects = append(namespacedEnterpriseObjects, c.cfg.TrustedBundle.ConfigMap(QueryserverNamespace))
 	}
 
 	// Global OSS-only objects.
@@ -874,6 +878,13 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers, c.queryServerContainer())
+
+		if c.cfg.TrustedBundle != nil {
+			trustedBundleHashAnnotations := c.cfg.TrustedBundle.HashAnnotations()
+			for k, v := range trustedBundleHashAnnotations {
+				d.Spec.Template.ObjectMeta.Annotations[k] = v
+			}
+		}
 	}
 
 	if overrides := c.cfg.APIServer.APIServerDeployment; overrides != nil {
@@ -1006,6 +1017,9 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		{Name: "TLS_KEY", Value: fmt.Sprintf("/%s/tls.key", ProjectCalicoApiServerTLSSecretName(c.cfg.Installation.Variant))},
 		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 	}
+	if c.cfg.TrustedBundle != nil {
+		env = append(env, corev1.EnvVar{Name: "TRUSTED_BUNDLE_PATH", Value: c.cfg.TrustedBundle.MountPath()})
+	}
 
 	env = append(env, c.cfg.K8SServiceEndpoint.EnvVars(c.hostNetwork(), c.cfg.Installation.KubernetesProvider)...)
 	env = append(env, GetTigeraSecurityGroupEnvVariables(c.cfg.AmazonCloudIntegration)...)
@@ -1016,6 +1030,9 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 
 	volumeMounts := []corev1.VolumeMount{
 		c.cfg.TLSKeyPair.VolumeMount(c.SupportedOSType()),
+	}
+	if c.cfg.TrustedBundle != nil {
+		volumeMounts = append(volumeMounts, c.cfg.TrustedBundle.VolumeMount(c.SupportedOSType()))
 	}
 
 	container := corev1.Container{
@@ -1072,6 +1089,10 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 				},
 			},
 		)
+
+		if c.cfg.TrustedBundle != nil {
+			volumes = append(volumes, c.cfg.TrustedBundle.Volume())
+		}
 
 		if c.cfg.ManagementCluster != nil {
 			volumes = append(volumes, corev1.Volume{

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -631,6 +631,15 @@ func managerClusterRole(managementCluster, managedCluster, openshift bool) *rbac
 				APIGroups: []string{""},
 				Resources: []string{"users", "groups", "serviceaccounts"},
 				Verbs:     []string{"impersonate"},
+			},
+			// Allow query server talk to Prometheus via the manager user.
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services/proxy"},
+				ResourceNames: []string{
+					"https:tigera-api:8080", "calico-node-prometheus:9090",
+				},
+				Verbs: []string{"get", "create"},
 			},
 		},
 	}

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,21 +18,19 @@ import (
 	"fmt"
 	"strconv"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-	networkpolicy "github.com/tigera/operator/pkg/render/common/networkpolicy"
-	"github.com/tigera/operator/pkg/render/testutils"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -43,8 +41,10 @@ import (
 	"github.com/tigera/operator/pkg/render/common/authentication"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	networkpolicy "github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/podaffinity"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/render/testutils"
 	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
@@ -307,6 +307,14 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				Resources: []string{"users", "groups", "serviceaccounts"},
 				Verbs:     []string{"impersonate"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services/proxy"},
+				ResourceNames: []string{
+					"https:tigera-api:8080", "calico-node-prometheus:9090",
+				},
+				Verbs: []string{"get", "create"},
+			},
 		}))
 	})
 
@@ -544,6 +552,14 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				APIGroups: []string{""},
 				Resources: []string{"users", "groups", "serviceaccounts"},
 				Verbs:     []string{"impersonate"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services/proxy"},
+				ResourceNames: []string{
+					"https:tigera-api:8080", "calico-node-prometheus:9090",
+				},
+				Verbs: []string{"get", "create"},
 			},
 		}))
 	})


### PR DESCRIPTION
## Description

This changeset allows Tigera query server talk to Prometheus to retrieve historical summary data. The extra Prometheus client certificate bundle is mounted into the queryserver container. When the request is made from queryserver to Prometheus, it will use the manager service account token to do authorization. Additional RBACs are added to the manager cluster role.

Pick https://github.com/tigera/operator/pull/2329 into release-v1.28 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
