### PR TITLE
Enforce default deny for calico-system

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1392,7 +1392,10 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	// deployment becomes unhealthy and reconciliation of non-NetworkPolicy resources in the core controller
 	// would resolve it, we render the network policies of components last to prevent a chicken-and-egg scenario.
 	if includeV3NetworkPolicy {
-		components = append(components, kubecontrollers.NewCalicoKubeControllersPolicy(&kubeControllersCfg))
+		components = append(components,
+			kubecontrollers.NewCalicoKubeControllersPolicy(&kubeControllersCfg),
+			render.NewPassthrough(networkpolicy.AllowTigeraDefaultDeny(common.CalicoNamespace)),
+		)
 	}
 
 	imageSet, err := imageset.GetImageSet(ctx, r.client, instance.Spec.Variant)

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1549,8 +1549,9 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			policies := v3.NetworkPolicyList{}
 			Expect(c.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(1))
-			Expect(policies.Items[0].Name).To(Equal("allow-tigera.kube-controller-access"))
+			Expect(policies.Items).To(HaveLen(2))
+			Expect(policies.Items[0].Name).To(Equal("allow-tigera.default-deny"))
+			Expect(policies.Items[1].Name).To(Equal("allow-tigera.kube-controller-access"))
 		})
 
 		It("should omit allow-tigera policy and not degrade when tier is not ready", func() {

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -702,6 +702,17 @@ func kubeControllersAllowTigeraPolicy(cfg *KubeControllersConfiguration) *v3.Net
 		})
 	}
 
+	ingressRules := []v3.Rule{
+		{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Source:   networkpolicy.PrometheusSourceEntityRule,
+			Destination: v3.EntityRule{
+				Ports: networkpolicy.Ports(uint16(cfg.MetricsPort)),
+			},
+		},
+	}
+
 	return &v3.NetworkPolicy{
 		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -712,8 +723,9 @@ func kubeControllersAllowTigeraPolicy(cfg *KubeControllersConfiguration) *v3.Net
 			Order:    &networkpolicy.HighPrecedenceOrder,
 			Tier:     networkpolicy.TigeraComponentTierName,
 			Selector: networkpolicy.KubernetesAppSelector(KubeController),
-			Types:    []v3.PolicyType{v3.PolicyTypeEgress},
+			Types:    []v3.PolicyType{v3.PolicyTypeEgress, v3.PolicyTypeIngress},
 			Egress:   egressRules,
+			Ingress:  ingressRules,
 		},
 	}
 }

--- a/pkg/render/testutils/expected_policies/dns.json
+++ b/pkg/render/testutils/expected_policies/dns.json
@@ -12,7 +12,7 @@
       {
         "action": "Allow",
         "source": {
-          "selector": "projectcalico.org/namespace in {'tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
+          "selector": "projectcalico.org/namespace in {'calico-system','tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
           "namespaceSelector": "all()"
         },
         "destination": {}

--- a/pkg/render/testutils/expected_policies/dns_ocp.json
+++ b/pkg/render/testutils/expected_policies/dns_ocp.json
@@ -12,7 +12,7 @@
       {
         "action":"Allow",
         "source":{
-          "selector":"projectcalico.org/namespace in {'tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
+          "selector":"projectcalico.org/namespace in {'calico-system','tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
           "namespaceSelector":"all()"
         },
         "destination":{}

--- a/pkg/render/testutils/expected_policies/kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers.json
@@ -10,7 +10,7 @@
     "tier": "allow-tigera",
     "selector": "k8s-app == 'calico-kube-controllers'",
     "types": [
-      "Egress"
+      "Egress", "Ingress"
     ],
     "egress": [
       {
@@ -43,6 +43,21 @@
           "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
           "ports": [
             9443
+          ]
+        }
+      }
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9094"
           ]
         }
       }

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
@@ -10,7 +10,7 @@
     "tier": "allow-tigera",
     "selector": "k8s-app == 'calico-kube-controllers'",
     "types": [
-      "Egress"
+      "Egress", "Ingress"
     ],
     "egress": [
       {
@@ -43,6 +43,21 @@
           "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
           "ports": [
             8080
+          ]
+        }
+      }
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9094"
           ]
         }
       }

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
@@ -10,7 +10,7 @@
     "tier": "allow-tigera",
     "selector": "k8s-app == 'calico-kube-controllers'",
     "types": [
-      "Egress"
+      "Egress","Ingress"
     ],
     "egress": [
       {
@@ -54,6 +54,21 @@
           "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'",
           "ports": [
             8080
+          ]
+        }
+      }
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9094"
           ]
         }
       }

