### PR TITLE
[1.28] Add missing egress flow to Guardian access policy

### DIFF
--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -378,6 +378,11 @@ func guardianAllowTigeraPolicy(cfg *GuardianConfiguration) (*v3.NetworkPolicy, e
 			Protocol:    &networkpolicy.TCPProtocol,
 			Destination: networkpolicy.PrometheusEntityRule,
 		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: TigeraAPIServerEntityRule,
+		},
 	}...)
 
 	// Assumes address has the form "host:port", required by net.Dial for TCP.

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Rendering tests", func() {
 			It("should adapt Guardian policy if ManagementClusterAddr is domain-based", func() {
 				renderGuardianPolicy("mydomain.io:8080", false)
 				policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
-				managementClusterEgressRule := policy.Spec.Egress[4]
+				managementClusterEgressRule := policy.Spec.Egress[5]
 				Expect(managementClusterEgressRule.Destination.Domains).To(Equal([]string{"mydomain.io"}))
 				Expect(managementClusterEgressRule.Destination.Ports).To(Equal(networkpolicy.Ports(8080)))
 			})

--- a/pkg/render/testutils/expected_policies/guardian.json
+++ b/pkg/render/testutils/expected_policies/guardian.json
@@ -165,6 +165,16 @@
       {
         "action": "Allow",
         "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "tigera-api",
+            "namespace": "tigera-system"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
         "source": {
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/guardian_ocp.json
+++ b/pkg/render/testutils/expected_policies/guardian_ocp.json
@@ -176,6 +176,16 @@
       {
         "action": "Allow",
         "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "tigera-api",
+            "namespace": "tigera-system"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
         "source": {
         },
         "destination": {


### PR DESCRIPTION
- Adds missing egress flow to Guardian access policy.
- The source code of Guardian was consulted to ensure there are no other missing egress flows.
- Fix was validated in a 3.15 MCM cluster by getting cluster into a state where a default-deny in a tier after allow-tigera was causing denies. Engaging the operator with this fix resolves denies.