### PR TITLE
Allow connection between DPI and linseed

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tigera/operator/pkg/render/intrusiondetection/dpi"
+
 	"github.com/go-logr/logr"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
@@ -395,6 +397,7 @@ func (c *keyPairCollection) component(bundle certificatemanagement.TrustedBundle
 			esgateway.ServiceAccountName,
 			esmetrics.ElasticsearchMetricsName,
 			render.IntrusionDetectionName,
+			dpi.DeepPacketInspectionName,
 		},
 		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 			// We do not want to delete the elastic keypair secret from the tigera-elasticsearch namespace when CertificateManagement is
@@ -433,6 +436,9 @@ func (r *ReconcileLogStorage) generateSecrets(
 
 		// Get certificate for intrusion detection controller, which Linseed needs to trust in a standalone or management cluster.
 		render.IntrusionDetectionTLSSecretName,
+
+		// Get certificate for DPI, which Linseed needs to trust in a standalone or management cluster.
+		render.DPITLSSecretName,
 
 		// Get compliance certificates, which Linseed needs to trust.
 		render.ComplianceServerCertSecret,

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -100,9 +100,10 @@ spec:
                   [Default: false]'
                 type: boolean
               bpfEnforceRPF:
-                description: 'BPFEnforceRPF enforce strict RPF on all interfaces with
-                  BPF programs regardless of what is the per-interfaces or global
-                  setting. Possible values are Disabled or Strict. [Default: Strict]'
+                description: 'BPFEnforceRPF enforce strict RPF on all host interfaces
+                  with BPF programs regardless of what is the per-interfaces or global
+                  setting. Possible values are Disabled, Strict or Loose. [Default:
+                  Strict]'
                 type: string
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -401,7 +401,7 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 		{Name: "TIGERA_COMPLIANCE_MAX_JOB_RETRIES", Value: "6"},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER", Value: c.cfg.ESClusterConfig.ClusterName()},
+		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 	}
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -524,7 +524,7 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 		{Name: "TIGERA_COMPLIANCE_JOB_NAMESPACE", Value: ComplianceNamespace},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER", Value: c.cfg.ESClusterConfig.ClusterName()},
+		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 	}
 	return &corev1.PodTemplate{
 		TypeMeta: metav1.TypeMeta{Kind: "PodTemplate", APIVersion: "v1"},
@@ -709,7 +709,7 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER", Value: c.cfg.ESClusterConfig.ClusterName()},
+		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 	}
 	if c.cfg.KeyValidatorConfig != nil {
 		envVars = append(envVars, c.cfg.KeyValidatorConfig.RequiredEnv("TIGERA_COMPLIANCE_")...)
@@ -896,7 +896,7 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 		{Name: "TIGERA_COMPLIANCE_SNAPSHOT_HOUR", Value: "0"},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER", Value: c.cfg.ESClusterConfig.ClusterName()},
+		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 	}
 
 	podTemplate := &corev1.PodTemplateSpec{
@@ -1021,7 +1021,7 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 		{Name: "NODENAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER", Value: c.cfg.ESClusterConfig.ClusterName()},
+		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 	}
 
 	volMounts := []corev1.VolumeMount{

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -213,7 +213,7 @@ var _ = Describe("compliance rendering tests", func() {
 
 			envs := d.Spec.Template.Spec.Containers[0].Env
 			expectedEnvs := []corev1.EnvVar{
-				{Name: "CLUSTER", Value: "cluster"},
+				{Name: "CLUSTER_NAME", Value: "cluster"},
 				{Name: "LINSEED_CLIENT_KEY", Value: "/tigera-compliance-controller-tls/tls.key"},
 				{Name: "LINSEED_CLIENT_CERT", Value: "/tigera-compliance-controller-tls/tls.crt"},
 			}
@@ -343,19 +343,19 @@ var _ = Describe("compliance rendering tests", func() {
 			complianceBenchmarker := rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER", Value: "cluster"},
+				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
 			))
 			Expect(complianceController.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER", Value: "cluster"},
+				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
 			))
 			Expect(complianceSnapshotter.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER", Value: "cluster"},
+				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
 			))
 			Expect(complianceBenchmarker.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER", Value: "cluster"},
+				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
 			))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER", Value: "cluster"},
