### PR TITLE
Pass user and password to connect to ES

### DIFF
--- a/pkg/controller/logstorage/linseed.go
+++ b/pkg/controller/logstorage/linseed.go
@@ -16,6 +16,7 @@ package logstorage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/tigera/operator/pkg/render/logstorage/linseed"
 	"github.com/tigera/operator/pkg/render/monitor"
@@ -76,7 +77,7 @@ func (r *ReconcileLogStorage) createLinseed(
 
 	// This secret should only ever contain one key.
 	if len(esAdminUserSecret.Data) != 1 {
-		r.status.SetDegraded(operatorv1.ResourceValidationError, "Elasticsearch admin user secret contains too many entries", nil, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceValidationError, fmt.Sprintf("secret should have exactly one entry. found %d", len(esAdminUserSecret.Data)), nil, reqLogger)
 		return reconcile.Result{}, false, nil
 	}
 
@@ -92,7 +93,7 @@ func (r *ReconcileLogStorage) createLinseed(
 		TrustedBundle:   trustedBundle,
 		ClusterDomain:   r.clusterDomain,
 		KeyPair:         linseedKeyPair,
-		EsAdminUserName: esAdminUserName,
+		ESAdminUserName: esAdminUserName,
 	}
 
 	linseedComponent := linseed.Linseed(cfg)

--- a/pkg/controller/logstorage/linseed.go
+++ b/pkg/controller/logstorage/linseed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ func (r *ReconcileLogStorage) createLinseed(
 	install *operatorv1.InstallationSpec,
 	variant operatorv1.ProductVariant,
 	pullSecrets []*corev1.Secret,
+	esAdminUserSecret *corev1.Secret,
 	hdler utils.ComponentHandler,
 	reqLogger logr.Logger,
 	ctx context.Context,
@@ -73,12 +74,25 @@ func (r *ReconcileLogStorage) createLinseed(
 	}
 	trustedBundle := certificateManager.CreateTrustedBundle(esInternalCertificate, prometheusCertificate)
 
+	// This secret should only ever contain one key.
+	if len(esAdminUserSecret.Data) != 1 {
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "Elasticsearch admin user secret contains too many entries", nil, reqLogger)
+		return reconcile.Result{}, false, nil
+	}
+
+	var esAdminUserName string
+	for k := range esAdminUserSecret.Data {
+		esAdminUserName = k
+		break
+	}
+
 	cfg := &linseed.Config{
-		Installation:  install,
-		PullSecrets:   pullSecrets,
-		TrustedBundle: trustedBundle,
-		ClusterDomain: r.clusterDomain,
-		KeyPair:       linseedKeyPair,
+		Installation:    install,
+		PullSecrets:     pullSecrets,
+		TrustedBundle:   trustedBundle,
+		ClusterDomain:   r.clusterDomain,
+		KeyPair:         linseedKeyPair,
+		EsAdminUserName: esAdminUserName,
 	}
 
 	linseedComponent := linseed.Linseed(cfg)

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020,2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -636,6 +636,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			install,
 			variant,
 			pullSecrets,
+			esAdminUserSecret,
 			hdler,
 			reqLogger,
 			ctx,

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -187,6 +187,10 @@ var KubeAPIServerServiceSelectorEntityRule = v3.EntityRule{
 var ESGatewayEntityRule = CreateEntityRule("tigera-elasticsearch", "tigera-secure-es-gateway", 5554)
 var ESGatewaySourceEntityRule = CreateSourceEntityRule("tigera-elasticsearch", "tigera-secure-es-gateway")
 var ESGatewayServiceSelectorEntityRule = CreateServiceSelectorEntityRule("tigera-elasticsearch", "tigera-secure-es-gateway-http")
+
+var LinseedEntityRule = CreateEntityRule("tigera-elasticsearch", "tigera-linseed", 443)
+var LinseedSourceEntityRule = CreateSourceEntityRule("tigera-elasticsearch", "tigera-linseed")
+var LinseedServiceSelectorEntityRule = CreateServiceSelectorEntityRule("tigera-elasticsearch", "tigera-linseed")
 
 const PrometheusSelector = "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')"
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1816,6 +1816,11 @@ func (es *elasticsearchComponent) elasticsearchAllowTigeraPolicy() *v3.NetworkPo
 		{
 			Action:      v3.Allow,
 			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.LinseedEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
 			Destination: networkpolicy.KubeAPIServerServiceSelectorEntityRule,
 		},
 	}...)
