### PR TITLE
[Cherry-pick] Rever secrets rbac & add rolling update strategy to linseed deployment

### DIFF
--- a/pkg/crds/enterprise/crd.projectcalico.org_egressgatewaypolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_egressgatewaypolicies.yaml
@@ -52,8 +52,6 @@ spec:
                         cidr:
                           description: The destination network CIDR.
                           type: string
-                      required:
-                      - cidr
                       type: object
                     gateway:
                       description: Gateway specifies the egress gateway that should
@@ -78,8 +76,6 @@ spec:
                       type: object
                   type: object
                 type: array
-            required:
-            - rules
             type: object
         type: object
     served: true

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/tigera/operator/pkg/ptr"
+
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -351,7 +353,11 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RecreateDeploymentStrategyType,
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: ptr.IntOrStrPtr("0"),
+					MaxSurge:       ptr.IntOrStrPtr("100%"),
+				},
 			},
 			Template: *podTemplate,
 			Replicas: l.cfg.Installation.ControlPlaneReplicas,

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -169,12 +169,6 @@ func (l *linseed) linseedClusterRole() *rbacv1.ClusterRole {
 			Verbs:     []string{"create"},
 		},
 		{
-			// Need to be able to get and create secrets associated with a token
-			APIGroups: []string{""},
-			Resources: []string{"secrets"},
-			Verbs:     []string{"get", "create"},
-		},
-		{
 			// Need to be able to list managed clusters
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"managedclusters"},

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -332,11 +332,6 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 			Verbs:     []string{"create"},
 		},
 		{
-			APIGroups: []string{""},
-			Resources: []string{"secrets"},
-			Verbs:     []string{"get", "create"},
-		},
-		{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"managedclusters"},
 			Verbs:     []string{"list", "watch"},

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -279,6 +279,9 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 	// Check deployment
 	deployment := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 	ExpectWithOffset(1, deployment).NotTo(BeNil())
+	ExpectWithOffset(1, deployment.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+	ExpectWithOffset(1, deployment.Spec.Strategy.RollingUpdate.MaxSurge).To(Equal(ptr.IntOrStrPtr("100%")))
+	ExpectWithOffset(1, deployment.Spec.Strategy.RollingUpdate.MaxUnavailable).To(Equal(ptr.IntOrStrPtr("0")))
 
 	// Check containers
 	expected := expectedContainers()


### PR DESCRIPTION
## Description

Cherry-pick: 
- https://github.com/tigera/operator/pull/2614
- 65450107a843c3c2b6829d4c3488dd548397be7f

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
