### PR TITLE
[cherry-pick] Remove CLUSTER_NAME for compliance; Will rely on Voltron to setup the…

### DIFF
--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -435,7 +435,6 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 		{Name: "TIGERA_COMPLIANCE_MAX_JOB_RETRIES", Value: "6"},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagementClusterConnection != nil)},
 	}
 	podTemplate := &corev1.PodTemplateSpec{
@@ -568,7 +567,6 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 		{Name: "TIGERA_COMPLIANCE_JOB_NAMESPACE", Value: ComplianceNamespace},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagementClusterConnection != nil)},
 	}
 
@@ -809,7 +807,6 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagementClusterConnection != nil)},
 	}
 	if c.cfg.KeyValidatorConfig != nil {
@@ -994,7 +991,6 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 		{Name: "TIGERA_COMPLIANCE_SNAPSHOT_HOUR", Value: "0"},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagementClusterConnection != nil)},
 	}
 
@@ -1147,7 +1143,6 @@ func (c *complianceComponent) complianceBenchmarkerDaemonSet() *appsv1.DaemonSet
 		{Name: "NODENAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "CLUSTER_NAME", Value: c.cfg.ESClusterConfig.ClusterName()},
 		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagementClusterConnection != nil)},
 	}
 

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -218,7 +218,6 @@ var _ = Describe("compliance rendering tests", func() {
 
 			envs := d.Spec.Template.Spec.Containers[0].Env
 			expectedEnvs := []corev1.EnvVar{
-				{Name: "CLUSTER_NAME", Value: "cluster"},
 				{Name: "LINSEED_CLIENT_KEY", Value: "/tigera-compliance-controller-tls/tls.key"},
 				{Name: "LINSEED_CLIENT_CERT", Value: "/tigera-compliance-controller-tls/tls.crt"},
 			}
@@ -347,21 +346,11 @@ var _ = Describe("compliance rendering tests", func() {
 			complianceSnapshotter := rtest.GetResource(resources, "compliance-snapshotter", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			complianceBenchmarker := rtest.GetResource(resources, "compliance-benchmarker", ns, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 
-			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
-			))
-			Expect(complianceController.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
-			))
-			Expect(complianceSnapshotter.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
-			))
-			Expect(complianceBenchmarker.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
-			))
-			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-				corev1.EnvVar{Name: "CLUSTER_NAME", Value: "cluster"},
-			))
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements())
+			Expect(complianceController.Spec.Template.Spec.Containers[0].Env).Should(ContainElements())
+			Expect(complianceSnapshotter.Spec.Template.Spec.Containers[0].Env).Should(ContainElements())
+			Expect(complianceBenchmarker.Spec.Template.Spec.Containers[0].Env).Should(ContainElements())
+			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].Env).Should(ContainElements())
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("tigera-ca-bundle"))
 			Expect(dpComplianceServer.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/etc/pki/tls/certs"))


### PR DESCRIPTION
… headers (#2699)

## Description

Cherry-pick: #2699

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