+				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
 			))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("tigera-ca-bundle"))

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -65,6 +65,7 @@ const (
 	ADAPIObjectPortName             = "anomaly-detection-api-https"
 	ADAPITLSSecretName              = "anomaly-detection-api-tls"
 	IntrusionDetectionTLSSecretName = "intrusion-detection-tls"
+	DPITLSSecretName                = "deep-packet-inspection-tls"
 	ADAPIExpectedServiceName        = "anomaly-detection-api.tigera-intrusion-detection.svc"
 	ADAPIPolicyName                 = networkpolicy.TigeraComponentPolicyPrefix + ADAPIObjectName
 	adAPIPort                       = 8080

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -15,6 +15,7 @@
 package dpi
 
 import (
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -55,9 +56,9 @@ type DPIConfig struct {
 	ManagedCluster     bool
 	HasNoLicense       bool
 	HasNoDPIResource   bool
-	ESSecrets          []*corev1.Secret
 	ESClusterConfig    *relasticsearch.ClusterConfig
 	ClusterDomain      string
+	DPICertSecret      certificatemanagement.KeyPairInterface
 }
 
 func DPI(cfg *DPIConfig) render.Component {
@@ -105,7 +106,7 @@ func (d *dpiComponent) Objects() (objsToCreate, objsToDelete []client.Object) {
 		)
 	} else {
 		toCreate = append(toCreate, d.dpiAllowTigeraPolicy())
-		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.ESSecrets...)...)...)
+		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace)...)...)
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(DeepPacketInspectionNamespace, d.cfg.PullSecrets...)...)...)
 		toCreate = append(toCreate,
 			d.dpiServiceAccount(),
@@ -132,7 +133,7 @@ func (d *dpiComponent) dpiDaemonset() *appsv1.DaemonSet {
 		initContainers = append(initContainers, d.cfg.TyphaNodeTLS.NodeSecret.InitContainer(DeepPacketInspectionNamespace))
 	}
 
-	podTemplate := relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
+	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: d.dpiAnnotations(),
 		},
@@ -148,7 +149,7 @@ func (d *dpiComponent) dpiDaemonset() *appsv1.DaemonSet {
 			Containers:     []corev1.Container{d.dpiContainer()},
 			Volumes:        d.dpiVolumes(),
 		},
-	}, d.cfg.ESClusterConfig, d.cfg.ESSecrets).(*corev1.PodTemplateSpec)
+	}
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -178,16 +179,14 @@ func (d *dpiComponent) dpiContainer() corev1.Container {
 		ReadinessProbe:  d.dpiReadinessProbes(),
 	}
 
-	return relasticsearch.ContainerDecorateIndexCreator(
-		relasticsearch.ContainerDecorate(dpiContainer, d.cfg.ESClusterConfig.ClusterName(),
-			render.ElasticsearchIntrusionDetectionUserSecret, d.cfg.ClusterDomain, meta.OSTypeLinux),
-		d.cfg.ESClusterConfig.Replicas(), d.cfg.ESClusterConfig.Shards())
+	return dpiContainer
 }
 
 func (d *dpiComponent) dpiVolumes() []corev1.Volume {
 	dirOrCreate := corev1.HostPathDirectoryOrCreate
 
 	return []corev1.Volume{
+		d.cfg.DPICertSecret.Volume(),
 		d.cfg.TyphaNodeTLS.TrustedBundle.Volume(),
 		d.cfg.TyphaNodeTLS.NodeSecret.Volume(),
 		{
@@ -215,7 +214,12 @@ func (d *dpiComponent) dpiEnvVars() []corev1.EnvVar {
 		{Name: "DPI_TYPHACAFILE", Value: d.cfg.TyphaNodeTLS.TrustedBundle.MountPath()},
 		{Name: "DPI_TYPHACERTFILE", Value: d.cfg.TyphaNodeTLS.NodeSecret.VolumeMountCertificateFilePath()},
 		{Name: "DPI_TYPHAKEYFILE", Value: d.cfg.TyphaNodeTLS.NodeSecret.VolumeMountKeyFilePath()},
-		{Name: "DPI_FIPSMODEENABLED", Value: operatorv1.IsFIPSModeEnabledString(d.cfg.Installation.FIPSMode)},
+
+		{Name: "CLUSTER_NAME", Value: d.cfg.ESClusterConfig.ClusterName()},
+
+		{Name: "LINSEED_CLIENT_CERT", Value: d.cfg.DPICertSecret.VolumeMountCertificateFilePath()},
+		{Name: "LINSEED_CLIENT_KEY", Value: d.cfg.DPICertSecret.VolumeMountKeyFilePath()},
+		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(d.cfg.Installation.FIPSMode)},
 	}
 	// We need at least the CN or URISAN set, we depend on the validation
 	// done by the core_controller that the Secret will have one.
@@ -233,6 +237,7 @@ func (d *dpiComponent) dpiVolumeMounts() []corev1.VolumeMount {
 		d.cfg.TyphaNodeTLS.TrustedBundle.VolumeMounts(d.SupportedOSType()),
 		d.cfg.TyphaNodeTLS.NodeSecret.VolumeMount(d.SupportedOSType()),
 		corev1.VolumeMount{MountPath: "/var/log/calico/snort-alerts", Name: "log-snort-alters"},
+		d.cfg.DPICertSecret.VolumeMount(d.SupportedOSType()),
 	)
 }
 
@@ -333,6 +338,7 @@ func (d *dpiComponent) dpiAnnotations() map[string]string {
 	}
 	annotations := d.cfg.TyphaNodeTLS.TrustedBundle.HashAnnotations()
 	annotations[d.cfg.TyphaNodeTLS.NodeSecret.HashAnnotationKey()] = d.cfg.TyphaNodeTLS.NodeSecret.HashAnnotationValue()
+	annotations[d.cfg.DPICertSecret.HashAnnotationKey()] = d.cfg.DPICertSecret.HashAnnotationValue()
 	return annotations
 }
 
