### PR TITLE
Add dynamic layers to tigera infra layer in SG EV-3506

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -331,16 +331,28 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		}
 	}
 
+	// Populate a list of namespaces to be displayed in the service graph Tigera infrastructure layer.
+	sgLayerTigeraNameSpaces := render.DefaultSGLayerTigeraNamespaces()
+	sgLayerTigeraNameSpaces[render.GuardianNamespace] = true
+
+	amz, err := utils.GetAmazonCloudIntegration(ctx, r.Client)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get the GetAmazonCloudIntegration configuration", err, reqLogger)
+	} else if amz != nil {
+		sgLayerTigeraNameSpaces[render.AmazonCloudIntegrationNamespace] = true
+	}
+
 	ch := utils.NewComponentHandler(log, r.Client, r.Scheme, managementClusterConnection)
 	guardianCfg := &render.GuardianConfiguration{
-		URL:               managementClusterConnection.Spec.ManagementClusterAddr,
-		TunnelCAType:      managementClusterConnection.Spec.TLS.CA,
-		PullSecrets:       pullSecrets,
-		Openshift:         r.Provider == operatorv1.ProviderOpenShift,
-		Installation:      instl,
-		TunnelSecret:      tunnelSecret,
-		TrustedCertBundle: trustedCertBundle,
-		UsePSP:            r.usePSP,
+		URL:                     managementClusterConnection.Spec.ManagementClusterAddr,
+		TunnelCAType:            managementClusterConnection.Spec.TLS.CA,
+		PullSecrets:             pullSecrets,
+		Openshift:               r.Provider == operatorv1.ProviderOpenShift,
+		Installation:            instl,
+		TunnelSecret:            tunnelSecret,
+		TrustedCertBundle:       trustedCertBundle,
+		UsePSP:                  r.usePSP,
+		SGLayerTigeraNameSpaces: sgLayerTigeraNameSpaces,
 	}
 
 	components := []render.Component{render.Guardian(guardianCfg)}

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -338,6 +338,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 	amz, err := utils.GetAmazonCloudIntegration(ctx, r.Client)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get the GetAmazonCloudIntegration configuration", err, reqLogger)
+		return reconcile.Result{}, nil
 	} else if amz != nil {
 		sgLayerTigeraNameSpaces[render.AmazonCloudIntegrationNamespace] = true
 	}

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -529,6 +529,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	amz, err := utils.GetAmazonCloudIntegration(ctx, r.client)
 	if err != nil && !errors.IsNotFound(err) {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get the GetAmazonCloudIntegration configuration", err, reqLogger)
+		return reconcile.Result{}, nil
 	} else if amz != nil {
 		sgLayerTigeraNameSpaces[render.AmazonCloudIntegrationNamespace] = true
 	}

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -359,6 +359,10 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		trustedSecretNames = append(trustedSecretNames, render.ComplianceServerCertSecret)
 	}
 
+	// Populate a list of namespaces to be displayed in the service graph Tigera infrastructure layer.
+	sgLayerTigeraNameSpaces := render.DefaultSGLayerTigeraNamespaces()
+	sgLayerTigeraNameSpaces[render.ManagerNamespace] = true
+
 	// Fetch the Authentication spec. If present, we use to configure user authentication.
 	authenticationCR, err := utils.GetAuthentication(ctx, r.client)
 	if err != nil && !errors.IsNotFound(err) {
@@ -370,6 +374,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, nil
 	} else if authenticationCR != nil {
 		trustedSecretNames = append(trustedSecretNames, render.DexTLSSecretName)
+		sgLayerTigeraNameSpaces[render.DexNamespace] = true
 	}
 
 	trustedBundle := certificateManager.CreateTrustedBundle()
@@ -521,6 +526,13 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		replicas = &mcmReplicas
 	}
 
