### PR TITLE
cherry-pick #2387 enable mtls for kube controller metrics endpoint

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1159,18 +1159,34 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		calicoVersion = components.EnterpriseRelease
 	}
 
-	// Query the KubeControllersConfiguration object. We'll use this to help configure kube-controllers.
-	kubeControllersConfig := &crdv1.KubeControllersConfiguration{}
-	err = r.client.Get(ctx, types.NamespacedName{Name: "default"}, kubeControllersConfig)
-	if err != nil && !apierrors.IsNotFound(err) {
+	kubeControllersMetricsPort, err := utils.GetKubeControllerMetricsPort(ctx, r.client)
+	if err != nil {
 		r.status.SetDegraded(operator.ResourceReadError, "Unable to read KubeControllersConfiguration", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
-	// Determine the port to use for kube-controllers metrics.
-	kubeControllersMetricsPort := 0
-	if kubeControllersConfig.Spec.PrometheusMetricsPort != nil {
-		kubeControllersMetricsPort = *kubeControllersConfig.Spec.PrometheusMetricsPort
+	// Secure calico kube controller metrics.
+	var kubeControllerTLS certificatemanagement.KeyPairInterface
+	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
+		// Create or Get TLS certificates for kube controller.
+		kubeControllerTLS, err = certificateManager.GetOrCreateKeyPair(
+			r.client,
+			kubecontrollers.KubeControllerPrometheusTLSSecret,
+			common.OperatorNamespace(),
+			dns.GetServiceDNSNames(kubecontrollers.KubeControllerMetrics, common.CalicoNamespace, r.clusterDomain))
+		if err != nil {
+			r.status.SetDegraded(operator.ResourceReadError, "Error finding or creating TLS certificate kube controllers metric", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+
+		// Add prometheus client certificate to Trusted bundle.
+		kubecontrollerprometheusTLS, err := certificateManager.GetCertificate(r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
+		if err != nil {
+			r.status.SetDegraded(operator.ResourceReadError, "Failed to get certificate for kube controllers", err, reqLogger)
+			return reconcile.Result{}, err
+		} else if kubecontrollerprometheusTLS != nil {
+			typhaNodeTLS.TrustedBundle.AddCertificates(kubeControllerTLS, kubecontrollerprometheusTLS)
+		}
 	}
 
 	nodeAppArmorProfile := ""
@@ -1226,7 +1242,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	components = append(components,
 		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
 			Namespace:       common.CalicoNamespace,
-			ServiceAccounts: []string{render.CalicoNodeObjectName, render.TyphaServiceAccountName},
+			ServiceAccounts: []string{render.CalicoNodeObjectName, render.TyphaServiceAccountName, kubecontrollers.KubeControllerMetrics},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				// this controller is responsible for rendering the tigera-ca-private secret.
 				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
@@ -1234,6 +1250,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
 				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(kubeControllerTLS, true, true),
 			},
 			TrustedBundle: typhaNodeTLS.TrustedBundle,
 		}))
@@ -1320,6 +1337,8 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		ManagerInternalSecret:       managerInternalTLSSecret,
 		Terminating:                 terminating,
 		UsePSP:                      r.usePSP,
+		MetricsServerTLS:            kubeControllerTLS,
+		TrustedBundle:               typhaNodeTLS.TrustedBundle,
 	}
 	components = append(components, kubecontrollers.NewCalicoKubeControllers(&kubeControllersCfg))
 

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -49,6 +49,7 @@ import (
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	rsecret "github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/kubecontrollers"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -148,6 +149,7 @@ func add(mgr manager.Manager, c controller.Controller) error {
 		monitor.PrometheusTLSSecretName,
 		render.FluentdPrometheusTLSSecretName,
 		render.NodePrometheusTLSServerSecret,
+		kubecontrollers.KubeControllerPrometheusTLSSecret,
 	} {
 		if err = utils.AddSecretsWatch(c, secret, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("monitor-controller failed to watch secret: %w", err)
@@ -276,7 +278,7 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		render.FluentdPrometheusTLSSecretName,
 		render.NodePrometheusTLSServerSecret,
 		render.ProjectCalicoApiServerTLSSecretName(install.Variant),
-	} {
+		kubecontrollers.KubeControllerPrometheusTLSSecret,} {
 		certificate, err := certificateManager.GetCertificate(r.client, certificateName, common.OperatorNamespace())
 		if err == nil {
 			trustedBundle.AddCertificates(certificate)
@@ -333,6 +335,12 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
+	kubeControllersMetricsPort, err := utils.GetKubeControllerMetricsPort(ctx, r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Unable to read KubeControllersConfiguration", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	monitorCfg := &monitor.Config{
 		Installation:             install,
 		PullSecrets:              pullSecrets,
@@ -343,6 +351,7 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		ClusterDomain:            r.clusterDomain,
 		TrustedCertBundle:        trustedBundle,
 		Openshift:                r.provider == operatorv1.ProviderOpenShift,
+		KubeControllerPort:       kubeControllersMetricsPort,
 	}
 
 	// Render prometheus component

--- a/pkg/controller/monitor/prometheus.go
+++ b/pkg/controller/monitor/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,6 +74,13 @@ func addServiceMonitorFluentdWatch(c controller.Controller) error {
 	})
 }
 
+func addServiceMonitorKubeControllerWatch(c controller.Controller) error {
+	return utils.AddNamespacedWatch(c, &monitoringv1.ServiceMonitor{
+		TypeMeta:   metav1.TypeMeta{Kind: monitoringv1.ServiceMonitorsKind, APIVersion: monitor.MonitoringAPIVersion},
+		ObjectMeta: metav1.ObjectMeta{Name: monitor.KubeControllerMetrics, Namespace: common.TigeraPrometheusNamespace},
+	})
+}
+
 func addWatch(c controller.Controller) error {
 	var err error
 	if err = addAlertmanagerWatch(c); err != nil {
@@ -98,6 +105,10 @@ func addWatch(c controller.Controller) error {
 
 	if err = addServiceMonitorFluentdWatch(c); err != nil {
 		return fmt.Errorf("failed to watch ServiceMonitor fluentd-metrics resource: %w", err)
+	}
+
+	if err = addServiceMonitorKubeControllerWatch(c); err != nil {
+		return fmt.Errorf("failed to watch ServiceMonitor calico-kube-controller-metrics resource: %w", err)
 	}
 
 	if err = utils.AddSecretsWatch(c, monitor.AlertmanagerConfigSecret, common.OperatorNamespace()); err != nil {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import (
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/render"
@@ -559,4 +560,21 @@ func AddTigeraStatusWatch(c controller.Controller, name string) error {
 	return c.Watch(&source.Kind{Type: &operatorv1.TigeraStatus{ObjectMeta: metav1.ObjectMeta{Name: name}}}, &handler.EnqueueRequestForObject{}, predicate.NewPredicateFuncs(func(object client.Object) bool {
 		return object.GetName() == name
 	}))
+}
+
+// GetKubeControllerMetricsPort fetches kube controller metrics port.
+func GetKubeControllerMetricsPort(ctx context.Context, client client.Client) (int, error) {
+	kubeControllersConfig := &crdv1.KubeControllersConfiguration{}
+	kubeControllersMetricsPort := 0
+
+	// Query the KubeControllersConfiguration object. We'll use this to help configure kube-controllers metric port.
+	err := client.Get(ctx, types.NamespacedName{Name: "default"}, kubeControllersConfig)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return 0, err
+	}
+
+	if kubeControllersConfig.Spec.PrometheusMetricsPort != nil {
+		kubeControllersMetricsPort = *kubeControllersConfig.Spec.PrometheusMetricsPort
+	}
+	return kubeControllersMetricsPort, nil
 }

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019,2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,7 +32,6 @@ import (
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
-	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/render"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
@@ -39,6 +39,7 @@ import (
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
@@ -63,6 +64,7 @@ const (
 	ElasticsearchKubeControllersUserName               = "tigera-ee-kube-controllers"
 	ElasticsearchKubeControllersSecureUserSecret       = "tigera-ee-kube-controllers-elasticsearch-access-gateway"
 	ElasticsearchKubeControllersVerificationUserSecret = "tigera-ee-kube-controllers-gateway-verification-credentials"
+	KubeControllerPrometheusTLSSecret                  = "calico-kube-controllers-metrics-tls"
 )
 
 type KubeControllersConfiguration struct {
@@ -90,7 +92,8 @@ type KubeControllersConfiguration struct {
 	TrustedBundle                certificatemanagement.TrustedBundle
 
 	// Whether or not the cluster supports pod security policies.
-	UsePSP bool
+	UsePSP           bool
+	MetricsServerTLS certificatemanagement.KeyPairInterface
 }
 
 func NewCalicoKubeControllers(cfg *KubeControllersConfiguration) *kubeControllersComponent {
@@ -436,6 +439,19 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		}
 	}
 
+	if c.cfg.MetricsServerTLS != nil {
+		env = append(env,
+			corev1.EnvVar{Name: "TLS_KEY_PATH", Value: c.cfg.MetricsServerTLS.VolumeMountKeyFilePath()},
+			corev1.EnvVar{Name: "TLS_CRT_PATH", Value: c.cfg.MetricsServerTLS.VolumeMountCertificateFilePath()},
+			corev1.EnvVar{Name: "CLIENT_COMMON_NAME", Value: monitor.PrometheusClientTLSSecretName},
+		)
+	}
+	if c.cfg.TrustedBundle != nil {
+		env = append(env,
+			corev1.EnvVar{Name: "CA_CRT_PATH", Value: c.cfg.TrustedBundle.MountPath()},
+		)
+	}
+
 	container := corev1.Container{
 		Name:      c.kubeControllerName,
 		Image:     c.image,
@@ -580,6 +596,10 @@ func (c *kubeControllersComponent) annotations() map[string]string {
 	} else {
 		am = make(map[string]string)
 	}
+
+	if c.cfg.MetricsServerTLS != nil {
+		am[c.cfg.MetricsServerTLS.HashAnnotationKey()] = c.cfg.MetricsServerTLS.HashAnnotationValue()
+	}
 	if c.cfg.ManagerInternalSecret != nil {
 		am[c.cfg.ManagerInternalSecret.HashAnnotationKey()] = c.cfg.ManagerInternalSecret.HashAnnotationValue()
 	}
@@ -603,6 +623,9 @@ func (c *kubeControllersComponent) kubeControllersVolumeMounts() []corev1.Volume
 	if c.cfg.TrustedBundle != nil {
 		mounts = append(mounts, c.cfg.TrustedBundle.VolumeMount(c.SupportedOSType()))
 	}
+	if c.cfg.MetricsServerTLS != nil {
+		mounts = append(mounts, c.cfg.MetricsServerTLS.VolumeMount(c.SupportedOSType()))
+	}
 	return mounts
 }
 
@@ -613,6 +636,9 @@ func (c *kubeControllersComponent) kubeControllersVolumes() []corev1.Volume {
 	}
 	if c.cfg.TrustedBundle != nil {
 		volumes = append(volumes, c.cfg.TrustedBundle.Volume())
+	}
+	if c.cfg.MetricsServerTLS != nil {
+		volumes = append(volumes, c.cfg.MetricsServerTLS.Volume())
 	}
 	return volumes
 }

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -373,6 +373,94 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(2))
 		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
 		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
+
+		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
+	})
+	It("should render all calico-kube-controllers resources for a default configuration using TigeraSecureEnterprise", func() {
+		var defaultMode int32 = 420
+		var kubeControllerTLS certificatemanagement.KeyPairInterface
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{name: kubecontrollers.KubeControllerServiceAccount, ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+			{name: kubecontrollers.KubeControllerRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+			{name: kubecontrollers.KubeControllerRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: kubecontrollers.KubeController, ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "Deployment"},
+			{name: kubecontrollers.KubeControllerPodSecurityPolicy, ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
+			{name: kubecontrollers.KubeControllerMetrics, ns: common.CalicoNamespace, group: "", version: "v1", kind: "Service"},
+		}
+
+		expectedEnv := []corev1.EnvVar{
+			{Name: "TLS_KEY_PATH", Value: "/calico-kube-controllers-metrics-tls/tls.key"},
+			{Name: "TLS_CRT_PATH", Value: "/calico-kube-controllers-metrics-tls/tls.crt"},
+			{Name: "CLIENT_COMMON_NAME", Value: "calico-node-prometheus-client-tls"},
+			{Name: "CA_CRT_PATH", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
+		}
+		expectedVolumeMounts := []corev1.VolumeMount{
+			{Name: "tigera-ca-bundle", MountPath: "/etc/pki/tls/certs/", ReadOnly: true},
+			{Name: "calico-kube-controllers-metrics-tls", MountPath: "/calico-kube-controllers-metrics-tls", ReadOnly: true},
+		}
+		expectedVolume := []corev1.Volume{
+			{
+				Name: "tigera-ca-bundle",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "tigera-ca-bundle"},
+					},
+				},
+			},
+			{
+				Name: "calico-kube-controllers-metrics-tls",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  "calico-kube-controllers-metrics-tls",
+						DefaultMode: &defaultMode,
+					},
+				},
+			},
+		}
+		scheme := runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		certificateManager, err := certificatemanager.Create(cli, nil, dns.DefaultClusterDomain)
+		Expect(err).NotTo(HaveOccurred())
+		kubeControllerTLS, err = certificateManager.GetOrCreateKeyPair(cli,
+			kubecontrollers.KubeControllerPrometheusTLSSecret,
+			common.OperatorNamespace(),
+			dns.GetServiceDNSNames(kubecontrollers.KubeControllerMetrics, common.CalicoNamespace, dns.DefaultClusterDomain))
+		Expect(err).NotTo(HaveOccurred())
+		// Override configuration to match expected Enterprise config.
+		instance.Variant = operatorv1.TigeraSecureEnterprise
+		cfg.MetricsPort = 9094
+		cfg.MetricsServerTLS = kubeControllerTLS
+
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+		// Should render the correct resources.
+		i := 0
+		for _, expectedRes := range expectedResources {
+			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+			i++
+		}
+
+		// The Deployment should have the correct configuration.
+		dp := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+
+		envs := dp.Spec.Template.Spec.Containers[0].Env
+		Expect(envs).To(ContainElements(expectedEnv))
+
+		Expect(len(dp.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(2))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElements(expectedVolumeMounts))
+
+		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(2))
+		Expect(dp.Spec.Template.Spec.Volumes).To(ContainElements(expectedVolume))
 
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 	})

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,7 +75,8 @@ const (
 	calicoNodePrometheusServiceName       = "calico-node-prometheus"
 	tigeraPrometheusServiceHealthEndpoint = "/health"
 
-	bearerTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	bearerTokenFile       = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	KubeControllerMetrics = "calico-kube-controllers-metrics"
 )
 
 var alertManagerSelector = fmt.Sprintf(
@@ -111,6 +112,7 @@ type Config struct {
 	ClusterDomain            string
 	TrustedCertBundle        certificatemanagement.TrustedBundle
 	Openshift                bool
+	KubeControllerPort       int
 }
 
 type monitorComponent struct {
@@ -192,6 +194,7 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 		mc.serviceMonitorElasticsearch(),
 		mc.serviceMonitorFluentd(),
 		mc.serviceMonitorQueryServer(),
+		mc.serviceMonitorCalicoKubeControllers(),
 		mc.prometheusHTTPAPIService(),
 		mc.clusterRole(),
 		mc.clusterRoleBinding(),
@@ -896,6 +899,14 @@ func allowTigeraPrometheusPolicy(cfg *Config) *v3.NetworkPolicy {
 			Action:   v3.Allow,
 			Protocol: &networkpolicy.TCPProtocol,
 			Destination: v3.EntityRule{
+				// Egress access for Kube controller port metrics.
+				Ports: networkpolicy.Ports(uint16(cfg.KubeControllerPort)),
+			},
+		},
+		{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
 				Selector: alertManagerSelector,
 				Ports:    networkpolicy.Ports(AlertmanagerPort),
 			},
@@ -989,6 +1000,31 @@ func allowTigeraPrometheusOperatorPolicy(cfg *Config) *v3.NetworkPolicy {
 			Selector: "operator == 'prometheus'",
 			Types:    []v3.PolicyType{v3.PolicyTypeEgress},
 			Egress:   egressRules,
+		},
+	}
+}
+
+func (mc *monitorComponent) serviceMonitorCalicoKubeControllers() *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.ServiceMonitorsKind, APIVersion: MonitoringAPIVersion},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeControllerMetrics,
+			Namespace: common.TigeraPrometheusNamespace,
+			Labels:    map[string]string{"team": "network-operators"},
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector:          metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "calico-kube-controllers"}},
+			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{"calico-system"}},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					HonorLabels:   true,
+					Interval:      "5s",
+					Port:          "metrics-port",
+					ScrapeTimeout: "5s",
+					Scheme:        "https",
+					TLSConfig:     mc.tlsConfig(KubeControllerMetrics),
+				},
+			},
 		},
 	}
 }

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,6 +125,7 @@ var _ = Describe("monitor rendering tests", func() {
 			{"elasticsearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"tigera-api", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
+			{"calico-kube-controllers-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
 			{name: monitor.TigeraPrometheusObjectName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: monitor.TigeraPrometheusObjectName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -437,6 +438,7 @@ var _ = Describe("monitor rendering tests", func() {
 			{"elasticsearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"tigera-api", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
+			{"calico-kube-controllers-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
 			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
 			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
@@ -581,6 +583,7 @@ var _ = Describe("monitor rendering tests", func() {
 		DescribeTable("should render allow-tigera policy",
 			func(scenario testutils.AllowTigeraScenario) {
 				cfg.Openshift = scenario.Openshift
+				cfg.KubeControllerPort = 9094
 
 				component := monitor.MonitorPolicy(cfg)
 				resourcesToCreate, _ := component.Objects()

--- a/pkg/render/testutils/expected_policies/prometheus.json
+++ b/pkg/render/testutils/expected_policies/prometheus.json
@@ -81,6 +81,15 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
           "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
           "ports": [
             9093

--- a/pkg/render/testutils/expected_policies/prometheus_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus_ocp.json
@@ -92,6 +92,15 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
+          "ports": [
+            9094
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
           "selector": "(app == 'alertmanager' && alertmanager == 'calico-node-alertmanager') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == 'calico-node-alertmanager')",
           "ports": [
             9093

--- a/pkg/render/testutils/fixtures.go
+++ b/pkg/render/testutils/fixtures.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ package testutils
 
 import (
 	"github.com/tigera/operator/pkg/common"
-	"github.com/tigera/operator/pkg/render/kubecontrollers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -27,7 +26,7 @@ var KubeControllersUserSecret = corev1.Secret{
 		APIVersion: "v1",
 	},
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      kubecontrollers.ElasticsearchKubeControllersUserSecret,
+		Name:      "tigera-ee-kube-controllers-elasticsearch-access",
 		Namespace: common.OperatorNamespace(),
 	},
 	Data: map[string][]byte{


### PR DESCRIPTION
## Description

https://github.com/tigera/operator/pull/2387

Added mtls change to secure kube controller metrics endpoints.

Operator changes -
PR - https://github.com/tigera/operator/pull/2387

When variant = TigeraSecureEnterprise ,
Created new tls keypair for kubecontrollers. Mounted the Prometheus keypair to the kubecontroller trustedbundle.
Added the kube controllers certificate to the bundle in monitor_controller (prometheus)
passed the cert and key to kubecontroller pods via env variables.
Made changes in prometheus pods to watch for kubecontroller metrics. Added new service monitors.
updated network policy egress in allow-tigera.prometheus to allow connecting with kube controllers metric endpoint
Kubecontroller changes:
PR - https://github.com/tigera/calico-private/pull/5576

prometheus server in kube controllers will accept traffic over https when cert and key values are passed and only accept certs from the trusted bundle and the common name in the prometheus cert.
else if cert and key not available it accept traffic over http.
Tested scenarios:
sudo -E ~/bin/kubefwd svc -n calico-system

Default port :9094
Kubecontroller port can be configure to diff port via
kubectl patch kubecontrollersconfiguration default --type=merge --patch '{"spec":{"prometheusMetricsPort": 9095}}'

setup:
https://docs.tigera.io/v3.14/maintenance/monitor/prometheus/byo-prometheus#verify-byo-prometheus

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
