### PR TITLE
Increase Elasticsearch readiness probe threshold and timeout

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -595,11 +595,13 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 					Command: []string{"/usr/bin/readiness-probe"},
 				},
 			},
-			FailureThreshold:    3,
-			InitialDelaySeconds: 10,
+			// 30s (init) + 10 * 10s (timeout) + 9 * 5s (period) which is approximately 3 minutes
+			// to account for a slow elasticsearch start.
+			FailureThreshold:    10,
+			InitialDelaySeconds: 30,
 			PeriodSeconds:       5,
 			SuccessThreshold:    1,
-			TimeoutSeconds:      5,
+			TimeoutSeconds:      10,
 		},
 		Resources:       es.resourceRequirements(),
 		SecurityContext: sc,


### PR DESCRIPTION
## Description

This changeset increases Elasticsearch readiness probe threshold and timeout to account for a slow elasticsearch cluster start.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
