### PR TITLE
Make es-gateway use rolling update instead of recreate strategy

### DIFF
--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tigera/operator/pkg/ptr"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -283,7 +285,11 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RecreateDeploymentStrategyType,
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: ptr.IntOrStrPtr("0"),
+					MaxSurge:       ptr.IntOrStrPtr("100%"),
+				},
 			},
 			Template: *podTemplate,
 			Replicas: e.cfg.Installation.ControlPlaneReplicas,


### PR DESCRIPTION
## Description

Update es gateway deployment strategy to use RollingUpdateDeployment instead of Recreate. Will set maxSurge to 100% and maxUnavailable to 0. This will ensure that 2 new pods will be created when rolling out a new version and old ones will be destroyed once all the new ones are up an ready.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
