### PR TITLE
Update and clarify release instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,39 +1,57 @@
 # Releasing the operator
 
-## Preparing for a release
+## Preparing a new release branch
 
-Checkout the branch from which you want to release. For a major or minor release,
-you will need to create a new `release-vX.Y` branch based on the target minor version.
+For a major or minor release, you will need to create a new
+`release-vX.Y` branch based on the target minor version.
 
-Make sure the appropriate versions have been updated in `config/calico_versions.yml`, `config/enterprise_versions.yml`
-or / and config/common_versions.yaml, make sure both the images have been updated and
-the title field has been updated with the release (the format should be `v<Major>.<Minor>.<Patch>`).
-Then ensure `make gen-versions` has been ran and the resulting updates have been committed. When updating versions
-for enterprise, if necessary also update the `TigeraRegistry` field in `pkg/components/images.go`.
+## Preparing for the release
 
-Make sure the branch is in a good state, e.g. Update any pins in go.mod, create PR, ensure tests pass and merge.
+Review the milestone for this release and ensure it is accurate. https://github.com/tigera/operator/milestones
+
+## Updating versions
+
+Checkout the branch from which you want to release. Ensure that you are using the correct
+operator version for the version of Calico or Calient that you are releasing. If in doubt,
+check [the releases page](https://github.com/tigera/operator/releases) to find the most
+recent Operator release for your Calico or Calient minor version.
+
+Update the image versions and the title field with the appropriate versions in the
+format `vX.Y.Z` for each of the following files:
+
+1. `config/calico_versions.yml` (Calico OSS version)
+2. `config/enterprise_versions.yml` (Calico Enterprise version)
+3. `config/common_versions.yaml` (components common to both)
+
+(When updating versions for enterprise, if necessary also update
+the `TigeraRegistry` field in `pkg/components/images.go`.)
+
+Then ensure `make gen-versions` has been ran and the resulting updates have been committed.
+
+Make sure the branch is in a good state: 
+
+1. Update any pins in go.mod
+2. Create a PR for all of the local changes (versions updates, gen-versions, etc)
+3. Ensure tests pass
 
 You should have no local changes and tests should be passing.
 
-## Creating release
+## Releasing 
 
-1. Review the milestone for this release and ensure it is accurate. https://github.com/tigera/operator/milestones
+1. Merge your PR to the release branch
 
-1. Choose a version e.g. `v1.0.1`
+1. Create a git tag for the new commit on the release branch and push it:
 
-1. Ensure the `title:` field in both config/calico_versions.yaml and config/enterprise_versions.yaml match
-   appropriate product release that the operator should install, if not see
-   [Preparing for a release](#preparing-for-a-release).
+```
+git tag v1.30.3
+git push --tags
+```
 
-1. Create a tag in git
+1. Log in to semaphore and find the new build for the release branch commit, and
+   click 'Rerun'. When Semaphore starts the rebuild, it will notice the new tag and
+   build and publish an operator release.
 
-   ```
-   git tag <version>
-   ```
-
-1. Push the git tag.
-
-1. Log in to semaphore and trigger a build on the tagged commit. Semaphore will build, test, and publish the release.
+## Release notes and milestones
 
 1. Run the following command to generate release notes for the release
 
@@ -49,9 +67,13 @@ You should have no local changes and tests should be passing.
 
 ## Updates for new Calico CRDs
 
+(TODO: We need to be able to detect new CRDs and do this automatically)
+
 If the release includes new Calico CRDs, add the new CRDs to `hack/gen-bundle/get-manifests.sh` and `config/manifests/bases/operator.clusterserviceversion.yaml`.
 
 ## Publishing a release on the RH Catalog
+
+(Note: We are not currently publishing to RH Catalog, but we will resume soon. These notes are left here for current and future reference.)
 
 We currently only publish operator releases targeting Calico. If the release targets Calico, continue onto the following steps to generate the
 operator bundle for it, and publish the release on the RH Catalog.


### PR DESCRIPTION
Do a clarification pass on operator release instructions.

These instructions will need to be tested before merge.