### PR TITLE
Fix! Missing rbac for flowlogs and snapshots and benchmarks

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -511,6 +511,11 @@ func (c *complianceComponent) complianceReporterClusterRole() *rbacv1.ClusterRol
 		},
 		{
 			APIGroups: []string{"linseed.tigera.io"},
+			Resources: []string{"snapshots", "benchmarks"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"linseed.tigera.io"},
 			Resources: []string{"compliancereports"},
 			Verbs:     []string{"create"},
 		},

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -469,7 +469,7 @@ func (c *intrusionDetectionComponent) intrusionDetectionClusterRole() *rbacv1.Cl
 				"waflogs",
 				"dnslogs",
 				"l7logs",
-				"flows",
+				"flowlogs",
 				"auditlogs",
 				"events",
 			},


### PR DESCRIPTION
## Description

Intrusion-detection-controllers needs to `get` for `flowlogs` and compliance-reporter need to `get` for `snapshots` and `benchmarks`

```
2023-04-20 17:19:31.454 [INFO][1] client.go 847: POST https://tigera-secure-es-http.tigera-elasticsearch.svc:9200/_bulk [status:200, request:0.021s]
2023-04-20 17:19:31.558 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="flowlogs" user="system:serviceaccount:tigera-intrusion-detection:intrusion-detection-controller" verb="get"
```

```
2023-04-20 17:19:38.204 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="benchmarks" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 17:19:40.167 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="snapshots" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
