### PR TITLE
Anomaly detection jobs should query Linseed (#2678)

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -505,6 +505,11 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating TLS certificate", err, reqLogger)
 		return reconcile.Result{}, err
 	}
+	anomalyDetectorKeyPair, err := certificateManager.GetOrCreateKeyPair(r.client, render.AnomalyDetectorTLSSecretName, common.OperatorNamespace(), []string{render.AnomalyDetectorTLSSecretName})
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating TLS certificate", err, reqLogger)
+		return reconcile.Result{}, err
+	}
 
 	if !r.dpiAPIReady.IsReady() {
 		log.Info("Waiting for DeepPacketInspection API to be ready")
@@ -558,6 +563,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		TrustedCertBundle:            trustedBundle,
 		ADAPIServerCertSecret:        adAPIServerTLSSecret,
 		IntrusionDetectionCertSecret: intrusionDetectionKeyPair,
+		AnomalyDetectorCertSecret:    anomalyDetectorKeyPair,
 		UsePSP:                       r.usePSP,
 	}
 	comp := render.IntrusionDetection(intrusionDetectionCfg)
@@ -608,17 +614,11 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		dpiComponent,
 		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
 			Namespace:       render.IntrusionDetectionNamespace,
-			ServiceAccounts: []string{render.IntrusionDetectionName},
-			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
-				rcertificatemanagement.NewKeyPairOption(intrusionDetectionCfg.IntrusionDetectionCertSecret, true, true),
-			},
-			TrustedBundle: trustedBundle,
-		}),
-		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       render.IntrusionDetectionNamespace,
-			ServiceAccounts: []string{render.IntrusionDetectionName, render.ADAPIObjectName},
+			ServiceAccounts: []string{render.IntrusionDetectionName, render.ADAPIObjectName, render.AnomalyDetectorsName},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(intrusionDetectionCfg.ADAPIServerCertSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(intrusionDetectionCfg.IntrusionDetectionCertSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(intrusionDetectionCfg.AnomalyDetectorCertSecret, true, true),
 			},
 			TrustedBundle: trustedBundle,
 		}),
@@ -627,13 +627,6 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 			ServiceAccounts: []string{dpi.DeepPacketInspectionName},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, false, true),
-			},
-			TrustedBundle: typhaNodeTLS.TrustedBundle,
-		}),
-		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       dpi.DeepPacketInspectionNamespace,
-			ServiceAccounts: []string{dpi.DeepPacketInspectionName},
-			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(dpiKeyPair, true, true),
 			},
 			TrustedBundle: typhaNodeTLS.TrustedBundle,

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -403,6 +403,7 @@ func (c *keyPairCollection) component(bundle certificatemanagement.TrustedBundle
 			esmetrics.ElasticsearchMetricsName,
 			render.IntrusionDetectionName,
 			dpi.DeepPacketInspectionName,
+			render.AnomalyDetectorsName,
 		},
 		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 			// We do not want to delete the elastic keypair secret from the tigera-elasticsearch namespace when CertificateManagement is
