### PR TITLE
Do not delete psp when cluster doesn't support psp

### DIFF
--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -109,7 +109,6 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 	} else if c.config.OpenShift {
 		objectsToCreate = append(objectsToCreate, c.getSecurityContextConstraints())
 	} else {
-		objectsToDelete = append(objectsToDelete, PodSecurityPolicy())
 		objectsToDelete = append(objectsToDelete, c.egwRole())
 		objectsToDelete = append(objectsToDelete, c.egwRoleBinding())
 	}

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -107,7 +107,6 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			version string
 			kind    string
 		}{
-			{"tigera-egressgateway", "", "policy", "v1beta1", "PodSecurityPolicy"},
 			{"egress-test", "test-ns", rbac, "v1", "Role"},
 			{"egress-test", "test-ns", rbac, "v1", "RoleBinding"},
 		}


### PR DESCRIPTION
## Description

When upgrading from psp to non-psp cluster, psp created should not be deleted as this results in an error. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