@@ -1845,6 +1850,12 @@ func (es *elasticsearchComponent) elasticsearchAllowTigeraPolicy() *v3.NetworkPo
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Source:      networkpolicy.ESGatewaySourceEntityRule,
+					Destination: elasticSearchIngressDestinationEntityRule,
+				},
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      networkpolicy.LinseedSourceEntityRule,
 					Destination: elasticSearchIngressDestinationEntityRule,
 				},
 				{

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,9 +86,10 @@ var _ = Describe("Linseed rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				KeyPair:       kp,
-				TrustedBundle: bundle,
-				ClusterDomain: clusterDomain,
+				KeyPair:         kp,
+				TrustedBundle:   bundle,
+				ClusterDomain:   clusterDomain,
+				EsAdminUserName: "elastic",
 			}
 		})
 
@@ -376,7 +377,11 @@ func expectedContainers() []corev1.Container {
 				PeriodSeconds:       5,
 			},
 			Env: []corev1.EnvVar{
-				{Name: "LINSEED_LOG_LEVEL", Value: "INFO"},
+				{
+					Name:      "LINSEED_LOG_LEVEL",
+					Value:     "INFO",
+					ValueFrom: nil,
+				},
 				{
 					Name:      "LINSEED_FIPS_MODE_ENABLED",
 					Value:     "false",
@@ -393,6 +398,37 @@ func expectedContainers() []corev1.Container {
 				{
 					Name:      "LINSEED_ELASTIC_ENDPOINT",
 					Value:     "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200",
+					ValueFrom: nil,
+				},
+				{
+					Name:      "LINSEED_ELASTIC_USERNAME",
+					Value:     "elastic",
+					ValueFrom: nil,
+				},
+				{
+					Name:  "LINSEED_ELASTIC_PASSWORD",
+					Value: "",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef:         nil,
+						ResourceFieldRef: nil,
+						ConfigMapKeyRef:  nil,
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "tigera-secure-es-elastic-user",
+							},
+							Key:      "elastic",
+							Optional: nil,
+						},
+					},
+				},
+				{
+					Name:      "LINSEED_ELASTIC_CLIENT_CERT_PATH",
+					Value:     "/etc/pki/tls/certs/tigera-ca-bundle.crt",
+					ValueFrom: nil,
+				},
+				{
+					Name:      "LINSEED_ELASTIC_CA_BUNDLE_PATH",
+					Value:     "/etc/pki/tls/certs/tigera-ca-bundle.crt",
 					ValueFrom: nil,
 				},
 			},

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Linseed rendering tests", func() {
 				KeyPair:         kp,
 				TrustedBundle:   bundle,
 				ClusterDomain:   clusterDomain,
-				EsAdminUserName: "elastic",
+				ESAdminUserName: "elastic",
 			}
 		})
 
@@ -110,9 +110,10 @@ var _ = Describe("Linseed rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				KeyPair:       kp,
-				TrustedBundle: bundle,
-				ClusterDomain: clusterDomain,
+				KeyPair:         kp,
+				TrustedBundle:   bundle,
+				ClusterDomain:   clusterDomain,
+				ESAdminUserName: "elastic",
 			}
 
 			component := Linseed(cfg)
