### PR TITLE
Fix missing certificate management configurations

### DIFF
--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -475,7 +475,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	}
 	certificateComponent := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
 		Namespace:       render.ComplianceNamespace,
-		ServiceAccounts: []string{render.ComplianceServerServiceAccount, render.ComplianceBenchmarkerServiceAccount, render.ComplianceSnapshotterServiceAccount, render.ComplianceControllerServiceAccount},
+		ServiceAccounts: []string{render.ComplianceServerServiceAccount, render.ComplianceBenchmarkerServiceAccount, render.ComplianceSnapshotterServiceAccount, render.ComplianceControllerServiceAccount, render.ComplianceReporterServiceAccount},
 		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 			rcertificatemanagement.NewKeyPairOption(complianceServerKeyPair, true, true),
 			rcertificatemanagement.NewKeyPairOption(controllerKeyPair.Interface, true, true),

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -475,7 +475,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	}
 	certificateComponent := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
 		Namespace:       render.ComplianceNamespace,
-		ServiceAccounts: []string{render.ComplianceServerServiceAccount},
+		ServiceAccounts: []string{render.ComplianceServerServiceAccount, render.ComplianceBenchmarkerServiceAccount, render.ComplianceSnapshotterServiceAccount, render.ComplianceControllerServiceAccount},
 		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 			rcertificatemanagement.NewKeyPairOption(complianceServerKeyPair, true, true),
 			rcertificatemanagement.NewKeyPairOption(controllerKeyPair.Interface, true, true),

--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/tls"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -59,6 +60,7 @@ var _ = Describe("Compliance controller tests", func() {
 	var r ReconcileCompliance
 	var mockStatus *status.MockStatus
 	var scheme *runtime.Scheme
