### PR TITLE
Copy pull secrets to the EGW namespace

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -33,4 +33,6 @@ const (
 	TiersFeature = "tiers"
 	// EgressAccessControl enables creation/update of NetworkPolicy with Domains
 	EgressAccessControlFeature = "egress-access-control"
+	// MultipleOwnersLabel used to indicate multiple owner references.
+	MultipleOwnersLabel = "operator.tigera.io/multipleOwners"
 )

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -34,5 +34,8 @@ const (
 	// EgressAccessControl enables creation/update of NetworkPolicy with Domains
 	EgressAccessControlFeature = "egress-access-control"
 	// MultipleOwnersLabel used to indicate multiple owner references.
+	// If the render code places this label on an object, the object mergeState machinery will merge owner
+	// references with any that already exist on the object rather than replace the owner references. Further
+	// the controller in the owner reference will not be set.
 	MultipleOwnersLabel = "operator.tigera.io/multipleOwners"
 )

--- a/pkg/common/components.go
+++ b/pkg/common/components.go
@@ -14,6 +14,10 @@
 
 package common
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // MergeMaps merges current and desired maps. If both current and desired maps contain the same key, the
 // desired map's value is used.
 func MergeMaps(current, desired map[string]string) map[string]string {
@@ -32,4 +36,18 @@ func MapExistsOrInitialize(m map[string]string) map[string]string {
 		return m
 	}
 	return make(map[string]string)
+}
+
+// MergeOwnerReferences merges desired and current owner references, removing the duplicates.
+func MergeOwnerReferences(desired, current []metav1.OwnerReference) []metav1.OwnerReference {
+	mergedOwnerReferences := append(desired, current...)
+	allKeys := make(map[metav1.OwnerReference]bool)
+	refList := []metav1.OwnerReference{}
+	for _, item := range mergedOwnerReferences {
+		if _, ok := allKeys[item]; !ok {
+			refList = append(refList, item)
+			allKeys[item] = true
+		}
+	}
+	return refList
 }

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -325,7 +325,7 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 	var errMsgs []string
 	for _, egw := range egwsToReconcile {
 		// Check if there are pull secrets in the EGW namespace.
-		// If present, use the existing pull secrets as owner references need to 
+		// If present, use the existing pull secrets, as owner references need to
 		// be updated.
 		nsSecrets, err := r.getNetworkingPullSecrets(pullSecrets, egw.Namespace)
 		if err == nil {

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -324,6 +324,13 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 	// Reconcile all the EGWs
 	var errMsgs []string
 	for _, egw := range egwsToReconcile {
+		// Check if there are pull secrets in the EGW namespace.
+		// If present, use the existing pull secrets as owner references need to 
+		// be updated.
+		nsSecrets, err := r.getNetworkingPullSecrets(pullSecrets, egw.Namespace)
+		if err == nil {
+			pullSecrets = nsSecrets
+		}
 		err = r.reconcileEgressGateway(ctx, &egw, reqLogger, variant, fc, pullSecrets, installation, namespaceAndNames)
 		if err != nil {
 			reqLogger.Error(err, "Error reconciling egress gateway")
@@ -421,6 +428,20 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 	egw.Status.State = operatorv1.TigeraStatusReady
 	setAvailable(r.client, ctx, egw, string(operatorv1.AllObjectsAvailable), "All objects available")
 	return nil
+}
+
+func (r *ReconcileEgressGateway) getNetworkingPullSecrets(pullSecrets []*v1.Secret, ns string) ([]*v1.Secret, error) {
+	secrets := []*v1.Secret{}
+	for _, ps := range pullSecrets {
+		s := &v1.Secret{}
+		err := r.client.Get(context.Background(), client.ObjectKey{Name: ps.Name, Namespace: ns}, s)
+		if err != nil {
+			return nil, err
+		}
+		secrets = append(secrets, s)
+	}
+
+	return secrets, nil
 }
 
 func (r *ReconcileEgressGateway) patchFelixConfig(ctx context.Context) (*crdv1.FelixConfiguration, error) {

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -310,13 +310,13 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, err
 	}
 
-	// Fetch any existing default FelixConfiguration object.
-	fc := &crdv1.FelixConfiguration{}
-	err = r.client.Get(ctx, types.NamespacedName{Name: "default"}, fc)
-	if err != nil && !errors.IsNotFound(err) {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading FelixConfiguration", err, reqLogger)
+	// patch and get the felix configuration
+	fc, err := r.patchFelixConfig(ctx)
+	if err != nil {
+		reqLogger.Error(err, "Error patching felix configuration")
+		r.status.SetDegraded(operatorv1.ResourcePatchError, "Error patching felix configuration", err, reqLogger)
 		for _, egw := range egwsToReconcile {
-			setDegraded(r.client, ctx, &egw, reconcileErr, fmt.Sprintf("Error reading felix configuration err = %s", err.Error()))
+			setDegraded(r.client, ctx, &egw, reconcileErr, fmt.Sprintf("Error patching felix configuration err = %s", err.Error()))
 		}
 		return reconcile.Result{}, err
 	}
@@ -421,6 +421,26 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 	egw.Status.State = operatorv1.TigeraStatusReady
 	setAvailable(r.client, ctx, egw, string(operatorv1.AllObjectsAvailable), "All objects available")
 	return nil
+}
+
+func (r *ReconcileEgressGateway) patchFelixConfig(ctx context.Context) (*crdv1.FelixConfiguration, error) {
+	// Fetch any existing default FelixConfiguration object.
+	fc := &crdv1.FelixConfiguration{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+
+	if err != nil && !errors.IsNotFound(err) {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Unable to read FelixConfiguration", err, log)
+		return nil, err
+	}
+
+	patchFrom := client.MergeFrom(fc.DeepCopy())
+	if fc.Spec.PolicySyncPathPrefix == "" {
+		fc.Spec.PolicySyncPathPrefix = "/var/run/nodeagent"
+	}
+	if err := r.client.Patch(ctx, fc, patchFrom); err != nil {
+		return nil, err
+	}
+	return fc, nil
 }
 
 // getRequestedEgressGateway returns the namespaced EgressGateway instance.

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -544,7 +544,8 @@ spec:
                 type: string
               floatingIPs:
                 description: FloatingIPs configures whether or not Felix will program
-                  floating IP addresses.
+                  non-OpenStack floating IP addresses.  (OpenStack-derived floating
+                  IPs are always programmed, regardless of this setting.)
                 enum:
                 - Enabled
                 - Disabled
@@ -1203,8 +1204,8 @@ spec:
                 type: boolean
               vxlanEnabled:
                 description: 'VXLANEnabled overrides whether Felix should create the
-                  VXLAN tunnel device for VXLAN networking. Optional as Felix determines
-                  this based on the existing IP pools. [Default: nil (unset)]'
+                  VXLAN tunnel device for IPv4 VXLAN networking. Optional as Felix
+                  determines this based on the existing IP pools. [Default: nil (unset)]'
                 type: boolean
               vxlanMTU:
                 description: 'VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel

--- a/pkg/render/common/secret/secrets.go
+++ b/pkg/render/common/secret/secrets.go
@@ -85,7 +85,6 @@ func CopyToNamespace(ns string, oSecrets ...*corev1.Secret) []*corev1.Secret {
 	for _, s := range oSecrets {
 		x := s.DeepCopy()
 		x.ObjectMeta = metav1.ObjectMeta{Name: s.Name, Namespace: ns}
-		x.ObjectMeta.OwnerReferences = append(x.ObjectMeta.OwnerReferences, s.ObjectMeta.OwnerReferences...)
 
 		secrets = append(secrets, x)
 	}

--- a/pkg/render/common/secret/secrets.go
+++ b/pkg/render/common/secret/secrets.go
@@ -85,6 +85,7 @@ func CopyToNamespace(ns string, oSecrets ...*corev1.Secret) []*corev1.Secret {
 	for _, s := range oSecrets {
 		x := s.DeepCopy()
 		x.ObjectMeta = metav1.ObjectMeta{Name: s.Name, Namespace: ns}
+		x.ObjectMeta.OwnerReferences = append(x.ObjectMeta.OwnerReferences, s.ObjectMeta.OwnerReferences...)
 
 		secrets = append(secrets, x)
 	}

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -296,6 +296,9 @@ func (c *component) egwPullSecrets() []*corev1.Secret {
 		x := secret.DeepCopy()
 		x.ObjectMeta = metav1.ObjectMeta{Name: secret.Name, Namespace: c.config.EgressGW.Namespace}
 		x.ObjectMeta.Labels = common.MapExistsOrInitialize(x.ObjectMeta.Labels)
+		// Each pull secret is shared across all of the EGW deployments in this namespace.
+		// As such, we mark it as having multiple owners so that we maintain multiple owner references
+		// when creating the secret so that it will only be GC'd when all of its owners have been deleted.
 		x.ObjectMeta.Labels[common.MultipleOwnersLabel] = "true"
 		secrets = append(secrets, x)
 	}

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 	var healthTimeoutDS int32 = 30
 	var interval int32 = 20
 	var timeout int32 = 40
+	var pullSecrets []*corev1.Secret
 	rbac := "rbac.authorization.k8s.io"
 	logSeverity := operatorv1.LogLevelInfo
 	labels := map[string]string{"egress-code": "red"}
@@ -87,6 +88,16 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		}
 		egw.Name = "egress-test"
 		egw.Namespace = "test-ns"
+
+		pullSecrets = []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "test-ns",
+				},
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			}}
+
 	})
 
 	It("should render EGW deployment", func() {
@@ -97,6 +108,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			version string
 			kind    string
 		}{
+			{"test-secret", "test-ns", "", "v1", "Secret"},
 			{"egress-test", "test-ns", "", "v1", "ServiceAccount"},
 			{"egress-test", "test-ns", "apps", "v1", "Deployment"},
 		}
@@ -113,7 +125,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		}
 
 		component := egressgateway.EgressGateway(&egressgateway.Config{
-			PullSecrets:  nil,
+			PullSecrets:  pullSecrets,
 			Installation: installation,
 			OSType:       rmeta.OSTypeLinux,
 			EgressGW:     egw,
@@ -314,5 +326,4 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 	})
-
 })


### PR DESCRIPTION
## Description
The changes cover the steps to copy
1. Pull secrets to the EGW namespace. If the pull secrets are already present, the ownerReferences in the secret is updated to include the new resource.
2. Patch ```policySyncPathPrefix``` in the felix config.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
