### PR TITLE
Add policyrecommendationscopes to CRDs list

### DIFF
--- a/hack/gen-bundle/get-manifests.sh
+++ b/hack/gen-bundle/get-manifests.sh
@@ -83,6 +83,7 @@ ippools
 kubecontrollersconfigurations
 networkpolicies
 networksets
+policyrecommendationscopes
 "
 
     # Download the Calico CRDs into CRD dir.


### PR DESCRIPTION
Add the policyrecommendationscopes to the list of CRDs when building manifests.