### PR TITLE
Fix periodic reconcile logic

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -91,6 +91,7 @@ const (
 	// This is separate from the calico/node prometheus metrics port, which is user configurable.
 	defaultNodeReporterPort = 9081
 	CalicoFinalizer         = "tigera.io/operator-cleanup"
+	reconcilePeriod         = 5 * time.Minute
 )
 
 const InstallationName string = "calico"
@@ -348,6 +349,13 @@ func add(c controller.Controller, r *ReconcileInstallation) error {
 				return fmt.Errorf("tigera-installation-controller failed to watch CRD resource: %v", err)
 			}
 		}
+	}
+
+	// Perform periodic reconciliation. This acts as a backstop to catch reconcile issues,
+	// and also makes sure we spot when things change that might not trigger a reconciliation.
+	err = utils.AddPeriodicReconcile(c, reconcilePeriod)
+	if err != nil {
+		return fmt.Errorf("tigera-installation-controller failed to create periodic reconcile watch: %w", err)
 	}
 
 	return nil
@@ -793,7 +801,7 @@ func mergeProvider(cr *operator.Installation, provider operator.Provider) error 
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.V(1).Info("Reconciling Installation.operator.tigera.io")
+	reqLogger.Info("Reconciling Installation.operator.tigera.io")
 
 	newActiveCM, err := r.checkActive(reqLogger)
 	if err != nil {
@@ -1517,14 +1525,11 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	// Created successfully. Requeue anyway so that we perform periodic reconciliation.
-	// This acts as a backstop to catch reconcile issues, and also makes sure we spot when
-	// things change that might not trigger a reconciliation.
 	reqLogger.V(1).Info("Finished reconciling network installation")
 	if terminating {
 		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	}
-	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
+	return reconcile.Result{}, nil
 }
 
 func readMTUFile() (int, error) {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 
 	"github.com/go-logr/logr"
@@ -122,6 +124,27 @@ func AddServiceWatch(c controller.Controller, name, namespace string) error {
 		TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "V1"},
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 	})
+}
+
+func AddPeriodicReconcile(c controller.Controller, period time.Duration) error {
+	return c.Watch(
+		&source.Channel{Source: createPeriodicReconcileChannel(period)},
+		&handler.EnqueueRequestForObject{},
+	)
+}
+
+func createPeriodicReconcileChannel(period time.Duration) chan event.GenericEvent {
+	periodicReconcileEvents := make(chan event.GenericEvent)
+	eventObject := &unstructured.Unstructured{}
+	eventObject.SetName(fmt.Sprintf("periodic-%s-reconcile-event", period.String()))
+
+	go func() {
+		for range time.Tick(period) {
+			periodicReconcileEvents <- event.GenericEvent{Object: eventObject}
+		}
+	}()
+
+	return periodicReconcileEvents
 }
 
 func WaitToAddLicenseKeyWatch(controller controller.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {


### PR DESCRIPTION
## Description
The current periodic reconcile implementation requeues each successful reconcile every 5 minutes. This causes each event from the initial set of events (from source.Kind watches) to be replayed every 5 minutes.

This PR
* Triggers a reconcile every 5 minutes by injecting an event via source.Channel.
* Re-enables the Info level logging of Reconcile invocations of the core controller. This helped masked the issue previously.


## For PR author
- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