@@ -446,6 +447,7 @@ func (r *ReconcileLogStorage) generateSecrets(
 
 		// Get certificate for intrusion detection controller, which Linseed needs to trust in a standalone or management cluster.
 		render.IntrusionDetectionTLSSecretName,
+		render.AnomalyDetectorTLSSecretName,
 
 		// Get certificate for DPI, which Linseed needs to trust in a standalone or management cluster.
 		render.DPITLSSecretName,

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -49,6 +49,7 @@ import (
 const (
 	IntrusionDetectionNamespace = "tigera-intrusion-detection"
 	IntrusionDetectionName      = "intrusion-detection-controller"
+	AnomalyDetectorsName        = "anomaly-detectors"
 
 	ElasticsearchIntrusionDetectionUserSecret    = "tigera-ee-intrusion-detection-elasticsearch-access"
 	ElasticsearchIntrusionDetectionJobUserSecret = "tigera-ee-installer-elasticsearch-access"
@@ -65,6 +66,7 @@ const (
 	ADAPIObjectPortName             = "anomaly-detection-api-https"
 	ADAPITLSSecretName              = "anomaly-detection-api-tls"
 	IntrusionDetectionTLSSecretName = "intrusion-detection-tls"
+	AnomalyDetectorTLSSecretName    = "anomaly-detector-tls"
 	DPITLSSecretName                = "deep-packet-inspection-tls"
 	ADAPIExpectedServiceName        = "anomaly-detection-api.tigera-intrusion-detection.svc"
 	ADAPIPolicyName                 = networkpolicy.TigeraComponentPolicyPrefix + ADAPIObjectName
@@ -125,6 +127,7 @@ type IntrusionDetectionConfiguration struct {
 	TrustedCertBundle            certificatemanagement.TrustedBundle
 	ADAPIServerCertSecret        certificatemanagement.KeyPairInterface
 	IntrusionDetectionCertSecret certificatemanagement.KeyPairInterface
+	AnomalyDetectorCertSecret    certificatemanagement.KeyPairInterface
 
 	// Whether the cluster supports pod security policies.
 	UsePSP bool
@@ -236,7 +239,9 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 			c.adDetectorServiceAccount(),
 			c.adDetectorSecret(),
 			c.adDetectorAccessRole(),
+			c.adDetectorAccessClusterRole(),
 			c.adDetectorRoleBinding(),
+			c.adDetectorClusterRoleBinding(),
 		)
 		adObjs = append(adObjs, c.adDetectorPodTemplates()...)
 
@@ -1704,6 +1709,33 @@ func (c *intrusionDetectionComponent) adDetectorAccessRole() *rbacv1.Role {
 		Rules: rules,
 	}
 }
+func (c *intrusionDetectionComponent) adDetectorAccessClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: adDetectorName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				// Add write access to Linseed APIs.
+				APIGroups: []string{"linseed.tigera.io"},
+				Resources: []string{"events"},
+				Verbs:     []string{"create"},
+			},
+			{
+				// Add read access to Linseed APIs.
+				APIGroups: []string{"linseed.tigera.io"},
+				Resources: []string{
+					"dnslogs",
+					"l7logs",
+					"flowlogs",
+				},
+				Verbs: []string{"get"},
+			},
+		},
+	}
+
+}
 
 func (c *intrusionDetectionComponent) adDetectorRoleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
@@ -1715,6 +1747,27 @@ func (c *intrusionDetectionComponent) adDetectorRoleBinding() *rbacv1.RoleBindin
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
+			Name:     adDetectorName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      adDetectorName,
+				Namespace: IntrusionDetectionNamespace,
+			},
+		},
+	}
+}
+
+func (c *intrusionDetectionComponent) adDetectorClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: adDetectorName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
 			Name:     adDetectorName,
 		},
 		Subjects: []rbacv1.Subject{
@@ -1756,6 +1809,26 @@ func (c *intrusionDetectionComponent) getBaseADDetectorsPodTemplate(podTemplateN
 			Name:  "FIPS_MODE_ENABLED",
 			Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode),
 		},
+		{
+			Name:  "LINSEED_URL",
+			Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain),
+		},
+		{
+			Name:  "LINSEED_CA",
+			Value: c.cfg.TrustedCertBundle.MountPath(),
+		},
+		{
+			Name:  "LINSEED_CLIENT_CERT",
+			Value: c.cfg.AnomalyDetectorCertSecret.VolumeMountCertificateFilePath(),
+		},
+		{
+			Name:  "LINSEED_CLIENT_KEY",
+			Value: c.cfg.AnomalyDetectorCertSecret.VolumeMountKeyFilePath(),
+		},
+		{
+			Name:  "LINSEED_TOKEN",
+			Value: GetLinseedTokenPath(false),
+		},
 	}
 
 	container := corev1.Container{
@@ -1766,6 +1839,7 @@ func (c *intrusionDetectionComponent) getBaseADDetectorsPodTemplate(podTemplateN
 		VolumeMounts: append(
 			c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType()),
 			c.cfg.ADAPIServerCertSecret.VolumeMount(c.SupportedOSType()),
+			c.cfg.AnomalyDetectorCertSecret.VolumeMount(c.SupportedOSType()),
 		),
 	}
 
@@ -1790,15 +1864,14 @@ func (c *intrusionDetectionComponent) getBaseADDetectorsPodTemplate(podTemplateN
 				Volumes: []corev1.Volume{
 					c.cfg.TrustedCertBundle.Volume(),
 					c.cfg.ADAPIServerCertSecret.Volume(),
+					c.cfg.AnomalyDetectorCertSecret.Volume(),
 				},
 				DNSPolicy:          corev1.DNSClusterFirst,
 				ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 				RestartPolicy:      corev1.RestartPolicyOnFailure,
 				ServiceAccountName: adDetectorName,
 				Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
-				Containers: []corev1.Container{
-					relasticsearch.ContainerDecorate(container, c.cfg.ESClusterConfig.ClusterName(), ElasticsearchADJobUserSecret, c.cfg.ClusterDomain, c.SupportedOSType()),
-				},
+				Containers:         []corev1.Container{container},
 			},
 		},
 	}
