### PR TITLE
Check more indicators for EKS discovery

### DIFF
--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -167,15 +167,40 @@ func isDockerEE(ctx context.Context, c kubernetes.Interface) (bool, error) {
 // EKS doesn't have any provider-specific API groups, so we need to use a different approach than
 // we use for other platforms in autodetectFromGroup.
 func isEKS(ctx context.Context, c kubernetes.Interface) (bool, error) {
-	cm, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "eks-certificates-controller", metav1.GetOptions{})
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			return false, nil
-		}
+	// This looks for a configmap that is used in EKS clusters for enabling access to EKS clusters
+	// https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
+	_, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "aws-auth", metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	} else if !kerrors.IsNotFound(err) {
 		return false, err
 	}
 
-	return (cm != nil), nil
+	// This is a config map that that use to be present in EKS cluster but now seems to be deprecated.
+	// We'll keep this detection so we ensure we detect EKS in older clusters that have this.
+	_, err = c.CoreV1().ConfigMaps("kube-system").Get(ctx, "eks-certificates-controller", metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	} else if !kerrors.IsNotFound(err) {
+		return false, err
+	}
+
+	// We'll check the labels on the kube-dns service if it exists and if we find the seemingly EKS
+	// specific label then we'll assume EKS.
+	dnsService, err := c.CoreV1().Services("kube-system").Get(ctx, "kube-dns", metav1.GetOptions{})
+	if err == nil {
+		if dnsService != nil {
+			for key := range dnsService.Labels {
+				if key == "eks.amazonaws.com/component" {
+					return true, nil
+				}
+			}
+		}
+	} else if !kerrors.IsNotFound(err) {
+		return false, err
+	}
+
+	return false, nil
 }
 
 // isRKE2 returns true if running on an RKE2 cluster, and false otherwise.

--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,6 +78,31 @@ var _ = Describe("provider discovery", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "eks-certificates-controller",
 				Namespace: "kube-system",
+			},
+		})
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderEKS))
+	})
+	It("should detect EKS based on aws-auth ConfigMap", func() {
+		c := fake.NewSimpleClientset(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "aws-auth",
+				Namespace: "kube-system",
+			},
+		})
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderEKS))
+	})
+	It("should detect EKS based on kube-dns service label", func() {
+		c := fake.NewSimpleClientset(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kube-dns",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"eks.amazonaws.com/component": "kube-dns",
+				},
 			},
 		})
 		p, e := AutoDiscoverProvider(context.Background(), c)


### PR DESCRIPTION
## Description

We have found in testing that the provider is not being detected as EKS in setups that were detected as EKS before. Upon looking at our detection/discovery code and looking at some EKS clusters, there was and still isn't a great means of detecting an EKS cluster. This PR expands the detection a bit to include a couple more indicators.

## For PR author

- [X] Tests for change.
  - I've also manually tested the discovery in a couple EKS clusters

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
