### PR TITLE
Drop cluster name from intrusion detection controller

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -385,10 +385,6 @@ func (c *intrusionDetectionComponent) intrusionDetectionJobContainer() corev1.Co
 				Value: c.cfg.TrustedCertBundle.MountPath(),
 			},
 			{
-				Name:  "CLUSTER_NAME",
-				Value: c.cfg.ESClusterConfig.ClusterName(),
-			},
-			{
 				Name:  "FIPS_MODE_ENABLED",
 				Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode),
 			},
@@ -702,10 +698,6 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 
 func (c *intrusionDetectionComponent) intrusionDetectionControllerContainer() corev1.Container {
 	envs := []corev1.EnvVar{
-		{
-			Name:  "CLUSTER_NAME",
-			Value: c.cfg.ESClusterConfig.ClusterName(),
-		},
 		{
 			Name:  "MULTI_CLUSTER_FORWARDING_CA",
 			Value: c.cfg.TrustedCertBundle.MountPath(),

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -541,7 +541,6 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		envs := dp.Spec.Template.Spec.Containers[0].Env
 
 		expectedEnvs := []expectedEnvVar{
-			{"CLUSTER_NAME", cfg.ESClusterConfig.ClusterName(), "", ""},
 			{"MULTI_CLUSTER_FORWARDING_CA", cfg.TrustedCertBundle.MountPath(), "", ""},
 			{"IDS_ENABLE_EVENT_FORWARDING", "true", "", ""},
 		}
@@ -668,7 +667,6 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 
 		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(idc.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "CLUSTER_NAME", Value: cfg.ESClusterConfig.ClusterName()},
 			corev1.EnvVar{Name: "MULTI_CLUSTER_FORWARDING_CA", Value: cfg.TrustedCertBundle.MountPath()},
 			corev1.EnvVar{Name: "DISABLE_ALERTS", Value: "yes"},
 			corev1.EnvVar{Name: "DISABLE_ANOMALY_DETECTION", Value: "yes"},


### PR DESCRIPTION
## Description

We are not going to set CLUSTER_NAME for intrusion detection. For managed cluster, Voltron will set this value. Inside a management cluster, Linseed will default to `cluster`

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
