### PR TITLE
Removes named resource clause on applicationlayers resource.

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1471,10 +1471,9 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 		},
 		// Allow the user to read applicationlayers to detect if WAF is enabled/disabled.
 		{
-			APIGroups:     []string{"operator.tigera.io"},
-			Resources:     []string{"applicationlayers"},
-			Verbs:         []string{"get"},
-			ResourceNames: []string{"tigera-secure"},
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"applicationlayers"},
+			Verbs:     []string{"get"},
 		},
 		// Allow the user to read services to view WAF configuration.
 		{
@@ -1626,10 +1625,9 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 		},
 		// Allow the user to read and write applicationlayers to enable/disable WAF.
 		{
-			APIGroups:     []string{"operator.tigera.io"},
-			Resources:     []string{"applicationlayers"},
-			ResourceNames: []string{"tigera-secure"},
-			Verbs:         []string{"get", "update", "patch", "create"},
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"applicationlayers"},
+			Verbs:     []string{"get", "update", "patch", "create"},
 		},
 		// Allow the user to read services to view WAF configuration.
 		{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1375,10 +1375,9 @@ var (
 			Verbs: []string{"get"},
 		},
 		{
-			APIGroups:     []string{"operator.tigera.io"},
-			Resources:     []string{"applicationlayers"},
-			Verbs:         []string{"get"},
-			ResourceNames: []string{"tigera-secure"},
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"applicationlayers"},
+			Verbs:     []string{"get"},
 		},
 		{
 			APIGroups: []string{""},
@@ -1492,10 +1491,9 @@ var (
 			Verbs: []string{"get"},
 		},
 		{
-			APIGroups:     []string{"operator.tigera.io"},
-			Resources:     []string{"applicationlayers"},
-			ResourceNames: []string{"tigera-secure"},
-			Verbs:         []string{"get", "update", "patch", "create"},
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"applicationlayers"},
+			Verbs:     []string{"get", "update", "patch", "create"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
## Description

This PR is part of a bugfix for [RS-707](https://tigera.atlassian.net/browse/RS-707).
There will also be a UI PR needed to follow-on from this.

For some reason when the UI makes a call to `/v3/authorizationreviews`, if the user's clusterrole specifies a `resourceName`, the user will not be deemed to have access.
This PR removes the `resourceName` on the `applicationlayers` resource, so the UI will correctly determine that the user has access.

I suspect this is because the AuthorizationReviews API doesn't support resourceNames.
 
## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.


[RS-707]: https://tigera.atlassian.net/browse/RS-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