### PR TITLE
[release-v1.29] Auto pick #2617: Move BGPFilter permissions from EE-only to OSS+EE in

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -503,6 +503,7 @@ func (c *apiServerComponent) calicoCustomResourcesClusterRole() *rbacv1.ClusterR
 				"globalnetworksets",
 				"networksets",
 				"bgpconfigurations",
+				"bgpfilters",
 				"bgppeers",
 				"felixconfigurations",
 				"kubecontrollersconfigurations",
@@ -1192,7 +1193,6 @@ func (c *apiServerComponent) tigeraCustomResourcesClusterRole() *rbacv1.ClusterR
 				"deeppacketinspections/status",
 				"uisettingsgroups",
 				"uisettings",
-				"bgpfilters",
 				"externalnetworks",
 			},
 			Verbs: []string{


### PR DESCRIPTION
Cherry pick of #2617 on release-v1.29.

#2617: Move BGPFilter permissions from EE-only to OSS+EE in

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

BGPFilters permissions were only being added to apiserver for EE, but they should be for both OSS+EE, this PR does this.

Fixes https://github.com/projectcalico/calico/issues/7598

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.