### PR TITLE
[RS-749] - Sets fluentd env vars for RS index replicas and shards.

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -354,7 +354,7 @@ spec:
                 type: integer
               healthTimeoutOverrides:
                 description: HealthTimeoutOverrides allows the internal watchdog timeouts
-                  of individual subcomponents to be overriden.  This is useful for
+                  of individual subcomponents to be overridden.  This is useful for
                   working around "false positive" liveness timeouts that can occur
                   in particularly stressful workloads or if CPU is constrained.  For
                   a list of active subcomponents, see Felix's logs.

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -754,11 +754,17 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		corev1.EnvVar{Name: "ELASTIC_DNS_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
 		corev1.EnvVar{Name: "ELASTIC_AUDIT_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
 		corev1.EnvVar{Name: "ELASTIC_BGP_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
+		corev1.EnvVar{Name: "ELASTIC_WAF_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
+		corev1.EnvVar{Name: "ELASTIC_L7_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
+		corev1.EnvVar{Name: "ELASTIC_RUNTIME_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
 
 		corev1.EnvVar{Name: "ELASTIC_FLOWS_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.FlowShards())},
 		corev1.EnvVar{Name: "ELASTIC_DNS_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
 		corev1.EnvVar{Name: "ELASTIC_AUDIT_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
 		corev1.EnvVar{Name: "ELASTIC_BGP_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
+		corev1.EnvVar{Name: "ELASTIC_WAF_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
+		corev1.EnvVar{Name: "ELASTIC_L7_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
+		corev1.EnvVar{Name: "ELASTIC_RUNTIME_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
 	)
 
 	if c.SupportedOSType() != rmeta.OSTypeWindows {


### PR DESCRIPTION
## Description

This PR fixes the RuntimeSecurity bug [RS-749](https://tigera.atlassian.net/browse/RS-749).

It adds env vars to the fluentd daemonset to configure the number of replicas and shards for the following indices, in the same way as is done for the other indices:
- tigera_secure_ee_l7
- tigera_secure_ee_runtime
- tigera_secure_ee_waf

This was tested on a calient cluster, where I observed that the fluentd pods now have the correct env vars, and that their values are correctly picked up from the `tigera-secure-elasticsearch` configmap.
## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.


[RS-749]: https://tigera.atlassian.net/browse/RS-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