+	var installation *operatorv1.Installation
 
 	expectedDNSNames := dns.GetServiceDNSNames(render.ComplianceServiceName, render.ComplianceNamespace, dns.DefaultClusterDomain)
 	BeforeEach(func() {
@@ -83,6 +85,7 @@ var _ = Describe("Compliance controller tests", func() {
 		mockStatus.On("AddCronJobs", mock.Anything)
 		mockStatus.On("IsAvailable").Return(true)
 		mockStatus.On("OnCRFound").Return()
+		mockStatus.On("AddCertificateSigningRequests", mock.Anything).Return()
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
 		mockStatus.On("ReadyToMonitor")
@@ -99,25 +102,25 @@ var _ = Describe("Compliance controller tests", func() {
 			licenseAPIReady: &utils.ReadyFlag{},
 			tierWatchReady:  &utils.ReadyFlag{},
 		}
-
 		// We start off with a 'standard' installation, with nothing special
+		installation = &operatorv1.Installation{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec: operatorv1.InstallationSpec{
+				Variant:  operatorv1.TigeraSecureEnterprise,
+				Registry: "some.registry.org/",
+			},
+			Status: operatorv1.InstallationStatus{
+				Variant: operatorv1.TigeraSecureEnterprise,
+				Computed: &operatorv1.InstallationSpec{
+					Registry: "my-reg",
+					// The test is provider agnostic.
+					KubernetesProvider: operatorv1.ProviderNone,
+				},
+			},
+		}
 		Expect(c.Create(
 			ctx,
-			&operatorv1.Installation{
-				ObjectMeta: metav1.ObjectMeta{Name: "default"},
-				Spec: operatorv1.InstallationSpec{
-					Variant:  operatorv1.TigeraSecureEnterprise,
-					Registry: "some.registry.org/",
-				},
-				Status: operatorv1.InstallationStatus{
-					Variant: operatorv1.TigeraSecureEnterprise,
-					Computed: &operatorv1.InstallationSpec{
-						Registry: "my-reg",
-						// The test is provider agnostic.
-						KubernetesProvider: operatorv1.ProviderNone,
-					},
-				},
-			})).NotTo(HaveOccurred())
+			installation)).NotTo(HaveOccurred())
 
 		// The compliance reconcile loop depends on a ton of objects that should be available in your client as
 		// prerequisites. Without them, compliance will not even start creating objects. Let's create them now.
@@ -356,6 +359,39 @@ var _ = Describe("Compliance controller tests", func() {
 			Namespace: render.ComplianceNamespace,
 		}, &dpl)).NotTo(HaveOccurred())
 		Expect(dpl.Spec.Template.ObjectMeta.Name).To(Equal(render.ComplianceControllerName))
+	})
+
+	It("should add cluster role bindings when certificate management is enabled", func() {
+		ca, err := tls.MakeCA(rmeta.DefaultOperatorCASignerName())
+		Expect(err).NotTo(HaveOccurred())
+		cert, _, _ := ca.Config.GetPEMBytes()
+		installation.Spec.CertificateManagement = &operatorv1.CertificateManagement{
+			CACert:     cert,
+			SignerName: "a.b/c",
+		}
+		Expect(c.Update(ctx, installation)).NotTo(HaveOccurred())
+		_, err = r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		crb := rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{},
+		}
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name: "tigera-compliance-benchmarker:csr-creator",
+		}, &crb)).NotTo(HaveOccurred())
+		Expect(crb.Subjects).To(HaveLen(1))
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name: "tigera-compliance-controller:csr-creator",
+		}, &crb)).NotTo(HaveOccurred())
+		Expect(crb.Subjects).To(HaveLen(1))
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name: "tigera-compliance-server:csr-creator",
+		}, &crb)).NotTo(HaveOccurred())
+		Expect(crb.Subjects).To(HaveLen(1))
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name: "tigera-compliance-snapshotter:csr-creator",
+		}, &crb)).NotTo(HaveOccurred())
+		Expect(crb.Subjects).To(HaveLen(1))
 	})
 
 	Context("image reconciliation", func() {

--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -392,6 +392,10 @@ var _ = Describe("Compliance controller tests", func() {
 			Name: "tigera-compliance-snapshotter:csr-creator",
 		}, &crb)).NotTo(HaveOccurred())
 		Expect(crb.Subjects).To(HaveLen(1))
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name: "tigera-compliance-reporter:csr-creator",
+		}, &crb)).NotTo(HaveOccurred())
+		Expect(crb.Subjects).To(HaveLen(1))
 	})
 
 	Context("image reconciliation", func() {

--- a/pkg/controller/logstorage/logstorage.go
+++ b/pkg/controller/logstorage/logstorage.go
@@ -184,7 +184,7 @@ func (r *ReconcileLogStorage) createLogStorage(
 		components = append(components,
 			rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
 				Namespace:       render.KibanaNamespace,
-				ServiceAccounts: []string{render.KibanaName},
+				ServiceAccounts: []string{render.KibanaObjectName},
 				KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 					// We do not want to delete the secret from the tigera-elasticsearch when CertificateManagement is
 					// enabled. Instead, it will be replaced with a TLS secret that serves merely to pass ECK's validation

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -397,7 +397,7 @@ func (c *keyPairCollection) component(bundle certificatemanagement.TrustedBundle
 	return rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
 		Namespace: render.ElasticsearchNamespace,
 		ServiceAccounts: []string{
-			render.ElasticsearchName,
+			render.ElasticsearchObjectName,
 			linseed.ServiceAccountName,
 			esgateway.ServiceAccountName,
 			esmetrics.ElasticsearchMetricsName,

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -438,6 +438,11 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagementClusterConnection != nil)},
 	}
+
+	var initContainers []corev1.Container
+	if c.cfg.ControllerKeyPair != nil && c.cfg.ControllerKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.ControllerKeyPair.InitContainer(ComplianceNamespace))
+	}
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ComplianceControllerName,
@@ -448,6 +453,7 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 			Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
 			NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 			ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
 					Name:            ComplianceControllerName,
@@ -1021,6 +1027,10 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 				MountPath: LinseedVolumeMountPath,
 			})
 	}
+	var initContainers []corev1.Container
+	if c.cfg.SnapshotterKeyPair != nil && c.cfg.SnapshotterKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.SnapshotterKeyPair.InitContainer(ComplianceNamespace))
+	}
 
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1032,6 +1042,7 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 			Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
 			NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 			ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
 					Name:            ComplianceSnapshotterName,
