### PR TITLE
Fix EGW icmp probes

### DIFF
--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -188,7 +188,7 @@ func (c *component) egwInitContainer() *corev1.Container {
 
 func (c *component) egwContainer() *corev1.Container {
 	sc := securitycontext.NewRootContext(false)
-	sc.Capabilities.Add = []corev1.Capability{"NET_ADMIN"}
+	sc.Capabilities.Add = []corev1.Capability{"NET_ADMIN", "NET_RAW"}
 
 	return &corev1.Container{
 		Name:            "egress-gateway",

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		Expect(egwContainer.SecurityContext.Capabilities).To(Equal(
 			&corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
-				Add:  []corev1.Capability{"NET_ADMIN"},
+				Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},
 			},
 		))
 		Expect(egwContainer.SecurityContext.SeccompProfile).To(Equal(


### PR DESCRIPTION
## Description

EGW ICMP probes are failing with the below message

```
2023-02-21 20:57:24.076 [WARNING][7] egressd/icmp_probe.go 49: ICMP probe failed:
ping: socket: Operation not permitted
 ip=172.16.101.150 rc=2
```
Add ```NET_RAW``` capabilities to the EGW container to fix this. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
