### PR TITLE
[release-v1.29] Add and update PodSecurityPolicy to match SecurityContext

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -450,6 +450,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			ClusterDomain:               r.clusterDomain,
 			ManagementClusterConnection: managementClusterConnection,
 			TrustedBundle:               trustedBundle,
+			UsePSP:                      r.usePSP,
 		}
 		pc := render.PacketCaptureAPI(packetCaptureApiCfg)
 		pcPolicy = render.PacketCaptureAPIPolicy(packetCaptureApiCfg)

--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -91,6 +91,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady
 		status:          status.New(mgr.GetClient(), "applicationlayer", opts.KubernetesVersion),
 		clusterDomain:   opts.ClusterDomain,
 		licenseAPIReady: licenseAPIReady,
+		usePSP:          opts.UsePSP,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -162,6 +163,7 @@ type ReconcileApplicationLayer struct {
 	status          status.StatusManager
 	clusterDomain   string
 	licenseAPIReady *utils.ReadyFlag
+	usePSP          bool
 }
 
 // Reconcile reads that state of the cluster for a ApplicationLayer object and makes changes
@@ -280,6 +282,7 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 		LogRequestsPerInterval: lcSpec.LogRequestsPerInterval,
 		LogIntervalSeconds:     lcSpec.LogIntervalSeconds,
 		ModSecurityConfigMap:   modSecurityRuleSet,
+		UsePSP:                 r.usePSP,
 	}
 	component := applicationlayer.ApplicationLayer(config)
 

--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -162,14 +162,12 @@ func (r *ReconcileEgressGateway) Reconcile(ctx context.Context, request reconcil
 	// If there are no Egress Gateway resources, return.
 	ch := utils.NewComponentHandler(log, r.client, r.scheme, nil)
 	if len(egws) == 0 {
-		objects := []client.Object{}
-
+		var objects []client.Object
 		if r.provider == operatorv1.ProviderOpenShift {
-			scc := egressgateway.SecurityContextConstraints()
-			objects = append(objects, scc)
-		} else if r.usePSP {
-			psp := egressgateway.PodSecurityPolicy()
-			objects = append(objects, psp)
+			objects = append(objects, egressgateway.SecurityContextConstraints())
+		}
+		if r.usePSP {
+			objects = append(objects, egressgateway.PodSecurityPolicy())
 		}
 		err := ch.CreateOrUpdateOrDelete(ctx, render.NewDeletionPassthrough(objects...), r.status)
 		if err != nil {

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1305,7 +1305,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	csiCfg := render.CSIConfiguration{
 		Installation: &instance.Spec,
 		Terminating:  terminating,
-		Openshift:    r.autoDetectedProvider == operator.ProviderOpenShift,
 		UsePSP:       r.usePSP,
 	}
 	components = append(components, render.CSI(&csiCfg))

--- a/pkg/controller/logstorage/esgateway.go
+++ b/pkg/controller/logstorage/esgateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +18,20 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"github.com/tigera/operator/pkg/controller/certificatemanager"
-	"github.com/tigera/operator/pkg/dns"
-	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
-	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	lscommon "github.com/tigera/operator/pkg/controller/logstorage/common"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
+	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 func (r *ReconcileLogStorage) createEsGateway(
@@ -43,6 +43,7 @@ func (r *ReconcileLogStorage) createEsGateway(
 	reqLogger logr.Logger,
 	ctx context.Context,
 	certificateManager certificatemanager.CertificateManager,
+	usePSP bool,
 ) (reconcile.Result, bool, error) {
 	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
 	svcDNSNames = append(svcDNSNames, dns.GetServiceDNSNames(esgateway.ServiceName, render.ElasticsearchNamespace, r.clusterDomain)...)
@@ -100,6 +101,7 @@ func (r *ReconcileLogStorage) createEsGateway(
 		ClusterDomain:              r.clusterDomain,
 		EsAdminUserName:            esAdminUserName,
 		ESGatewayKeyPair:           gatewayKeyPair,
+		UsePSP:                     usePSP,
 	}
 
 	esGatewayComponent := esgateway.EsGateway(cfg)

--- a/pkg/controller/logstorage/esmetrics.go
+++ b/pkg/controller/logstorage/esmetrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ func (r *ReconcileLogStorage) createEsMetrics(
 	ctx context.Context,
 	hdler utils.ComponentHandler,
 	clusterDomain string,
+	usePSP bool,
 ) (reconcile.Result, bool, error) {
 	esMetricsSecret, err := utils.GetSecret(context.Background(), r.client, esmetrics.ElasticsearchMetricsSecret, common.OperatorNamespace())
 	if err != nil {
@@ -99,6 +100,7 @@ func (r *ReconcileLogStorage) createEsMetrics(
 		ClusterDomain:        r.clusterDomain,
 		ServerTLS:            serverTLS,
 		TrustedBundle:        trustedBundle,
+		UsePSP:               usePSP,
 	}
 	esMetricsComponent := esmetrics.ElasticsearchMetrics(esMetricsCfg)
 	components := []render.Component{esMetricsComponent,

--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -195,7 +195,7 @@ func isRKE2(ctx context.Context, c kubernetes.Interface) (bool, error) {
 }
 
 // SupportsPodSecurityPolicies returns true if the cluster contains the policy/v1beta1 PodSecurityPolicy API,
-// and false otherwise. This API is scheuled to be removed in Kubernetes v1.25, but should still be used
+// and false otherwise. This API is scheduled to be removed in Kubernetes v1.25, but should still be used
 // in earlier Kubernetes versions.
 func SupportsPodSecurityPolicies(c kubernetes.Interface) (bool, error) {
 	resources, err := c.Discovery().ServerResourcesForGroupVersion("policy/v1beta1")

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -32,7 +32,6 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
-	"github.com/tigera/operator/pkg/ptr"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -119,7 +118,7 @@ type APIServerConfiguration struct {
 	TunnelCASecret              certificatemanagement.KeyPairInterface
 	TrustedBundle               certificatemanagement.TrustedBundle
 
-	// Whether or not the cluster supports pod security policies.
+	// Whether the cluster supports pod security policies.
 	UsePSP bool
 }
 
@@ -186,7 +185,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.authReaderRoleBinding)
 	globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.webhookReaderClusterRole)
 	globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.webhookReaderClusterRoleBinding)
-	if !c.cfg.Openshift && c.cfg.UsePSP {
+	if c.cfg.UsePSP {
 		globalObjects, objsToDelete = populateLists(globalObjects, objsToDelete, c.apiServerPodSecurityPolicy)
 	}
 
@@ -524,7 +523,7 @@ func (c *apiServerComponent) calicoCustomResourcesClusterRole() *rbacv1.ClusterR
 			},
 		},
 	}
-	if !c.cfg.Openshift {
+	if c.cfg.UsePSP {
 		// Allow access to the pod security policy in case this is enforced on the cluster
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups:     []string{"policy"},
@@ -1125,15 +1124,11 @@ func (c *apiServerComponent) apiServerPodSecurityPolicy() (client.Object, client
 		nameToDelete = enterpriseName
 	}
 
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(name)
-	psp.Spec.Privileged = false
-	psp.Spec.AllowPrivilegeEscalation = ptr.BoolToPtr(false)
+	psp := podsecuritypolicy.NewBasePolicy(name)
 	psp.Spec.Volumes = append(psp.Spec.Volumes, policyv1beta1.HostPath)
 	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
 
-	pspToDelete := podsecuritypolicy.NewBasePolicy()
-	pspToDelete.GetObjectMeta().SetName(nameToDelete)
+	pspToDelete := podsecuritypolicy.NewBasePolicy(nameToDelete)
 
 	return psp, pspToDelete
 }
@@ -1211,7 +1206,7 @@ func (c *apiServerComponent) tigeraCustomResourcesClusterRole() *rbacv1.ClusterR
 			},
 		},
 	}
-	if !c.cfg.Openshift {
+	if c.cfg.UsePSP {
 		// Allow access to the pod security policy in case this is enforced on the cluster
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups:     []string{"policy"},

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,6 +102,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Openshift:          openshift,
 			TLSKeyPair:         kp,
 			TrustedBundle:      trustedBundle,
+			UsePSP:             true,
 		}
 	})
 
@@ -139,6 +141,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoApiServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
 		kp, err := certificateManager.GetOrCreateKeyPair(cli, render.ProjectCalicoApiServerTLSSecretName(instance.Variant), common.OperatorNamespace(), dnsNames)
@@ -169,10 +172,8 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		// - 1 Server service
 		Expect(resources).To(HaveLen(len(expectedResources)))
 
-		i := 0
 		for _, expectedRes := range expectedResources {
 			rtest.ExpectResourceInList(resources, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-			i++
 		}
 
 		ns := rtest.GetResource(resources, "tigera-system", "", "", "v1", "Namespace").(*corev1.Namespace)
@@ -408,6 +409,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		component, err := render.APIServer(cfg)
@@ -461,6 +463,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		component, err := render.APIServer(cfg)
@@ -535,6 +538,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		cfg.Installation.ControlPlaneNodeSelector = map[string]string{"nodeName": "control01"}
@@ -602,6 +606,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		component, err := render.APIServer(cfg)
@@ -754,12 +759,11 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
-		i := 0
 		for _, expectedRes := range expectedResources {
 			rtest.ExpectResourceInList(resources, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-			i++
 		}
 		Expect(resources).To(HaveLen(len(expectedResources)))
 
@@ -831,13 +835,12 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 		Expect(resources).To(HaveLen(len(expectedResources)))
 
-		i := 0
 		for _, expectedRes := range expectedResources {
 			rtest.ExpectResourceInList(resources, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-			i++
 		}
 
 		dep := rtest.GetResource(resources, "tigera-apiserver", "tigera-system", "apps", "v1", "Deployment")
@@ -919,12 +922,11 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "tigera-network-admin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "tigera-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
-		i := 0
 		for _, expectedRes := range expectedResources {
 			rtest.ExpectResourceInList(resources, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-			i++
 		}
 		Expect(resources).To(HaveLen(len(expectedResources)))
 		dep := rtest.GetResource(resources, "tigera-apiserver", "tigera-system", "apps", "v1", "Deployment")
@@ -1534,6 +1536,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			APIServer:          apiserver,
 			Openshift:          openshift,
 			TLSKeyPair:         kp,
+			UsePSP:             true,
 		}
 	})
 
@@ -1558,6 +1561,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			{name: "calico-api", ns: "calico-apiserver", group: "", version: "v1", kind: "Service"},
 			{name: "calico-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "calico-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{name: "calico-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 			{name: "allow-apiserver", ns: "calico-apiserver", group: "networking.k8s.io", version: "v1", kind: "NetworkPolicy"},
 		}
 		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoApiServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
@@ -1570,10 +1574,8 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 
 		resources, _ := component.Objects()
 
-		i := 0
 		for _, expectedRes := range expectedResources {
 			rtest.ExpectResourceInList(resources, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-			i++
 		}
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
@@ -1679,6 +1681,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "calico-api", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhook-reader"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-webhook-reader"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}},
+			&policyv1beta1.PodSecurityPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "policy/v1beta1", Kind: "PodSecurityPolicy"}},
 			&netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "NetworkPolicy"}},
 		}
 