+	amz, err := utils.GetAmazonCloudIntegration(ctx, r.client)
+	if err != nil && !errors.IsNotFound(err) {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get the GetAmazonCloudIntegration configuration", err, reqLogger)
+	} else if amz != nil {
+		sgLayerTigeraNameSpaces[render.AmazonCloudIntegrationNamespace] = true
+	}
+
 	managerCfg := &render.ManagerConfiguration{
 		KeyValidatorConfig:      keyValidatorConfig,
 		ESSecrets:               esSecrets,
@@ -540,6 +552,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		Compliance:              complianceCR,
 		ComplianceLicenseActive: complianceLicenseFeatureActive,
 		UsePSP:                  r.usePSP,
+		SGLayerTigeraNameSpaces: sgLayerTigeraNameSpaces,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -90,7 +90,8 @@ type GuardianConfiguration struct {
 	TunnelCAType      operatorv1.CAType
 
 	// Whether the cluster supports pod security policies.
-	UsePSP bool
+	UsePSP                  bool
+	SGLayerTigeraNameSpaces map[string]bool
 }
 
 type GuardianComponent struct {
@@ -132,7 +133,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		managerClusterRoleBinding(),
 		managerClusterWideSettingsGroup(),
 		managerUserSpecificSettingsGroup(),
-		managerClusterWideTigeraLayer(),
+		managerClusterWideTigeraLayer(c.cfg.SGLayerTigeraNameSpaces),
 		managerClusterWideDefaultView(),
 	)
 

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -154,6 +154,8 @@ type ManagerConfiguration struct {
 
 	// Whether the cluster supports pod security policies.
 	UsePSP bool
+
+	SGLayerTigeraNameSpaces map[string]bool
 }
 
 type managerComponent struct {
@@ -210,7 +212,7 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 		managerClusterRoleBinding(),
 		managerClusterWideSettingsGroup(),
 		managerUserSpecificSettingsGroup(),
-		managerClusterWideTigeraLayer(),
+		managerClusterWideTigeraLayer(c.cfg.SGLayerTigeraNameSpaces),
 		managerClusterWideDefaultView(),
 	)
 	objs = append(objs, c.getTLSObjects()...)
@@ -942,33 +944,15 @@ func managerUserSpecificSettingsGroup() *v3.UISettingsGroup {
 // all of the tigera namespaces.
 //
 // Calico Enterprise only
-func managerClusterWideTigeraLayer() *v3.UISettings {
-	namespaces := []string{
-		"tigera-compliance",
-		"tigera-dex",
-		"tigera-dpi",
-		"tigera-eck-operator",
-		"tigera-elasticsearch",
-		"tigera-fluentd",
-		"tigera-guardian",
-		"tigera-intrusion-detection",
-		"tigera-kibana",
-		"tigera-manager",
-		"tigera-operator",
-		"tigera-packetcapture",
-		"tigera-policy-recommendation",
-		"tigera-prometheus",
-		"tigera-system",
-		"calico-system",
-	}
-	nodes := make([]v3.UIGraphNode, len(namespaces))
-	for i := range namespaces {
-		ns := namespaces[i]
-		nodes[i] = v3.UIGraphNode{
+func managerClusterWideTigeraLayer(namespaces map[string]bool) *v3.UISettings {
+
+	nodes := make([]v3.UIGraphNode, 0, len(namespaces))
+	for ns := range namespaces {
+		nodes = append(nodes, v3.UIGraphNode{
 			ID:   "namespace/" + ns,
 			Type: "namespace",
 			Name: ns,
-		}
+		})
 	}
 
 	return &v3.UISettings{
@@ -1009,5 +993,25 @@ func managerClusterWideDefaultView() *v3.UISettings {
 				}},
 			},
 		},
+	}
+}
+
+// DefaultSGLayerTigeraNamespaces returns the default list of namespaces to be displayed in Service graph
+// map is used to avoid duplication of namespaces.
+func DefaultSGLayerTigeraNamespaces() map[string]bool {
+	return map[string]bool{
+		"tigera-compliance":            true,
+		"tigera-dpi":                   true,
+		"tigera-eck-operator":          true,
+		"tigera-elasticsearch":         true,
+		"tigera-fluentd":               true,
+		"tigera-intrusion-detection":   true,
+		"tigera-kibana":                true,
+		"tigera-operator":              true,
+		"tigera-packetcapture":         true,
+		"tigera-policy-recommendation": true,
+		"tigera-prometheus":            true,
+		"tigera-system":                true,
+		"calico-system":                true,
 	}
 }


### PR DESCRIPTION
## Description

Issue: https://tigera.atlassian.net/browse/EV-3506

Changes:

Service graph Layer should display any all the namespace created by the product.

Added a changes to dynamically populate namespace that applicable for  cluster type
Standalone cluster/Management cluster:
- Additional layers : tigera-manager, tigera-dex, tigera-amazon-cloud-integration based on CR.

Managed cluster: 
 - Additional layers :  tigera-guardian, tigera-amazon-cloud-integration based on CR.


Testing:

Management cluster: with dex enabled
![image](https://github.com/tigera/operator/assets/102720382/b22de4a0-ad76-49a5-9c51-2ef45cefe58f)


Managed cluster:
![image](https://github.com/tigera/operator/assets/102720382/b4c48191-e9ff-4a74-b71c-78b3f8a889cd)


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
