### PR TITLE
Modify Linseed deployment to set Elastic credentials

### DIFF
--- a/pkg/controller/logstorage/linseed.go
+++ b/pkg/controller/logstorage/linseed.go
@@ -16,7 +16,6 @@ package logstorage
 
 import (
 	"context"
-	"fmt"
 
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 
@@ -36,7 +35,6 @@ func (r *ReconcileLogStorage) createLinseed(
 	install *operatorv1.InstallationSpec,
 	variant operatorv1.ProductVariant,
 	pullSecrets []*corev1.Secret,
-	esAdminUserSecret *corev1.Secret,
 	hdler utils.ComponentHandler,
 	reqLogger logr.Logger,
 	ctx context.Context,
@@ -47,17 +45,6 @@ func (r *ReconcileLogStorage) createLinseed(
 	usePSP bool,
 	esClusterConfig *relasticsearch.ClusterConfig,
 ) (reconcile.Result, bool, error) {
-	// This secret should only ever contain one key.
-	if len(esAdminUserSecret.Data) != 1 {
-		r.status.SetDegraded(operatorv1.ResourceValidationError, fmt.Sprintf("secret should have exactly one entry. found %d", len(esAdminUserSecret.Data)), nil, reqLogger)
-		return reconcile.Result{}, false, nil
-	}
-
-	var esAdminUserName string
-	for k := range esAdminUserSecret.Data {
-		esAdminUserName = k
-		break
-	}
 
 	cfg := &linseed.Config{
 		Installation:      install,
@@ -66,7 +53,6 @@ func (r *ReconcileLogStorage) createLinseed(
 		ClusterDomain:     r.clusterDomain,
 		KeyPair:           linseedKeyPair,
 		TokenKeyPair:      tokenKeyPair,
-		ESAdminUserName:   esAdminUserName,
 		UsePSP:            usePSP,
 		ESClusterConfig:   esClusterConfig,
 		ManagementCluster: managementCluster,

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -846,7 +846,6 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 			install,
 			variant,
 			pullSecrets,
-			esAdminUserSecret,
 			hdler,
 			reqLogger,
 			ctx,

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -91,6 +91,7 @@ const (
 	ElasticsearchInternalPort       = 9300
 	ElasticsearchOperatorUserSecret = "tigera-ee-operator-elasticsearch-access"
 	ElasticsearchAdminUserSecret    = "tigera-secure-es-elastic-user"
+	ElasticsearchLinseedUserSecret  = "tigera-ee-linseed-elasticsearch-access-gateway"
 	ElasticsearchPolicyName         = networkpolicy.TigeraComponentPolicyPrefix + "elasticsearch-access"
 	ElasticsearchInternalPolicyName = networkpolicy.TigeraComponentPolicyPrefix + "elasticsearch-internal"
 

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -95,9 +95,6 @@ type Config struct {
 	// ClusterDomain to use when building service URLs.
 	ClusterDomain string
 
-	// ESAdminUserName is the admin user used to connect to Elastic
-	ESAdminUserName string
-
 	// Whether this is a management cluster
 	ManagementCluster bool
 
@@ -257,10 +254,13 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 		{Name: "ELASTIC_SCHEME", Value: "https"},
 		{Name: "ELASTIC_HOST", Value: "tigera-secure-es-http.tigera-elasticsearch.svc"},
 		{Name: "ELASTIC_PORT", Value: "9200"},
-		{Name: "ELASTIC_USERNAME", Value: l.cfg.ESAdminUserName},
+		{
+			Name:      "ELASTIC_USERNAME",
+			ValueFrom: secret.GetEnvVarSource(render.ElasticsearchLinseedUserSecret, "username", false),
+		},
 		{
 			Name:      "ELASTIC_PASSWORD",
-			ValueFrom: secret.GetEnvVarSource(render.ElasticsearchAdminUserSecret, l.cfg.ESAdminUserName, false),
+			ValueFrom: secret.GetEnvVarSource(render.ElasticsearchLinseedUserSecret, "password", false),
 		},
 		{Name: "ELASTIC_CA", Value: l.cfg.TrustedBundle.MountPath()},
 	}

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -92,7 +92,6 @@ var _ = Describe("Linseed rendering tests", func() {
 				KeyPair:         kp,
 				TrustedBundle:   bundle,
 				ClusterDomain:   clusterDomain,
-				ESAdminUserName: "elastic",
 				UsePSP:          true,
 				ESClusterConfig: esClusterConfig,
 			}
@@ -130,7 +129,6 @@ var _ = Describe("Linseed rendering tests", func() {
 				KeyPair:         kp,
 				TrustedBundle:   bundle,
 				ClusterDomain:   clusterDomain,
-				ESAdminUserName: "elastic",
 				UsePSP:          true,
 				ESClusterConfig: esClusterConfig,
 			}
@@ -527,7 +525,15 @@ func expectedContainers() []corev1.Container {
 				},
 				{
 					Name:  "ELASTIC_USERNAME",
-					Value: "elastic",
+					Value: "",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "tigera-ee-linseed-elasticsearch-access-gateway",
+							},
+							Key: "username",
+						},
+					},
 				},
 				{
 					Name:  "ELASTIC_PASSWORD",
@@ -535,9 +541,9 @@ func expectedContainers() []corev1.Container {
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "tigera-secure-es-elastic-user",
+								Name: "tigera-ee-linseed-elasticsearch-access-gateway",
 							},
-							Key: "elastic",
+							Key: "password",
 						},
 					},
 				},


### PR DESCRIPTION
based on non-admin kube-controllers created secret rather than Elastic admin secret

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Relates to Enterprise commit: https://github.com/tigera/calico-private/pull/6326

## For PR author

- [x] Tests for change.
~~- [ ] If changing pkg/apis/, run `make gen-files`~~
~~- [ ] If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
