### PR TITLE
Cherry-pick fips changes to 1.30

### DIFF
--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -41,9 +41,8 @@ var (
 {{- end }}
 {{ with index .Components "calico/kube-controllers" }}
 	ComponentCalicoKubeControllersFIPS = component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
+		Version: "{{ .Version }}-fips",
+		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components  "calico/node" }}
@@ -54,9 +53,8 @@ var (
 {{- end }}
 {{ with index .Components  "calico/node" }}
 	ComponentCalicoNodeFIPS = component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
+		Version: "{{ .Version }}-fips",
+		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with .Components.typha }}
@@ -67,9 +65,8 @@ var (
 {{- end }}
 {{ with .Components.typha }}
 	ComponentCalicoTyphaFIPS = component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
+		Version: "{{ .Version }}-fips",
+		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with .Components.flexvol }}
@@ -86,9 +83,8 @@ var (
 {{- end }}
 {{ with index .Components "calico/apiserver"}}
 	ComponentCalicoAPIServerFIPS = component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
+		Version: "{{ .Version }}-fips",
+		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components "calico/windows-upgrade"}}
@@ -105,9 +101,8 @@ var (
 {{- end }}
 {{ with index .Components "calico/csi"}}
 	ComponentCalicoCSIFIPS = component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
+		Version: "{{ .Version }}-fips",
+		Image:   "{{ .Image }}",
 	}
 {{- end }}
 {{ with index .Components "csi-node-driver-registrar"}}