@@ -1215,6 +1226,10 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 			})
 	}
 
+	var initContainers []corev1.Container
+	if c.cfg.BenchmarkerKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.BenchmarkerKeyPair.InitContainer(ComplianceNamespace))
+	}
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ComplianceBenchmarkerName,
@@ -1225,6 +1240,7 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 			HostPID:            true,
 			Tolerations:        rmeta.TolerateAll,
 			ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
 					Name:            ComplianceBenchmarkerName,

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -615,6 +615,10 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 				MountPath: LinseedVolumeMountPath,
 			})
 	}
+	var initContainers []corev1.Container
+	if c.cfg.ReporterKeyPair != nil && c.cfg.ReporterKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.ReporterKeyPair.InitContainer(ComplianceNamespace))
+	}
 
 	return &corev1.PodTemplate{
 		TypeMeta: metav1.TypeMeta{Kind: "PodTemplate", APIVersion: "v1"},
@@ -638,6 +642,7 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 				Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
 				NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 				ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
+				InitContainers:     initContainers,
 				Containers: []corev1.Container{
 					{
 						Name:            "reporter",

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -533,9 +533,23 @@ var _ = Describe("compliance rendering tests", func() {
 			cfg.Installation.CertificateManagement = &operatorv1.CertificateManagement{CACert: cert}
 			certificateManager, err := certificatemanager.Create(cli, cfg.Installation, clusterDomain)
 			Expect(err).NotTo(HaveOccurred())
+
 			complianceTLS, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceServerCertSecret, common.OperatorNamespace(), []string{""})
 			Expect(err).NotTo(HaveOccurred())
 			cfg.ServerKeyPair = complianceTLS
+
+			controllerKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceControllerSecret, common.OperatorNamespace(), []string{""})
+			Expect(err).NotTo(HaveOccurred())
+			cfg.ControllerKeyPair = controllerKeyPair
+
+			cenchmarkerKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceBenchmarkerSecret, common.OperatorNamespace(), []string{""})
+			Expect(err).NotTo(HaveOccurred())
+			cfg.BenchmarkerKeyPair = cenchmarkerKeyPair
+
+			snapshotterKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceSnapshotterSecret, common.OperatorNamespace(), []string{""})
+			Expect(err).NotTo(HaveOccurred())
+			cfg.SnapshotterKeyPair = snapshotterKeyPair
+
 			component, err := render.Compliance(cfg)
 			Expect(err).ShouldNot(HaveOccurred())
 			resources, _ := component.Objects()
@@ -594,6 +608,21 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(server.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			csrInitContainer := server.Spec.Template.Spec.InitContainers[0]
 			Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ComplianceServerCertSecret)))
+
+			controller := rtest.GetResource(resources, "compliance-controller", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(controller.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			csrInitContainer = controller.Spec.Template.Spec.InitContainers[0]
+			Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ComplianceControllerSecret)))
+
+			benchmarker := rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+			Expect(benchmarker.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			csrInitContainer = benchmarker.Spec.Template.Spec.InitContainers[0]
+			Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ComplianceBenchmarkerSecret)))
+
+			snapshotter := rtest.GetResource(resources, "compliance-snapshotter", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(snapshotter.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			csrInitContainer = snapshotter.Spec.Template.Spec.InitContainers[0]
+			Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ComplianceSnapshotterSecret)))
 		})
 	})
 

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -542,13 +542,17 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			cfg.ControllerKeyPair = controllerKeyPair
 
-			cenchmarkerKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceBenchmarkerSecret, common.OperatorNamespace(), []string{""})
+			benchmarkerKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceBenchmarkerSecret, common.OperatorNamespace(), []string{""})
 			Expect(err).NotTo(HaveOccurred())
-			cfg.BenchmarkerKeyPair = cenchmarkerKeyPair
+			cfg.BenchmarkerKeyPair = benchmarkerKeyPair
 
 			snapshotterKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceSnapshotterSecret, common.OperatorNamespace(), []string{""})
 			Expect(err).NotTo(HaveOccurred())
 			cfg.SnapshotterKeyPair = snapshotterKeyPair
