### PR TITLE
[release-v1.30] Bump Prometheus version to v2.43.1

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -103,7 +103,7 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v2.42.0
+    version: v2.43.1
   prometheus:
     image: tigera/prometheus
     version: master

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -188,7 +188,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = component{
-		Version: "v2.42.0",
+		Version: "v2.43.1",
 	}
 
 	ComponentPrometheus = component{


### PR DESCRIPTION
## Description

Pick https://github.com/tigera/operator/pull/2631 into release v1.30 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
