### PR TITLE
cherry-pick #2671 Add missing namespaces to SG layer tigera infrastructure EV-3506

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -960,6 +960,12 @@ func managerClusterWideTigeraLayer() *v3.UISettings {
 		"tigera-prometheus",
 		"tigera-system",
 		"calico-system",
+		"tigera-amazon-cloud-integration",
+		"tigera-firewall-controller",
+		"calico-cloud",
+		"tigera-image-assurance",
+		"tigera-runtime-security",
+		"tigera-skraper",
 	}
 	nodes := make([]v3.UIGraphNode, len(namespaces))
 	for i := range namespaces {


### PR DESCRIPTION
Add missing namespaces to SG layer tigera infrastructure EV-3506

Added namespaces:
// CE
"tigera-amazon-cloud-integration",
"tigera-firewall-controller",
//CC
"calico-cloud",
"tigera-image-assurance",
"tigera-runtime-security",
"tigera-skraper",

https://tigera.atlassian.net/browse/EV-3506

![image](https://github.com/tigera/operator/assets/102720382/b759ce47-e802-4dab-932f-c761b9be5f33)



## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