--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -28,6 +28,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -36,14 +37,18 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 )
 
 const (
 	APLName                          = "application-layer"
+	RoleName                         = "application-layer"
+	PodSecurityPolicyName            = "application-layer"
 	ApplicationLayerDaemonsetName    = "l7-log-collector"
 	L7CollectorContainerName         = "l7-collector"
 	ProxyContainerName               = "envoy-proxy"
@@ -96,6 +101,9 @@ type Config struct {
 	dikastesImage   string
 	dikastesEnabled bool
 	envoyConfigMap  *corev1.ConfigMap
+
+	// Whether the cluster supports pod security policies.
+	UsePSP bool
 }
 
 func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
@@ -166,6 +174,14 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 	// If we're running on openshift, we need to add in an SCC.
 	if c.config.Installation.KubernetesProvider == operatorv1.ProviderOpenShift {
 		objs = append(objs, c.securityContextConstraints())
+	}
+
+	if c.config.UsePSP {
+		objs = append(objs,
+			c.role(),
+			c.roleBinding(),
+			c.podSecurityPolicy(),
+		)
 	}
 
 	return objs, nil
@@ -507,6 +523,63 @@ func (c *component) clusterAdminClusterRoleBinding() *rbacv1.ClusterRoleBinding 
 			},
 		},
 	}
+}
+
+func (c *component) role() *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: common.CalicoNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+
+				APIGroups:     []string{"policy"},
+				Resources:     []string{"podsecuritypolicies"},
+				Verbs:         []string{"use"},
+				ResourceNames: []string{PodSecurityPolicyName},
+			},
+		},
+	}
+}
+
+func (c *component) roleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RoleName,
+			Namespace: common.CalicoNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     RoleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      APLName,
+				Namespace: common.CalicoNamespace,
+			},
+		},
+	}
+}
+
+func (c *component) podSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	psp := podsecuritypolicy.NewBasePolicy(PodSecurityPolicyName)
+	psp.Spec.Privileged = true
+	psp.Spec.AllowPrivilegeEscalation = ptr.BoolToPtr(true)
+	psp.Spec.RequiredDropCapabilities = nil
+	psp.Spec.AllowedCapabilities = []corev1.Capability{
+		"NET_ADMIN",
+		"NET_RAW",
+	}
+	psp.Spec.HostIPC = true
+	psp.Spec.HostNetwork = true
+	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
+	psp.Spec.Volumes = append(psp.Spec.Volumes, policyv1beta1.CSI, policyv1beta1.FlexVolume)
+	return psp
 }
 
 // securityContextConstraints returns SCC needed for daemonset to run on Openshift.

--- a/pkg/render/common/podsecuritypolicy/pod_secruity_policy.go
+++ b/pkg/render/common/podsecuritypolicy/pod_secruity_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tigera/operator/pkg/ptr"
 )
 
 // NewBasePolicy creates the base pod security policy with the minimal required permissions to be overridden if
 // necessary.