@@ -118,9 +113,8 @@ var (
 {{- end }}
 {{ with index .Components "csi-node-driver-registrar"}}
 	ComponentCalicoCSIRegistrarFIPS = component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
+		Version: "{{ .Version }}-fips",
+		Image:   "{{ .Image }}",
 	}
 {{- end }}
 	ComponentOperatorInit = component{

--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -39,16 +39,37 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components "calico/kube-controllers" }}
+	ComponentCalicoKubeControllersFIPS = component{
+		Version:  "{{ .Version }}-fips",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
+	}
+{{- end }}
 {{ with index .Components  "calico/node" }}
 	ComponentCalicoNode = component{
 		Version: "{{ .Version }}",
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components  "calico/node" }}
+	ComponentCalicoNodeFIPS = component{
+		Version:  "{{ .Version }}-fips",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
+	}
+{{- end }}
 {{ with .Components.typha }}
 	ComponentCalicoTypha = component{
 		Version: "{{ .Version }}",
 		Image:   "{{ .Image }}",
+	}
+{{- end }}
+{{ with .Components.typha }}
+	ComponentCalicoTyphaFIPS = component{
+		Version:  "{{ .Version }}-fips",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.flexvol }}
@@ -63,6 +84,13 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components "calico/apiserver"}}
+	ComponentCalicoAPIServerFIPS = component{
+		Version:  "{{ .Version }}-fips",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
+	}
+{{- end }}
 {{ with index .Components "calico/windows-upgrade"}}
 	ComponentWindowsUpgrade = component{
 		Version: "{{ .Version }}",
@@ -75,10 +103,24 @@ var (
 		Image:   "{{ .Image }}",
 	}
 {{- end }}
+{{ with index .Components "calico/csi"}}
+	ComponentCalicoCSIFIPS = component{
+		Version:  "{{ .Version }}-fips",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
+	}
+{{- end }}
 {{ with index .Components "csi-node-driver-registrar"}}
 	ComponentCalicoCSIRegistrar = component{
 		Version: "{{ .Version }}",
 		Image:   "{{ .Image }}",
+	}
+{{- end }}
+{{ with index .Components "csi-node-driver-registrar"}}
+	ComponentCalicoCSIRegistrarFIPS = component{
+		Version:  "{{ .Version }}-fips",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 	ComponentOperatorInit = component{
@@ -90,13 +132,19 @@ var (
 		ComponentCalicoCNI,
 		ComponentCalicoCNIFIPS,
 		ComponentCalicoKubeControllers,
+		ComponentCalicoKubeControllersFIPS,
 		ComponentCalicoNode,
+		ComponentCalicoNodeFIPS,
 		ComponentCalicoTypha,
+		ComponentCalicoTyphaFIPS,
 		ComponentFlexVolume,
 		ComponentOperatorInit,
 		ComponentCalicoAPIServer,
+		ComponentCalicoAPIServerFIPS,
 		ComponentWindowsUpgrade,
 		ComponentCalicoCSI,
+		ComponentCalicoCSIFIPS,
 		ComponentCalicoCSIRegistrar,
+		ComponentCalicoCSIRegistrarFIPS,
 	}
 )

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -38,9 +38,8 @@ var (
 	}
 
 	ComponentCalicoKubeControllersFIPS = component{
-		Version:  "master-fips",
-		Image:    "calico/kube-controllers",
-		Registry: "",
+		Version: "v3.26.0-fips",
+		Image:   "calico/kube-controllers",
 	}
 
 	ComponentCalicoNode = component{
@@ -49,9 +48,8 @@ var (
 	}
 
 	ComponentCalicoNodeFIPS = component{
-		Version:  "master-fips",
-		Image:    "calico/node",
-		Registry: "",
+		Version: "v3.26.0-fips",
+		Image:   "calico/node",
 	}
 
 	ComponentCalicoTypha = component{
@@ -60,9 +58,8 @@ var (
 	}
 
 	ComponentCalicoTyphaFIPS = component{
-		Version:  "master-fips",
-		Image:    "calico/typha",
-		Registry: "",
+		Version: "v3.26.0-fips",
+		Image:   "calico/typha",
 	}
 
 	ComponentFlexVolume = component{
@@ -76,9 +73,8 @@ var (
 	}
 
 	ComponentCalicoAPIServerFIPS = component{
-		Version:  "master-fips",
-		Image:    "calico/apiserver",
-		Registry: "",
+		Version: "v3.26.0-fips",
+		Image:   "calico/apiserver",
 	}
 
 	ComponentWindowsUpgrade = component{
@@ -92,9 +88,8 @@ var (
 	}
 
 	ComponentCalicoCSIFIPS = component{
-		Version:  "master-fips",
-		Image:    "calico/csi",
-		Registry: "",
+		Version: "v3.26.0-fips",
+		Image:   "calico/csi",
 	}
 
 	ComponentCalicoCSIRegistrar = component{
@@ -103,9 +98,8 @@ var (
 	}
 
 	ComponentCalicoCSIRegistrarFIPS = component{
-		Version:  "master-fips",
-		Image:    "calico/node-driver-registrar",
-		Registry: "",
+		Version: "v3.26.0-fips",
+		Image:   "calico/node-driver-registrar",
 	}
 	ComponentOperatorInit = component{
 		Version: version.VERSION,

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -37,14 +37,32 @@ var (
 		Image:   "calico/kube-controllers",
 	}
 
+	ComponentCalicoKubeControllersFIPS = component{
+		Version:  "master-fips",
+		Image:    "calico/kube-controllers",
+		Registry: "",
+	}
+
 	ComponentCalicoNode = component{
 		Version: "v3.26.0",
 		Image:   "calico/node",
 	}
 
+	ComponentCalicoNodeFIPS = component{
+		Version:  "master-fips",
+		Image:    "calico/node",
+		Registry: "",
+	}
+
 	ComponentCalicoTypha = component{
 		Version: "v3.26.0",
 		Image:   "calico/typha",
+	}
+
+	ComponentCalicoTyphaFIPS = component{
+		Version:  "master-fips",
+		Image:    "calico/typha",
+		Registry: "",
 	}
 
 	ComponentFlexVolume = component{
@@ -57,6 +75,12 @@ var (
 		Image:   "calico/apiserver",
 	}
 
+	ComponentCalicoAPIServerFIPS = component{
+		Version:  "master-fips",
+		Image:    "calico/apiserver",
+		Registry: "",
+	}
+
 	ComponentWindowsUpgrade = component{
 		Version: "v3.26.0",
 		Image:   "calico/windows-upgrade",
@@ -67,9 +91,21 @@ var (
 		Image:   "calico/csi",
 	}
 
+	ComponentCalicoCSIFIPS = component{
+		Version:  "master-fips",
+		Image:    "calico/csi",
+		Registry: "",
+	}
+
 	ComponentCalicoCSIRegistrar = component{
 		Version: "v3.26.0",
 		Image:   "calico/node-driver-registrar",
+	}
+
+	ComponentCalicoCSIRegistrarFIPS = component{
+		Version:  "master-fips",
+		Image:    "calico/node-driver-registrar",
+		Registry: "",
 	}
 	ComponentOperatorInit = component{
 		Version: version.VERSION,
@@ -80,13 +116,19 @@ var (
 		ComponentCalicoCNI,
 		ComponentCalicoCNIFIPS,
 		ComponentCalicoKubeControllers,
+		ComponentCalicoKubeControllersFIPS,
 		ComponentCalicoNode,
+		ComponentCalicoNodeFIPS,
 		ComponentCalicoTypha,
+		ComponentCalicoTyphaFIPS,
 		ComponentFlexVolume,
 		ComponentOperatorInit,
 		ComponentCalicoAPIServer,
+		ComponentCalicoAPIServerFIPS,
 		ComponentWindowsUpgrade,
 		ComponentCalicoCSI,
+		ComponentCalicoCSIFIPS,
 		ComponentCalicoCSIRegistrar,
+		ComponentCalicoCSIRegistrarFIPS,
 	}
 )

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -38,12 +38,17 @@ func GetReference(c component, registry, imagePath, imagePrefix string, is *oper
 			ComponentCalicoCNI,
 			ComponentCalicoCNIFIPS,
 			ComponentCalicoTypha,
+			ComponentCalicoTyphaFIPS,
 			ComponentCalicoKubeControllers,
+			ComponentCalicoKubeControllersFIPS,
 			ComponentFlexVolume,
 			ComponentCalicoAPIServer,
+			ComponentCalicoAPIServerFIPS,
 			ComponentWindowsUpgrade,
 			ComponentCalicoCSI,
-			ComponentCalicoCSIRegistrar:
+			ComponentCalicoCSIFIPS,
+			ComponentCalicoCSIRegistrar,
+			ComponentCalicoCSIRegistrarFIPS:
 
 			registry = CalicoRegistry
 		case ComponentOperatorInit:

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -145,9 +145,16 @@ func (c *apiServerComponent) ResolveImages(is *operatorv1.ImageSet) error {
 			errMsgs = append(errMsgs, err.Error())
 		}
 	} else {
-		c.apiServerImage, err = components.GetReference(components.ComponentCalicoAPIServer, reg, path, prefix, is)
-		if err != nil {
-			errMsgs = append(errMsgs, err.Error())
+		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
+			c.apiServerImage, err = components.GetReference(components.ComponentCalicoAPIServerFIPS, reg, path, prefix, is)
+			if err != nil {
+				errMsgs = append(errMsgs, err.Error())
+			}
+		} else {
+			c.apiServerImage, err = components.GetReference(components.ComponentCalicoAPIServer, reg, path, prefix, is)
+			if err != nil {
+				errMsgs = append(errMsgs, err.Error())
+			}
 		}
 	}
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2006,5 +2006,19 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(d.Spec.Template.Spec.Tolerations).To(HaveLen(1))
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(tol))
 		})
+		It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
+			fipsEnabled := operatorv1.FIPSModeEnabled
+			cfg.Installation.FIPSMode = &fipsEnabled
+
+			component, err := render.APIServer(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(component.ResolveImages(nil)).To(BeNil())
+			resources, _ := component.Objects()
+
+			d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(d.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
+		})
+
 	})
 })

--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -365,12 +365,20 @@ func (c *csiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 
 		c.csiRegistrarImage, err = components.GetReference(components.ComponentCSINodeDriverRegistrarPrivate, reg, path, prefix, is)
 	} else {
-		c.csiImage, err = components.GetReference(components.ComponentCalicoCSI, reg, path, prefix, is)
-		if err != nil {
-			return err
-		}
+		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
+			c.csiImage, err = components.GetReference(components.ComponentCalicoCSIFIPS, reg, path, prefix, is)
+			if err != nil {
+				return err
+			}
+			c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrarFIPS, reg, path, prefix, is)
+		} else {
+			c.csiImage, err = components.GetReference(components.ComponentCalicoCSI, reg, path, prefix, is)
+			if err != nil {
+				return err
+			}
 
-		c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrar, reg, path, prefix, is)
+			c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrar, reg, path, prefix, is)
+		}
 	}
 
 	return err

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -283,4 +283,17 @@ var _ = Describe("CSI rendering tests", func() {
 		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("%s%s:%s", components.CalicoRegistry, components.ComponentCalicoCSI.Image, components.ComponentCalicoCSI.Version)))
 		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("%s%s:%s", components.CalicoRegistry, components.ComponentCalicoCSIRegistrar.Image, components.ComponentCalicoCSIRegistrar.Version)))
 	})