--- a/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
@@ -10,7 +10,7 @@
     "tier": "allow-tigera",
     "selector": "k8s-app == 'calico-kube-controllers'",
     "types": [
-      "Egress"
+      "Egress","Ingress"
     ],
     "egress": [
       {
@@ -54,6 +54,21 @@
           "namespaceSelector": "projectcalico.org/name == 'tigera-manager'",
           "ports": [
             9443
+          ]
+        }
+      }
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')",
+          "namespaceSelector": "name == 'tigera-prometheus'"
+        },
+        "destination": {
+          "ports": [
+            "9094"
           ]
         }
       }

--- a/pkg/render/testutils/expected_policies/node_local_dns_dual.json
+++ b/pkg/render/testutils/expected_policies/node_local_dns_dual.json
@@ -7,7 +7,7 @@
   "spec": {
     "tier":"allow-tigera",
     "order":10,
-    "selector": "projectcalico.org/namespace in {'tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
+    "selector": "projectcalico.org/namespace in {'calico-system','tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
     "egress":[
        {
          "action":"Allow",

--- a/pkg/render/testutils/expected_policies/node_local_dns_ipv4.json
+++ b/pkg/render/testutils/expected_policies/node_local_dns_ipv4.json
@@ -7,7 +7,7 @@
   "spec": {
     "tier":"allow-tigera",
     "order":10,
-    "selector": "projectcalico.org/namespace in {'tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
+    "selector": "projectcalico.org/namespace in {'calico-system','tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
     "egress":[
        {
          "action":"Allow",

--- a/pkg/render/testutils/expected_policies/node_local_dns_ipv6.json
+++ b/pkg/render/testutils/expected_policies/node_local_dns_ipv6.json
@@ -7,7 +7,7 @@
   "spec": {
     "tier":"allow-tigera",
     "order":10,
-    "selector": "projectcalico.org/namespace in {'tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
+    "selector": "projectcalico.org/namespace in {'calico-system','tigera-guardian','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-system','tigera-skraper'}",
     "egress":[
        {
          "action":"Allow",

--- a/pkg/render/tiers/tiers.go
+++ b/pkg/render/tiers/tiers.go
@@ -33,6 +33,7 @@ const (
 )
 
 var TigeraNamespaceSelector = createNamespaceSelector(
+	common.CalicoNamespace,
 	render.GuardianNamespace,
 	render.ComplianceNamespace,
 	render.DexNamespace,


### PR DESCRIPTION
## Description
Renders a default deny in the `calico-system` namespace. This change also fixes issues with NodeLocal DNSCache through the inclusion of `calico-system` in the Tigera namespace selector.

Change was tested in a MCM setup with NodeLocal DNSCache and L7 logging enabled (for CSI validation) in both management and managed clusters.


The following calico components are in the `calico-system` namespace and were tested*:
- kube-controllers: flows are policed, existing policy needed an additional ingress rule based on flow logs.
- es-kube-controllers: flows are policed, no new rules required based on flow logs.
- CSI daemonset: does not require networking (driver communicates with kubelet via UDS, also confirmed no flows in flow logs)
- Windows upgrader daemon set: not tested*, but appears to not require networking to install/upgrade.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