-func NewBasePolicy() *policyv1beta1.PodSecurityPolicy {
-	falseBool := false
-	ptrBoolFalse := &falseBool
+func NewBasePolicy(name string) *policyv1beta1.PodSecurityPolicy {
 	// This PodSecurityPolicy is equivalent to a "restricted" pod security standard,
 	// according to: https://kubernetes.io/docs/reference/access-authn-authz/psp-to-pod-security-standards/
 	return &policyv1beta1.PodSecurityPolicy{
@@ -33,18 +33,19 @@ func NewBasePolicy() *policyv1beta1.PodSecurityPolicy {
 			Annotations: map[string]string{
 				"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "*",
 			},
+			Name: name,
 		},
 		Spec: policyv1beta1.PodSecurityPolicySpec{
 			Privileged:               false,
-			AllowPrivilegeEscalation: ptrBoolFalse,
+			AllowPrivilegeEscalation: ptr.BoolToPtr(false),
 			RequiredDropCapabilities: []corev1.Capability{"ALL"},
 			Volumes: []policyv1beta1.FSType{
 				policyv1beta1.ConfigMap,
+				policyv1beta1.DownwardAPI,
 				policyv1beta1.EmptyDir,
+				policyv1beta1.PersistentVolumeClaim,
 				policyv1beta1.Projected,
 				policyv1beta1.Secret,
-				policyv1beta1.DownwardAPI,
-				policyv1beta1.PersistentVolumeClaim,
 			},
 			HostPorts: []policyv1beta1.HostPortRange{{
 				Min: int32(0),

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -62,8 +62,8 @@ var _ = Describe("CSI rendering tests", func() {
 		Expect(comp.ResolveImages(nil)).To(BeNil())
 		createObjs, delObjs := comp.Objects()
 
-		Expect(len(delObjs)).To(Equal(0))
-		Expect(len(createObjs)).To(Equal(len(expectedCreateObjs)))
+		Expect(createObjs).To(HaveLen(len(expectedCreateObjs)))
+		Expect(delObjs).To(HaveLen(0))
 
 		for i, expectedRes := range expectedCreateObjs {
 			rtest.ExpectResource(createObjs[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
@@ -151,10 +151,12 @@ var _ = Describe("CSI rendering tests", func() {
 	})
 
 	It("should render CSI's PSP and the corresponding clusterroles when UsePSP is set true", func() {
-		cfg.Openshift = false
 		cfg.UsePSP = true
-
 		resources, _ := render.CSI(&cfg).Objects()
+
+		ds := rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		Expect(ds).NotTo(BeNil())
+		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(Equal("csi-node-driver"))
 
 		serviceAccount := rtest.GetResource(resources, render.CSIDaemonSetName, render.CSIDaemonSetNamespace, "", "v1", "ServiceAccount")
 		Expect(serviceAccount).ToNot(BeNil())
@@ -186,21 +188,11 @@ var _ = Describe("CSI rendering tests", func() {
 		))
 	})
 
-	It("should not add ServiceAccountName field when UsePSP is false or not on Openshift", func() {
-		cfg.Openshift = false
+	It("should not add ServiceAccountName field when UsePSP is false", func() {
 		cfg.UsePSP = false
-
 		resources, _ := render.CSI(&cfg).Objects()
 
 		ds := rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
-		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
-
-		cfg.Openshift = true
-		cfg.UsePSP = true
-
-		resources, _ = render.CSI(&cfg).Objects()
-
-		ds = rtest.GetResource(resources, render.CSIDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
 	})
 

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -159,7 +159,7 @@ type FluentdConfiguration struct {
 	TrustedBundle    certificatemanagement.TrustedBundle
 	ManagedCluster   bool
 
-	// Whether or not the cluster supports pod security policies.
+	// Whether the cluster supports pod security policies.
 	UsePSP bool
 	// Whether to use User provided certificate or not.
 	UseSyslogCertificate bool
@@ -272,13 +272,12 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, c.filtersConfigMap())
 	}
 	if c.cfg.EKSConfig != nil && c.cfg.OSType == rmeta.OSTypeLinux {
-		if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
+		if c.cfg.UsePSP {
 			objs = append(objs,
 				c.eksLogForwarderClusterRole(),
-				c.eksLogForwarderClusterRoleBinding())
-			if c.cfg.UsePSP {
-				objs = append(objs, c.eksLogForwarderPodSecurityPolicy())
-			}
+				c.eksLogForwarderClusterRoleBinding(),
+				c.eksLogForwarderPodSecurityPolicy(),
+			)
 		}
 		objs = append(objs, c.eksLogForwarderServiceAccount(),
 			c.eksLogForwarderSecret(),
@@ -287,13 +286,12 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 
 	// Windows PSP does not support allowedHostPaths yet.
 	// See: https://github.com/kubernetes/kubernetes/issues/93165#issuecomment-693049808
-	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.cfg.OSType == rmeta.OSTypeLinux {
+	if c.cfg.UsePSP && c.cfg.OSType == rmeta.OSTypeLinux {
 		objs = append(objs,
 			c.fluentdClusterRole(),
-			c.fluentdClusterRoleBinding())
-		if c.cfg.UsePSP {
-			objs = append(objs, c.fluentdPodSecurityPolicy())
-		}
+			c.fluentdClusterRoleBinding(),
+			c.fluentdPodSecurityPolicy(),
+		)
 	}
 
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.cfg.ESSecrets...)...)...)
@@ -863,12 +861,7 @@ func (c *fluentdComponent) volumes() []corev1.Volume {
 }
 
 func (c *fluentdComponent) fluentdPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(c.fluentdName())
-	psp.Spec.RequiredDropCapabilities = nil
-	psp.Spec.AllowedCapabilities = []corev1.Capability{
-		corev1.Capability("CAP_CHOWN"),
-	}
+	psp := podsecuritypolicy.NewBasePolicy(c.fluentdName())
 	psp.Spec.Volumes = append(psp.Spec.Volumes, policyv1beta1.HostPath)
 	psp.Spec.AllowedHostPaths = []policyv1beta1.AllowedHostPath{
 		{
@@ -1057,8 +1050,7 @@ func (c *fluentdComponent) eksLogForwarderVolumes() []corev1.Volume {
 }
 
 func (c *fluentdComponent) eksLogForwarderPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(eksLogForwarderName)
+	psp := podsecuritypolicy.NewBasePolicy(eksLogForwarderName)
 	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
 	return psp
 }
@@ -1090,7 +1082,6 @@ func (c *fluentdComponent) eksLogForwarderClusterRole() *rbacv1.ClusterRole {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: eksLogForwarderName,
 		},
-
 		Rules: []rbacv1.PolicyRule{
 			{
 				// Allow access to the pod security policy in case this is enforced on the cluster

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -31,7 +31,6 @@ import (
 	"github.com/tigera/api/pkg/lib/numorstring"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/ptr"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
@@ -90,7 +89,7 @@ type GuardianConfiguration struct {
 	TrustedCertBundle certificatemanagement.TrustedBundle
 	TunnelCAType      operatorv1.CAType
 
-	// Whether or not the cluster supports pod security policies.
+	// Whether the cluster supports pod security policies.
 	UsePSP bool
 }
 
@@ -129,7 +128,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		// Add tigera-manager service account for impersonation
 		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 		managerServiceAccount(),
-		managerClusterRole(false, true, c.cfg.Openshift),
+		managerClusterRole(false, true, c.cfg.UsePSP),
 		managerClusterRoleBinding(),
 		managerClusterWideSettingsGroup(),
 		managerUserSpecificSettingsGroup(),
@@ -137,10 +136,9 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		managerClusterWideDefaultView(),
 	)
 
-	if !c.cfg.Openshift && c.cfg.UsePSP {
-		objs = append(objs, c.podsecuritypolicy())
+	if c.cfg.UsePSP {
+		objs = append(objs, c.podSecurityPolicy())
 	}
-
 	return objs, nil
 }
 
@@ -182,24 +180,18 @@ func (c *GuardianComponent) service() *corev1.Service {
 	}
 }
 
-func (c *GuardianComponent) serviceAccount() client.Object {
+func (c *GuardianComponent) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: GuardianServiceAccountName, Namespace: GuardianNamespace},
 	}
 }
 
-func (c *GuardianComponent) podsecuritypolicy() client.Object {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(GuardianPodSecurityPolicyName)
-	psp.Spec.Privileged = false
-	psp.Spec.AllowPrivilegeEscalation = ptr.BoolToPtr(false)
-	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyMustRunAsNonRoot
-
-	return psp
+func (c *GuardianComponent) podSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	return podsecuritypolicy.NewBasePolicy(GuardianPodSecurityPolicyName)
 }
 
-func (c *GuardianComponent) clusterRole() client.Object {
+func (c *GuardianComponent) clusterRole() *rbacv1.ClusterRole {
 	policyRules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
@@ -208,7 +200,7 @@ func (c *GuardianComponent) clusterRole() client.Object {
 		},
 	}
 
-	if !c.cfg.Openshift && c.cfg.UsePSP {
+	if c.cfg.UsePSP {
 		// Allow access to the pod security policy in case this is enforced on the cluster
 		policyRules = append(policyRules, rbacv1.PolicyRule{
 			APIGroups:     []string{"policy"},
@@ -227,7 +219,7 @@ func (c *GuardianComponent) clusterRole() client.Object {
 	}
 }
 
-func (c *GuardianComponent) clusterRoleBinding() client.Object {
+func (c *GuardianComponent) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -248,7 +240,7 @@ func (c *GuardianComponent) clusterRoleBinding() client.Object {
 	}
 }
 
-func (c *GuardianComponent) deployment() client.Object {
+func (c *GuardianComponent) deployment() *appsv1.Deployment {
 	var replicas int32 = 1
 
 	return &appsv1.Deployment{

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -58,12 +58,13 @@ const (
 	IntrusionDetectionControllerPolicyName = networkpolicy.TigeraComponentPolicyPrefix + IntrusionDetectionControllerName
 	IntrusionDetectionInstallerPolicyName  = networkpolicy.TigeraComponentPolicyPrefix + "intrusion-detection-elastic"
 
-	ADAPIObjectName          = "anomaly-detection-api"
-	ADAPIObjectPortName      = "anomaly-detection-api-https"
-	ADAPITLSSecretName       = "anomaly-detection-api-tls"
-	ADAPIExpectedServiceName = "anomaly-detection-api.tigera-intrusion-detection.svc"
-	ADAPIPolicyName          = networkpolicy.TigeraComponentPolicyPrefix + ADAPIObjectName
-	adAPIPort                = 8080
+	ADAPIObjectName            = "anomaly-detection-api"
+	ADAPIPodSecurityPolicyName = "anomaly-detection-api"
+	ADAPIObjectPortName        = "anomaly-detection-api-https"
+	ADAPITLSSecretName         = "anomaly-detection-api-tls"
+	ADAPIExpectedServiceName   = "anomaly-detection-api.tigera-intrusion-detection.svc"
+	ADAPIPolicyName            = networkpolicy.TigeraComponentPolicyPrefix + ADAPIObjectName
+	adAPIPort                  = 8080
 
 	ADPersistentVolumeClaimName            = "tigera-anomaly-detection"
 	DefaultAnomalyDetectionPVRequestSizeGi = "10Gi"
@@ -117,7 +118,7 @@ type IntrusionDetectionConfiguration struct {
 	TrustedCertBundle     certificatemanagement.TrustedBundle
 	ADAPIServerCertSecret certificatemanagement.KeyPairInterface
 
-	// Whether or not the cluster supports pod security policies.
+	// Whether the cluster supports pod security policies.
 	UsePSP bool
 }
 
@@ -256,13 +257,13 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 		}
 	}
 
-	if !c.cfg.Openshift {
+	if c.cfg.UsePSP {
 		objs = append(objs,
 			c.intrusionDetectionPSPClusterRole(),
-			c.intrusionDetectionPSPClusterRoleBinding())
-		if c.cfg.UsePSP {
-			objs = append(objs, c.intrusionDetectionPodSecurityPolicy())
-		}
+			c.intrusionDetectionPSPClusterRoleBinding(),
+			c.intrusionDetectionPodSecurityPolicy(),
+			c.adAPIPodSecurityPolicy(),
+		)
 	}
 
 	if c.cfg.HasNoLicense {
@@ -1240,9 +1241,7 @@ func (c *intrusionDetectionComponent) adJobsGlobalertTemplates() []client.Object
 }
 
 func (c *intrusionDetectionComponent) intrusionDetectionPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName("intrusion-detection")
-
+	psp := podsecuritypolicy.NewBasePolicy("intrusion-detection")
 	if c.syslogForwardingIsEnabled() {
 		psp.Spec.Volumes = append(psp.Spec.Volumes, policyv1beta1.HostPath)
 		psp.Spec.AllowedHostPaths = []policyv1beta1.AllowedHostPath{
@@ -1251,9 +1250,8 @@ func (c *intrusionDetectionComponent) intrusionDetectionPodSecurityPolicy() *pol
 				ReadOnly:   false,
 			},
 		}
+		psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
 	}
-
-	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
 	return psp
 }
 
@@ -1317,23 +1315,34 @@ func (c *intrusionDetectionComponent) adAPIServiceAccount() *corev1.ServiceAccou
 }
 
 func (c *intrusionDetectionComponent) adAPIAccessClusterRole() *rbacv1.ClusterRole {
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"authorization.k8s.io"},
+			Resources: []string{"subjectaccessreviews"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{"authentication.k8s.io"},
+			Resources: []string{"tokenreviews"},
+			Verbs:     []string{"create"},
+		},
+	}
+
+	if c.cfg.UsePSP {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{ADAPIPodSecurityPolicyName},
+		})
+	}
+
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ADAPIObjectName,
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"authorization.k8s.io"},
-				Resources: []string{"subjectaccessreviews"},
-				Verbs:     []string{"create"},
-			},
-			{
-				APIGroups: []string{"authentication.k8s.io"},
-				Resources: []string{"tokenreviews"},
-				Verbs:     []string{"create"},
-			},
-		},
+		Rules: rules,
 	}
 }
 
@@ -1410,6 +1419,10 @@ func (c *intrusionDetectionComponent) adPersistentVolumeClaim() *corev1.Persiste
 	}
 
 	return &adPVC
+}
+
+func (c *intrusionDetectionComponent) adAPIPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	return podsecuritypolicy.NewBasePolicy(ADAPIPodSecurityPolicyName)
 }
 
 func (c *intrusionDetectionComponent) adAPIDeployment() *appsv1.Deployment {

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -163,9 +163,10 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
+			{name: "anomaly-detection-api", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
-		Expect(len(resources)).To(Equal(len(expectedResources)))
+		Expect(resources).To(HaveLen(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
@@ -315,13 +316,17 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		}))
 
 		adAPIClusterRole := rtest.GetResource(resources, render.ADAPIObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(len(adAPIClusterRole.Rules)).To(Equal(2))
+		Expect(adAPIClusterRole.Rules).To(HaveLen(3))
 		Expect(adAPIClusterRole.Rules[0].APIGroups).To(ConsistOf("authorization.k8s.io"))
 		Expect(adAPIClusterRole.Rules[0].Resources).To(ConsistOf("subjectaccessreviews"))
 		Expect(adAPIClusterRole.Rules[0].Verbs).To(ConsistOf("create"))
 		Expect(adAPIClusterRole.Rules[1].APIGroups).To(ConsistOf("authentication.k8s.io"))
 		Expect(adAPIClusterRole.Rules[1].Resources).To(ConsistOf("tokenreviews"))
 		Expect(adAPIClusterRole.Rules[1].Verbs).To(ConsistOf("create"))
+		Expect(adAPIClusterRole.Rules[2].APIGroups).To(ConsistOf("policy"))
+		Expect(adAPIClusterRole.Rules[2].Resources).To(ConsistOf("podsecuritypolicies"))
+		Expect(adAPIClusterRole.Rules[2].Verbs).To(ConsistOf("use"))
+		Expect(adAPIClusterRole.Rules[2].ResourceNames).To(ConsistOf("anomaly-detection-api"))
 
 		adAPIClusterRoleBinding := rtest.GetResource(resources, render.ADAPIObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
 		Expect(adAPIClusterRoleBinding.RoleRef).To(Equal(rbacv1.RoleRef{
@@ -498,9 +503,10 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
+			{name: "anomaly-detection-api", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
-		Expect(len(resources)).To(Equal(len(expectedResources)))
+		Expect(resources).To(HaveLen(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
@@ -623,9 +629,10 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
+			{name: "anomaly-detection-api", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
-		Expect(len(resources)).To(Equal(len(expectedResources)))
+		Expect(resources).To(HaveLen(len(expectedResources)))
 
 		for i, expectedRes := range expectedResources {
 			rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
@@ -817,6 +824,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "intrusion-detection-psp", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "intrusion-detection", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
+			{name: "anomaly-detection-api", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 		}
 
 		Expect(toCreate).To(HaveLen(len(expectedResources)))

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -90,7 +90,7 @@ type KubeControllersConfiguration struct {
 	KubeControllersGatewaySecret *corev1.Secret
 	TrustedBundle                certificatemanagement.TrustedBundle
 
-	// Whether or not the cluster supports pod security policies.
+	// Whether the cluster supports pod security policies.
 	UsePSP bool
 }
 
@@ -238,7 +238,7 @@ func (c *kubeControllersComponent) Objects() ([]client.Object, []client.Object) 
 			secret.CopyToNamespace(common.CalicoNamespace, c.cfg.KubeControllersGatewaySecret)...)...)
 	}
 
-	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.cfg.UsePSP {
+	if c.cfg.UsePSP {
 		objectsToCreate = append(objectsToCreate, c.controllersPodSecurityPolicy())
 	}
 
@@ -313,7 +313,7 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration, kubeContr
 		},
 	}
 
-	if cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
+	if cfg.UsePSP {
 		// Allow access to the pod security policy in case this is enforced on the cluster
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups:     []string{"policy"},
@@ -597,9 +597,7 @@ func (c *kubeControllersComponent) annotations() map[string]string {
 }
 
 func (c *kubeControllersComponent) controllersPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(c.kubeControllerName)
-	return psp
+	return podsecuritypolicy.NewBasePolicy(c.kubeControllerName)
 }
 
 func (c *kubeControllersComponent) kubeControllersVolumeMounts() []corev1.VolumeMount {

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -43,6 +43,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/ptr"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -203,7 +204,7 @@ type ElasticsearchConfiguration struct {
 	ApplyTrial                  bool
 	KeyStoreSecret              *corev1.Secret
 
-	// Whether or not the cluster supports pod security policies.
+	// Whether the cluster supports pod security policies.
 	UsePSP bool
 }
 
@@ -307,25 +308,19 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 			toCreate = append(toCreate, es.eckOperatorClusterAdminClusterRoleBinding())
 		}
 
-		// Apply the pod security policies for all providers except OpenShift
-		if es.cfg.Provider != operatorv1.ProviderOpenShift {
+		if es.cfg.UsePSP {
 			toCreate = append(toCreate,
 				es.elasticsearchClusterRoleBinding(),
-				es.elasticsearchClusterRole())
-
-			if es.cfg.UsePSP {
-				toCreate = append(toCreate,
-					es.eckOperatorPodSecurityPolicy(),
-					es.elasticsearchPodSecurityPolicy())
-			}
-
+				es.elasticsearchClusterRole(),
+				es.eckOperatorPodSecurityPolicy(),
+				es.elasticsearchPodSecurityPolicy(),
+			)
 			if !operatorv1.IsFIPSModeEnabled(es.cfg.Installation.FIPSMode) {
 				toCreate = append(toCreate,
 					es.kibanaClusterRoleBinding(),
-					es.kibanaClusterRole())
-				if es.cfg.UsePSP {
-					toCreate = append(toCreate, es.kibanaPodSecurityPolicy())
-				}
+					es.kibanaClusterRole(),
+					es.kibanaPodSecurityPolicy(),
+				)
 			}
 		}
 
@@ -382,14 +377,12 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 				toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(ElasticsearchNamespace, es.cfg.CuratorSecrets...)...)...)
 				toCreate = append(toCreate, es.esCuratorServiceAccount())
 
-				// If the provider is not OpenShift apply the pod security policy for the curator.
-				if es.cfg.Provider != operatorv1.ProviderOpenShift {
+				if es.cfg.UsePSP {
 					toCreate = append(toCreate,
 						es.curatorClusterRole(),
-						es.curatorClusterRoleBinding())
-					if es.cfg.UsePSP {
-						toCreate = append(toCreate, es.curatorPodSecurityPolicy())
-					}
+						es.curatorClusterRoleBinding(),
+						es.curatorPodSecurityPolicy(),
+					)
 				}
 
 				toCreate = append(toCreate, es.curatorCronJob())
@@ -1130,7 +1123,7 @@ func (es elasticsearchComponent) eckOperatorClusterRole() *rbacv1.ClusterRole {
 		},
 	}
 
-	if es.cfg.Provider != operatorv1.ProviderOpenShift {
+	if es.cfg.UsePSP {
 		// Allow access to the pod security policy in case this is enforced on the cluster
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups:     []string{"policy"},
@@ -1304,9 +1297,7 @@ func (es elasticsearchComponent) eckOperatorStatefulSet() *appsv1.StatefulSet {
 }
 
 func (es elasticsearchComponent) eckOperatorPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(ECKOperatorName)
-	return psp
+	return podsecuritypolicy.NewBasePolicy(ECKOperatorName)
 }
 
 func (es elasticsearchComponent) kibanaServiceAccount() *corev1.ServiceAccount {
@@ -1577,9 +1568,7 @@ func (es elasticsearchComponent) curatorClusterRoleBinding() *rbacv1.ClusterRole
 }
 
 func (es elasticsearchComponent) curatorPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(EsCuratorName)
-	return psp
+	return podsecuritypolicy.NewBasePolicy(EsCuratorName)
 }
 
 // Applying this in the eck namespace will start a trial license for enterprise features.
@@ -1636,15 +1625,14 @@ func (es elasticsearchComponent) elasticsearchClusterRoleBinding() *rbacv1.Clust
 }
 
 func (es elasticsearchComponent) elasticsearchPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	trueBool := true
-	ptrBoolTrue := &trueBool
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName("tigera-elasticsearch")
+	psp := podsecuritypolicy.NewBasePolicy("tigera-elasticsearch")
 	psp.Spec.Privileged = true
-	psp.Spec.AllowPrivilegeEscalation = ptrBoolTrue
+	psp.Spec.AllowPrivilegeEscalation = ptr.BoolToPtr(true)
 	psp.Spec.RequiredDropCapabilities = nil
 	psp.Spec.AllowedCapabilities = []corev1.Capability{
-		corev1.Capability("CAP_CHOWN"),
+		"SETGID",
+		"SETUID",
+		"SYS_CHROOT",
 	}
 	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
 	return psp
@@ -1688,9 +1676,7 @@ func (es elasticsearchComponent) kibanaClusterRoleBinding() *rbacv1.ClusterRoleB
 }
 
 func (es elasticsearchComponent) kibanaPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName("tigera-kibana")
-	return psp
+	return podsecuritypolicy.NewBasePolicy("tigera-kibana")
 }
 
 func (es elasticsearchComponent) oidcUserRole() client.Object {

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -19,6 +19,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,17 +33,20 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 const (
-	ElasticsearchMetricsSecret          = "tigera-ee-elasticsearch-metrics-elasticsearch-access"
-	ElasticsearchMetricsServerTLSSecret = "tigera-ee-elasticsearch-metrics-tls"
-	ElasticsearchMetricsName            = "tigera-elasticsearch-metrics"
-	ElasticsearchMetricsPolicyName      = networkpolicy.TigeraComponentPolicyPrefix + "elasticsearch-metrics"
-	ElasticsearchMetricsPort            = 9081
+	ElasticsearchMetricsSecret                = "tigera-ee-elasticsearch-metrics-elasticsearch-access"
+	ElasticsearchMetricsServerTLSSecret       = "tigera-ee-elasticsearch-metrics-tls"
+	ElasticsearchMetricsName                  = "tigera-elasticsearch-metrics"
+	ElasticsearchMetricsRoleName              = "tigera-elasticsearch-metrics"
+	ElasticsearchMetricsPodSecurityPolicyName = "tigera-elasticsearch-metrics"
+	ElasticsearchMetricsPolicyName            = networkpolicy.TigeraComponentPolicyPrefix + "elasticsearch-metrics"
+	ElasticsearchMetricsPort                  = 9081
 )
 
 var ESMetricsSourceEntityRule = networkpolicy.CreateSourceEntityRule(render.ElasticsearchNamespace, ElasticsearchMetricsName)
@@ -60,6 +65,9 @@ type Config struct {
 	ClusterDomain        string
 	ServerTLS            certificatemanagement.KeyPairInterface
 	TrustedBundle        certificatemanagement.TrustedBundle
+
+	// Whether the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type elasticsearchMetrics struct {
@@ -89,6 +97,13 @@ func (e *elasticsearchMetrics) Objects() (objsToCreate, objsToDelete []client.Ob
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(render.ElasticsearchNamespace, e.cfg.ESMetricsCredsSecret)...)...)
 	toCreate = append(toCreate, e.metricsService(), e.metricsDeployment(), e.serviceAccount())
 
+	if e.cfg.UsePSP {
+		toCreate = append(toCreate,
+			e.metricsRole(),
+			e.metricsRoleBinding(),
+			e.metricsPodSecurityPolicy(),
+		)
+	}
 	return toCreate, objsToDelete
 }
 
@@ -108,6 +123,50 @@ func (e *elasticsearchMetrics) Ready() bool {
 
 func (e *elasticsearchMetrics) SupportedOSType() rmeta.OSType {
 	return rmeta.OSTypeLinux
+}
+
+func (e *elasticsearchMetrics) metricsRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ElasticsearchMetricsRoleName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"policy"},
+				Resources:     []string{"podsecuritypolicies"},
+				Verbs:         []string{"use"},
+				ResourceNames: []string{ElasticsearchMetricsPodSecurityPolicyName},
+			},
+		},
+	}
+}
+
+func (e *elasticsearchMetrics) metricsRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ElasticsearchMetricsRoleName,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     ElasticsearchMetricsRoleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      ElasticsearchMetricsName,
+				Namespace: render.ElasticsearchNamespace,
+			},
+		},
+	}
+}
+
+func (e *elasticsearchMetrics) metricsPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	return podsecuritypolicy.NewBasePolicy(ElasticsearchMetricsPodSecurityPolicyName)
 }
 
 func (e *elasticsearchMetrics) metricsService() *corev1.Service {

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Elasticsearch metrics", func() {
 				ClusterDomain: "cluster.local",
 				ServerTLS:     secret,
 				TrustedBundle: bundle,
+				UsePSP:        true,
 			}
 		})
 
