### PR TITLE
Fix! Linseed controller needs get and create for secrets

### DIFF
--- a/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
@@ -99,6 +99,11 @@ spec:
                                 the dashboard card
                               format: int32
                               type: integer
+                          required:
+                          - height
+                          - width
+                          - xPos
+                          - yPos
                           type: object
                         selectedNamespace:
                           description: Namespace user selected for the dashboard

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -169,6 +169,12 @@ func (l *linseed) linseedClusterRole() *rbacv1.ClusterRole {
 			Verbs:     []string{"create"},
 		},
 		{
+			// Need to be able to get and create secrets associated with a token
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
 			// Need to be able to list managed clusters
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"managedclusters"},

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -332,6 +332,11 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 			Verbs:     []string{"create"},
 		},
 		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "create"},
+		},
+		{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"managedclusters"},
 			Verbs:     []string{"list", "watch"},


### PR DESCRIPTION
## Description

Linseed controller needs to access and write secrets.

```
token_controller.go 318: error checking token cluster="vara-bz-ba2c" error=secrets "tigera-compliance-snapshotter-tigera-linseed-token" is forbidden: User "system:serviceaccount:tigera-elasticsearch:tigera-linseed" cannot get resource "secrets" in API group "" in the namespace "tigera-compliance" service="tigera-compliance-snapshotter" tenant=""
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
