### PR TITLE
Add IPTables backend to EGW CRD

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -41,3 +41,10 @@ const (
 	LogLevelFatal LogLevel = "Fatal"
 	LogLevelError LogLevel = "Error"
 )
+
+type IptablesBackend string
+
+const (
+	IptablesBackendLegacy   IptablesBackend = "Legacy"
+	IptablesBackendNFTables IptablesBackend = "NFT"
+)

--- a/api/v1/egressgateway_types.go
+++ b/api/v1/egressgateway_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +79,13 @@ type EgressGatewaySpec struct {
 	// +optional
 	// +kubebuilder:default:=Info
 	LogSeverity *LogLevel `json:"logSeverity,omitempty"`
+
+	// IPTablesBackend is used to configure whether Egress Gateway must use
+	// nft or legacy. If not specified, Egress Gateway will auto-detect which
+	// backend to use. If both are supported, nft is preferred.
+	// +kubebuilder:validation:Enum=Legacy;NFT
+	// +optional
+	IPTablesBackend *IptablesBackend `json:"ipTablesBackend,omitempty"`
 
 	// Template describes the EGW Deployment pod that will be created.
 	// +optional
@@ -305,6 +314,13 @@ type EgressGatewayList struct {
 
 func (c *EgressGateway) GetLogSeverity() string {
 	return string(*c.Spec.LogSeverity)
+}
+
+func (c *EgressGateway) GetIPTablesBackend() string {
+	if c.Spec.IPTablesBackend != nil {
+		return strings.ToLower(string(*c.Spec.IPTablesBackend))
+	}
+	return ""
 }
 
 func (c *EgressGateway) GetTerminationGracePeriodSeconds() *int64 {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1912,6 +1912,11 @@ func (in *EgressGatewaySpec) DeepCopyInto(out *EgressGatewaySpec) {
 		*out = new(LogLevel)
 		**out = **in
 	}
+	if in.IPTablesBackend != nil {
+		in, out := &in.IPTablesBackend, &out.IPTablesBackend
+		*out = new(IptablesBackend)
+		**out = **in
+	}
 	if in.Template != nil {
 		in, out := &in.Template, &out.Template
 		*out = new(EgressGatewayDeploymentPodTemplateSpec)

--- a/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
+++ b/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
@@ -24,9 +24,6 @@ type IptablesBackend string
 
 const (
 	KindFelixConfiguration = "FelixConfiguration"
-
-	IptablesBackendLegacy   = "Legacy"
-	IptablesBackendNFTables = "NFT"
 )
 
 // +kubebuilder:validation:Enum=DoNothing;Enable;Disable

--- a/pkg/controller/migration/convert/felix_vars_test.go
+++ b/pkg/controller/migration/convert/felix_vars_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"github.com/tigera/api/pkg/lib/numorstring"
 	"github.com/tigera/operator/pkg/apis"
 
+	operatorv1 "github.com/tigera/operator/api/v1"
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -218,7 +219,7 @@ var _ = Describe("felix env parser", func() {
 			f := crdv1.FelixConfiguration{}
 			Expect(c.client.Get(ctx, types.NamespacedName{Name: "default"}, &f)).ToNot(HaveOccurred())
 			Expect(f.Spec.IptablesBackend).ToNot(BeNil())
-			legacy := crdv1.IptablesBackend(crdv1.IptablesBackendLegacy)
+			legacy := crdv1.IptablesBackend(string(operatorv1.IptablesBackendLegacy))
 			Expect(f.Spec.IptablesBackend).To(Equal(&legacy))
 		})
 	})

--- a/pkg/crds/operator/operator.tigera.io_egressgateways.yaml
+++ b/pkg/crds/operator/operator.tigera.io_egressgateways.yaml
@@ -156,6 +156,14 @@ spec:
                       type: string
                   type: object
                 type: array
+              ipTablesBackend:
+                description: IPTablesBackend is used to configure whether Egress Gateway
+                  must use nft or legacy. If not specified, Egress Gateway will auto-detect
+                  which backend to use. If both are supported, nft is preferred.
+                enum:
+                - Legacy
+                - NFT
+                type: string
               logSeverity:
                 default: Info
                 description: 'LogSeverity defines the logging level of the Egress

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -265,6 +265,10 @@ func (c *component) egwEnvVars() []corev1.EnvVar {
 		{Name: "LOG_SEVERITY", Value: c.config.EgressGW.GetLogSeverity()},
 	}
 
+	if c.config.EgressGW.GetIPTablesBackend() != "" {
+		envVar = append(envVar, corev1.EnvVar{Name: "IPTABLES_BACKEND", Value: c.config.EgressGW.GetIPTablesBackend()})
+	}
+
 	icmpProbeIPs, icmpInterval, icmpTimeout := c.getICMPProbe()
 	if icmpProbeIPs != "" {
 		icmpEnvVar := []corev1.EnvVar{

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 	var pullSecrets []*corev1.Secret
 	rbac := "rbac.authorization.k8s.io"
 	logSeverity := operatorv1.LogLevelInfo
+	iptablesBackend := operatorv1.IptablesBackendNFTables
 	labels := map[string]string{"egress-code": "red"}
 
 	topoConstraint := corev1.TopologySpreadConstraint{
@@ -73,6 +74,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 				},
 				ExternalNetworks: []string{"one", "two"},
 				LogSeverity:      &logSeverity,
+				IPTablesBackend:  &iptablesBackend,
 				Template: &operatorv1.EgressGatewayDeploymentPodTemplateSpec{
 					Metadata: &operatorv1.EgressGatewayMetadata{Labels: labels},
 					Spec: &operatorv1.EgressGatewayDeploymentPodSpec{
@@ -193,6 +195,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			{Name: "ICMP_PROBE_TIMEOUT", Value: "40s"},
 			{Name: "HTTP_PROBE_INTERVAL", Value: "20s"},
 			{Name: "HTTP_PROBE_TIMEOUT", Value: "40s"},
+			{Name: "IPTABLES_BACKEND", Value: "nft"},
 		}
 		for _, elem := range expectedEnvVars {
 			Expect(egwContainer.Env).To(ContainElement(elem))


### PR DESCRIPTION
## Description

This PR adds changes to the EGW CRD, so that users can specify the ```IPTablesBackend```. This can be set to ```nft``` or ```legacy```. 

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