@@ -102,8 +103,11 @@ var _ = Describe("Elasticsearch metrics", func() {
 				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "", "v1", "Service"},
 				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "apps", "v1", "Deployment"},
 				{ElasticsearchMetricsName, render.ElasticsearchNamespace, "", "v1", "ServiceAccount"},
+				{"tigera-elasticsearch-metrics", "tigera-elasticsearch", "rbac.authorization.k8s.io", "v1", "Role"},
+				{"tigera-elasticsearch-metrics", "tigera-elasticsearch", "rbac.authorization.k8s.io", "v1", "RoleBinding"},
+				{"tigera-elasticsearch-metrics", "", "policy", "v1beta1", "PodSecurityPolicy"},
 			}
-			Expect(len(resources)).To(Equal(len(expectedResources)))
+			Expect(resources).To(HaveLen(len(expectedResources)))
 			for i, expectedRes := range expectedResources {
 				rtest.ExpectResource(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 			}
@@ -241,6 +245,18 @@ var _ = Describe("Elasticsearch metrics", func() {
 				&corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				}))
+		})
+
+		It("should render properly when PSP is not supported by the cluster", func() {
+			cfg.UsePSP = false
+			component := ElasticsearchMetrics(cfg)
+			Expect(component.ResolveImages(nil)).To(BeNil())
+			resources, _ := component.Objects()
+
+			// Should not contain any PodSecurityPolicies
+			for _, r := range resources {
+				Expect(r.GetObjectKind().GroupVersionKind().Kind).NotTo(Equal("PodSecurityPolicy"))
+			}
 		})
 
 		It("should apply controlPlaneNodeSelector correctly", func() {

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -22,6 +22,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/configmap"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
@@ -45,22 +47,23 @@ import (
 )
 
 const (
-	MonitoringAPIVersion        = "monitoring.coreos.com/v1"
-	CalicoNodeAlertmanager      = "calico-node-alertmanager"
-	CalicoNodeMonitor           = "calico-node-monitor"
-	CalicoNodePrometheus        = "calico-node-prometheus"
-	ElasticsearchMetrics        = "elasticsearch-metrics"
-	FluentdMetrics              = "fluentd-metrics"
-	TigeraPrometheusObjectName  = "tigera-prometheus"
-	TigeraPrometheusSAName      = "prometheus"
-	TigeraPrometheusDPRate      = "tigera-prometheus-dp-rate"
-	TigeraPrometheusRole        = "tigera-prometheus-role"
-	TigeraPrometheusRoleBinding = "tigera-prometheus-role-binding"
+	MonitoringAPIVersion   = "monitoring.coreos.com/v1"
+	CalicoNodeAlertmanager = "calico-node-alertmanager"
+	CalicoNodeMonitor      = "calico-node-monitor"
+	CalicoNodePrometheus   = "calico-node-prometheus"
+
+	CalicoPrometheusOperator = "calico-prometheus-operator"
+
+	TigeraPrometheusObjectName            = "tigera-prometheus"
+	TigeraPrometheusDPRate                = "tigera-prometheus-dp-rate"
+	TigeraPrometheusRole                  = "tigera-prometheus-role"
+	TigeraPrometheusRoleBinding           = "tigera-prometheus-role-binding"
+	TigeraPrometheusPodSecurityPolicyName = "tigera-prometheus"
 
 	PrometheusAPIPolicyName       = networkpolicy.TigeraComponentPolicyPrefix + "tigera-prometheus-api"
 	PrometheusClientTLSSecretName = "calico-node-prometheus-client-tls"
 	PrometheusDefaultPort         = 9090
-	PrometheusHTTPAPIServiceName  = "prometheus-http-api"
+	PrometheusServiceServiceName  = "prometheus-http-api"
 	PrometheusOperatorPolicyName  = networkpolicy.TigeraComponentPolicyPrefix + "prometheus-operator"
 	PrometheusPolicyName          = networkpolicy.TigeraComponentPolicyPrefix + "prometheus"
 	PrometheusProxyPort           = 9095
@@ -71,6 +74,9 @@ const (
 	AlertmanagerConfigSecret   = "alertmanager-calico-node-alertmanager"
 	AlertmanagerPort           = 9093
 	MeshAlertManagerPolicyName = AlertManagerPolicyName + "-mesh"
+
+	ElasticsearchMetrics = "elasticsearch-metrics"
+	FluentdMetrics       = "fluentd-metrics"
 
 	calicoNodePrometheusServiceName       = "calico-node-prometheus"
 	tigeraPrometheusServiceHealthEndpoint = "/health"
@@ -111,6 +117,7 @@ type Config struct {
 	ClusterDomain            string
 	TrustedCertBundle        certificatemanagement.TrustedBundle
 	Openshift                bool
+	UsePSP                   bool
 }
 
 type monitorComponent struct {
@@ -165,36 +172,33 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 	}
 
 	// Create role and role bindings first.
-	// Operator needs the create/update roles for Alertmanger configuration secret for example.
+	// Operator needs the create/update roles for Alertmanager configuration secret for example.
 	toCreate = append(toCreate,
-		mc.role(),
-		mc.roleBinding(),
+		mc.operatorRole(),
+		mc.operatorRoleBinding(),
 	)
 
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.cfg.PullSecrets...)...)...)
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.cfg.AlertmanagerConfigSecret)...)...)
 
