### PR TITLE
Remove GeoIP downloader from Elasticsearch as we have no use for it.

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1382,6 +1382,9 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 			"enabled":        true,
 			"licenseEdition": "enterpriseEdition",
 		},
+		// Telemetry is unwanted for the majority of our customers and if enabled can cause blocked flows. This flag
+		// can still be overwritten in the Kibana Settings if the user desires it.
+		"telemetry.optIn": false,
 	}
 
 	var initContainers []corev1.Container

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1039,6 +1039,8 @@ func (es elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentVo
 		"node.data":                   "true",
 		"node.ingest":                 "true",
 		"cluster.max_shards_per_node": 10000,
+		// Disable geoip downloader. This removes an error from the startup logs, because our network policy blocks it.
+		"ingest.geoip.downloader.enabled": false,
 	}
 
 	if es.cfg.Installation.CertificateManagement != nil {

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -295,10 +295,11 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 				// Check that the expected config made it's way to the Elastic CR
 				Expect(nodeSet.Config.Data).Should(Equal(map[string]interface{}{
-					"node.master":                 "true",
-					"node.data":                   "true",
-					"node.ingest":                 "true",
-					"cluster.max_shards_per_node": 10000,
+					"node.master":                     "true",
+					"node.data":                       "true",
+					"node.ingest":                     "true",
+					"cluster.max_shards_per_node":     10000,
+					"ingest.geoip.downloader.enabled": false,
 				}))
 				resultECK := rtest.GetResource(createResources, render.ECKOperatorName, render.ECKOperatorNamespace,
 					"apps", "v1", "StatefulSet").(*appsv1.StatefulSet)
@@ -1389,11 +1390,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[0].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":                 "true",
-						"node.data":                   "true",
-						"node.ingest":                 "true",
-						"cluster.max_shards_per_node": 10000,
-						"node.attr.zone":              "us-west-2a",
+						"node.master":                     "true",
+						"node.data":                       "true",
+						"node.ingest":                     "true",
+						"cluster.max_shards_per_node":     10000,
+						"ingest.geoip.downloader.enabled": false,
+						"node.attr.zone":                  "us-west-2a",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
 
@@ -1409,11 +1411,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[1].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":                 "true",
-						"node.data":                   "true",
-						"node.ingest":                 "true",
-						"cluster.max_shards_per_node": 10000,
-						"node.attr.zone":              "us-west-2b",
+						"node.master":                     "true",
+						"node.data":                       "true",
+						"node.ingest":                     "true",
+						"cluster.max_shards_per_node":     10000,
+						"ingest.geoip.downloader.enabled": false,
+						"node.attr.zone":                  "us-west-2b",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
 				})
@@ -1479,12 +1482,13 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[0].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":                 "true",
-						"node.data":                   "true",
-						"node.ingest":                 "true",
-						"cluster.max_shards_per_node": 10000,
-						"node.attr.zone":              "us-west-2a",
-						"node.attr.rack":              "rack1",
+						"node.master":                     "true",
+						"node.data":                       "true",
+						"node.ingest":                     "true",
+						"cluster.max_shards_per_node":     10000,
+						"ingest.geoip.downloader.enabled": false,
+						"node.attr.zone":                  "us-west-2a",
+						"node.attr.rack":                  "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",
 					}))
 
@@ -1509,12 +1513,13 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					}))
 					Expect(nodeSets[1].Config.Data).Should(Equal(map[string]interface{}{
-						"node.master":                 "true",
-						"node.data":                   "true",
-						"node.ingest":                 "true",
-						"cluster.max_shards_per_node": 10000,
-						"node.attr.zone":              "us-west-2b",
-						"node.attr.rack":              "rack1",
+						"node.master":                     "true",
+						"node.data":                       "true",
+						"node.ingest":                     "true",
+						"cluster.max_shards_per_node":     10000,
+						"ingest.geoip.downloader.enabled": false,
+						"node.attr.zone":                  "us-west-2b",
+						"node.attr.rack":                  "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",
 					}))
 				})


### PR DESCRIPTION
Currently we have a denied flow in brand new clusters, which does not give a very nice impression.