### PR TITLE
Automated cherry pick of #2541: update go-build to v0.82 (golang 1.19.7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ VALIDARCHES = $(filter-out $(EXCLUDEARCH),$(ARCHES))
 # We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.
 ifeq ($(ARCH), $(filter $(ARCH),amd64))
 CGO_ENABLED=1
+GOEXPERIMENT=boringcrypto
+TAGS=osusergo,netgo
 else
 CGO_ENABLED=0
 endif
@@ -224,9 +226,12 @@ endif
 build: $(BINDIR)/operator-$(ARCH)
 $(BINDIR)/operator-$(ARCH): $(SRC_FILES)
 	mkdir -p $(BINDIR)
-	$(CONTAINERIZED) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
+	$(CONTAINERIZED) -e CGO_ENABLED=$(CGO_ENABLED) -e GOEXPERIMENT=$(GOEXPERIMENT) $(CALICO_BUILD) \
 	sh -c '$(GIT_CONFIG_SSH) \
-	go build -v -i -o $(BINDIR)/operator-$(ARCH) -ldflags "-X $(PACKAGE_NAME)/version.VERSION=$(GIT_VERSION) -w" ./main.go'
+	go build -buildvcs=false -v -o $(BINDIR)/operator-$(ARCH) -tags $(TAGS) -ldflags "-X $(PACKAGE_NAME)/version.VERSION=$(GIT_VERSION) -w" ./main.go'
+ifeq ($(ARCH), $(filter $(ARCH),amd64))
+	$(CONTAINERIZED) $(CALICO_BUILD) sh -c 'strings $(BINDIR)/operator-$(ARCH) | grep '_Cfunc__goboringcrypto_' 1> /dev/null'
+endif
 
 .PHONY: image
 image: build $(BUILD_IMAGE)
@@ -342,13 +347,8 @@ cluster-destroy: $(BINDIR)/kubectl $(BINDIR)/kind
 ###############################################################################
 .PHONY: static-checks
 ## Perform static checks on the code.
-static-checks: check-boring-ssl
+static-checks:
 	$(CONTAINERIZED) $(CALICO_BUILD) golangci-lint run --deadline 5m
-
-check-boring-ssl: $(BINDIR)/operator-amd64
-	$(CONTAINERIZED) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
-		go tool nm $(BINDIR)/operator-amd64 > $(BINDIR)/tags.txt && grep '_Cfunc__goboringcrypto_' $(BINDIR)/tags.txt 1> /dev/null
-	-rm -f $(BINDIR)/tags.txt
 
 .PHONY: fix
 ## Fix static checks

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ endif
 
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=v0.78
+GO_BUILD_VER?=v0.82
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(ARCH)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./api -name '*.go')

--- a/pkg/common/autoscale.go
+++ b/pkg/common/autoscale.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,22 @@ package common
 // GetTyphaScaleCount will return the number of Typhas needed for the number of nodes.
 //
 // Nodes       Replicas
-//   1-2              1
-//   3-4              2
-//  <200              3
-//  >400              4
-//  >600              5
-//  >800              6
+//
+//	 1-2              1
+//	 3-4              2
+//	<200              3
+//	>400              4
+//	>600              5
+//	>800              6
+//
 // >1000              7
-//    .....
+//
+//	.....
+//
 // >2000              12
