### PR TITLE
[EV-3352][EV-3353] Update manager-role, network-admin and ui-user clu…

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1494,7 +1494,7 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login",
+				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login", "recommendations",
 			},
 			Verbs: []string{"get"},
 		})
@@ -1649,7 +1649,7 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{"lma.tigera.io"},
 			Resources: []string{"*"},
 			ResourceNames: []string{
-				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login", "elasticsearch_superuser",
+				"flows", "audit*", "l7", "events", "dns", "waf", "kibana_login", "elasticsearch_superuser", "recommendations",
 			},
 			Verbs: []string{"get"},
 		})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -593,7 +593,6 @@ func managerClusterRole(managementCluster, managedCluster, usePSP bool) *rbacv1.
 				Resources: []string{"tokenreviews"},
 				Verbs:     []string{"create"},
 			},
-
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
@@ -610,6 +609,14 @@ func managerClusterRole(managementCluster, managedCluster, usePSP bool) *rbacv1.
 					"stagedkubernetesnetworkpolicies",
 				},
 				Verbs: []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{
+					"tier.stagedglobalnetworkpolicies",
+					"stagednetworkpolicies",
+				},
+				Verbs: []string{"patch"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},


### PR DESCRIPTION
…sterroles for policy rec

* Adds the `patch` verb to stagednetworkpolicies resources for `tigera-manager-role` cluster role. Used for `/batchAction` es-proxy endpoint to update the StagedAction and annotations for StagedNetworPolicies

* Adds the `recommendations` resource for `/batchAction` and `recommendations` es-proxy endpoints.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
