### PR TITLE
Omit updates for NetworkPolicy/Tier when Spec is identical

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -449,6 +449,20 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 		// APIServer.
 		dui.SetOwnerReferences(cui.GetOwnerReferences())
 		return dui
+	case *v3.NetworkPolicy:
+		cnp := current.(*v3.NetworkPolicy)
+		dnp := desired.(*v3.NetworkPolicy)
+		if reflect.DeepEqual(cnp.Spec, dnp.Spec) {
+			return nil
+		}
+		return dnp
+	case *v3.Tier:
+		ct := current.(*v3.Tier)
+		dt := desired.(*v3.Tier)
+		if reflect.DeepEqual(ct.Spec, dt.Spec) {
+			return nil
+		}
+		return dt
 	default:
 		// Default to just using the desired state, with an updated RV.
 		return desired

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-
 	"github.com/tigera/operator/pkg/common"
 
 	apps "k8s.io/api/apps/v1"
@@ -1387,6 +1386,65 @@ var _ = Describe("Mocked client Component handler tests", func() {
 		Expect(err).NotTo(BeNil())
 
 		Expect(mc.Index).To(Equal(4))
+	})
+
+	It("NetworkPolicy updates are omitted if there is no change", func() {
+		np := &v3.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-tigera.test-policy",
+				Namespace: "tigera-namespace",
+			},
+			Spec: v3.NetworkPolicySpec{
+				Tier:     "allow-tigera",
+				Selector: "k8s-app == 'tigera-component'",
+				Egress: []v3.Rule{
+					{
+						Action: "Allow",
+					},
+				},
+				Types: []v3.PolicyType{"Egress"},
+			},
+		}
+
+		fc := &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs:            []client.Object{np},
+		}
+
+		mc.Info = append(mc.Info, mockReturn{
+			Method: "Get",
+			Return: nil,
+			Obj:    np,
+		})
+
+		err := handler.CreateOrUpdateOrDelete(ctx, fc, nil)
+		Expect(err).To(BeNil())
+		Expect(mc.Index).To(Equal(1))
+	})
+
+	It("Tier updates are omitted if there is no change", func() {
+		order := 9000.0
+		t := &v3.Tier{
+			TypeMeta:   metav1.TypeMeta{Kind: "Tier", APIVersion: "projectcalico.org/v3"},
+			ObjectMeta: metav1.ObjectMeta{Name: "test-tier"},
+			Spec:       v3.TierSpec{Order: &order},
+		}
+
+		fc := &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs:            []client.Object{t},
+		}
+
+		mc.Info = append(mc.Info, mockReturn{
+			Method: "Get",
+			Return: nil,
+			Obj:    t,
+		})
+
+		err := handler.CreateOrUpdateOrDelete(ctx, fc, nil)
+		Expect(err).To(BeNil())
+		Expect(mc.Index).To(Equal(1))
 	})
 })
 


### PR DESCRIPTION
## Description
Omits updates for NetworkPolicy and Tier when Spec identical. The defaulting and conversion code paths were validated to ensure that we can safely perform a DeepEquals check on the spec.

This only addresses a subset of unnecessary PUTs, a broader solution will be explored.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
