### PR TITLE
release-v1.29 cherry pick of #2377: Fix race condition where trusted bundle is rendered twice 

### DIFF
--- a/pkg/controller/logstorage/esgateway.go
+++ b/pkg/controller/logstorage/esgateway.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
+	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
@@ -44,13 +45,13 @@ func (r *ReconcileLogStorage) createEsGateway(
 	ctx context.Context,
 	certificateManager certificatemanager.CertificateManager,
 	usePSP bool,
-) (reconcile.Result, bool, error) {
+) (reconcile.Result, certificatemanagement.TrustedBundle, bool, error) {
 	svcDNSNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, r.clusterDomain)
 	svcDNSNames = append(svcDNSNames, dns.GetServiceDNSNames(esgateway.ServiceName, render.ElasticsearchNamespace, r.clusterDomain)...)
 	gatewayKeyPair, err := certificateManager.GetOrCreateKeyPair(r.client, render.TigeraElasticsearchGatewaySecret, common.OperatorNamespace(), svcDNSNames)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating TLS certificate", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	}
 
 	var kibanaCertificate certificatemanagement.CertificateInterface
@@ -58,27 +59,39 @@ func (r *ReconcileLogStorage) createEsGateway(
 		kibanaCertificate, err = certificateManager.GetCertificate(r.client, render.TigeraKibanaCertSecret, common.OperatorNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Kibana tls certificate secret", err, reqLogger)
-			return reconcile.Result{}, false, err
+			return reconcile.Result{}, nil, false, err
 		} else if kibanaCertificate == nil {
 			r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for internal Kibana tls certificate secret to be available", nil, reqLogger)
-			return reconcile.Result{}, false, nil
+			return reconcile.Result{}, nil, false, nil
 		}
 	}
 	esInternalCertificate, err := certificateManager.GetCertificate(r.client, render.TigeraElasticsearchInternalCertSecret, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch tls certificate secret", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	} else if esInternalCertificate == nil {
 		reqLogger.Info("Waiting for internal Elasticsearch tls certificate secret to be available")
 		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for internal Elasticsearch tls certificate secret to be available", nil, reqLogger)
-		return reconcile.Result{}, false, nil
+		return reconcile.Result{}, nil, false, nil
 	}
-	trustedBundle := certificateManager.CreateTrustedBundle(esInternalCertificate, kibanaCertificate)
+
+	// Esgateway.go will render the trusted bundle for the whole namespace, so we want to include also the Prometheus
+	// TLS certificate, which the elasticsearch-metrics server depends on.
+	prometheusCertificate, err := certificateManager.GetCertificate(r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, reqLogger)
+		return reconcile.Result{}, nil, false, err
+	} else if prometheusCertificate == nil {
+		reqLogger.Info("Prometheus secrets are not available yet, waiting until they become available")
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Prometheus secrets are not available yet, waiting until they become available", nil, reqLogger)
+		return reconcile.Result{}, nil, false, nil
+	}
+	trustedBundle := certificateManager.CreateTrustedBundle(esInternalCertificate, kibanaCertificate, prometheusCertificate, gatewayKeyPair)
 
 	// This secret should only ever contain one key.
 	if len(esAdminUserSecret.Data) != 1 {
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "Elasticsearch admin user secret contains too many entries", nil, reqLogger)
-		return reconcile.Result{}, false, nil
+		return reconcile.Result{}, nil, false, nil
 	}
 
 	var esAdminUserName string
@@ -90,7 +103,7 @@ func (r *ReconcileLogStorage) createEsGateway(
 	kubeControllersGatewaySecret, kubeControllersVerificationSecret, kubeControllersSecureUserSecret, err := lscommon.CreateKubeControllersSecrets(ctx, esAdminUserSecret, esAdminUserName, r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Failed to create kube-controllers secrets for Elasticsearch gateway", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	}
 
 	cfg := &esgateway.Config{
@@ -108,7 +121,7 @@ func (r *ReconcileLogStorage) createEsGateway(
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, esGatewayComponent); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
-		return reconcile.Result{}, false, err
+		return reconcile.Result{}, nil, false, err
 	}
 
 	certificateComponent := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
@@ -120,11 +133,11 @@ func (r *ReconcileLogStorage) createEsGateway(
 		TrustedBundle: trustedBundle,
 	})
 
-	for _, comp := range []render.Component{esGatewayComponent, certificateComponent} {
+	for _, comp := range []render.Component{certificateComponent, esGatewayComponent} {
 		if err := hdler.CreateOrUpdateOrDelete(ctx, comp, r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating / deleting resource", err, reqLogger)
-			return reconcile.Result{}, false, err
+			return reconcile.Result{}, nil, false, err
 		}
 	}
-	return reconcile.Result{}, true, nil
+	return reconcile.Result{}, trustedBundle, true, nil
 }

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 var log = logf.Log.WithName("controller_logstorage")
@@ -608,7 +609,8 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		if err != nil || !proceed {
 			return result, err
 		}
-		result, proceed, err = r.createEsGateway(
+		var trustedBundle certificatemanagement.TrustedBundle
+		result, trustedBundle, proceed, err = r.createEsGateway(
 			install,
 			variant,
 			pullSecrets,
@@ -643,6 +645,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			hdler,
 			r.clusterDomain,
 			r.usePSP,
+			trustedBundle,
 		)
 		if err != nil || !proceed {
 			return result, err


### PR DESCRIPTION
Original fix was merged to master and cherry-picked to v1.28, but never picked to v1.29 which was already cut at the time of the original cut.

Original: https://github.com/tigera/operator/pull/2377
v1.28 cherry-pick: https://github.com/tigera/operator/pull/2378

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