-//    .....
+//
+//	.....
+//
 // >3600             20
 func GetExpectedTyphaScale(nodes int) int {
 	var maxNodesPerTypha int = 200

--- a/pkg/common/k8svalidation/v1helper/v1helper.go
+++ b/pkg/common/k8svalidation/v1helper/v1helper.go
@@ -7,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/common/k8svalidation/v1validation.go
+++ b/pkg/common/k8svalidation/v1validation.go
@@ -5,7 +5,9 @@ Copyright 2014 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/common/operator_namespace.go
+++ b/pkg/common/operator_namespace.go
@@ -42,10 +42,11 @@ func init() {
 
 // OperatorNamespace returns the namespace the operator is running in.
 // The value returned is based on the following priority (these are evaluated at startup):
-//   If the OPERATOR_NAMESPACE environment variable is non-empty then that is return.
-//   If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
-//   then the contents is returned.
-//   The default "tigera-operator" is returned.
+//
+//	If the OPERATOR_NAMESPACE environment variable is non-empty then that is return.
+//	If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
+//	then the contents is returned.
+//	The default "tigera-operator" is returned.
 func OperatorNamespace() string {
 	return namespace
 }

--- a/pkg/common/operator_serviceaccount.go
+++ b/pkg/common/operator_serviceaccount.go
@@ -29,10 +29,11 @@ func init() {
 
 // OperatorServiceAccount returns the ServiceAccount name the operator is running in.
 // The value returned is based on the following priority (these are evaluated at startup):
-//   If the OPERATOR_SERVICEACCOUNT environment variable is non-empty then that is return.
-//   If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
-//   then the contents is returned.
-//   The default "tigera-operator" is returned.
+//
+//	If the OPERATOR_SERVICEACCOUNT environment variable is non-empty then that is return.
+//	If the file /var/run/secrets/kubernetes.io/serviceaccount/namespace is non-empty
+//	then the contents is returned.
+//	The default "tigera-operator" is returned.
 func OperatorServiceAccount() string {
 	return serviceAccount
 }

--- a/pkg/controller/migration/convert/ippools.go
+++ b/pkg/controller/migration/convert/ippools.go
@@ -181,8 +181,9 @@ func isIpv6(ip net.IP) bool {
 
 // selectInitialPool searches through pools for enabled pools, returning the
 // first to match one of the following:
-//   1. one prefixed with default-ipv and matching the isver IP version
-//   2. one matching isver IP version
+//  1. one prefixed with default-ipv and matching the isver IP version
+//  2. one matching isver IP version
+//
 // if none match then nil, nil is returned
 // if there is an error parsing the cidr in a pool then that error will be returned
 func selectInitialPool(pools []crdv1.IPPool, isver func(ip net.IP) bool) (*crdv1.IPPool, error) {

--- a/pkg/controller/status/mock.go
+++ b/pkg/controller/status/mock.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -45,12 +45,12 @@ var log = logf.Log.WithName("status_manager")
 // a TigeraStatus API object. The status manager uses the following conditions/states to represent the
 // component's current status:
 //
-// - Available: The component is successfully running. All pods launched by the component are healthy.
-//              An upgrade may or may not be occurring.
-// - Progressing: A state change is occurring. It may be that the component is being installed for the
-//                first time, or being upgraded to a new configuration or version.
-// - Degraded: The component is not running the desired state and is not progressing towards it. Either the
-//             component has not been installed, has been updated with invalid configuration, or has crashed.
+//   - Available: The component is successfully running. All pods launched by the component are healthy.
+//     An upgrade may or may not be occurring.
+//   - Progressing: A state change is occurring. It may be that the component is being installed for the
+//     first time, or being upgraded to a new configuration or version.
+//   - Degraded: The component is not running the desired state and is not progressing towards it. Either the
+//     component has not been installed, has been updated with invalid configuration, or has crashed.
 //
 // Each of these states can be set independently of each other. For example, a component can be both available and
 // degraded if it is running successfully but a configuration change has resulted in a configuration that cannot

--- a/pkg/render/common/secret/secrets.go
+++ b/pkg/render/common/secret/secrets.go
@@ -17,13 +17,14 @@ import (
 )
 
 // CreateTLSSecret Creates a new TLS secret with the information passed
-//   ca: The ca to use for creating the Cert/Key pair. This is required.
-//   secretName: The name of the secret.
-//   secretKeyName: The name of the data field that will contain the key.
-//   secretCertName: The name of the data field that will contain the cert.
-//   dur: How long the certificate will be valid.
-//   hostnames: The first will be used as the CN, and the rest as SANs. If
-//     no hostnames are provided then "localhost" will be used.
+//
+//	ca: The ca to use for creating the Cert/Key pair. This is required.
+//	secretName: The name of the secret.
+//	secretKeyName: The name of the data field that will contain the key.
+//	secretCertName: The name of the data field that will contain the cert.
+//	dur: How long the certificate will be valid.
+//	hostnames: The first will be used as the CN, and the rest as SANs. If
+//	  no hostnames are provided then "localhost" will be used.
 //
 // The first hostname provided is used as the common name for the certificate. If hostnames are not provided, localhost
 // is used. This code came from:

--- a/pkg/render/tiers/tiers_suite_test.go
+++ b/pkg/render/tiers/tiers_suite_test.go
@@ -1,10 +1,10 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022, 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Cherry pick of #2541 on release-v1.28.

#2541: update go-build to v0.82 (golang 1.19.7)