### PR TITLE
Fix! Mount linseed tokens as secret instead of config maps

### DIFF
--- a/pkg/crds/enterprise/crd.projectcalico.org_egressgatewaypolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_egressgatewaypolicies.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: egressgatewaypolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: EgressGatewayPolicy
+    listKind: EgressGatewayPolicyList
+    plural: egressgatewaypolicies
+    singular: egressgatewaypolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EgressGatewayPolicySpec contains the egress policy rules
+              for each destination network
+            properties:
+              rules:
+                description: The ordered set of Egress Gateway Policies to define
+                  how traffic exit a cluster
+                items:
+                  description: EgressGatewayRule defines an Egress Gateway to reach
+                    a destination network
+                  properties:
+                    description:
+                      description: The description of the EgressGatewayPolicy rule.
+                      type: string
+                    destination:
+                      description: The destination network that can be reached via
+                        egress gateway. If no destination is set, the default route,
+                        0.0.0.0/0, is used instead.
+                      properties:
+                        cidr:
+                          description: The destination network CIDR.
+                          type: string
+                      required:
+                      - cidr
+                      type: object
+                    gateway:
+                      description: Gateway specifies the egress gateway that should
+                        be used for the specified destination. If no gateway is set
+                        then the destination is routed normally rather than via an
+                        egress gateway.
+                      properties:
+                        maxNextHops:
+                          description: MaxNextHops specifies the maximum number of
+                            egress gateway replicas from the selected deployment that
+                            a pod should depend on.
+                          type: integer
+                        namespaceSelector:
+                          description: NamespaceSelector selects one or more namespaces
+                            containing an egress gateway deployment.
+                          type: string
+                        selector:
+                          description: Selector is an expression used to pick out
+                            the egress gateway that the destination can be reached
+                            via.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            required:
+            - rules
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -509,7 +509,7 @@ func (c *complianceComponent) complianceReporterClusterRole() *rbacv1.ClusterRol
 		},
 		{
 			APIGroups: []string{"linseed.tigera.io"},
-			Resources: []string{"snapshots", "benchmarks"},
+			Resources: []string{"snapshots", "benchmarks", "auditlogs"},
 			Verbs:     []string{"get"},
 		},
 		{

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -415,11 +415,9 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 			corev1.Volume{
 				Name: LinseedTokenVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: fmt.Sprintf(LinseedTokenSecret, ComplianceControllerServiceAccount),
-						},
-						Items: []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: fmt.Sprintf(LinseedTokenSecret, ComplianceControllerServiceAccount),
+						Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
 					},
 				},
 			})
@@ -1011,11 +1009,9 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 			corev1.Volume{
 				Name: LinseedTokenVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: fmt.Sprintf(LinseedTokenSecret, ComplianceSnapshotterServiceAccount),
-						},
-						Items: []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: fmt.Sprintf(LinseedTokenSecret, ComplianceSnapshotterServiceAccount),
+						Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
 					},
 				},
 			})
@@ -1206,11 +1202,9 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 			corev1.Volume{
 				Name: LinseedTokenVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: fmt.Sprintf(LinseedTokenSecret, ComplianceBenchmarkerServiceAccount),
-						},
-						Items: []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: fmt.Sprintf(LinseedTokenSecret, ComplianceBenchmarkerServiceAccount),
+						Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
 					},
 				},
 			})


### PR DESCRIPTION
## Description
Firs commit:

Linseed tokens needs to be mounted as secret instead of config maps.

```
 Events:                                                                                                                                                                                                 │
│   Type     Reason       Age                   From     Message                                                                                                                                          │
│   ----     ------       ----                  ----     -------                                                                                                                                          │
│   Warning  FailedMount  8m53s (x34 over 81m)  kubelet  (combined from similar events): Unable to attach or mount volumes: unmounted volumes=[linseed-token], unattached volumes=[etc-kubernetes usr-bin │
│ tigera-ca-bundle kube-api-access-d8hmj var-lib-kubelet etc-systemd tigera-compliance-benchmarker-tls var-lib-etcd linseed-token[]: timed out waiting for the condition                                  │
│   Warning  FailedMount  4m48s (x48 over 90m)  kubelet  MountVolume.SetUp failed for volume "linseed-token" : configmap "tigera-compliance-benchmarker-tigera-linseed-token" not found                   │
│                                                                                                                                                                                                         
```

Second commit:

Compliance reporter needs to access auditlogs:

```
2023-04-20 23:30:12.228 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 23:30:17.472 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 23:30:22.676 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 23:30:32.534 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 23:30:36.640 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 23:30:39.640 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 23:30:42.844 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-20 23:30:46.040 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="auditlogs" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"

```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
