### PR TITLE
Remove Elastic SELinux init container

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1431,15 +1431,9 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 						// The Image is not populated for the container so no need to get and check it
 						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(2))
+						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
 						initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 						Expect(initset).ToNot(BeNil())
-						Expect(initset.Image).To(Equal(
-							fmt.Sprintf("some.registry.org/%s:%s",
-								components.ComponentElasticsearch.Image,
-								components.ComponentElasticsearch.Version)))
-						initlogctx := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-log-selinux-context")
-						Expect(initlogctx).ToNot(BeNil())
 						Expect(initset.Image).To(Equal(
 							fmt.Sprintf("some.registry.org/%s:%s",
 								components.ComponentElasticsearch.Image,
@@ -1555,16 +1549,10 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 						// The Image is not populated for the container so no need to get and check it
 						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(2))
+						Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
 						initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 						Expect(initset).ToNot(BeNil())
 						Expect(initset.Image).To(Equal(
-							fmt.Sprintf("some.registry.org/%s@%s",
-								components.ComponentElasticsearch.Image,
-								"sha256:elasticsearchhash")))
-						initlogctx := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-log-selinux-context")
-						Expect(initlogctx).ToNot(BeNil())
-						Expect(initlogctx.Image).To(Equal(
 							fmt.Sprintf("some.registry.org/%s@%s",
 								components.ComponentElasticsearch.Image,
 								"sha256:elasticsearchhash")))

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -759,45 +759,6 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 		)
 	}
 
-	// Init container that logs the SELinux context of the `/usr/share/elasticsearch` folder.
-	// This init container is added as a workaround for a bug where Elasticsearch fails to starts when
-	// under some scenarios Kubernetes starts the main container before all the init containers have
-	// completed, SELinux is also enabled on the node, and Kubernetes/kubelet is using the Docker runtime.
-	//
-	// When SELinux is enabled, SELinux policy only allows a container to read a file/folder when their
-	// SELinux labels match or when the mounts are configured to be shared among multiple containers (the
-	// latter isn't used by Kubernetes). These SELinux labels are managed by the container runtime.
-	// This assignment of SELinux labels and relabelling of files/folders happen when the container is started.
-	// The container runtime also assigns the same SELinux labels to containers created within the same sandbox.
-	// The exception to this SELinux label assignment being when a container is privileged, the Docker runtime
-	// mounts the container's files/folders with a different SELinux label than the one used for the sandbox.
-	//
-	// In Kubernetes, pods are created within the same sandbox. This ensures that files/folders can be shared by
-	// containers running in the same pod. Kubernetes also explicitly requests relabelling of SELinux labels so
-	// that any mounted file/folder gets the right SELinux labels.
-	//
-	// The bug manifests on a SELinux enabled node, when the main container starts before the privileged container
-	// is complete. The main Elasticsearch container fails to read/write files on the shared volume mounts because
-	// the privileged container is the last init container to start and it uses different SELinux labels
-	// than the rest of the containers in the shared (pod) sandbox.
-	//
-	// Adding this additional init container after the privileged init container ensures that the volume mounts
-	// always get the correct SELinux labels and guarantees the labels will be correct for the main container.
-
-	initLogContextContainer := corev1.Container{
-		Name:  "elastic-internal-init-log-selinux-context",
-		Image: es.esImage,
-		Command: []string{
-			"/bin/sh",
-		},
-		Args: []string{
-			"-c",
-			"ls -ldZ /usr/share/elasticsearch",
-		},
-		SecurityContext: securitycontext.NewRootContext(false),
-	}
-	initContainers = append(initContainers, initLogContextContainer)
-
 	// default to controlPlaneNodeSelector unless DataNodeSelector is set
 	nodeSels := es.cfg.Installation.ControlPlaneNodeSelector
 	if es.cfg.LogStorage.Spec.DataNodeSelector != nil {

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 				// Verify that an initContainer is added
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(initContainers).To(HaveLen(2))
+				Expect(initContainers).To(HaveLen(1))
 				Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
 				Expect(*initContainers[0].SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
 				Expect(*initContainers[0].SecurityContext.Privileged).To(BeTrue())
@@ -261,21 +261,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					},
 				))
 				Expect(initContainers[0].SecurityContext.SeccompProfile).To(Equal(
-					&corev1.SeccompProfile{
-						Type: corev1.SeccompProfileTypeRuntimeDefault,
-					}))
-				Expect(initContainers[1].Name).To(Equal("elastic-internal-init-log-selinux-context"))
-				Expect(*initContainers[1].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
-				Expect(*initContainers[1].SecurityContext.Privileged).To(BeFalse())
-				Expect(*initContainers[1].SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-				Expect(*initContainers[1].SecurityContext.RunAsNonRoot).To(BeFalse())
-				Expect(*initContainers[1].SecurityContext.RunAsUser).To(BeEquivalentTo(0))
-				Expect(initContainers[1].SecurityContext.Capabilities).To(Equal(
-					&corev1.Capabilities{
-						Drop: []corev1.Capability{"ALL"},
-					},
-				))
-				Expect(initContainers[1].SecurityContext.SeccompProfile).To(Equal(
 					&corev1.SeccompProfile{
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					}))
@@ -485,7 +470,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
 
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(initContainers).To(HaveLen(5))
+				Expect(initContainers).To(HaveLen(4))
 				compareInitContainer := func(ic corev1.Container, expectedName string, expectedVolumes []corev1.VolumeMount) {
 					Expect(ic.Name).To(Equal(expectedName))
 					Expect(ic.VolumeMounts).To(HaveLen(len(expectedVolumes)))
@@ -504,7 +489,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				compareInitContainer(initContainers[3], "key-cert-elastic-transport", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: certificatemanagement.CSRCMountPath},
 				})
-				compareInitContainer(initContainers[4], "elastic-internal-init-log-selinux-context", []corev1.VolumeMount{})
 			})
 		})
 
@@ -848,7 +832,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					},
 				},
 			))
-			Expect(initContainers).To(HaveLen(3))
+			Expect(initContainers).To(HaveLen(2))
 			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-keystore"))
 			Expect(initContainers[1].Image).To(ContainSubstring("-fips"))
 			Expect(initContainers[1].Command).To(Equal([]string{"/bin/sh"}))


### PR DESCRIPTION
## Description

This Elastic init log container was added to resolve a k8s/docker runtime race where the main container starts before the prepare fs init container .

This workaround doesn't seem to be needed anymore as k8s dreprecated dockershim in late 2020. From my experiments in a RKE2 cluster on RockyLinux 8 with SELinux enabled by default, logStorage starts fine without it.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
