### PR TITLE
Reboot the operator when CRDs for prometheus become available.

### DIFF
--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,12 +78,11 @@ var _ = Describe("Monitor controller tests", func() {
 
 		// Create an object we can use throughout the test to do the monitor reconcile loops.
 		r = ReconcileMonitor{
-			client:          cli,
-			scheme:          scheme,
-			provider:        operatorv1.ProviderNone,
-			status:          mockStatus,
-			prometheusReady: &utils.ReadyFlag{},
-			tierWatchReady:  &utils.ReadyFlag{},
+			client:         cli,
+			scheme:         scheme,
+			provider:       operatorv1.ProviderNone,
+			status:         mockStatus,
+			tierWatchReady: &utils.ReadyFlag{},
 		}
 
 		// We start off with a 'standard' installation, with nothing special
@@ -112,7 +111,6 @@ var _ = Describe("Monitor controller tests", func() {
 		Expect(cli.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
 
 		// Mark that watches were successful.
-		r.prometheusReady.MarkAsReady()
 		r.tierWatchReady.MarkAsReady()
 	})
 


### PR DESCRIPTION
During test cycles an issue came up when the tester wanted to test bringing your own prometheus CRDs and applying the prometheus CRDs after applying your custom-resources.yaml. The operator will never render the prometheus resources.

We have implemented a ready flag to detect this, but even if the ready flag is ready, the controller-runtime won't let us apply prometheus resources. It prints:
```
"msg":"if kind is a CRD, it should be installed before calling Start"
```

In this PR I propose a solution that:
- Reboots the operator, just like we do in a few other scenario's where CRDs are initially not available.
- Removes the ready flag.
- Does not start the controller if the CRDs are not present during startup for Variant=Enterprise clusters.

The result is is that on one of the first lines in the logs you will see this:
```
2023/05/18 19:30:16 [INFO] Version: v1.23.0-1.dev-870-g4bb3f49c26bd-dirty
2023/05/18 19:30:16 [INFO] Go Version: go1.20.3 X:boringcrypto
2023/05/18 19:30:16 [INFO] Go OS/Arch: linux/amd64
2023/05/18 19:30:18 [INFO] Active operator: proceeding
{"level":"info","ts":"2023-05-18T19:30:19Z","logger":"setup","msg":"Checking type of cluster","provider":""}
{"level":"info","ts":"2023-05-18T19:30:19Z","logger":"setup","msg":"Checking if PodSecurityPolicies are supported by the cluster","supported":false}
{"level":"info","ts":"2023-05-18T19:30:19Z","logger":"setup","msg":"Checking if TSEE controllers are required","required":true}
{"level":"info","ts":"2023-05-18T19:30:19Z","logger":"typha_autoscaler","msg":"Starting typha autoscaler","syncPeriod":10}
{"level":"error","ts":"2023-05-18T19:30:19Z","logger":"controller_monitor","msg":"cannot start monitor_controller until the CRDs for monitoring.coreos.com/v1 are present, starting a go routine to monitor monitoring.coreos.com/v1 CRDs","error":"the server could not find the requested resource","stacktrace":"github.com/tigera/operator/pkg/controller/monitor.Add\n\t/go/src/github.com/tigera/operator/pkg/controller/monitor/monitor_controller.go:85\ngithub.com/tigera/operator/controllers.(*MonitorReconciler).SetupWithManager\n\t/go/src/github.com/tigera/operator/controllers/monitor_controller.go:40\ngithub.com/tigera/operator/controllers.AddToManager\n\t/go/src/github.com/tigera/operator/controllers/controllers.go:80\nmain.main\n\t/go/src/github.com/tigera/operator/main.go:309\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```

Once CRDs are applied, you will see this:
```
{"level":"info","ts":"2023-05-18T19:37:44Z","logger":"controller_monitor","msg":"Rebooting to enable monitor_controller now that monitoring.coreos.com/v1 CRDs are present."}
```

I could have opted to keep the ready flag. An advantage would be that you will have more frequent logs showing why the monitor is degraded. I removed it to make the code simpler. Please comment if you would like to see that done differently.
