### PR TITLE
Add NET_RAW capability to ocp scc.

### DIFF
--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -490,7 +490,7 @@ func SecurityContextConstraints() *ocsv1.SecurityContextConstraints {
 		AllowHostPorts:           false,
 		AllowPrivilegeEscalation: ptr.BoolToPtr(true),
 		AllowPrivilegedContainer: true,
-		AllowedCapabilities:      []corev1.Capability{corev1.Capability("NET_ADMIN")},
+		AllowedCapabilities:      []corev1.Capability{corev1.Capability("NET_ADMIN"), corev1.Capability("NET_RAW")},
 		FSGroup:                  ocsv1.FSGroupStrategyOptions{Type: ocsv1.FSGroupStrategyMustRunAs},
 		RunAsUser:                ocsv1.RunAsUserStrategyOptions{Type: ocsv1.RunAsUserStrategyRunAsAny},
 		ReadOnlyRootFilesystem:   false,


### PR DESCRIPTION
## Description

EGW deployments require NET_RAW capability for ICMP probes to work.
Adding NET_RAW to the AllowedCapabilities in the OCP SCC.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