@@ -1975,7 +2048,7 @@ func (c *intrusionDetectionComponent) adDetectorAllowTigeraPolicy() *v3.NetworkP
 		{
 			Action:      v3.Allow,
 			Protocol:    &networkpolicy.TCPProtocol,
-			Destination: networkpolicy.CreateEntityRule(ElasticsearchNamespace, "tigera-secure-es-gateway", 5554, 9200),
+			Destination: networkpolicy.LinseedEntityRule,
 		},
 		{
 			Action:      v3.Allow,

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -61,11 +61,12 @@ type expectedEnvVar struct {
 
 var _ = Describe("Intrusion Detection rendering tests", func() {
 	var (
-		cfg          *render.IntrusionDetectionConfiguration
-		bundle       certificatemanagement.TrustedBundle
-		adAPIKeyPair certificatemanagement.KeyPairInterface
-		keyPair      certificatemanagement.KeyPairInterface
-		cli          client.Client
+		cfg            *render.IntrusionDetectionConfiguration
+		bundle         certificatemanagement.TrustedBundle
+		adAPIKeyPair   certificatemanagement.KeyPairInterface
+		keyPair        certificatemanagement.KeyPairInterface
+		anomalyKeyPair certificatemanagement.KeyPairInterface
+		cli            client.Client
 	)
 
 	expectedIDPolicyForUnmanaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/intrusion-detection-controller_unmanaged.json")
@@ -91,6 +92,9 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		secretTLS, err := certificatemanagement.CreateSelfSignedSecret(render.IntrusionDetectionTLSSecretName, "", "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		keyPair = certificatemanagement.NewKeyPair(secretTLS, []string{""}, "")
+		anomalySecretTLS, err := certificatemanagement.CreateSelfSignedSecret(render.AnomalyDetectorTLSSecretName, "", "", nil)
+		Expect(err).NotTo(HaveOccurred())
+		anomalyKeyPair = certificatemanagement.NewKeyPair(anomalySecretTLS, []string{""}, "")
 		bundle = certificateManager.CreateTrustedBundle()
 		// Initialize a default instance to use. Each test can override this to its
 		// desired configuration.
@@ -98,6 +102,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			TrustedCertBundle:            bundle,
 			ADAPIServerCertSecret:        adAPIKeyPair,
 			IntrusionDetectionCertSecret: keyPair,
+			AnomalyDetectorCertSecret:    anomalyKeyPair,
 			Installation:                 &operatorv1.InstallationSpec{Registry: "testregistry.com/"},
 			ESClusterConfig:              relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1),
 			ClusterDomain:                dns.DefaultClusterDomain,
@@ -167,7 +172,9 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Secret"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: "anomaly-detectors", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
+			{name: "anomaly-detectors", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: render.ADJobPodTemplateBaseName + ".training", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: render.ADJobPodTemplateBaseName + ".detection", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: "allow-tigera.intrusion-detection-elastic", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
@@ -332,6 +339,29 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			},
 		))
 
+		detectorsClusterRole := rtest.GetResource(resources, "anomaly-detectors", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(detectorsClusterRole.Rules).To(HaveLen(2))
+		Expect(detectorsClusterRole.Rules).To(Equal(
+			[]rbacv1.PolicyRule{
+				{
+					// Add write access to Linseed APIs.
+					APIGroups: []string{"linseed.tigera.io"},
+					Resources: []string{"events"},
+					Verbs:     []string{"create"},
+				},
+				{
+					// Add read access to Linseed APIs.
+					APIGroups: []string{"linseed.tigera.io"},
+					Resources: []string{
+						"dnslogs",
+						"l7logs",
+						"flowlogs",
+					},
+					Verbs: []string{"get"},
+				},
+			},
+		))
+
 		detectorsRoleBinding := rtest.GetResource(resources, "anomaly-detectors", render.IntrusionDetectionNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
 		Expect(detectorsRoleBinding.RoleRef).To(Equal(rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -339,6 +369,17 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			Name:     "anomaly-detectors",
 		}))
 		Expect(detectorsRoleBinding.Subjects).To(ConsistOf(rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      "anomaly-detectors",
+			Namespace: render.IntrusionDetectionNamespace,
+		}))
+		detectorsClusterRoleBinding := rtest.GetResource(resources, "anomaly-detectors", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+		Expect(detectorsClusterRoleBinding.RoleRef).To(Equal(rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "anomaly-detectors",
+		}))
+		Expect(detectorsClusterRoleBinding.Subjects).To(ConsistOf(rbacv1.Subject{
 			Kind:      "ServiceAccount",
 			Name:      "anomaly-detectors",
 			Namespace: render.IntrusionDetectionNamespace,
@@ -524,7 +565,9 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Secret"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: "anomaly-detectors", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
+			{name: "anomaly-detectors", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: render.ADJobPodTemplateBaseName + ".training", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: render.ADJobPodTemplateBaseName + ".detection", ns: render.IntrusionDetectionNamespace, group: "", version: "v1", kind: "PodTemplate"},
 			{name: "allow-tigera.intrusion-detection-elastic", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
@@ -582,11 +625,11 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 
 		// expect AD PodTemplate EnvVars
 		expectedADEnvs := []expectedEnvVar{
-			{"ELASTIC_HOST", dns.GetServiceDNSNames(render.ESGatewayServiceName, render.ElasticsearchNamespace, cfg.ClusterDomain)[2], "", ""},
-			{"ELASTIC_PORT", strconv.Itoa(render.ElasticsearchDefaultPort), "", ""},
-			{"ELASTIC_CA", certificatemanagement.TrustedCertBundleMountPath, "", ""},
-			{"ELASTIC_USERNAME", "", render.ElasticsearchADJobUserSecret, "username"},
-			{"ELASTIC_PASSWORD", "", render.ElasticsearchADJobUserSecret, "password"},
+			{"LINSEED_URL", "https://tigera-linseed.tigera-elasticsearch.svc", "", ""},
+			{"LINSEED_CA", certificatemanagement.TrustedCertBundleMountPath, "", ""},
+			{"LINSEED_CLIENT_CERT", cfg.AnomalyDetectorCertSecret.VolumeMountCertificateFilePath(), "", ""},
+			{"LINSEED_CLIENT_KEY", cfg.AnomalyDetectorCertSecret.VolumeMountKeyFilePath(), "", ""},
+			{"LINSEED_TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token", "", ""},
 			{"MODEL_STORAGE_API_HOST", render.ADAPIExpectedServiceName, "", ""},
 			{"MODEL_STORAGE_API_PORT", strconv.Itoa(8080), "", ""},
 			{"MODEL_STORAGE_CLIENT_CERT", cfg.ADAPIServerCertSecret.VolumeMountCertificateFilePath(), "", ""},
@@ -887,7 +930,9 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "ServiceAccount"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "Secret"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+			{name: "anomaly-detectors", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "anomaly-detectors", ns: "tigera-intrusion-detection", group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
+			{name: "anomaly-detectors", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera.io.detectors.training", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "PodTemplate"},
 			{name: "tigera.io.detectors.detection", ns: "tigera-intrusion-detection", group: "", version: "v1", kind: "PodTemplate"},
 			{name: "allow-tigera.intrusion-detection-elastic", ns: "tigera-intrusion-detection", group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},

--- a/pkg/render/testutils/expected_policies/ad-detectors.json
+++ b/pkg/render/testutils/expected_policies/ad-detectors.json
@@ -53,10 +53,9 @@
         "protocol": "TCP",
         "destination": {
           "ports": [
-            5554,
-            9200
+            8444
           ],
-          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "selector": "k8s-app == 'tigera-linseed'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },

--- a/pkg/render/testutils/expected_policies/ad-detectors_ocp.json
+++ b/pkg/render/testutils/expected_policies/ad-detectors_ocp.json
@@ -64,10 +64,9 @@
         "protocol": "TCP",
         "destination": {
           "ports": [
-            5554,
-            9200
+            8444
           ],
-          "selector": "k8s-app == 'tigera-secure-es-gateway'",
+          "selector": "k8s-app == 'tigera-linseed'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },


### PR DESCRIPTION
* Anomaly detection jobs should query Linseed

* Use its own secret

## Description

Cherry-pick #2678

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
