### PR TITLE
Allow configuration of Calico host mount path

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -123,6 +123,11 @@ type InstallationSpec struct {
 	// +optional
 	TyphaMetricsPort *int32 `json:"typhaMetricsPort,omitempty"`
 
+	// DataVolumePath optionally specifies a custom path for Calico to persist data. If not specified, the path will
+	// default to /etc/calico.
+	// +optional
+	DataVolumePath string `json:"dataVolumePath"`
+
 	// FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be
 	// enabled by default. If set to 'None', FlexVolume will be disabled. The default is based on the
 	// kubernetesProvider.

--- a/pkg/controller/utils/merge.go
+++ b/pkg/controller/utils/merge.go
@@ -108,6 +108,11 @@ func OverrideInstallationSpec(cfg, override operatorv1.InstallationSpec) operato
 		inst.TyphaMetricsPort = override.TyphaMetricsPort
 	}
 
+	switch compareFields(inst.DataVolumePath, override.DataVolumePath) {
+	case BOnlySet, Different:
+		inst.DataVolumePath = override.DataVolumePath
+	}
+
 	switch compareFields(inst.FlexVolumePath, override.FlexVolumePath) {
 	case BOnlySet, Different:
 		inst.FlexVolumePath = override.FlexVolumePath

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -5586,6 +5586,11 @@ spec:
                         type: object
                     type: object
                 type: object
+              dataVolumePath:
+                description: DataVolumePath optionally specifies a custom path for
+                  Calico to persist data. If not specified, the path will default
+                  to /etc/calico.
+                type: string
               fipsMode:
                 description: 'FIPSMode uses images and features only that are using
                   FIPS 140-2 validated cryptographic modules and standards. Default:
@@ -13591,6 +13596,11 @@ spec:
                             type: object
                         type: object
                     type: object
+                  dataVolumePath:
+                    description: DataVolumePath optionally specifies a custom path
+                      for Calico to persist data. If not specified, the path will
+                      default to /etc/calico.
+                    type: string
                   fipsMode:
                     description: 'FIPSMode uses images and features only that are
                       using FIPS 140-2 validated cryptographic modules and standards.

--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -186,6 +186,11 @@ func (c *csiComponent) csiContainers() []corev1.Container {
 }
 
 func (c *csiComponent) csiVolumes() []corev1.Volume {
+	dataVolumePath := c.cfg.Installation.DataVolumePath
+	if dataVolumePath == "" {
+		dataVolumePath = "/etc/calico"
+	}
+
 	hostPathTypeDir := corev1.HostPathDirectory
 	hostPathTypeDirOrCreate := corev1.HostPathDirectoryOrCreate
 	return []corev1.Volume{
@@ -201,7 +206,7 @@ func (c *csiComponent) csiVolumes() []corev1.Volume {
 			Name: "etccalico",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: filepath.Clean("/etc/calico"),
+					Path: filepath.Clean(dataVolumePath),
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Calico persists data to `/etc/calico` on the host but unfortunately some operating systems, like [Talos](https://www.talos.dev/), mount `/etc/` as read-only. This change allows configuration of the host mount path.

Fixes https://github.com/tigera/operator/issues/2444

I am aware there are no tests. I wanted to get a draft PR open to move the issue along. I'd like to understand if:
- This is the right way to make the change.
- If the field name is inline with expectations.
- If the field name is in the correct place.
- What the best way to test this change would be.

Thanks!

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