+
+			reporterKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.ComplianceReporterSecret, common.OperatorNamespace(), []string{""})
+			Expect(err).NotTo(HaveOccurred())
+			cfg.ReporterKeyPair = reporterKeyPair
 
 			component, err := render.Compliance(cfg)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -623,6 +627,11 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(snapshotter.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			csrInitContainer = snapshotter.Spec.Template.Spec.InitContainers[0]
 			Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ComplianceSnapshotterSecret)))
+
+			reporter := rtest.GetResource(resources, "tigera.io.report", ns, "", "v1", "PodTemplate").(*corev1.PodTemplate)
+			Expect(reporter.Template.Spec.InitContainers).To(HaveLen(1))
+			csrInitContainer = reporter.Template.Spec.InitContainers[0]
+			Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ComplianceReporterSecret)))
 		})
 	})
 

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -1852,7 +1852,10 @@ func (c *intrusionDetectionComponent) getBaseADDetectorsPodTemplate(podTemplateN
 			c.cfg.AnomalyDetectorCertSecret.VolumeMount(c.SupportedOSType()),
 		),
 	}
-
+	var initContainers []corev1.Container
+	if c.cfg.AnomalyDetectorCertSecret != nil && c.cfg.AnomalyDetectorCertSecret.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.AnomalyDetectorCertSecret.InitContainer(IntrusionDetectionNamespace))
+	}
 	return corev1.PodTemplate{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodTemplate",
@@ -1882,6 +1885,7 @@ func (c *intrusionDetectionComponent) getBaseADDetectorsPodTemplate(podTemplateN
 				ServiceAccountName: adDetectorName,
 				Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
 				Containers:         []corev1.Container{container},
+				InitContainers:     initContainers,
 			},
 		},
 	}

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -692,6 +692,10 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 		}
 		container.Env = append(container.Env, envVars...)
 	}
+	var initContainers []corev1.Container
+	if c.cfg.IntrusionDetectionCertSecret != nil && c.cfg.IntrusionDetectionCertSecret.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.IntrusionDetectionCertSecret.InitContainer(IntrusionDetectionNamespace))
+	}
 
 	return relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -704,6 +708,7 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 			NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 			ServiceAccountName: IntrusionDetectionName,
 			ImagePullSecrets:   ps,
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				container,
 			},

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -528,12 +528,16 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		container = relasticsearch.ContainerDecorate(container, render.DefaultElasticsearchClusterName,
 			ElasticsearchKubeControllersUserSecret, c.cfg.ClusterDomain, rmeta.OSTypeLinux)
 	}
-
+	var initContainers []corev1.Container
+	if c.cfg.MetricsServerTLS != nil && c.cfg.MetricsServerTLS.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.MetricsServerTLS.InitContainer(common.CalicoNamespace))
+	}
 	podSpec := corev1.PodSpec{
 		NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 		Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...),
 		ImagePullSecrets:   c.cfg.Installation.ImagePullSecrets,
 		ServiceAccountName: c.kubeControllerServiceAccountName,
+		InitContainers:     initContainers,
 		Containers:         []corev1.Container{container},
 		Volumes:            c.kubeControllersVolumes(),
 	}

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -42,14 +43,19 @@ import (
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/kubecontrollers"
 	"github.com/tigera/operator/pkg/render/testutils"
+	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 var _ = Describe("kube-controllers rendering tests", func() {
-	var instance *operatorv1.InstallationSpec
-	var k8sServiceEp k8sapi.ServiceEndpoint
-	var cfg kubecontrollers.KubeControllersConfiguration
-	var internalManagerTLSSecret certificatemanagement.KeyPairInterface
+	var (
+		instance                 *operatorv1.InstallationSpec
+		k8sServiceEp             k8sapi.ServiceEndpoint
+		cfg                      kubecontrollers.KubeControllersConfiguration
+		internalManagerTLSSecret certificatemanagement.KeyPairInterface
+		cli                      client.Client
+	)
+
 	esEnvs := []corev1.EnvVar{
 		{Name: "ELASTIC_INDEX_SUFFIX", Value: "cluster"},
 		{Name: "ELASTIC_SCHEME", Value: "https"},
@@ -119,7 +125,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 		scheme := runtime.NewScheme()
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
-		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		cli = fake.NewClientBuilder().WithScheme(scheme).Build()
 		certificateManager, err := certificatemanager.Create(cli, nil, dns.DefaultClusterDomain)
 		Expect(err).NotTo(HaveOccurred())
 		internalManagerTLSSecret, err = certificateManager.GetOrCreateKeyPair(cli, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), []string{render.ManagerInternalTLSSecretName})
@@ -1091,5 +1097,27 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: false}),
 			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, Openshift: true}),
 		)
