### PR TITLE
Automated cherry pick of #2668: Fix! Windows needs c: prefix for the token path

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -627,7 +627,7 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		{Name: "DNS_LOG_FILE", Value: c.path("/var/log/calico/dnslogs/dns.log")},
 		{Name: "FLUENTD_ES_SECURE", Value: "true"},
 		{Name: "NODENAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
-		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagedCluster)},
+		{Name: "LINSEED_TOKEN", Value: c.path(GetLinseedTokenPath(c.cfg.ManagedCluster))},
 	}
 
 	if c.cfg.LogCollector.Spec.AdditionalStores != nil {

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -145,6 +145,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 				},
 			},
+			corev1.EnvVar{Name: "LINSEED_TOKEN", Value: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
 		))
 
 		container := ds.Spec.Template.Spec.Containers[0]
@@ -272,6 +273,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
 				},
 			},
+			{Name: "LINSEED_TOKEN", Value: "c:/var/run/secrets/kubernetes.io/serviceaccount/token"},
 		}
 		for _, expected := range expectedEnvs {
 			Expect(envs).To(ContainElement(expected))


### PR DESCRIPTION
Cherry pick of #2668 on release-v1.30.

#2668: Fix! Windows needs c: prefix for the token path