### PR TITLE
Use the right registry for OSS cni-fips

### DIFF
--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -1,10 +1,10 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,6 +36,7 @@ func GetReference(c component, registry, imagePath, imagePrefix string, is *oper
 		switch c {
 		case ComponentCalicoNode,
 			ComponentCalicoCNI,
+			ComponentCalicoCNIFIPS,
 			ComponentCalicoTypha,
 			ComponentCalicoKubeControllers,
 			ComponentFlexVolume,

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -414,6 +414,12 @@ spec:
                 type: string
               iptablesFilterAllowAction:
                 type: string
+              iptablesFilterDenyAction:
+                description: IptablesFilterDenyAction controls what happens to traffic
+                  that is denied by network policy. By default Calico blocks traffic
+                  with an iptables "DROP" action. If you want to use "REJECT" action
+                  instead you can configure it in here.
+                type: string
               iptablesLockFilePath:
                 description: 'IptablesLockFilePath is the location of the iptables
                   lock file. You may need to change this if the lock file is not in


### PR DESCRIPTION
```
$ docker run tigera/operator:latest  --print-images=list | grep fips
2023/02/03 16:17:25 [ERROR] Failed to read namespace file: open /var/run/secrets/kubernetes.io/serviceaccount/namespace: no such file or directory
2023/02/03 16:17:25 [INFO] Failed to read serviceaccount/namespace file
docker.io/calico/cni:master-fips
gcr.io/unique-caldron-775/cnx/tigera/elasticsearch:master-fips
gcr.io/unique-caldron-775/cnx/tigera/cni:master-fips
```