### PR TITLE
[release-v1.29] Add PSP PolicyRule for anomaly detection detectors

### DIFF
--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -286,19 +286,27 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		Expect(detectorsSecret.GetObjectMeta().GetAnnotations()[corev1.ServiceAccountNameKey]).To(Equal("anomaly-detectors"))
 
 		detectorsRole := rtest.GetResource(resources, "anomaly-detectors", render.IntrusionDetectionNamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
-		Expect(len(detectorsRole.Rules)).To(Equal(1))
-		Expect(detectorsRole.Rules).To(ContainElements(
-			rbacv1.PolicyRule{
-				APIGroups: []string{
-					render.ADResourceGroup,
+		Expect(detectorsRole.Rules).To(HaveLen(2))
+		Expect(detectorsRole.Rules).To(Equal(
+			[]rbacv1.PolicyRule{
+				{
+					APIGroups: []string{
+						render.ADResourceGroup,
+					},
+					Resources: []string{
+						render.ADDetectorsModelResourceName, render.ADLogTypeMetaDataResourceName,
+					},
+					Verbs: []string{
+						"get",
+						"create",
+						"update",
+					},
 				},
-				Resources: []string{
-					render.ADDetectorsModelResourceName, render.ADLogTypeMetaDataResourceName,
-				},
-				Verbs: []string{
-					"get",
-					"create",
-					"update",
+				{
+					APIGroups:     []string{"policy"},
+					Resources:     []string{"podsecuritypolicies"},
+					Verbs:         []string{"use"},
+					ResourceNames: []string{"anomaly-detection-api"},
 				},
 			},
 		))


### PR DESCRIPTION
## Description

When PSP Pod Admission Controller is enabled in a cluster before v1.25, add the PSP PolicyRule for anomaly detection detectors. This is missed in https://github.com/tigera/operator/pull/2433.

Pick https://github.com/tigera/operator/pull/2555 into release v1.29 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
