### PR TITLE
add calico node cluster role

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -393,10 +393,10 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"patch"},
 			},
 			{
-				// Used for creating service account tokens to be used by the CNI plugin.
+				// Allows Calico to use the K8s TokenRequest API to create the tokens used by the CNI plugin.
 				APIGroups:     []string{""},
 				Resources:     []string{"serviceaccounts/token"},
-				ResourceNames: []string{"calico-cni-plugin"},
+				ResourceNames: []string{"calico-node"},
 				Verbs:         []string{"create"},
 			},
 			{
@@ -563,6 +563,13 @@ func (c *nodeComponent) cniPluginRole() *rbacv1.ClusterRole {
 				APIGroups: []string{""},
 				Resources: []string{"pods/status"},
 				Verbs:     []string{"patch"},
+			},
+			{
+				// Used for creating service account tokens to be used by the CNI plugin.
+				APIGroups:     []string{""},
+				Resources:     []string{"serviceaccounts/token"},
+				ResourceNames: []string{"calico-cni-plugin"},
+				Verbs:         []string{"create"},
 			},
 			{
 				// Most IPAM resources need full CRUD permissions so we can allocate and


### PR DESCRIPTION
## Description
It seems the `calico-node` ClusterRole with `serviceaccounts/token` is missing from `nodeRole` function causing the following error when migrating from unmanaged manifest based calico install to Tigera Operator: `2023-05-06 10:31:46.151 [FATAL][1] cni-installer/<nil> <nil>: Unable to create token for CNI kubeconfig error=serviceaccounts "calico-node" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot create resource "serviceaccounts/token" in API group "" in the namespace "kube-system"`

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