-	// This is to delete a service that had been released in v3.8 with a typo in the name.
-	// TODO Remove the toDelete object after we drop support for v3.8.
-	toDelete := []client.Object{
-		mc.serviceMonitorElasicsearchToDelete(),
-	}
-
 	toCreate = append(toCreate,
-		mc.alertmanagerService(),
-		mc.alertmanager(),
+		mc.prometheusOperatorServiceAccount(),
+		mc.prometheusOperatorClusterRole(),
+		mc.prometheusOperatorClusterRoleBinding(),
 		mc.prometheusServiceAccount(),
 		mc.prometheusClusterRole(),
 		mc.prometheusClusterRoleBinding(),
 		mc.prometheus(),
+		mc.alertmanagerService(),
+		mc.alertmanager(),
+		mc.prometheusServiceService(),
+		mc.prometheusServiceClusterRole(),
+		mc.prometheusServiceClusterRoleBinding(),
 		mc.prometheusRule(),
 		mc.serviceMonitorCalicoNode(),
 		mc.serviceMonitorElasticsearch(),
 		mc.serviceMonitorFluentd(),
 		mc.serviceMonitorQueryServer(),
-		mc.prometheusHTTPAPIService(),
-		mc.clusterRole(),
-		mc.clusterRoleBinding(),
 	)
 
 	if mc.cfg.KeyValidatorConfig != nil {
@@ -202,58 +206,151 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, configmap.ToRuntimeObjects(mc.cfg.KeyValidatorConfig.RequiredConfigMaps(common.TigeraPrometheusNamespace)...)...)
 	}
 
