### PR TITLE
Fix! Reporter is missing access to flows

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -509,7 +509,7 @@ func (c *complianceComponent) complianceReporterClusterRole() *rbacv1.ClusterRol
 		},
 		{
 			APIGroups: []string{"linseed.tigera.io"},
-			Resources: []string{"snapshots", "benchmarks", "auditlogs"},
+			Resources: []string{"snapshots", "benchmarks", "auditlogs", "flows"},
 			Verbs:     []string{"get"},
 		},
 		{


### PR DESCRIPTION
## Description

Compliance reporter needs to access flows

```
2023-04-21 16:01:06.905 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="flows" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-21 16:01:57.502 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="flows" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-21 16:03:05.952 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="flows" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-21 16:06:24.743 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="flows" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-21 16:31:07.648 [INFO][1] token.go 162: User not authorized cluster="cluster" group="linseed.tigera.io" resource="flows" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-21 17:09:32.493 [INFO][1] token.go 162: User not authorized cluster="asincu-bz-0bbf" group="linseed.tigera.io" resource="flows" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
2023-04-21 17:10:21.700 [INFO][1] token.go 162: User not authorized cluster="asincu-bz-0bbf" group="linseed.tigera.io" resource="flows" user="system:serviceaccount:tigera-compliance:tigera-compliance-reporter" verb="get"
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