+
+	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
+		fipsEnabled := operatorv1.FIPSModeEnabled
+		cfg.Installation.FIPSMode = &fipsEnabled
+		cfg.Installation.Variant = operatorv1.Calico
+
+		comp := render.CSI(&cfg)
+		Expect(comp.ResolveImages(nil)).To(BeNil())
+		createObjs, _ := comp.Objects()
+		dsResource := rtest.GetResource(createObjs, "csi-node-driver", common.CalicoNamespace, "apps", "v1", "DaemonSet")
+		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
+		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(ContainSubstring("-fips"))
+	})
 })

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -211,7 +211,11 @@ func (c *kubeControllersComponent) ResolveImages(is *operatorv1.ImageSet) error 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		c.image, err = components.GetReference(components.ComponentTigeraKubeControllers, reg, path, prefix, is)
 	} else {
-		c.image, err = components.GetReference(components.ComponentCalicoKubeControllers, reg, path, prefix, is)
+		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
+			c.image, err = components.GetReference(components.ComponentCalicoKubeControllersFIPS, reg, path, prefix, is)
+		} else {
+			c.image, err = components.GetReference(components.ComponentCalicoKubeControllers, reg, path, prefix, is)
+		}
 	}
 	return err
 }

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -671,6 +671,26 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(passed).To(Equal(true))
 	})
 
