### PR TITLE
Revert access to secrets for Linseed

### DIFF
--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -171,12 +171,6 @@ func (l *linseed) linseedClusterRole() *rbacv1.ClusterRole {
 			Verbs:     []string{"create"},
 		},
 		{
-			// Need to be able to get and create secrets associated with a token
-			APIGroups: []string{""},
-			Resources: []string{"secrets"},
-			Verbs:     []string{"get", "create"},
-		},
-		{
 			// Need to be able to list managed clusters
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"managedclusters"},

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -335,11 +335,6 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 			Verbs:     []string{"create"},
 		},
 		{
-			APIGroups: []string{""},
-			Resources: []string{"secrets"},
-			Verbs:     []string{"get", "create"},
-		},
-		{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"managedclusters"},
 			Verbs:     []string{"list", "watch"},


### PR DESCRIPTION
## Description

Revert https://github.com/tigera/operator/pull/2605 and also keep the CRD changes

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
