### PR TITLE
Cherry pick (#2517) to rel-1.29

### DIFF
--- a/pkg/controller/logstorage/logstorage.go
+++ b/pkg/controller/logstorage/logstorage.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ func (r *ReconcileLogStorage) createLogStorage(
 		}
 	}
 
-	elasticsearch, err := r.getElasticsearch(ctx)
+	elasticsearch, err := utils.GetElasticsearch(ctx, r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred trying to retrieve Elasticsearch", err, reqLogger)
 		return reconcile.Result{}, false, finalizerCleanup, err

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
 
@@ -666,18 +665,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *ReconcileLogStorage) getElasticsearch(ctx context.Context) (*esv1.Elasticsearch, error) {
-	es := esv1.Elasticsearch{}
-	err := r.client.Get(ctx, client.ObjectKey{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}, &es)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return &es, nil
 }
 
 func (r *ReconcileLogStorage) getElasticsearchService(ctx context.Context) (*corev1.Service, error) {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -559,4 +561,16 @@ func AddTigeraStatusWatch(c controller.Controller, name string) error {
 	return c.Watch(&source.Kind{Type: &operatorv1.TigeraStatus{ObjectMeta: metav1.ObjectMeta{Name: name}}}, &handler.EnqueueRequestForObject{}, predicate.NewPredicateFuncs(func(object client.Object) bool {
 		return object.GetName() == name
 	}))
+}
+
+func GetElasticsearch(ctx context.Context, c client.Client) (*esv1.Elasticsearch, error) {
+	es := esv1.Elasticsearch{}
+	err := c.Get(ctx, client.ObjectKey{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}, &es)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &es, nil
 }


### PR DESCRIPTION
stabilise intrusion detection failures due to elastic search not being ready

* increase number of retries for intrusion-detection-es-job-installer

k8s < 1.26 does not support PodFailurePolicy API. To support more retries for older versions of kubernetes we need to set BackoffLimit to a higher number (default is 6) to prevent installation failures when responses from elastic search takes more time.

* add check for elasticsearch readiness to reconcile intrusion_detection

Check to make sure elasticsearch is in Ready phase as a pre-requisite to reconcile intrusion detection.

* update intrusiondetection_controller_test

* move the duplicated function GetElasticSearch to utils.go

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
