### PR TITLE
Add waf resource to the lma.tigera.io resource group

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1492,7 +1492,7 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "kibana_login",
+				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login",
 			},
 			Verbs: []string{"get"},
 		})
@@ -1647,7 +1647,7 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "kibana_login", "elasticsearch_superuser",
+				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login", "elasticsearch_superuser",
 			},
 			Verbs: []string{"get"},
 		})

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1492,7 +1492,7 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login",
+				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login",
 			},
 			Verbs: []string{"get"},
 		})
@@ -1647,7 +1647,7 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login", "elasticsearch_superuser",
+				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login", "elasticsearch_superuser",
 			},
 			Verbs: []string{"get"},
 		})

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1370,7 +1370,7 @@ var (
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "kibana_login",
+				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login",
 			},
 			Verbs: []string{"get"},
 		},
@@ -1487,7 +1487,7 @@ var (
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "kibana_login", "elasticsearch_superuser",
+				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login", "elasticsearch_superuser",
 			},
 			Verbs: []string{"get"},
 		},

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1370,7 +1370,7 @@ var (
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login",
+				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login",
 			},
 			Verbs: []string{"get"},
 		},
@@ -1487,7 +1487,7 @@ var (
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "waf", "runtime", "kibana_login", "elasticsearch_superuser",
+				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login", "elasticsearch_superuser",
 			},
 			Verbs: []string{"get"},
 		},


### PR DESCRIPTION
## Description

This follows the change made in https://github.com/tigera/calico-private/pull/5891 and is related to https://tigera.atlassian.net/browse/RS-825 and https://tigera.atlassian.net/browse/TSLA-3861 where we want to standardise ES roles and permissions for Enterprise and CC.

Resources `waf` and `runtime` map to ES roles `waf_viewer` and `runtime_viewer`. This adds the `waf` resource to the `lma.tigera.io` resource group as an effort towards standardising ES roles and permissions for Enterprise and CC (described in https://tigera.atlassian.net/browse/TSLA-3861).

The `runtime` resource is not included here as it's related to a calico-cloud only feature. The idea would be to expose it in `operator-cloud`.



## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
