### PR TITLE
Add temporary role for calico-node during namespace migration

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -827,6 +827,11 @@ func (c *nodeComponent) clusterAdminClusterRoleBinding() *rbacv1.ClusterRoleBind
 				Name:      CalicoNodeObjectName,
 				Namespace: common.CalicoNamespace,
 			},
+			{
+				Kind:      "ServiceAccount",
+				Name:      CalicoCNIPluginObjectName,
+				Namespace: common.CalicoNamespace,
+			},
 		},
 	}
 	return crb

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -231,6 +231,14 @@ func (c *nodeComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, certificatemanagement.CSRClusterRole())
 	}
 
+	if c.cfg.MigrateNamespaces {
+		objs = append(objs, migration.ClusterRoleForKubeSystemNode())
+		objs = append(objs, migration.ClusterRoleBindingForKubeSystemNode())
+	} else {
+		objsToDelete = append(objsToDelete, migration.ClusterRoleForKubeSystemNode())
+		objsToDelete = append(objsToDelete, migration.ClusterRoleBindingForKubeSystemNode())
+	}
+
 	if c.cfg.Terminating {
 		return objsToKeep, append(objs, objsToDelete...)
 	}
@@ -799,7 +807,7 @@ func (c *nodeComponent) birdTemplateConfigMap() *corev1.ConfigMap {
 }
 
 // clusterAdminClusterRoleBinding returns a ClusterRoleBinding for DockerEE to give
-// the cluster-admin role to calico-node, this is needed for calico-node to be
+// the cluster-admin role to calico-node and calico-cni-plugin, this is needed for calico-node/calico-cni-plugin to be
 // able to use hostNetwork in Docker Enterprise.
 func (c *nodeComponent) clusterAdminClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	crb := &rbacv1.ClusterRoleBinding{

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -2237,7 +2237,8 @@ var _ = Describe("Node rendering tests", func() {
 				component := render.Node(&cfg)
 				Expect(component.ResolveImages(nil)).To(BeNil())
 				resources, _ := component.Objects()
-				Expect(len(resources)).To(Equal(defaultNumExpectedResources), fmt.Sprintf("resources are %v", resources))
+				// +2 for temporary calico-node ClusterRole and ClusterRoleBinding during namespace migration
+				Expect(len(resources)).To(Equal(defaultNumExpectedResources+2), fmt.Sprintf("resources are %v", resources))
 
 				// Should render the correct resources.
 				Expect(rtest.GetResource(resources, "calico-node", "calico-system", "", "v1", "ServiceAccount")).ToNot(BeNil())


### PR DESCRIPTION
## Description
Calico fails to upgrade from manifest installation < v3.26 to operator installation > v3.26. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The failure is caused by the introduction of new service account for cni-plugin. When calico performs upgrade and migration to the operator at the same time, during the migration calico-node looses the ability to create service token for calico-node cni-plugin in the kube-system and the migration fails. For migration we give calico-node ability to create servicetoken in kube-system as prior to v3.26, and remove the ability once all services are migrated to calico-system namespace

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
