### PR TITLE
[release-v1.30] Auto pick #2706: Linseed must be able to verify Voltron's certificate

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -437,6 +437,10 @@ func (r *ReconcileLogStorage) generateSecrets(
 		// Get certificate for es-proxy, which Linseed and es-gateway need to trust.
 		render.ManagerTLSSecretName,
 
+		// Linseed needs the manager internal cert in order to verify the cert presented by Voltron when provisioning
+		// tokens into managed clusters.
+		render.ManagerInternalTLSSecretName,
+
 		// Get certificate for fluentd, which Linseed needs to trust in a standalone or management cluster.
 		render.FluentdPrometheusTLSSecretName,
 


### PR DESCRIPTION
Cherry pick of #2706 on release-v1.30.

#2706: Linseed must be able to verify Voltron's certificate

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.