+	})
+
+	It("should render init containers when certificate management is enabled", func() {
+
+		instance.Variant = operatorv1.TigeraSecureEnterprise
+		cfg.ManagerInternalSecret = internalManagerTLSSecret
+		cfg.MetricsPort = 9094
+		ca, _ := tls.MakeCA(rmeta.DefaultOperatorCASignerName())
+		cert, _, _ := ca.Config.GetPEMBytes() // create a valid pem block
+		cfg.Installation.CertificateManagement = &operatorv1.CertificateManagement{CACert: cert}
+		certificateManager, err := certificatemanager.Create(cli, cfg.Installation, dns.DefaultClusterDomain)
+		Expect(err).NotTo(HaveOccurred())
+		tls, err := certificateManager.GetOrCreateKeyPair(cli, kubecontrollers.KubeControllerPrometheusTLSSecret, common.OperatorNamespace(), []string{""})
+		Expect(err).NotTo(HaveOccurred())
+		cfg.MetricsServerTLS = tls
+
+		resources, _ := kubecontrollers.NewCalicoKubeControllers(&cfg).Objects()
+
+		dp := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(dp.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+		csrInitContainer := dp.Spec.Template.Spec.InitContainers[0]
+		Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", kubecontrollers.KubeControllerPrometheusTLSSecret)))
 	})
 })

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -63,7 +63,8 @@ const (
 	ECKOperatorPolicyName   = networkpolicy.TigeraComponentPolicyPrefix + "elastic-operator-access"
 	ECKEnterpriseTrial      = "eck-trial-license"
 
-	ElasticsearchNamespace = "tigera-elasticsearch"
+	ElasticsearchObjectName = "tigera-elasticsearch"
+	ElasticsearchNamespace  = ElasticsearchObjectName
 
 	// TigeraLinseedSecret is the name of the secret that holds the TLS key pair mounted into Linseed.
 	// The secret contains server key and certificate.
@@ -95,8 +96,9 @@ const (
 	ElasticsearchInternalPolicyName = networkpolicy.TigeraComponentPolicyPrefix + "elasticsearch-internal"
 
 	KibanaName         = "tigera-secure"
-	KibanaNamespace    = "tigera-kibana"
-	KibanaBasePath     = "tigera-kibana"
+	KibanaObjectName   = "tigera-kibana"
+	KibanaNamespace    = KibanaObjectName
+	KibanaBasePath     = KibanaObjectName
 	KibanaServiceName  = "tigera-secure-kb-http"
 	KibanaDefaultRoute = "/app/kibana#/dashboards?%s&title=%s"
 	KibanaPolicyName   = networkpolicy.TigeraComponentPolicyPrefix + "kibana-access"
@@ -501,7 +503,7 @@ func (es elasticsearchComponent) linseedExternalRoleAndBinding() (*rbacv1.Cluste
 			{
 				Kind:      "ServiceAccount",
 				Name:      "tigera-linseed",
-				Namespace: "tigera-elasticsearch",
+				Namespace: ElasticsearchNamespace,
 			},
 		},
 	}
@@ -540,7 +542,7 @@ func (es elasticsearchComponent) elasticsearchExternalService() *corev1.Service 
 func (es elasticsearchComponent) elasticsearchServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-elasticsearch",
+			Name:      ElasticsearchObjectName,
 			Namespace: ElasticsearchNamespace,
 		},
 	}