+	if mc.cfg.UsePSP {
+		toCreate = append(toCreate, mc.prometheusOperatorPodSecurityPolicy())
+	}
+
 	// Remove the pod monitor that existed prior to v1.25.
+	var toDelete []client.Object
 	toDelete = append(toDelete, &monitoringv1.PodMonitor{ObjectMeta: metav1.ObjectMeta{Name: FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}})
 
 	return toCreate, toDelete
 }
 
-func (mc *monitorComponent) clusterRole() client.Object {
-	rules := []rbacv1.PolicyRule{
-		{
-			APIGroups: []string{"authentication.k8s.io"},
-			Resources: []string{"tokenreviews"},
-			Verbs:     []string{"create"},
-		},
-		{
-			APIGroups: []string{"authorization.k8s.io"},
-			Resources: []string{"subjectaccessreviews"},
-			Verbs:     []string{"create"},
-		},
-	}
+func (mc *monitorComponent) Ready() bool {
+	return true
+}
 
-	return &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+func (mc *monitorComponent) prometheusOperatorServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: TigeraPrometheusObjectName,
+			Name:      CalicoPrometheusOperator,
+			Namespace: common.TigeraPrometheusNamespace,
 		},
-		Rules: rules,
 	}
 }
 
-func (mc *monitorComponent) clusterRoleBinding() client.Object {
+func (mc *monitorComponent) prometheusOperatorClusterRole() *rbacv1.ClusterRole {
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"monitoring.coreos.com"},
+			Resources: []string{
+				"alertmanagers",
+				"alertmanagers/finalizers",
+				"alertmanagerconfigs",
+				"prometheuses",
+				"prometheuses/finalizers",
+				"prometheuses/status",
+				"thanosrulers",
+				"thanosrulers/finalizers",
+				"servicemonitors",
+				"podmonitors",
+				"probes",
+				"prometheusrules",
+			},
+			Verbs: []string{"*"},
+		},
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{"statefulsets"},
+			Verbs:     []string{"*"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"configmaps",
+				"secrets",
+			},
+			Verbs: []string{"*"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs: []string{
+				"delete",
+				"list",
+			},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"services",
+				"services/finalizers",
+				"endpoints",
+			},
+			Verbs: []string{
+				"create",
+				"delete",
+				"get",
+				"update",
+			},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs: []string{
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{"networking.k8s.io"},
+			Resources: []string{"ingresses"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+	}
+
+	if mc.cfg.UsePSP {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{TigeraPrometheusPodSecurityPolicyName},
+		})
+	}
+
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperator},
+		Rules:      rules,
+	}
+}
+
+func (mc *monitorComponent) prometheusOperatorClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: TigeraPrometheusObjectName,
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperator},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      CalicoPrometheusOperator,
+				Namespace: common.TigeraPrometheusNamespace,
+			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     TigeraPrometheusObjectName,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      TigeraPrometheusSAName,
-				Namespace: common.TigeraPrometheusNamespace,
-			},
+			Name:     CalicoPrometheusOperator,
 		},
 	}
 }
 
-func (mc *monitorComponent) Ready() bool {
-	return true
+func (mc *monitorComponent) prometheusOperatorPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	return podsecuritypolicy.NewBasePolicy(TigeraPrometheusPodSecurityPolicyName)
 }
 
 func (mc *monitorComponent) alertmanager() *monitoringv1.Alertmanager {
@@ -264,13 +361,14 @@ func (mc *monitorComponent) alertmanager() *monitoringv1.Alertmanager {
 			Namespace: common.TigeraPrometheusNamespace,
 		},
 		Spec: monitoringv1.AlertmanagerSpec{
-			Image:            &mc.alertmanagerImage,
-			ImagePullSecrets: secret.GetReferenceList(mc.cfg.PullSecrets),
-			Replicas:         ptr.Int32ToPtr(3),
-			Version:          components.ComponentCoreOSAlertmanager.Version,
-			Tolerations:      mc.cfg.Installation.ControlPlaneTolerations,
-			NodeSelector:     mc.cfg.Installation.ControlPlaneNodeSelector,
-			SecurityContext:  securitycontext.NewNonRootPodContext(),
+			Image:              &mc.alertmanagerImage,
+			ImagePullSecrets:   secret.GetReferenceList(mc.cfg.PullSecrets),
+			NodeSelector:       mc.cfg.Installation.ControlPlaneNodeSelector,
+			Replicas:           ptr.Int32ToPtr(3),
+			SecurityContext:    securitycontext.NewNonRootPodContext(),
+			ServiceAccountName: PrometheusServiceAccountName,
+			Tolerations:        mc.cfg.Installation.ControlPlaneTolerations,
+			Version:            components.ComponentCoreOSAlertmanager.Version,
 		},
 	}
 }
@@ -443,42 +541,53 @@ func (mc *monitorComponent) prometheusServiceAccount() *corev1.ServiceAccount {
 }
 
 func (mc *monitorComponent) prometheusClusterRole() *rbacv1.ClusterRole {
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"endpoints",
+				"nodes",
+				"pods",
+				"services",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups:     []string{""},
+			Resources:     []string{"services/proxy"},
+			ResourceNames: []string{"https:tigera-api:8080"},
+			Verbs:         []string{"get"},
+		},
+		{
+			NonResourceURLs: []string{"/metrics"},
+			Verbs:           []string{"get"},
+		},
+	}
+
+	if mc.cfg.UsePSP {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{TigeraPrometheusPodSecurityPolicyName},
+		})
+	}
+
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus",
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{
-					"endpoints",
-					"nodes",
-					"pods",
-					"services",
-				},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"configmaps"},
-				Verbs:     []string{"get"},
-			},
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"services/proxy"},
-				ResourceNames: []string{"https:tigera-api:8080"},
-				Verbs:         []string{"get"},
-			},
-			{
-				NonResourceURLs: []string{"/metrics"},
-				Verbs:           []string{"get"},
-			},
-		},
+		Rules: rules,
 	}
 }
 
@@ -503,15 +612,59 @@ func (mc *monitorComponent) prometheusClusterRoleBinding() *rbacv1.ClusterRoleBi
 	}
 }
 
-// prometheusHTTPAPIService sets up a service to open http connection for the prometheus instance
-func (mc *monitorComponent) prometheusHTTPAPIService() *corev1.Service {
+func (mc *monitorComponent) prometheusServiceClusterRole() client.Object {
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"authentication.k8s.io"},
+			Resources: []string{"tokenreviews"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{"authorization.k8s.io"},
+			Resources: []string{"subjectaccessreviews"},
+			Verbs:     []string{"create"},
+		},
+	}
+
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TigeraPrometheusObjectName,
+		},
+		Rules: rules,
+	}
+}
+
+func (mc *monitorComponent) prometheusServiceClusterRoleBinding() client.Object {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TigeraPrometheusObjectName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     TigeraPrometheusObjectName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      PrometheusServiceAccountName,
+				Namespace: common.TigeraPrometheusNamespace,
+			},
+		},
+	}
+}
+
+// prometheusServiceService sets up a service to open http connection for the prometheus instance
+func (mc *monitorComponent) prometheusServiceService() *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      PrometheusHTTPAPIServiceName,
+			Name:      PrometheusServiceServiceName,
 			Namespace: common.TigeraPrometheusNamespace,
 		},
 		Spec: corev1.ServiceSpec{
@@ -691,20 +844,7 @@ func (mc *monitorComponent) serviceMonitorQueryServer() *monitoringv1.ServiceMon
 	}
 }
 
