### PR TITLE
Enable communication between linseed and fluentd

### DIFF
--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -108,7 +108,7 @@ var (
 	}
 
 	ComponentFluentd = component{
-		Version: "master",
+		Version: "feature-multi-tenant-elasticsearch",
 		Image:   "tigera/fluentd",
 	}
 

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020,2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ func add(mgr manager.Manager, c controller.Controller) error {
 		render.ElasticsearchLogCollectorUserSecret, render.ElasticsearchEksLogForwarderUserSecret,
 		relasticsearch.PublicCertSecret, render.S3FluentdSecretName, render.EksLogForwarderSecret,
 		render.SplunkFluentdTokenSecretName, render.SplunkFluentdCertificateSecretName, monitor.PrometheusTLSSecretName,
-		render.FluentdPrometheusTLSSecretName,
+		render.FluentdPrometheusTLSSecretName, render.TigeraLinseedSecret,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("log-collector-controller failed to watch the Secret resource(%s): %v", secretName, err)
@@ -401,8 +401,18 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, nil
 	}
 
+	linseedCertificate, err := certificateManager.GetCertificate(r.client, render.TigeraLinseedSecret, common.OperatorNamespace())
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceValidationError, fmt.Sprintf("Failed to retrieve / validate  %s", render.TigeraLinseedSecret), err, reqLogger)
+		return reconcile.Result{}, err
+	} else if esgwCertificate == nil {
+		log.Info("Linseed certificate is not available yet, waiting until they become available")
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Linseed certificate are not available yet, waiting until they become available", nil, reqLogger)
+		return reconcile.Result{}, nil
+	}
+
 	// Fluentd needs to mount system certificates in the case where Splunk, Syslog or AWS are used.
-	trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates(prometheusCertificate, esgwCertificate)
+	trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates(prometheusCertificate, esgwCertificate, linseedCertificate)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create tigera-ca-bundle configmap", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -341,7 +341,7 @@ func (l *linseed) linseedAllowTigeraPolicy() *v3.NetworkPolicy {
 
 	// Ingress needs to be allowed from all clients.
 	linseedIngressDestinationEntityRule := v3.EntityRule{
-		Ports: networkpolicy.Ports(Port),
+		Ports: networkpolicy.Ports(TargetPort),
 	}
 	return &v3.NetworkPolicy{
 		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
@@ -44,6 +44,19 @@
         }
       },
       {
+        "action": "Deny",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-linseed'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "notPorts": [
+            8444
+          ]
+        }
+      },
+      {
         "action": "Allow",
         "protocol": "UDP",
         "destination": {

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
@@ -44,6 +44,19 @@
         }
       },
       {
+        "action": "Deny",
+        "protocol": "TCP",
+        "source": {
+        },
+        "destination": {
+          "selector": "k8s-app == 'tigera-linseed'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "notPorts": [
+            8444
+          ]
+        }
+      },
+      {
         "action": "Allow",
         "protocol": "UDP",
         "destination": {

--- a/pkg/render/testutils/expected_policies/linseed.json
+++ b/pkg/render/testutils/expected_policies/linseed.json
@@ -23,7 +23,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -36,7 +36,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -49,7 +49,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -62,7 +62,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -75,7 +75,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -83,7 +83,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -96,7 +96,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -109,7 +109,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -122,7 +122,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -135,7 +135,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -148,7 +148,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -161,7 +161,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -174,7 +174,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -187,7 +187,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",

--- a/pkg/render/testutils/expected_policies/linseed_ocp.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp.json
@@ -23,7 +23,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -36,7 +36,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -49,7 +49,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -62,7 +62,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -75,7 +75,7 @@
         },
         "destination": {
           "ports": [
-            443
+            8444
           ]
         }
       },
@@ -83,7 +83,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -96,7 +96,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -109,7 +109,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -122,7 +122,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -135,7 +135,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -148,7 +148,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -161,7 +161,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -174,7 +174,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",
@@ -187,7 +187,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            443
+            8444
           ]
         },
         "protocol": "TCP",


### PR DESCRIPTION
## Description

- Update fluentD image to use feature branch instead of master
- Update tigera-bundle to include linseed for fluentD
- Update policies to use target port instead of service port
- Update fluentD environment variables to enabled Linseed

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