@@ -357,7 +363,7 @@ func (d *dpiComponent) dpiAllowTigeraPolicy() *v3.NetworkPolicy {
 		egressRules = append(egressRules, v3.Rule{
 			Action:      v3.Allow,
 			Protocol:    &networkpolicy.TCPProtocol,
-			Destination: networkpolicy.ESGatewayServiceSelectorEntityRule,
+			Destination: networkpolicy.LinseedServiceSelectorEntityRule,
 		})
 	}
 

--- a/pkg/render/intrusiondetection/dpi/dpi_test.go
+++ b/pkg/render/intrusiondetection/dpi/dpi_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -157,6 +158,7 @@ var _ = Describe("DPI rendering tests", func() {
 		clusterDomain = "cluster.local"
 		installation  *operatorv1.InstallationSpec
 		typhaNodeTLS  *render.TyphaNodeTLS
+		dpiCertSecret certificatemanagement.KeyPairInterface
 		cfg           *dpi.DPIConfig
 	)
 
@@ -176,7 +178,9 @@ var _ = Describe("DPI rendering tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		typhaKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
 		Expect(err).NotTo(HaveOccurred())
-		trustedBundle := certificateManager.CreateTrustedBundle(nodeKeyPair, typhaKeyPair)
+		dpiCertSecret, err = certificateManager.GetOrCreateKeyPair(cli, render.DPITLSSecretName, common.OperatorNamespace(), []string{""})
+		Expect(err).NotTo(HaveOccurred())
+		trustedBundle := certificateManager.CreateTrustedBundle(nodeKeyPair, typhaKeyPair, dpiCertSecret)
 		typhaNodeTLS = &render.TyphaNodeTLS{
 			TyphaSecret:   typhaKeyPair,
 			NodeSecret:    nodeKeyPair,
@@ -192,8 +196,8 @@ var _ = Describe("DPI rendering tests", func() {
 			HasNoLicense:       false,
 			HasNoDPIResource:   false,
 			ESClusterConfig:    esConfigMap,
-			ESSecrets:          nil,
 			ClusterDomain:      dns.DefaultClusterDomain,
+			DPICertSecret:      dpiCertSecret,
 		}
 	})
 
@@ -220,7 +224,10 @@ var _ = Describe("DPI rendering tests", func() {
 
 		ds := rtest.GetResource(resources, dpi.DeepPacketInspectionName, dpi.DeepPacketInspectionNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-			corev1.EnvVar{Name: "ELASTIC_INDEX_SUFFIX", Value: "clusterTestName"},
+			corev1.EnvVar{Name: "CLUSTER_NAME", Value: "clusterTestName"},
+			corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: "/deep-packet-inspection-tls/tls.crt"},
+			corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: "/deep-packet-inspection-tls/tls.key"},
+			corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "false"},
 		))
 		Expect(len(ds.Spec.Template.Spec.Containers)).Should(Equal(1))
 		Expect(*ds.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu()).Should(Equal(resource.MustParse(dpi.DefaultCPURequest)))

--- a/pkg/render/testutils/expected_policies/dpi_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/dpi_unmanaged.json
@@ -39,7 +39,7 @@
         "destination": {
           "services": {
             "namespace": "tigera-elasticsearch",
-            "name": "tigera-secure-es-gateway-http"
+            "name": "tigera-linseed"
           }
         }
       }

--- a/pkg/render/testutils/expected_policies/dpi_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/dpi_unmanaged_ocp.json
@@ -49,7 +49,7 @@
         "destination": {
           "services": {
             "namespace": "tigera-elasticsearch",
-            "name": "tigera-secure-es-gateway-http"
+            "name": "tigera-linseed"
           }
         }
       }


### PR DESCRIPTION
## Description

- Allow connection between DPI and Linseed
- Generate certificates for DPI for mTLS connection
- Remove connection to es-gateway

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