+	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
+		fipsEnabled := operatorv1.FIPSModeEnabled
+		cfg.Installation.FIPSMode = &fipsEnabled
+		cfg.Installation.Variant = operatorv1.Calico
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+		depResource := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment")
+		Expect(depResource).ToNot(BeNil())
+		deployment := depResource.(*appsv1.Deployment)
+
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == kubecontrollers.KubeController {
+				Expect(container.Image).To(ContainSubstring("-fips"))
+				break
+			}
+		}
+
+	})
+
 	It("should add the OIDC prefix env variables", func() {
 		instance.Variant = operatorv1.TigeraSecureEnterprise
 		cfg.LogStorageExists = true

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -159,13 +159,14 @@ func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNode, reg, path, prefix, is))
 		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentFlexVolumePrivate, reg, path, prefix, is))
 	} else {
+		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentFlexVolume, reg, path, prefix, is))
 		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
 			c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNIFIPS, reg, path, prefix, is))
+			c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNodeFIPS, reg, path, prefix, is))
 		} else {
 			c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNI, reg, path, prefix, is))
+			c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNode, reg, path, prefix, is))
 		}
-		c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNode, reg, path, prefix, is))
-		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentFlexVolume, reg, path, prefix, is))
 	}
 
 	if len(errMsgs) != 0 {

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -3384,6 +3384,7 @@ var _ = Describe("Node rendering tests", func() {
 
 				Expect(nodeDS.Spec.Template.Spec.Containers[0].Name).To(Equal("calico-node"))
 				Expect(nodeDS.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
+				Expect(nodeDS.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
 
 				Expect(nodeDS.Spec.Template.Spec.InitContainers[1].Name).To(Equal("install-cni"))
 				Expect(nodeDS.Spec.Template.Spec.InitContainers[1].Image).To(ContainSubstring("-fips"))

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -96,7 +96,11 @@ func (c *typhaComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		c.typhaImage, err = components.GetReference(components.ComponentTigeraTypha, reg, path, prefix, is)
 	} else {
-		c.typhaImage, err = components.GetReference(components.ComponentCalicoTypha, reg, path, prefix, is)
+		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
+			c.typhaImage, err = components.GetReference(components.ComponentCalicoTyphaFIPS, reg, path, prefix, is)
+		} else {
+			c.typhaImage, err = components.GetReference(components.ComponentCalicoTypha, reg, path, prefix, is)
+		}
 	}
 	if err != nil {
 		return err

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -144,6 +144,23 @@ var _ = Describe("Typha rendering tests", func() {
 			}))
 	})
 
+	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
+		fipsEnabled := operatorv1.FIPSModeEnabled
+		cfg.Installation.FIPSMode = &fipsEnabled
+		cfg.Installation.Variant = operatorv1.Calico
+		component := render.Typha(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
+		Expect(dResource).ToNot(BeNil())
+
+		d := dResource.(*appsv1.Deployment)
+		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+
+		tc := d.Spec.Template.Spec.Containers[0]
+		Expect(tc.Image).To(ContainSubstring("-fips"))
+	})
+
 	It("should include updates needed for migration of core components from kube-system namespace", func() {
 		expectedResources := []struct {
 			name    string


### PR DESCRIPTION
## Description

Cherry-pick https://github.com/tigera/operator/pull/2661 to release-v1.30

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
