### PR TITLE
Remove /etc/calico host path volume

### DIFF
--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -121,10 +121,6 @@ func (c *csiComponent) csiContainers() []corev1.Container {
 				MountPath: filepath.Clean("/var/run"),
 			},
 			{
-				Name:      "etccalico",
-				MountPath: filepath.Clean("/etc/calico"),
-			},
-			{
 				Name:      "socket-dir",
 				MountPath: filepath.Clean("/csi"),
 			},
@@ -194,14 +190,6 @@ func (c *csiComponent) csiVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: filepath.Clean("/var/run"),
-				},
-			},
-		},
-		{
-			Name: "etccalico",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: filepath.Clean("/etc/calico"),
 				},
 			},
 		},


### PR DESCRIPTION
## Description

The host path volume is unused, and should be removed instead of configurable. Removal of this host path volume will allow the operator to be used with immutable Linux distributions, where /etc is read-only, like Talos.

As discussed in https://github.com/tigera/operator/pull/2518.

Fixes https://github.com/tigera/operator/issues/2444

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