@@ -378,14 +379,12 @@ func expectedContainers() []corev1.Container {
 			},
 			Env: []corev1.EnvVar{
 				{
-					Name:      "LINSEED_LOG_LEVEL",
-					Value:     "INFO",
-					ValueFrom: nil,
+					Name:  "LINSEED_LOG_LEVEL",
+					Value: "INFO",
 				},
 				{
-					Name:      "LINSEED_FIPS_MODE_ENABLED",
-					Value:     "false",
-					ValueFrom: nil,
+					Name:  "LINSEED_FIPS_MODE_ENABLED",
+					Value: "false",
 				},
 				{
 					Name:  "LINSEED_HTTPS_CERT",
@@ -396,40 +395,32 @@ func expectedContainers() []corev1.Container {
 					Value: "/tigera-secure-linseed-cert/tls.key",
 				},
 				{
-					Name:      "LINSEED_ELASTIC_ENDPOINT",
-					Value:     "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200",
-					ValueFrom: nil,
+					Name:  "LINSEED_ELASTIC_ENDPOINT",
+					Value: "https://tigera-secure-es-http.tigera-elasticsearch.svc:9200",
 				},
 				{
-					Name:      "LINSEED_ELASTIC_USERNAME",
-					Value:     "elastic",
-					ValueFrom: nil,
+					Name:  "LINSEED_ELASTIC_USERNAME",
+					Value: "elastic",
 				},
 				{
 					Name:  "LINSEED_ELASTIC_PASSWORD",
 					Value: "",
 					ValueFrom: &corev1.EnvVarSource{
-						FieldRef:         nil,
-						ResourceFieldRef: nil,
-						ConfigMapKeyRef:  nil,
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "tigera-secure-es-elastic-user",
 							},
-							Key:      "elastic",
-							Optional: nil,
+							Key: "elastic",
 						},
 					},
 				},
 				{
-					Name:      "LINSEED_ELASTIC_CLIENT_CERT_PATH",
-					Value:     "/etc/pki/tls/certs/tigera-ca-bundle.crt",
-					ValueFrom: nil,
+					Name:  "LINSEED_ELASTIC_CLIENT_CERT_PATH",
+					Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt",
 				},
 				{
-					Name:      "LINSEED_ELASTIC_CA_BUNDLE_PATH",
-					Value:     "/etc/pki/tls/certs/tigera-ca-bundle.crt",
-					ValueFrom: nil,
+					Name:  "LINSEED_ELASTIC_CA_BUNDLE_PATH",
+					Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt",
 				},
 			},
 			VolumeMounts: []corev1.VolumeMount{

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -727,6 +727,12 @@ func (c *managerComponent) managerAllowTigeraNetworkPolicy() *v3.NetworkPolicy {
 			Protocol:    &networkpolicy.TCPProtocol,
 			Source:      v3.EntityRule{},
 			Destination: networkpolicy.ESGatewayEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Source:      v3.EntityRule{},
+			Destination: networkpolicy.LinseedEntityRule,
 		},
 		{
 			Action:      v3.Allow,

--- a/pkg/render/testutils/expected_policies/elasticsearch.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch.json
@@ -42,6 +42,20 @@
       },
       {
         "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-linseed'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            9200
+          ]
+        }
+      },
+
+      {
+        "action": "Allow",
         "destination": {
           "ports": [
             9200
@@ -94,6 +108,17 @@
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
           "ports": [
             5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-linseed'",
+          "ports": [
+            443
           ]
         }
       },

--- a/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
@@ -42,6 +42,19 @@
       },
       {
         "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-linseed'",
+          "namespaceSelector": "name == 'tigera-elasticsearch'"
+        },
+        "destination": {
+          "ports": [
+            9200
+          ]
+        }
+      },
+      {
+        "action": "Allow",
         "destination": {
           "ports": [
             9200
@@ -105,6 +118,17 @@
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
           "ports": [
             5554
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-linseed'",
+          "ports": [
+            443
           ]
         }
       },

--- a/pkg/render/testutils/expected_policies/manager.json
+++ b/pkg/render/testutils/expected_policies/manager.json
@@ -81,6 +81,19 @@
       {
         "action": "Allow",
         "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-linseed'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
         "destination": {
           "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-server'",

--- a/pkg/render/testutils/expected_policies/manager_ocp.json
+++ b/pkg/render/testutils/expected_policies/manager_ocp.json
@@ -81,6 +81,19 @@
       {
         "action": "Allow",
         "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-linseed'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "ports": [
+            443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
         "destination": {
           "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-server'",


### PR DESCRIPTION
## Description

Pass user and password when connecting to ES, alongside certificates. Enabled access between Linseed and Elastic, Linseed and Manager (es-proxy)

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
