### PR TITLE
Add missing namespaces to SG layer tigera infrastructure EV-3506

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -962,6 +962,8 @@ func managerClusterWideTigeraLayer() *v3.UISettings {
 		"tigera-prometheus",
 		"tigera-system",
 		"calico-system",
+		"tigera-amazon-cloud-integration",
+		"tigera-firewall-controller",
 	}
 	nodes := make([]v3.UIGraphNode, len(namespaces))
 	for i := range namespaces {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -964,6 +964,10 @@ func managerClusterWideTigeraLayer() *v3.UISettings {
 		"calico-system",
 		"tigera-amazon-cloud-integration",
 		"tigera-firewall-controller",
+		"calico-cloud",
+		"tigera-image-assurance",
+		"tigera-runtime-security",
+		"tigera-skraper",
 	}
 	nodes := make([]v3.UIGraphNode, len(namespaces))
 	for i := range namespaces {


### PR DESCRIPTION
## Description

Add missing namespaces to SG layer tigera infrastructure EV-3506 

Added namespaces:
// CE
		"tigera-amazon-cloud-integration",
		"tigera-firewall-controller",
//CC
		"calico-cloud",
		"tigera-image-assurance",
		"tigera-runtime-security",
		"tigera-skraper",

https://tigera.atlassian.net/browse/EV-3506

![image](https://github.com/tigera/operator/assets/102720382/0f588e49-0649-4245-bac8-03e42ca0890b)


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