-// This is to delete a service that had been released in v3.8 with a typo in the name.
-// TODO Remove this object after we drop support for v3.8.
-func (mc *monitorComponent) serviceMonitorElasicsearchToDelete() *monitoringv1.ServiceMonitor {
-	return &monitoringv1.ServiceMonitor{
-		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.ServiceMonitorsKind, APIVersion: MonitoringAPIVersion},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "elasticearch-metrics",
-			Namespace: common.TigeraPrometheusNamespace,
-			Labels:    map[string]string{"team": "network-operators"},
-		},
-	}
-}
-
-func (mc *monitorComponent) role() *rbacv1.Role {
+func (mc *monitorComponent) operatorRole() *rbacv1.Role {
 	// list and watch have to be cluster scopes for watches to work.
 	// In controller-runtime, watches are by default non-namespaced.
 	return &rbacv1.Role{
@@ -737,7 +877,7 @@ func (mc *monitorComponent) role() *rbacv1.Role {
 	}
 }
 
-func (mc *monitorComponent) roleBinding() *rbacv1.RoleBinding {
+func (mc *monitorComponent) operatorRoleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -93,6 +93,7 @@ var _ = Describe("monitor rendering tests", func() {
 			AlertmanagerConfigSecret: defaultAlertmanagerConfigSecret,
 			ClusterDomain:            "example.org",
 			TrustedCertBundle:        bundle,
+			UsePSP:                   true,
 		}
 	})
 
@@ -114,20 +115,24 @@ var _ = Describe("monitor rendering tests", func() {
 			{"tigera-prometheus-role-binding", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
 			{"alertmanager-calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Secret"},
-			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Service"},
-			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
+			{"calico-prometheus-operator", "tigera-prometheus", "", "v1", "ServiceAccount"},
+			{"calico-prometheus-operator", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
+			{"calico-prometheus-operator", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 			{"prometheus", common.TigeraPrometheusNamespace, "", "v1", "ServiceAccount"},
 			{"prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
 			{"prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 			{"calico-node-prometheus", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind},
+			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Service"},
+			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
+			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
+			{"tigera-prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
+			{"tigera-prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 			{"tigera-prometheus-dp-rate", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusRuleKind},
 			{"calico-node-monitor", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"elasticsearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"tigera-api", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
-			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
-			{name: monitor.TigeraPrometheusObjectName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-			{name: monitor.TigeraPrometheusObjectName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+			{"tigera-prometheus", "", "policy", "v1beta1", "PodSecurityPolicy"},
 		}
 
 		Expect(toCreate).To(HaveLen(len(expectedResources)))
@@ -137,10 +142,7 @@ var _ = Describe("monitor rendering tests", func() {
 			rtest.ExpectResource(obj, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 
-		Expect(toDelete).To(HaveLen(2))
-
-		obj := toDelete[0]
-		rtest.ExpectResource(obj, "elasticearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind)
+		Expect(toDelete).To(HaveLen(1))
 
 		// Check the namespace.
 		namespace := rtest.GetResource(toCreate, "tigera-prometheus", "", "", "v1", "Namespace").(*corev1.Namespace)
@@ -152,6 +154,111 @@ var _ = Describe("monitor rendering tests", func() {
 		component := monitor.Monitor(cfg)
 		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
 		toCreate, _ := component.Objects()
+
+		// Prometheus Operator
+		_, ok := rtest.GetResource(toCreate, "calico-prometheus-operator", "tigera-prometheus", "", "v1", "ServiceAccount").(*corev1.ServiceAccount)
+		Expect(ok).To(BeTrue())
+		promOperClusterRoleObj, ok := rtest.GetResource(toCreate, "calico-prometheus-operator", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(ok).To(BeTrue())
+		Expect(promOperClusterRoleObj.Rules).To(HaveLen(9))
+		Expect(promOperClusterRoleObj.Rules[0]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{"monitoring.coreos.com"},
+			Resources: []string{
+				"alertmanagers",
+				"alertmanagers/finalizers",
+				"alertmanagerconfigs",
+				"prometheuses",
+				"prometheuses/finalizers",
+				"prometheuses/status",
+				"thanosrulers",
+				"thanosrulers/finalizers",
+				"servicemonitors",
+				"podmonitors",
+				"probes",
+				"prometheusrules",
+			},
+			Verbs: []string{"*"},
+		}))
+		Expect(promOperClusterRoleObj.Rules[1]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"statefulsets"},
+			Verbs:     []string{"*"},
+		}))
+		Expect(promOperClusterRoleObj.Rules[2]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{
+				"configmaps",
+				"secrets",
+			},
+			Verbs: []string{"*"},
+		}))
+		Expect(promOperClusterRoleObj.Rules[3]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs: []string{
+				"delete",
+				"list",
+			},
+		}))
+		Expect(promOperClusterRoleObj.Rules[4]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{
+				"services",
+				"services/finalizers",
+				"endpoints",
+			},
+			Verbs: []string{
+				"create",
+				"delete",
+				"get",
+				"update",
+			},
+		}))
+		Expect(promOperClusterRoleObj.Rules[5]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs: []string{
+				"list",
+				"watch",
+			},
+		}))
+		Expect(promOperClusterRoleObj.Rules[6]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"namespaces"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		}))
+		Expect(promOperClusterRoleObj.Rules[7]).To(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{"networking.k8s.io"},
+			Resources: []string{"ingresses"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		}))
+		Expect(promOperClusterRoleObj.Rules[8]).To(Equal(rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{"tigera-prometheus"},
+		}))
+		promOperClusterRoleBindingObj, ok := rtest.GetResource(toCreate, "calico-prometheus-operator", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+		Expect(ok).To(BeTrue())
+		Expect(promOperClusterRoleBindingObj.Subjects).To(HaveLen(1))
+		Expect(promOperClusterRoleBindingObj.Subjects[0]).To(Equal(rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      "calico-prometheus-operator",
+			Namespace: "tigera-prometheus",
+		}))
+		Expect(promOperClusterRoleBindingObj.RoleRef).To(Equal(rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "calico-prometheus-operator",
+		}))
 
 		// Alertmanager
 		alertmanagerObj, ok := rtest.GetResource(toCreate, monitor.CalicoNodeAlertmanager, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind).(*monitoringv1.Alertmanager)
@@ -217,7 +324,7 @@ var _ = Describe("monitor rendering tests", func() {
 		// Prometheus ClusterRole
 		prometheusClusterRoleObj, ok := rtest.GetResource(toCreate, "prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(ok).To(BeTrue())
-		Expect(prometheusClusterRoleObj.Rules).To(HaveLen(4))
+		Expect(prometheusClusterRoleObj.Rules).To(HaveLen(5))
 		Expect(prometheusClusterRoleObj.Rules[0].APIGroups).To(HaveLen(1))
 		Expect(prometheusClusterRoleObj.Rules[0].APIGroups[0]).To(Equal(""))
 		Expect(prometheusClusterRoleObj.Rules[0].Resources).To(HaveLen(4))
@@ -251,6 +358,14 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(prometheusClusterRoleObj.Rules[3].NonResourceURLs[0]).To(Equal("/metrics"))
 		Expect(prometheusClusterRoleObj.Rules[3].Verbs).To(HaveLen(1))
 		Expect(prometheusClusterRoleObj.Rules[3].Verbs[0]).To(Equal("get"))
+		Expect(prometheusClusterRoleObj.Rules[4].APIGroups).To(HaveLen(1))
+		Expect(prometheusClusterRoleObj.Rules[4].APIGroups[0]).To(Equal("policy"))
+		Expect(prometheusClusterRoleObj.Rules[4].Resources).To(HaveLen(1))
+		Expect(prometheusClusterRoleObj.Rules[4].Resources[0]).To(Equal("podsecuritypolicies"))
+		Expect(prometheusClusterRoleObj.Rules[4].ResourceNames).To(HaveLen(1))
+		Expect(prometheusClusterRoleObj.Rules[4].ResourceNames[0]).To(Equal("tigera-prometheus"))
+		Expect(prometheusClusterRoleObj.Rules[4].Verbs).To(HaveLen(1))
+		Expect(prometheusClusterRoleObj.Rules[4].Verbs[0]).To(Equal("use"))
 
 		// Prometheus ClusterRoleBinding
 		prometheusClusterRolebindingObj, ok := rtest.GetResource(toCreate, "prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
@@ -264,7 +379,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(prometheusClusterRolebindingObj.Subjects[0].Namespace).To(Equal("tigera-prometheus"))
 
 		// Prometheus HTTP API service
-		prometheusServiceObj, ok := rtest.GetResource(toCreate, monitor.PrometheusHTTPAPIServiceName, common.TigeraPrometheusNamespace, "", "v1", "Service").(*corev1.Service)
+		prometheusServiceObj, ok := rtest.GetResource(toCreate, "prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service").(*corev1.Service)
 		Expect(ok).To(BeTrue())
 		Expect(prometheusServiceObj.Spec.Selector).To(HaveLen(1))
 		Expect(prometheusServiceObj.Spec.Selector["prometheus"]).To(Equal("calico-node-prometheus"))
@@ -401,6 +516,18 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(rolebindingObj.Subjects[0].Namespace).To(Equal(common.OperatorNamespace()))
 	})
 
+	It("should render properly when PSP is not supported by the cluster", func() {
+		cfg.UsePSP = false
+		component := monitor.Monitor(cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		// Should not contain any PodSecurityPolicies
+		for _, r := range resources {
+			Expect(r.GetObjectKind().GroupVersionKind().Kind).NotTo(Equal("PodSecurityPolicy"))
+		}
+	})
+
 	It("Should render Prometheus resources when Dex is enabled", func() {
 		authentication := &operatorv1.Authentication{
 			Spec: operatorv1.AuthenticationSpec{
@@ -434,20 +561,24 @@ var _ = Describe("monitor rendering tests", func() {
 			{"tigera-prometheus-role-binding", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
 			{"alertmanager-calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Secret"},
-			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Service"},
-			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
+			{"calico-prometheus-operator", "tigera-prometheus", "", "v1", "ServiceAccount"},
+			{"calico-prometheus-operator", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
+			{"calico-prometheus-operator", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 			{"prometheus", common.TigeraPrometheusNamespace, "", "v1", "ServiceAccount"},
 			{"prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
 			{"prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 			{"calico-node-prometheus", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind},
+			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Service"},
+			{"calico-node-alertmanager", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind},
+			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
+			{"tigera-prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
+			{"tigera-prometheus", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
 			{"tigera-prometheus-dp-rate", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusRuleKind},
 			{"calico-node-monitor", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"elasticsearch-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
 			{"tigera-api", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind},
-			{"prometheus-http-api", common.TigeraPrometheusNamespace, "", "v1", "Service"},
-			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole"},
-			{monitor.TigeraPrometheusObjectName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"},
+			{"tigera-prometheus", "", "policy", "v1beta1", "PodSecurityPolicy"},
 		}
 
 		Expect(toCreate).To(HaveLen(len(expectedResources)))
@@ -457,7 +588,7 @@ var _ = Describe("monitor rendering tests", func() {
 			rtest.ExpectResource(obj, expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
 
-		Expect(toDelete).To(HaveLen(2))
+		Expect(toDelete).To(HaveLen(1))
 
 		// Prometheus
 		prometheusObj, ok := rtest.GetResource(toCreate, monitor.CalicoNodePrometheus, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind).(*monitoringv1.Prometheus)

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1714,6 +1714,7 @@ var _ = Describe("Node rendering tests", func() {
 					{name: "calico-node", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 					{name: "calico-node", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 					{name: "cni-config", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ConfigMap"},
+					{name: common.NodeDaemonSetName, ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 					{name: common.NodeDaemonSetName, ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
 				}
 
@@ -1826,6 +1827,7 @@ var _ = Describe("Node rendering tests", func() {
 					{name: "calico-node", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 					{name: "calico-node-metrics", ns: "calico-system", group: "", version: "v1", kind: "Service"},
 					{name: "cni-config", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ConfigMap"},
+					{name: common.NodeDaemonSetName, ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 					{name: common.NodeDaemonSetName, ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
 				}
 
@@ -2017,6 +2019,7 @@ var _ = Describe("Node rendering tests", func() {
 					{name: "calico-node", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 					{name: "cni-config", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ConfigMap"},
 					{name: render.BirdTemplatesConfigMapName, ns: common.CalicoNamespace, group: "", version: "v1", kind: "ConfigMap"},
+					{name: common.NodeDaemonSetName, ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
 					{name: common.NodeDaemonSetName, ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
 				}
 
@@ -2177,7 +2180,7 @@ var _ = Describe("Node rendering tests", func() {
 				component := render.Node(&cfg)
 				Expect(component.ResolveImages(nil)).To(BeNil())
 				resources, _ := component.Objects()
-				Expect(len(resources)).To(Equal(defaultNumExpectedResources-1), fmt.Sprintf("resources are %v", resources))
+				Expect(len(resources)).To(Equal(defaultNumExpectedResources), fmt.Sprintf("resources are %v", resources))
 
 				// Should render the correct resources.
 				Expect(rtest.GetResource(resources, "calico-node", "calico-system", "", "v1", "ServiceAccount")).ToNot(BeNil())

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -17,6 +17,7 @@ package render
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,6 +31,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/configmap"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -45,6 +47,7 @@ const (
 	PacketCaptureClusterRoleBindingName = PacketCaptureName
 	PacketCaptureDeploymentName         = PacketCaptureName
 	PacketCaptureServiceName            = PacketCaptureName
+	PacketCapturePodSecurityPolicyName  = PacketCaptureName
 	PacketCapturePolicyName             = networkpolicy.TigeraComponentPolicyPrefix + PacketCaptureName
 	PacketCapturePort                   = 8444
 
@@ -66,6 +69,9 @@ type PacketCaptureApiConfiguration struct {
 	TrustedBundle               certificatemanagement.TrustedBundle
 	ClusterDomain               string
 	ManagementClusterConnection *operatorv1.ManagementClusterConnection
+
+	// Whether the cluster supports pod security policies.
+	UsePSP bool
 }
 
 type packetCaptureApiComponent struct {
@@ -122,6 +128,10 @@ func (pc *packetCaptureApiComponent) Objects() ([]client.Object, []client.Object
 	if pc.cfg.TrustedBundle != nil {
 		objs = append(objs, pc.cfg.TrustedBundle.ConfigMap(PacketCaptureNamespace))
 	}
+
+	if pc.cfg.UsePSP {
+		objs = append(objs, pc.podSecurityPolicy())
+	}
 	return objs, nil
 }
 
@@ -152,7 +162,7 @@ func (pc *packetCaptureApiComponent) service() *corev1.Service {
 	}
 }
 
-func (pc *packetCaptureApiComponent) serviceAccount() client.Object {
+func (pc *packetCaptureApiComponent) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: PacketCaptureServiceAccountName, Namespace: PacketCaptureNamespace},
@@ -183,6 +193,15 @@ func (pc *packetCaptureApiComponent) clusterRole() client.Object {
 		},
 	}
 
+	if pc.cfg.UsePSP {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{PacketCapturePodSecurityPolicyName},
+		})
+	}
+
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -192,7 +211,7 @@ func (pc *packetCaptureApiComponent) clusterRole() client.Object {
 	}
 }
 
-func (pc *packetCaptureApiComponent) clusterRoleBinding() client.Object {
+func (pc *packetCaptureApiComponent) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -213,7 +232,11 @@ func (pc *packetCaptureApiComponent) clusterRoleBinding() client.Object {
 	}
 }
 
-func (pc *packetCaptureApiComponent) deployment() client.Object {
+func (pc *packetCaptureApiComponent) podSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	return podsecuritypolicy.NewBasePolicy(PacketCapturePodSecurityPolicyName)
+}
+
+func (pc *packetCaptureApiComponent) deployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -71,7 +71,7 @@ type TyphaConfiguration struct {
 	// that is one less.
 	FelixHealthPort int
 
-	// Whether or not the cluster supports pod security policies.
+	// Whether the cluster supports pod security policies.
 	UsePSP bool
 }
 
@@ -117,7 +117,7 @@ func (c *typhaComponent) Objects() ([]client.Object, []client.Object) {
 		c.typhaPodDisruptionBudget(),
 	}
 
-	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift && c.cfg.UsePSP {
+	if c.cfg.UsePSP {
 		objs = append(objs, c.typhaPodSecurityPolicy())
 	}
 
@@ -338,7 +338,7 @@ func (c *typhaComponent) typhaRole() *rbacv1.ClusterRole {
 		}
 		role.Rules = append(role.Rules, extraRules...)
 	}
-	if c.cfg.Installation.KubernetesProvider != operatorv1.ProviderOpenShift {
+	if c.cfg.UsePSP {
 		// Allow access to the pod security policy in case this is enforced on the cluster
 		role.Rules = append(role.Rules, rbacv1.PolicyRule{
 			APIGroups:     []string{"policy"},
@@ -642,8 +642,7 @@ func (c *typhaComponent) typhaService() *corev1.Service {
 }
 
 func (c *typhaComponent) typhaPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy()
-	psp.GetObjectMeta().SetName(common.TyphaDeploymentName)
+	psp := podsecuritypolicy.NewBasePolicy(common.TyphaDeploymentName)
 	psp.Spec.HostNetwork = true
 	return psp
 }


### PR DESCRIPTION
## Description

This changeset add and update `PodSecurityPolicy` for open source and enterprise components to match the recent work for SecurityContext in [1]. This is also required for all components to work in a CIS hardened RKE2 cluster.

To summarize the changes:
* Update Elasticsearch and Fluentd capabilities in `PodSecurityPolicy` to match `SecurityContext`.
* Add missing `PodSecurityPolicy` for all enterprise components. Enterprise components like packetcapture, esgateway, l7-log-collector, etc. are able to be deployed without creating `PodSecurityPolicy` manually.
* Manage Prometheus operator `ClusterRole` and `ClusterRoleBinding` in operator.
* use `UsePSP` as the only flag to determine whether we need to render `PodSecurityPolicy` or not.

[1] https://github.com/tigera/operator/pull/2433

Pick https://github.com/tigera/operator/pull/2504 into release v1.29 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