@@ -753,7 +755,8 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 					"memory": resource.MustParse("50Mi"),
 				},
 			},
-			SecurityContext: securitycontext.NewRootContext(false),
+			// Without a root context, it is not able to ln and chown.
+			SecurityContext: securitycontext.NewRootContext(true),
 			VolumeMounts: []corev1.VolumeMount{
 				// Create transport mount, such that ECK will not auto-fill this with a secret volume.
 				{
@@ -836,7 +839,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			ImagePullSecrets:             secret.GetReferenceList(es.cfg.PullSecrets),
 			NodeSelector:                 nodeSels,
 			Tolerations:                  es.cfg.Installation.ControlPlaneTolerations,
-			ServiceAccountName:           "tigera-elasticsearch",
+			ServiceAccountName:           ElasticsearchObjectName,
 			Volumes:                      volumes,
 			AutomountServiceAccountToken: &autoMountToken,
 		},
@@ -1357,7 +1360,7 @@ func (es elasticsearchComponent) eckOperatorPodSecurityPolicy() *policyv1beta1.P
 func (es elasticsearchComponent) kibanaServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-kibana",
+			Name:      KibanaObjectName,
 			Namespace: KibanaNamespace,
 		},
 	}
@@ -1470,7 +1473,7 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 				},
 				Spec: corev1.PodSpec{
 					ImagePullSecrets:             secret.GetReferenceList(es.cfg.PullSecrets),
-					ServiceAccountName:           "tigera-kibana",
+					ServiceAccountName:           KibanaObjectName,
 					NodeSelector:                 es.cfg.Installation.ControlPlaneNodeSelector,
 					Tolerations:                  es.cfg.Installation.ControlPlaneTolerations,
 					InitContainers:               initContainers,
@@ -1647,7 +1650,7 @@ func (es elasticsearchComponent) elasticEnterpriseTrial() *corev1.Secret {
 func (es elasticsearchComponent) elasticsearchClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tigera-elasticsearch",
+			Name: ElasticsearchObjectName,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -1655,7 +1658,7 @@ func (es elasticsearchComponent) elasticsearchClusterRole() *rbacv1.ClusterRole 
 				APIGroups:     []string{"policy"},
 				Resources:     []string{"podsecuritypolicies"},
 				Verbs:         []string{"use"},
-				ResourceNames: []string{"tigera-elasticsearch"},
+				ResourceNames: []string{ElasticsearchObjectName},
 			},
 		},
 	}
@@ -1664,17 +1667,17 @@ func (es elasticsearchComponent) elasticsearchClusterRole() *rbacv1.ClusterRole 
 func (es elasticsearchComponent) elasticsearchClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tigera-elasticsearch",
+			Name: ElasticsearchObjectName,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "tigera-elasticsearch",
+			Name:     ElasticsearchObjectName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "tigera-elasticsearch",
+				Name:      ElasticsearchObjectName,
 				Namespace: ElasticsearchNamespace,
 			},
 		},
@@ -1682,7 +1685,7 @@ func (es elasticsearchComponent) elasticsearchClusterRoleBinding() *rbacv1.Clust
 }
 
 func (es elasticsearchComponent) elasticsearchPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	psp := podsecuritypolicy.NewBasePolicy("tigera-elasticsearch")
+	psp := podsecuritypolicy.NewBasePolicy(ElasticsearchObjectName)
 	psp.Spec.Privileged = true
 	psp.Spec.AllowPrivilegeEscalation = ptr.BoolToPtr(true)
 	psp.Spec.RequiredDropCapabilities = nil
@@ -1698,7 +1701,7 @@ func (es elasticsearchComponent) elasticsearchPodSecurityPolicy() *policyv1beta1
 func (es elasticsearchComponent) kibanaClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tigera-kibana",
