### PR TITLE
Cherry-pick(iptables-backend) to 3.16

### DIFF
--- a/pkg/controller/egressgateway/egressgateway_controller.go
+++ b/pkg/controller/egressgateway/egressgateway_controller.go
@@ -384,6 +384,14 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 		egwVXLANVNI = *fc.Spec.EgressIPVXLANVNI
 	}
 
+	ipTablesBackend := ""
+	if fc.Spec.IptablesBackend != nil {
+		backend := strings.ToLower(string(*fc.Spec.IptablesBackend))
+		if backend != "auto" {
+			ipTablesBackend = backend
+		}
+	}
+
 	openshift := r.provider == operatorv1.ProviderOpenShift
 	config := &egressgateway.Config{
 		PullSecrets:       pullSecrets,
@@ -392,6 +400,7 @@ func (r *ReconcileEgressGateway) reconcileEgressGateway(ctx context.Context, egw
 		EgressGW:          egw,
 		VXLANPort:         egwVXLANPort,
 		VXLANVNI:          egwVXLANVNI,
+		IptablesBackend:   ipTablesBackend,
 		UsePSP:            r.usePSP,
 		OpenShift:         openshift,
 		NamespaceAndNames: namespaceAndNames,

--- a/pkg/controller/egressgateway/egressgateway_controller_test.go
+++ b/pkg/controller/egressgateway/egressgateway_controller_test.go
@@ -320,6 +320,84 @@ var _ = Describe("Egress Gateway controller tests", func() {
 				Expect(initContainer.Env).To(ContainElement(elem))
 				Expect(initContainer_blue.Env).To(ContainElement(elem))
 			}
+			var backend crdv1.IptablesBackend
+			backend = "Auto"
+			fc.Spec.IptablesBackend = &backend
+			Expect(c.Update(ctx, fc)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &dep)).To(BeNil())
+			dep_blue = appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-blue",
+					Namespace: "calico-gw",
+				},
+			}
+			Expect(test.GetResource(c, &dep_blue)).To(BeNil())
+			initContainer = dep.Spec.Template.Spec.InitContainers[0]
+			initContainer_blue = dep_blue.Spec.Template.Spec.InitContainers[0]
+			expectedInitEnvVar = []corev1.EnvVar{
+				{Name: "EGRESS_VXLAN_VNI", Value: "4100"},
+				{Name: "EGRESS_VXLAN_PORT", Value: "4800"},
+			}
+			for _, elem := range expectedInitEnvVar {
+				Expect(initContainer.Env).To(ContainElement(elem))
+				Expect(initContainer_blue.Env).To(ContainElement(elem))
+			}
+
+			backend = "legacy"
+			fc.Spec.IptablesBackend = &backend
+			Expect(c.Update(ctx, fc)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &dep)).To(BeNil())
+			dep_blue = appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-blue",
+					Namespace: "calico-gw",
+				},
+			}
+			Expect(test.GetResource(c, &dep_blue)).To(BeNil())
+			initContainer = dep.Spec.Template.Spec.InitContainers[0]
+			initContainer_blue = dep_blue.Spec.Template.Spec.InitContainers[0]
+			expectedInitEnvVar = []corev1.EnvVar{
+				{Name: "EGRESS_VXLAN_VNI", Value: "4100"},
+				{Name: "EGRESS_VXLAN_PORT", Value: "4800"},
+				{Name: "IPTABLES_BACKEND", Value: "legacy"},
+			}
+			for _, elem := range expectedInitEnvVar {
+				Expect(initContainer.Env).To(ContainElement(elem))
+				Expect(initContainer_blue.Env).To(ContainElement(elem))
+			}
+
+			backend = "NFT"
+			fc.Spec.IptablesBackend = &backend
+			Expect(c.Update(ctx, fc)).NotTo(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(test.GetResource(c, &dep)).To(BeNil())
+			dep_blue = appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "calico-blue",
+					Namespace: "calico-gw",
+				},
+			}
+			Expect(test.GetResource(c, &dep_blue)).To(BeNil())
+			initContainer = dep.Spec.Template.Spec.InitContainers[0]
+			initContainer_blue = dep_blue.Spec.Template.Spec.InitContainers[0]
+			expectedInitEnvVar = []corev1.EnvVar{
+				{Name: "EGRESS_VXLAN_VNI", Value: "4100"},
+				{Name: "EGRESS_VXLAN_PORT", Value: "4800"},
+				{Name: "IPTABLES_BACKEND", Value: "nft"},
+			}
+			for _, elem := range expectedInitEnvVar {
+				Expect(initContainer.Env).To(ContainElement(elem))
+				Expect(initContainer_blue.Env).To(ContainElement(elem))
+			}
+
 		})
 
 		It("should use a single psp when EGW is created with on a psp cluster", func() {

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -74,9 +74,10 @@ type Config struct {
 	OSType       rmeta.OSType
 	EgressGW     *operatorv1.EgressGateway
 
-	egwImage  string
-	VXLANVNI  int
-	VXLANPort int
+	egwImage        string
+	VXLANVNI        int
+	VXLANPort       int
+	IptablesBackend string
 
 	OpenShift bool
 	// Whether the cluster supports pod security policies.
@@ -294,11 +295,15 @@ func (c *component) egwEnvVars() []corev1.EnvVar {
 
 func (c *component) egwInitEnvVars() []corev1.EnvVar {
 	egressPodIp := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}
-	return []corev1.EnvVar{
+	envVar := []corev1.EnvVar{
 		{Name: "EGRESS_VXLAN_VNI", Value: fmt.Sprintf("%d", c.config.VXLANVNI)},
 		{Name: "EGRESS_VXLAN_PORT", Value: fmt.Sprintf("%d", c.config.VXLANPort)},
 		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIp},
 	}
+	if c.config.IptablesBackend != "" {
+		envVar = append(envVar, corev1.EnvVar{Name: "IPTABLES_BACKEND", Value: c.config.IptablesBackend})
+	}
+	return envVar
 }
 
 func (c *component) egwPullSecrets() []*corev1.Secret {

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -125,12 +125,13 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		}
 
 		component := egressgateway.EgressGateway(&egressgateway.Config{
-			PullSecrets:  pullSecrets,
-			Installation: installation,
-			OSType:       rmeta.OSTypeLinux,
-			EgressGW:     egw,
-			VXLANVNI:     4097,
-			VXLANPort:    4790,
+			PullSecrets:     pullSecrets,
+			Installation:    installation,
+			OSType:          rmeta.OSTypeLinux,
+			EgressGW:        egw,
+			VXLANVNI:        4097,
+			VXLANPort:       4790,
+			IptablesBackend: "nft",
 		})
 		resources, resToBeDeleted := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
@@ -162,6 +163,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		expectedInitEnvVars := []corev1.EnvVar{
 			{Name: "EGRESS_VXLAN_VNI", Value: "4097"},
 			{Name: "EGRESS_VXLAN_PORT", Value: "4790"},
+			{Name: "IPTABLES_BACKEND", Value: "nft"},
 		}
 		for _, elem := range expectedInitEnvVars {
 			Expect(initContainer.Env).To(ContainElement(elem))


### PR DESCRIPTION
## Description

Cherry-pick PR https://github.com/tigera/operator/pull/2606 to branch 1.29
## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
