### PR TITLE
Update runAsUser for es-proxy and aws securitygroup

### DIFF
--- a/pkg/render/aws-securitygroup-setup.go
+++ b/pkg/render/aws-securitygroup-setup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019,2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,8 +110,8 @@ func (c *awsSGSetupComponent) setupJob() *batchv1.Job {
 								Value: "/etc/kubernetes/kubeconfig",
 							},
 						},
-						// UID 1001 is used in the operator Dockerfile.
-						SecurityContext: securitycontext.NewBaseContext(1001, 0),
+						// UID 10001 is used in the operator Dockerfile.
+						SecurityContext: securitycontext.NewBaseContext(10001, 0),
 					}},
 				},
 			},

--- a/pkg/render/aws-securitygroup-setup_test.go
+++ b/pkg/render/aws-securitygroup-setup_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,6 +80,6 @@ var _ = Describe("AWS SecurityGroup Setup rendering tests", func() {
 		Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
 		Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
 		Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
-		Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(1001))
+		Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(10001))
 	})
 })

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019,2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1515,7 +1515,6 @@ func (c *intrusionDetectionComponent) adAPIDeployment() *appsv1.Deployment {
 									},
 								},
 							},
-							Command: []string{"/anomaly-detection-api"},
 							VolumeMounts: []corev1.VolumeMount{
 								c.cfg.TrustedCertBundle.VolumeMount(c.SupportedOSType()),
 								c.cfg.ADAPIServerCertSecret.VolumeMount(c.SupportedOSType()),

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -494,8 +494,8 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		Name:          "tigera-es-proxy",
 		Image:         c.esProxyImage,
 		LivenessProbe: c.managerEsProxyProbe(),
-		// UID 1001 is used in the es-proxy Dockerfile.
-		SecurityContext: securitycontext.NewBaseContext(1001, 0),
+		// UID 10001 is used in the es-proxy Dockerfile.
+		SecurityContext: securitycontext.NewBaseContext(10001, 0),
 		Env:             env,
 		VolumeMounts:    volumeMounts,
 	}

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(*esProxy.SecurityContext.Privileged).To(BeFalse())
 		Expect(*esProxy.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
 		Expect(*esProxy.SecurityContext.RunAsNonRoot).To(BeTrue())
-		Expect(*esProxy.SecurityContext.RunAsUser).To(BeEquivalentTo(1001))
+		Expect(*esProxy.SecurityContext.RunAsUser).To(BeEquivalentTo(10001))
 
 		// voltron container
 		Expect(voltron.Env).To(ContainElements([]corev1.EnvVar{


### PR DESCRIPTION
## Description

Update UID and GID from 1001 to 10001 to be consistent with Dockerfile changes in each component.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