+			Name: KibanaObjectName,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -1706,7 +1709,7 @@ func (es elasticsearchComponent) kibanaClusterRole() *rbacv1.ClusterRole {
 				APIGroups:     []string{"policy"},
 				Resources:     []string{"podsecuritypolicies"},
 				Verbs:         []string{"use"},
-				ResourceNames: []string{"tigera-kibana"},
+				ResourceNames: []string{KibanaObjectName},
 			},
 		},
 	}
@@ -1715,17 +1718,17 @@ func (es elasticsearchComponent) kibanaClusterRole() *rbacv1.ClusterRole {
 func (es elasticsearchComponent) kibanaClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tigera-kibana",
+			Name: KibanaObjectName,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "tigera-kibana",
+			Name:     KibanaObjectName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "tigera-kibana",
+				Name:      KibanaObjectName,
 				Namespace: KibanaNamespace,
 			},
 		},
@@ -1733,7 +1736,7 @@ func (es elasticsearchComponent) kibanaClusterRoleBinding() *rbacv1.ClusterRoleB
 }
 
 func (es elasticsearchComponent) kibanaPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
-	return podsecuritypolicy.NewBasePolicy("tigera-kibana")
+	return podsecuritypolicy.NewBasePolicy(KibanaObjectName)
 }
 
 func (es elasticsearchComponent) oidcUserRole() client.Object {

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -572,24 +572,25 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
 				Expect(initContainers).To(HaveLen(4))
-				compareInitContainer := func(ic corev1.Container, expectedName string, expectedVolumes []corev1.VolumeMount) {
+				compareInitContainer := func(ic corev1.Container, expectedName string, expectedVolumes []corev1.VolumeMount, privileged bool) {
 					Expect(ic.Name).To(Equal(expectedName))
 					Expect(ic.VolumeMounts).To(HaveLen(len(expectedVolumes)))
+					Expect(ic.SecurityContext.Privileged).To(Equal(&privileged))
 					for i, vm := range ic.VolumeMounts {
 						Expect(vm.Name).To(Equal(expectedVolumes[i].Name))
 						Expect(vm.MountPath).To(Equal(expectedVolumes[i].MountPath))
 					}
 				}
-				compareInitContainer(initContainers[0], "elastic-internal-init-os-settings", []corev1.VolumeMount{})
+				compareInitContainer(initContainers[0], "elastic-internal-init-os-settings", []corev1.VolumeMount{}, true)
 				compareInitContainer(initContainers[1], "elastic-internal-init-filesystem", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: "/csr"},
-				})
+				}, true)
 				compareInitContainer(initContainers[2], "key-cert-elastic", []corev1.VolumeMount{
 					{Name: "elastic-internal-http-certificates", MountPath: certificatemanagement.CSRCMountPath},
-				})
+				}, false)
 				compareInitContainer(initContainers[3], "key-cert-elastic-transport", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: certificatemanagement.CSRCMountPath},
-				})
+				}, false)
 			})
 		})
 

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -243,6 +243,10 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 		pr.cfg.TrustedBundle.Volume(),
 		pr.cfg.PolicyRecommendationCertSecret.Volume(),
 	}
+	var initContainers []corev1.Container
+	if pr.cfg.PolicyRecommendationCertSecret != nil && pr.cfg.PolicyRecommendationCertSecret.UseCertificateManagement() {
+		initContainers = append(initContainers, pr.cfg.PolicyRecommendationCertSecret.InitContainer(PolicyRecommendationNamespace))
+	}
 
 	container := relasticsearch.ContainerDecorateIndexCreator(
 		relasticsearch.ContainerDecorate(
@@ -269,7 +273,8 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 			Containers: []corev1.Container{
 				container,
 			},
-			Volumes: volumes,
+			InitContainers: initContainers,
+			Volumes:        volumes,
 		},
 	}, pr.cfg.ESClusterConfig, pr.cfg.ESSecrets).(*corev1.PodTemplateSpec)
 


### PR DESCRIPTION
The certificate management feature has not kept up with recent changes to the operator. A number of issues were identified and patched:
- Missing RBAC for service accounts for newer components that have a tls secret
- Missing security context
- Missing init containers for newer tls secrets