### PR TITLE
Use correct calico-node UID when running in non-privileged mode.

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -82,6 +82,12 @@ spec:
                   the cluster.  It should not match the workload interfaces (usually
                   named cali...).
                 type: string
+              bpfDisableGROForIfaces:
+                description: BPFDisableGROForIfaces is a regular expression that controls
+                  which interfaces Felix should disable the Generic Receive Offload
+                  [GRO] option.  It should not match the workload interfaces (usually
+                  named cali...).
+                type: string
               bpfDisableUnprivileged:
                 description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
                   sysctl to disable unprivileged use of BPF.  This ensures that unprivileged

--- a/pkg/render/common/securitycontext/security_context.go
+++ b/pkg/render/common/securitycontext/security_context.go
@@ -76,8 +76,3 @@ func NewNonRootPodContext() *corev1.PodSecurityContext {
 		},
 	}
 }
-
-// GetNonRootUID returns the non-root UID
-func GetNonRootUID() int64 {
-	return runAsUserID
-}

--- a/pkg/render/common/securitycontext/security_context.go
+++ b/pkg/render/common/securitycontext/security_context.go
@@ -76,3 +76,8 @@ func NewNonRootPodContext() *corev1.PodSecurityContext {
 		},
 	}
 }
+
+// GetNonRootUID returns the non-root UID
+func GetNonRootUID() int64 {
+	return runAsUserID
+}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1820,9 +1820,9 @@ func (c *nodeComponent) hostPathInitContainer() corev1.Container {
 		ImagePullPolicy: ImagePullPolicy(),
 		Command:         []string{"sh", "-c", "calico-node -hostpath-init"},
 		Env: []corev1.EnvVar{
-			{Name: "NODE_USER_ID", Value: "999"},
+			{Name: "NODE_USER_ID", Value: fmt.Sprintf("%d", securitycontext.GetNonRootUID())},
 		},
-		SecurityContext: securitycontext.NewRootContext(false),
+		SecurityContext: securitycontext.NewRootContext(true),
 		VolumeMounts:    mounts,
 	}
 }

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1228,6 +1228,9 @@ func (c *nodeComponent) nodeContainer() corev1.Container {
 			"NET_BIND_SERVICE",
 			"NET_RAW",
 		}
+		// Set the privilege escalation to true so that routes, ipsets can be programmed.
+		sc.AllowPrivilegeEscalation = ptr.BoolToPtr(true)
+		sc.Capabilities.Drop = []corev1.Capability{}
 	}
 
 	lp, rp := c.nodeLivenessReadinessProbes()

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1820,7 +1820,7 @@ func (c *nodeComponent) hostPathInitContainer() corev1.Container {
 		ImagePullPolicy: ImagePullPolicy(),
 		Command:         []string{"sh", "-c", "calico-node -hostpath-init"},
 		Env: []corev1.EnvVar{
-			{Name: "NODE_USER_ID", Value: fmt.Sprintf("%d", securitycontext.GetNonRootUID())},
+			{Name: "NODE_USER_ID", Value: "10001"},
 		},
 		SecurityContext: securitycontext.NewRootContext(true),
 		VolumeMounts:    mounts,

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -874,14 +874,14 @@ var _ = Describe("Node rendering tests", func() {
 				nodeContainer := rtest.GetContainer(ds.Spec.Template.Spec.Containers, "calico-node")
 				Expect(nodeContainer).ToNot(BeNil())
 				Expect(nodeContainer.SecurityContext).ToNot(BeNil())
-				Expect(*nodeContainer.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+				Expect(*nodeContainer.SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
 				Expect(*nodeContainer.SecurityContext.Privileged).To(BeFalse())
 				Expect(*nodeContainer.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
 				Expect(*nodeContainer.SecurityContext.RunAsNonRoot).To(BeTrue())
 				Expect(*nodeContainer.SecurityContext.RunAsUser).To(BeEquivalentTo(10001))
 				Expect(nodeContainer.SecurityContext.Capabilities).To(Equal(
 					&corev1.Capabilities{
-						Drop: []corev1.Capability{"ALL"},
+						Drop: []corev1.Capability{},
 						Add: []corev1.Capability{
 							"NET_ADMIN",
 							"NET_BIND_SERVICE",

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	tls2 "github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -896,7 +897,7 @@ var _ = Describe("Node rendering tests", func() {
 
 				// hostpath init container should have the correct env and security context.
 				hostPathContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "hostpath-init")
-				rtest.ExpectEnv(hostPathContainer.Env, "NODE_USER_ID", "999")
+				rtest.ExpectEnv(hostPathContainer.Env, "NODE_USER_ID", fmt.Sprintf("%d", securitycontext.GetNonRootUID()))
 				Expect(*hostPathContainer.SecurityContext.RunAsUser).To(Equal(int64(0)))
 
 				// Verify hostpath init container volume mounts.

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	tls2 "github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -897,7 +896,7 @@ var _ = Describe("Node rendering tests", func() {
 
 				// hostpath init container should have the correct env and security context.
 				hostPathContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "hostpath-init")
-				rtest.ExpectEnv(hostPathContainer.Env, "NODE_USER_ID", fmt.Sprintf("%d", securitycontext.GetNonRootUID()))
+				rtest.ExpectEnv(hostPathContainer.Env, "NODE_USER_ID", "10001")
 				Expect(*hostPathContainer.SecurityContext.RunAsUser).To(Equal(int64(0)))
 
 				// Verify hostpath init container volume mounts.


### PR DESCRIPTION
## Description

When enabling non-privileged mode, the ownership of directories that `calico-node` uses should be changed to UID of calico-node. 

In non-privileged mode, the UID of calico-node is 10001. 

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
