### PR TITLE
Remove and replace deprecated ioutil

### DIFF
--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -108,7 +107,7 @@ func GetComponents(versionsPath string) (Release, error) {
 // readComponents opens a versions.yml file and returns a Release
 func readComponents(versionsPath string) (Release, error) {
 	var cr Release
-	f, err := ioutil.ReadFile(versionsPath)
+	f, err := os.ReadFile(versionsPath)
 	if err != nil {
 		return cr, err
 	}

--- a/pkg/common/operator_namespace.go
+++ b/pkg/common/operator_namespace.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/cloudflare/cfssl/log"
@@ -29,7 +28,7 @@ func init() {
 		namespace = v
 		return
 	}
-	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	body, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		log.Errorf("Failed to read namespace file: %v", err)
 	} else {
@@ -42,10 +41,11 @@ func init() {
 
 // OperatorNamespace returns the namespace the operator is running in.
 // The value returned is based on the following priority (these are evaluated at startup):
-//   If the OPERATOR_NAMESPACE environment variable is non-empty then that is return.
-//   If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
-//   then the contents is returned.
-//   The default "tigera-operator" is returned.
+//
+//	If the OPERATOR_NAMESPACE environment variable is non-empty then that is return.
+//	If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
+//	then the contents is returned.
+//	The default "tigera-operator" is returned.
 func OperatorNamespace() string {
 	return namespace
 }

--- a/pkg/common/operator_serviceaccount.go
+++ b/pkg/common/operator_serviceaccount.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/cloudflare/cfssl/log"
@@ -29,10 +28,11 @@ func init() {
 
 // OperatorServiceAccount returns the ServiceAccount name the operator is running in.
 // The value returned is based on the following priority (these are evaluated at startup):
-//   If the OPERATOR_SERVICEACCOUNT environment variable is non-empty then that is return.
-//   If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
-//   then the contents is returned.
-//   The default "tigera-operator" is returned.
+//
+//	If the OPERATOR_SERVICEACCOUNT environment variable is non-empty then that is return.
+//	If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
+//	then the contents is returned.
+//	The default "tigera-operator" is returned.
 func OperatorServiceAccount() string {
 	return serviceAccount
 }
@@ -42,7 +42,7 @@ func getServiceAccount() string {
 	if ok {
 		return v
 	}
-	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	body, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		log.Info("Failed to read serviceaccount/namespace file")
 	} else {

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -1498,7 +1497,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 func readMTUFile() (int, error) {
 	filename := "/var/lib/calico/mtu"
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// File doesn't exist, return zero.

--- a/pkg/controller/utils/elasticsearch_test.go
+++ b/pkg/controller/utils/elasticsearch_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,14 +19,15 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 
-	elastic "github.com/olivere/elastic/v7"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	elastic "github.com/olivere/elastic/v7"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -108,7 +109,7 @@ func (t *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 			return &http.Response{
 				StatusCode: 200,
 				Request:    req,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
+				Body:       io.NopCloser(strings.NewReader("")),
 			}, nil
 		}
 	case "GET":
@@ -131,34 +132,34 @@ func (t *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		switch req.URL.String() {
 		case baseURI + "/_ilm/policy/" + indexName + "_policy":
 			if newPolicies {
-				actualBody, err := ioutil.ReadAll(req.Body)
+				actualBody, err := io.ReadAll(req.Body)
 				Expect(err).To(BeNil())
 
 				jsonFile, err := os.Open("test_files/01_put_policy.json")
 				Expect(err).To(BeNil())
 				defer jsonFile.Close()
-				expectedBody, _ := ioutil.ReadAll(jsonFile)
+				expectedBody, _ := io.ReadAll(jsonFile)
 				Expect(actualBody).To(MatchJSON(expectedBody))
 
 				return &http.Response{
 					StatusCode: 200,
 					Request:    req,
-					Body:       ioutil.NopCloser(bytes.NewBufferString("{}")),
+					Body:       io.NopCloser(bytes.NewBufferString("{}")),
 				}, nil
 			}
-			actualBody, err := ioutil.ReadAll(req.Body)
+			actualBody, err := io.ReadAll(req.Body)
 			Expect(err).To(BeNil())
 
 			jsonFile, err := os.Open("test_files/02_put_policy.json")
 			Expect(err).To(BeNil())
 			defer jsonFile.Close()
-			expectedBody, _ := ioutil.ReadAll(jsonFile)
+			expectedBody, _ := io.ReadAll(jsonFile)
 			Expect(actualBody).To(MatchJSON(expectedBody))
 
 			return &http.Response{
 				StatusCode: 200,
 				Request:    req,
-				Body:       ioutil.NopCloser(bytes.NewBufferString("{}")),
+				Body:       io.NopCloser(bytes.NewBufferString("{}")),
 			}, nil
 		}
 	}
@@ -166,10 +167,10 @@ func (t *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	if os.Getenv("ELASTIC_TEST_DEBUG") == "yes" {
 		_, _ = fmt.Fprintf(os.Stderr, "%s %s\n", req.Method, req.URL)
 		if req.Body != nil {
-			b, _ := ioutil.ReadAll(req.Body)
+			b, _ := io.ReadAll(req.Body)
 			_ = req.Body.Close()
 			body := string(b)
-			req.Body = ioutil.NopCloser(bytes.NewReader(b))
+			req.Body = io.NopCloser(bytes.NewReader(b))
 			_, _ = fmt.Fprintln(os.Stderr, body)
 		}
 	}
@@ -177,7 +178,7 @@ func (t *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return &http.Response{
 		Request:    req,
 		StatusCode: 500,
-		Body:       ioutil.NopCloser(strings.NewReader("")),
+		Body:       io.NopCloser(strings.NewReader("")),
 	}, nil
 }
 

--- a/pkg/render/common/authentication/types.go
+++ b/pkg/render/common/authentication/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -65,7 +65,7 @@ func NewWellKnownConfig(issuerURL string, rootCA []byte) (*WellKnownConfig, erro
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body: %v", err)
 	}
@@ -101,7 +101,7 @@ func (wk *WellKnownConfig) GetJWKS() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	keys, err := ioutil.ReadAll(resp.Body)
+	keys, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This changeset removes deprecated `io/ioutil` uses.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
