### PR TITLE
Prototype ability for operator to install multiple copies of tigera-manager

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -327,6 +327,7 @@ var HostPortsTypes []HostPortsType = []HostPortsType{
 	HostPortsEnabled,
 	HostPortsDisabled,
 }
+
 var HostPortsTypesString []string = []string{
 	HostPortsEnabled.String(),
 	HostPortsDisabled.String(),
@@ -502,6 +503,7 @@ var EncapsulationTypes []EncapsulationType = []EncapsulationType{
 	EncapsulationVXLANCrossSubnet,
 	EncapsulationNone,
 }
+
 var EncapsulationTypesString []string = []string{
 	EncapsulationIPIPCrossSubnet.String(),
 	EncapsulationIPIP.String(),
@@ -524,6 +526,7 @@ var NATOutgoingTypes []NATOutgoingType = []NATOutgoingType{
 	NATOutgoingEnabled,
 	NATOutgoingDisabled,
 }
+
 var NATOutgoingTypesString []string = []string{
 	NATOutgoingEnabled.String(),
 	NATOutgoingDisabled.String(),
@@ -588,6 +591,7 @@ var CNIPluginTypes []CNIPluginType = []CNIPluginType{
 	PluginAmazonVPC,
 	PluginAzureVNET,
 }
+
 var CNIPluginTypesString []string = []string{
 	PluginCalico.String(),
 	PluginGKE.String(),

--- a/api/v1/manager_types.go
+++ b/api/v1/manager_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
+++ b/pkg/controller/amazoncloudintegration/amazoncloudintegration_controller.go
@@ -206,7 +206,7 @@ func (r *ReconcileAmazonCloudIntegration) Reconcile(ctx context.Context, request
 		return reconcile.Result{}, err
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -157,7 +157,7 @@ func add(c controller.Controller, r *ReconcileAPIServer) error {
 	}
 
 	for _, secretName := range []string{
-		"calico-apiserver-certs", "tigera-apiserver-certs", render.PacketCaptureCertSecret,
+		"calico-apiserver-certs", "tigera-apiserver-certs", render.PacketCaptureServerCert,
 		certificatemanagement.CASecretName, render.DexTLSSecretName, monitor.PrometheusClientTLSSecretName,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
@@ -255,7 +255,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	}
 	ns := rmeta.APIServerNamespace(variant)
 
-	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err
@@ -408,7 +408,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	if variant == operatorv1.TigeraSecureEnterprise {
 		packetCaptureCertSecret, err := certificateManager.GetOrCreateKeyPair(
 			r.client,
-			render.PacketCaptureCertSecret,
+			render.PacketCaptureServerCert,
 			common.OperatorNamespace(),
 			dns.GetServiceDNSNames(render.PacketCaptureServiceName, render.PacketCaptureNamespace, r.clusterDomain))
 		if err != nil {

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -267,7 +267,7 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	}
 
 	// Secret used for TLS between dex and other components.
-	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(oprv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err
@@ -287,7 +287,7 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	}
 
 	// Dex will be configured with the contents of this secret, such as clientID and clientSecret.
-	idpSecret, err := utils.GetIdpSecret(ctx, r.client, authentication)
+	idpSecret, err := utils.GetIDPSecret(ctx, r.client, authentication)
 	if err != nil {
 		r.status.SetDegraded(oprv1.ResourceValidationError, "Invalid or missing identity provider secret", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -136,8 +136,8 @@ func add(mgr manager.Manager, c controller.Controller) error {
 	}
 
 	// Watch for changes to the secrets associated with the PacketCapture APIs.
-	if err = utils.AddSecretsWatch(c, render.PacketCaptureCertSecret, common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, render.PacketCaptureCertSecret, err)
+	if err = utils.AddSecretsWatch(c, render.PacketCaptureServerCert, common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, render.PacketCaptureServerCert, err)
 	}
 	// Watch for changes to the secrets associated with Prometheus.
 	if err = utils.AddSecretsWatch(c, monitor.PrometheusTLSSecretName, common.OperatorNamespace()); err != nil {
@@ -249,7 +249,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		return result, err
 	}
 
-	certificateManager, err := certificatemanager.Create(r.Client, instl, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.Client, instl, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err
@@ -278,7 +278,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		trustedCertBundle = certificateManager.CreateTrustedBundle()
 	}
 
-	for _, secretName := range []string{render.PacketCaptureCertSecret, monitor.PrometheusTLSSecretName, render.ProjectCalicoAPIServerTLSSecretName(instl.Variant)} {
+	for _, secretName := range []string{render.PacketCaptureServerCert, monitor.PrometheusTLSSecretName, render.ProjectCalicoAPIServerTLSSecretName(instl.Variant)} {
 		secret, err := certificateManager.GetCertificate(r.Client, secretName, common.OperatorNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve %s", secretName), err, reqLogger)

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -343,7 +343,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1054,7 +1054,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, &instance.Spec, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, &instance.Spec, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operator.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/installation/windows/calico_windows_upgrader.go
+++ b/pkg/controller/installation/windows/calico_windows_upgrader.go
@@ -44,9 +44,7 @@ const (
 	defaultMaxUnavailable int32 = 1
 )
 
-var (
-	windowsLog = logf.Log.WithName("windows_upgrader")
-)
+var windowsLog = logf.Log.WithName("windows_upgrader")
 
 type CalicoWindowsUpgrader interface {
 	UpdateConfig(install *operatorv1.InstallationSpec)
@@ -301,7 +299,7 @@ func (w *calicoWindowsUpgrader) Start(ctx context.Context) {
 				if w.install.KubernetesProvider == operatorv1.ProviderAKS {
 					w.updateWindowsNodes()
 				} else {
-					windowsLog.V(1).Info("windows upgrader only runs on AKS, skipping update call")
+					windowsLog.V(2).Info("windows upgrader only runs on AKS, skipping update call")
 				}
 			case <-ctx.Done():
 				windowsLog.Info("Stopping main loop")

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -461,7 +461,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -383,7 +383,7 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 	}
 	managedCluster := managementClusterConnection != nil
 
-	certificateManager, err := certificatemanager.Create(r.client, installation, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, installation, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/logstorage/eskubecontrollers.go
+++ b/pkg/controller/logstorage/eskubecontrollers.go
@@ -47,7 +47,7 @@ func (r *ReconcileLogStorage) createESKubeControllers(
 		return reconcile.Result{}, false, err
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, false, err

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -679,7 +679,7 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -32,9 +32,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/go-logr/logr"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
+	octrl "github.com/tigera/operator/pkg/controller"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/compliance"
 	"github.com/tigera/operator/pkg/controller/options"
@@ -81,7 +83,20 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return err
 	}
 
-	err = utils.AddSecretsWatch(controller, render.VoltronLinseedTLS, render.ManagerNamespace)
+	// The namespace(s) we need to monitor depend upon what tenancy mode we're running in.
+	// For single-tenant, everything is installed in the tigera-manager namespace.
+	installNS := render.ManagerNamespace
+	truthNS := common.OperatorNamespace()
+	watchNamespaces := []string{installNS, truthNS}
+	if opts.MultiTenant {
+		// For multi-tenant, the manager could be installed in any number of namespaces.
+		// So, we need to watch the resources we care about across all namespaces.
+		installNS = ""
+		truthNS = ""
+		watchNamespaces = []string{""}
+	}
+
+	err = utils.AddSecretsWatch(controller, render.VoltronLinseedTLS, installNS)
 	if err != nil {
 		return err
 	}
@@ -89,11 +104,87 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	go utils.WaitToAddLicenseKeyWatch(controller, k8sClient, log, licenseAPIReady)
 	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, controller, k8sClient, log, tierWatchReady)
 	go utils.WaitToAddNetworkPolicyWatches(controller, k8sClient, log, []types.NamespacedName{
-		{Name: render.ManagerPolicyName, Namespace: render.ManagerNamespace},
-		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.ManagerNamespace},
+		{Name: render.ManagerPolicyName, Namespace: installNS},
+		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: installNS},
 	})
 
-	return add(mgr, controller)
+	// Watch for changes to primary resource Manager
+	err = controller.Watch(&source.Kind{Type: &operatorv1.Manager{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("manager-controller failed to watch primary resource: %w", err)
+	}
+
+	err = utils.AddAPIServerWatch(controller)
+	if err != nil {
+		return fmt.Errorf("manager-controller failed to watch APIServer resource: %w", err)
+	}
+
+	err = utils.AddComplianceWatch(controller)
+	if err != nil {
+		return fmt.Errorf("manager-controller failed to watch compliance resource: %w", err)
+	}
+
+	// Watch any secrets that this controller depends upon.
+	for _, namespace := range watchNamespaces {
+		for _, secretName := range []string{
+			render.ManagerTLSSecretName, relasticsearch.PublicCertSecret, render.ElasticsearchManagerUserSecret,
+			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret, render.PacketCaptureServerCert,
+			render.ManagerInternalTLSSecretName, monitor.PrometheusTLSSecretName, certificatemanagement.CASecretName,
+		} {
+			if err = utils.AddSecretsWatch(controller, secretName, namespace); err != nil {
+				return fmt.Errorf("manager-controller failed to watch the secret '%s' in '%s' namespace: %w", secretName, namespace, err)
+			}
+		}
+	}
+
+	// This may or may not exist, it depends on what the OIDC type is in the Authentication CR.
+	if err = utils.AddConfigMapWatch(controller, tigerakvc.StaticWellKnownJWKSConfigMapName, common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("manager-controller failed to watch ConfigMap resource %s: %w", tigerakvc.StaticWellKnownJWKSConfigMapName, err)
+	}
+
+	if err = utils.AddConfigMapWatch(controller, relasticsearch.ClusterConfigConfigMapName, common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("compliance-controller failed to watch the ConfigMap resource: %w", err)
+	}
+
+	if err = utils.AddNetworkWatch(controller); err != nil {
+		return fmt.Errorf("manager-controller failed to watch Network resource: %w", err)
+	}
+
+	if err = imageset.AddImageSetWatch(controller); err != nil {
+		return fmt.Errorf("manager-controller failed to watch ImageSet: %w", err)
+	}
+
+	if err = utils.AddNamespaceWatch(controller, common.TigeraPrometheusNamespace); err != nil {
+		return fmt.Errorf("manager-controller failed to watch the '%s' namespace: %w", common.TigeraPrometheusNamespace, err)
+	}
+
+	// Watch for changes to primary resource ManagementCluster
+	err = controller.Watch(&source.Kind{Type: &operatorv1.ManagementCluster{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("manager-controller failed to watch primary resource: %w", err)
+	}
+
+	// Watch for changes to primary resource ManagementClusterConnection
+	err = controller.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("manager-controller failed to watch primary resource: %w", err)
+	}
+
+	err = controller.Watch(&source.Kind{Type: &operatorv1.Authentication{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("manager-controller failed to watch resource: %w", err)
+	}
+
+	if err = utils.AddConfigMapWatch(controller, render.ECKLicenseConfigMapName, render.ECKOperatorNamespace); err != nil {
+		return fmt.Errorf("manager-controller failed to watch the ConfigMap resource: %v", err)
+	}
+
+	// Watch for changes to TigeraStatus.
+	if err = utils.AddTigeraStatusWatch(controller, ResourceName); err != nil {
+		return fmt.Errorf("manager-controller failed to watch manager Tigerastatus: %w", err)
+	}
+
+	return nil
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -107,97 +198,15 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady
 		licenseAPIReady: licenseAPIReady,
 		tierWatchReady:  tierWatchReady,
 		usePSP:          opts.UsePSP,
+		multiTenant:     opts.MultiTenant,
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
 }
 
-// add adds watches for resources that are available at startup
-func add(mgr manager.Manager, c controller.Controller) error {
-	var err error
-
-	// Watch for changes to primary resource Manager
-	err = c.Watch(&source.Kind{Type: &operatorv1.Manager{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return fmt.Errorf("manager-controller failed to watch primary resource: %w", err)
-	}
-
-	err = utils.AddAPIServerWatch(c)
-	if err != nil {
-		return fmt.Errorf("manager-controller failed to watch APIServer resource: %w", err)
-	}
-
-	err = utils.AddComplianceWatch(c)
-	if err != nil {
-		return fmt.Errorf("manager-controller failed to watch compliance resource: %w", err)
-	}
-
-	// Watch the given secrets in each both the manager and operator namespaces
-	for _, namespace := range []string{common.OperatorNamespace(), render.ManagerNamespace} {
-		for _, secretName := range []string{
-			render.ManagerTLSSecretName, relasticsearch.PublicCertSecret, render.ElasticsearchManagerUserSecret,
-			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret, render.PacketCaptureCertSecret,
-			render.ManagerInternalTLSSecretName, monitor.PrometheusTLSSecretName, certificatemanagement.CASecretName,
-		} {
-			if err = utils.AddSecretsWatch(c, secretName, namespace); err != nil {
-				return fmt.Errorf("manager-controller failed to watch the secret '%s' in '%s' namespace: %w", secretName, namespace, err)
-			}
-		}
-	}
-
-	// This may or may not exist, it depends on what the OIDC type is in the Authentication CR.
-	if err = utils.AddConfigMapWatch(c, tigerakvc.StaticWellKnownJWKSConfigMapName, common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("manager-controller failed to watch ConfigMap resource %s: %w", tigerakvc.StaticWellKnownJWKSConfigMapName, err)
-	}
-
-	if err = utils.AddConfigMapWatch(c, relasticsearch.ClusterConfigConfigMapName, common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("compliance-controller failed to watch the ConfigMap resource: %w", err)
-	}
-
-	if err = utils.AddNetworkWatch(c); err != nil {
-		return fmt.Errorf("manager-controller failed to watch Network resource: %w", err)
-	}
-
-	if err = imageset.AddImageSetWatch(c); err != nil {
-		return fmt.Errorf("manager-controller failed to watch ImageSet: %w", err)
-	}
-
-	if err = utils.AddNamespaceWatch(c, common.TigeraPrometheusNamespace); err != nil {
-		return fmt.Errorf("manager-controller failed to watch the '%s' namespace: %w", common.TigeraPrometheusNamespace, err)
-	}
-
-	// Watch for changes to primary resource ManagementCluster
-	err = c.Watch(&source.Kind{Type: &operatorv1.ManagementCluster{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return fmt.Errorf("manager-controller failed to watch primary resource: %w", err)
-	}
-
-	// Watch for changes to primary resource ManagementClusterConnection
-	err = c.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return fmt.Errorf("manager-controller failed to watch primary resource: %w", err)
-	}
-
-	err = c.Watch(&source.Kind{Type: &operatorv1.Authentication{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return fmt.Errorf("manager-controller failed to watch resource: %w", err)
-	}
-
-	if err = utils.AddConfigMapWatch(c, render.ECKLicenseConfigMapName, render.ECKOperatorNamespace); err != nil {
-		return fmt.Errorf("manager-controller failed to watch the ConfigMap resource: %v", err)
-	}
-
-	// Watch for changes to TigeraStatus.
-	if err = utils.AddTigeraStatusWatch(c, ResourceName); err != nil {
-		return fmt.Errorf("manager-controller failed to watch manager Tigerastatus: %w", err)
-	}
-
-	return nil
-}
-
 var _ reconcile.Reconciler = &ReconcileManager{}
 
-// ReconcileManager reconciles a Manager object
+// ReconcileManager reconciles a Manager object.
 type ReconcileManager struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
@@ -209,13 +218,18 @@ type ReconcileManager struct {
 	licenseAPIReady *utils.ReadyFlag
 	tierWatchReady  *utils.ReadyFlag
 	usePSP          bool
+
+	// Whether or not the operator is running in multi-tenant mode.
+	multiTenant bool
 }
 
 // GetManager returns the default manager instance with defaults populated.
-func GetManager(ctx context.Context, cli client.Client) (*operatorv1.Manager, error) {
+func GetManager(ctx context.Context, cli client.Client, ns string) (*operatorv1.Manager, error) {
+	key := client.ObjectKey{Name: "tigera-secure", Namespace: ns}
+
 	// Fetch the manager instance. We only support a single instance named "tigera-secure".
 	instance := &operatorv1.Manager{}
-	err := cli.Get(ctx, utils.DefaultTSEEInstanceKey, instance)
+	err := cli.Get(ctx, key, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -231,22 +245,37 @@ func GetManager(ctx context.Context, cli client.Client) (*operatorv1.Manager, er
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling Manager")
+	// Perform any common preparation that needs to be done for single-tenant and multi-tenant scenarios.
+	logc := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	logc.Info("Reconciling Manager")
 
-	// Fetch the Manager instance
-	instance, err := GetManager(ctx, r.client)
+	if r.multiTenant && request.Namespace == "" {
+		// For now, if we're running in multi-tenant mode, just skip any non-namespaced triggers.
+		// A potential improvement here would be to reconcile multiple Manager instances.
+		return reconcile.Result{}, nil
+	}
+
+	// In single-tenant mode, the manager is always global scoped. However, for multi-tenant mode
+	// the manager instance will belong to a particualr namespace.
+	ns := ""
+	if r.multiTenant {
+		ns = request.Namespace
+	}
+
+	// Fetch the Manager instance that corresponds with this reconcile trigger.
+	instance, err := GetManager(ctx, r.client, ns)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Info("Manager object not found")
+			logc.Info("Manager object not found")
 			r.status.OnCRNotFound()
 			return reconcile.Result{}, nil
 		}
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying Manager", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying Manager", err, logc)
 		return reconcile.Result{}, err
 	}
-	reqLogger.V(2).Info("Loaded config", "config", instance)
+	logc.V(2).Info("Loaded config", "config", instance)
 	r.status.OnCRFound()
+
 	// SetMetaData in the TigeraStatus such as observedGenerations.
 	defer r.status.SetMetaData(&instance.ObjectMeta)
 
@@ -264,40 +293,41 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	}
 
-	if !utils.IsAPIServerReady(r.client, reqLogger) {
-		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tigera API server to be ready", nil, reqLogger)
+	if !utils.IsAPIServerReady(r.client, logc) {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tigera API server to be ready", nil, logc)
 		return reconcile.Result{}, nil
 	}
 
 	// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
 	if !r.tierWatchReady.IsReady() {
-		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tier watch to be established", nil, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tier watch to be established", nil, logc)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure the allow-tigera tier exists, before rendering any network policies within it.
 	if err := r.client.Get(ctx, client.ObjectKey{Name: networkpolicy.TigeraComponentTierName}, &v3.Tier{}); err != nil {
 		if errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for allow-tigera tier to be created", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for allow-tigera tier to be created", err, logc)
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		} else {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying allow-tigera tier", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying allow-tigera tier", err, logc)
 			return reconcile.Result{}, err
 		}
 	}
 
 	if !r.licenseAPIReady.IsReady() {
-		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for LicenseKeyAPI to be ready", nil, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for LicenseKeyAPI to be ready", nil, logc)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// TODO: Do we need a license per-tenant in the management cluster?
 	license, err := utils.FetchLicenseKey(ctx, r.client)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceNotFound, "License not found", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "License not found", err, logc)
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying license", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying license", err, logc)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
@@ -307,140 +337,180 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	variant, installation, err := utils.GetInstallation(ctx, r.client)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceNotFound, "Installation not found", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "Installation not found", err, logc)
 			return reconcile.Result{}, err
 		}
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying installation", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying installation", err, logc)
 		return reconcile.Result{}, err
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, installation, r.clusterDomain)
+	// Package up the request parameters needed to reconcile
+	common := octrl.NewRequest(request.NamespacedName, r.multiTenant, render.ManagerNamespace)
+	args := ReconcileArgs{
+		Manager:      instance,
+		Variant:      variant,
+		Installation: installation,
+		License:      license,
+	}
+	return r.reconcileInstance(ctx, logc, args, common)
+}
+
+type ReconcileArgs struct {
+	Variant      operatorv1.ProductVariant
+	Installation *operatorv1.InstallationSpec
+	Manager      *operatorv1.Manager
+	License      v3.LicenseKey
+}
+
+func (r *ReconcileManager) reconcileInstance(ctx context.Context, logc logr.Logger, args ReconcileArgs, request octrl.Request) (reconcile.Result, error) {
+	certificateManager, err := certificatemanager.Create(r.client, args.Installation, r.clusterDomain, request.TruthNamespace())
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, logc)
 		return reconcile.Result{}, err
 	}
 
 	// Get or create a certificate for clients of the manager pod es-proxy container.
-	svcDNSNames := append(dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain), "localhost")
+	svcDNSNames := append(dns.GetServiceDNSNames(render.ManagerServiceName, request.InstallNamespace(), r.clusterDomain), "localhost")
 	tlsSecret, err := certificateManager.GetOrCreateKeyPair(
 		r.client,
 		render.ManagerTLSSecretName,
-		common.OperatorNamespace(),
+		request.TruthNamespace(),
 		svcDNSNames)
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting or creating manager TLS certificate", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting or creating manager TLS certificate", err, logc)
 		return reconcile.Result{}, err
 	}
 
 	// Determine if compliance is enabled.
-	complianceLicenseFeatureActive := utils.IsFeatureActive(license, common.ComplianceFeature)
+	complianceLicenseFeatureActive := utils.IsFeatureActive(args.License, common.ComplianceFeature)
 	complianceCR, err := compliance.GetCompliance(ctx, r.client)
 	if err != nil && !errors.IsNotFound(err) {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying compliance: ", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying compliance: ", err, logc)
 		return reconcile.Result{}, err
 	}
 
 	// Build a trusted bundle containing all of the certificates of components that communicate with the manager pod.
 	// This bundle contains the root CA used to sign all operator-generated certificates, as well as the explicitly named
 	// certificates, in case the user has provided their own cert in lieu of the default certificate.
-	trustedSecretNames := []string{
-		render.PacketCaptureCertSecret,
-		monitor.PrometheusTLSSecretName,
-		relasticsearch.PublicCertSecret,
-		render.ProjectCalicoAPIServerTLSSecretName(installation.Variant),
-		render.TigeraLinseedSecret,
-	}
-	if complianceLicenseFeatureActive && complianceCR != nil {
-		// Check that compliance is running.
-		if complianceCR.Status.State != operatorv1.TigeraStatusReady {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, "Compliance is not ready", nil, reqLogger)
-			return reconcile.Result{}, nil
+	var authenticationCR *operatorv1.Authentication
+	var trustedSecretNames []string
+	if !r.multiTenant {
+		// For multi-tenant systems, we don't support user-provided certs for all components. So, we don't need to include these,
+		// and the bundle will simply use the root CA for the tenant. For single-tenant systems, we need to include these in case
+		// any of them haven't been signed by the root CA.
+		trustedSecretNames = []string{
+			render.PacketCaptureServerCert,
+			monitor.PrometheusTLSSecretName,
+			relasticsearch.PublicCertSecret,
+			render.ProjectCalicoAPIServerTLSSecretName(args.Installation.Variant),
+			render.TigeraLinseedSecret,
 		}
-		trustedSecretNames = append(trustedSecretNames, render.ComplianceServerCertSecret)
+
+		if complianceLicenseFeatureActive && complianceCR != nil {
+			// Check that compliance is running.
+			if complianceCR.Status.State != operatorv1.TigeraStatusReady {
+				r.status.SetDegraded(operatorv1.ResourceNotReady, "Compliance is not ready", nil, logc)
+				return reconcile.Result{}, nil
+			}
+			trustedSecretNames = append(trustedSecretNames, render.ComplianceServerCertSecret)
+		}
+
+		// Fetch the Authentication spec. If present, we use to configure user authentication.
+		authenticationCR, err = utils.GetAuthentication(ctx, r.client)
+		if err != nil && !errors.IsNotFound(err) {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error while fetching Authentication", err, logc)
+			return reconcile.Result{}, err
+		}
+		if authenticationCR != nil && authenticationCR.Status.State != operatorv1.TigeraStatusReady {
+			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Authentication is not ready authenticationCR status: %s", authenticationCR.Status.State), nil, logc)
+			return reconcile.Result{}, nil
+		} else if authenticationCR != nil {
+			trustedSecretNames = append(trustedSecretNames, render.DexTLSSecretName)
+		}
 	}
 
-	// Fetch the Authentication spec. If present, we use to configure user authentication.
-	authenticationCR, err := utils.GetAuthentication(ctx, r.client)
-	if err != nil && !errors.IsNotFound(err) {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error while fetching Authentication", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-	if authenticationCR != nil && authenticationCR.Status.State != operatorv1.TigeraStatusReady {
-		r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Authentication is not ready authenticationCR status: %s", authenticationCR.Status.State), nil, reqLogger)
-		return reconcile.Result{}, nil
-	} else if authenticationCR != nil {
-		trustedSecretNames = append(trustedSecretNames, render.DexTLSSecretName)
-	}
-
+	// TODO: Trusted bundle for all components will be in the same namespace for multi-tenancy.
+	// So, we'll need to refactor this. I think for multi-tenancy, we can simplify the trusted-bundle generation
+	// altogether so that we only ever need a single cert for it. In single-tenant, we need more complexity in order
+	// to support BYO certs.
+	//
+	// That said, it's probably a good idea to move certificate management to its own controller anyway so that
+	// it's not so scattered!
 	trustedBundle := certificateManager.CreateTrustedBundle()
-	for _, secretName := range trustedSecretNames {
-		certificate, err := certificateManager.GetCertificate(r.client, secretName, common.OperatorNamespace())
+	for _, secret := range trustedSecretNames {
+		certificate, err := certificateManager.GetCertificate(r.client, secret, request.TruthNamespace())
 		if err != nil {
-			r.status.SetDegraded(operatorv1.CertificateError, fmt.Sprintf("Failed to retrieve %s", secretName), err, reqLogger)
+			r.status.SetDegraded(operatorv1.CertificateError, fmt.Sprintf("Failed to retrieve %s", secret), err, logc)
 			return reconcile.Result{}, err
 		} else if certificate == nil {
-			reqLogger.Info(fmt.Sprintf("Waiting for secret '%s' to become available", secretName))
-			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret '%s' to become available", secretName), nil, reqLogger)
+			logc.Info(fmt.Sprintf("Waiting for secret '%s' to become available", secret))
+			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret '%s' to become available", secret), nil, logc)
 			return reconcile.Result{}, nil
 		}
 		trustedBundle.AddCertificates(certificate)
 	}
-	certificateManager.AddToStatusManager(r.status, render.ManagerNamespace)
+	certificateManager.AddToStatusManager(r.status, request.InstallNamespace())
 
 	// Check that Prometheus is running
+	// TODO: We'll need to run an instance of Prometheus per-tenant? Or do we use labels to delimit metrics?
+	//       Probably the former.
 	ns := &corev1.Namespace{}
 	if err = r.client.Get(ctx, client.ObjectKey{Name: common.TigeraPrometheusNamespace}, ns); err != nil {
 		if errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceNotFound, "tigera-prometheus namespace does not exist Dependency on tigera-prometheus not satisfied", nil, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "tigera-prometheus namespace does not exist Dependency on tigera-prometheus not satisfied", nil, logc)
 		} else {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying prometheus", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying prometheus", err, logc)
 		}
 		return reconcile.Result{}, err
 	}
 
-	pullSecrets, err := utils.GetNetworkingPullSecrets(installation, r.client)
+	pullSecrets, err := utils.GetNetworkingPullSecrets(args.Installation, r.client)
 	if err != nil {
 		log.Error(err, "Error with Pull secrets")
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error retrieving pull secrets", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error retrieving pull secrets", err, logc)
 		return reconcile.Result{}, err
 	}
 
-	esClusterConfig, err := utils.GetElasticsearchClusterConfig(context.Background(), r.client)
+	clusterConfig, err := utils.GetElasticsearchClusterConfig(context.Background(), r.client)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceNotFound, "Elasticsearch cluster configuration is not available, waiting for it to become available", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "Elasticsearch cluster configuration is not available, waiting for it to become available", err, logc)
 			return reconcile.Result{}, nil
 		}
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get the elasticsearch cluster configuration", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get the elasticsearch cluster configuration", err, logc)
 		return reconcile.Result{}, err
 	}
 
-	// Get secrets used by the manager to authenticate with Elasticsearch.
-	esSecrets, err := utils.ElasticsearchSecrets(ctx, []string{render.ElasticsearchManagerUserSecret}, r.client)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceNotFound, "Elasticsearch secrets are not available yet, waiting until they become available", err, reqLogger)
-			return reconcile.Result{}, nil
+	var esSecrets []*corev1.Secret
+	if !r.multiTenant {
+		// Get secrets used by the manager to authenticate with Elasticsearch. This is used for Kibana login, and isn't
+		// needed for multi-tenant installations since currently Kibana is not supported in that mode.
+		esSecrets, err = utils.ElasticsearchSecrets(ctx, []string{render.ElasticsearchManagerUserSecret}, r.client)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				r.status.SetDegraded(operatorv1.ResourceNotFound, "Elasticsearch secrets are not available yet, waiting until they become available", err, logc)
+				return reconcile.Result{}, nil
+			}
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch credentials", err, logc)
+			return reconcile.Result{}, err
 		}
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch credentials", err, reqLogger)
-		return reconcile.Result{}, err
 	}
 
 	managementCluster, err := utils.GetManagementCluster(ctx, r.client)
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementCluster", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementCluster", err, logc)
 		return reconcile.Result{}, err
 	}
 
 	managementClusterConnection, err := utils.GetManagementClusterConnection(ctx, r.client)
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementClusterConnection", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementClusterConnection", err, logc)
 		return reconcile.Result{}, err
 	}
 
 	if managementClusterConnection != nil && managementCluster != nil {
 		err = fmt.Errorf("having both a ManagementCluster and a ManagementClusterConnection is not supported")
-		r.status.SetDegraded(operatorv1.ResourceValidationError, "", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "", err, logc)
 		return reconcile.Result{}, err
 	}
 
@@ -454,7 +524,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		// Write the discovered configuration back to the API. This is essentially a poor-man's defaulting, and
 		// ensures that we don't surprise anyone by changing defaults in a future version of the operator.
 		if err := r.client.Patch(ctx, managementCluster, preDefaultPatchFrom); err != nil {
-			r.status.SetDegraded(operatorv1.ResourceUpdateError, "", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceUpdateError, "", err, logc)
 			return reconcile.Result{}, err
 		}
 
@@ -464,58 +534,60 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		linseedVoltronSecret, err = certificateManager.GetOrCreateKeyPair(
 			r.client,
 			render.VoltronLinseedTLS,
-			common.OperatorNamespace(),
+			request.TruthNamespace(),
 			linseedDNSNames)
 		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting or creating Voltron Linseed TLS certificate", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting or creating Voltron Linseed TLS certificate", err, logc)
 			return reconcile.Result{}, err
 		}
 
 		// We expect that the secret that holds the certificates for tunnel certificate generation
-		// is already created by the Api Server
-		tunnelSecret, err = certificateManager.GetKeyPair(r.client, render.VoltronTunnelSecretName, common.OperatorNamespace())
+		// is already created by the API server.
+		// TODO: Need to make sure this secret is generated in per-tenant namespace by the tigera-apiserver.
+		tunnelSecret, err = certificateManager.GetKeyPair(r.client, render.VoltronTunnelSecretName, request.TruthNamespace())
 		if tunnelSecret == nil {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret %s in namespace %s to be available", render.VoltronTunnelSecretName, common.OperatorNamespace()), nil, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret %s in namespace %s to be available", render.VoltronTunnelSecretName, request.TruthNamespace()), nil, logc)
 			return reconcile.Result{}, err
 		} else if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.VoltronTunnelSecretName, common.OperatorNamespace()), err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.VoltronTunnelSecretName, request.TruthNamespace()), err, logc)
 			return reconcile.Result{}, nil
 		}
 
 		// We expect that the secret that holds the certificates for internal communication within the management
-		// K8S cluster is already created by the KubeControllers
-		internalTrafficSecret, err = certificateManager.GetKeyPair(r.client, render.ManagerInternalTLSSecretName, common.OperatorNamespace())
+		// cluster is already created by kube-controllers.
+		internalTrafficSecret, err = certificateManager.GetKeyPair(r.client, render.ManagerInternalTLSSecretName, request.TruthNamespace())
 		if internalTrafficSecret == nil {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret %s in namespace %s to be available", render.ManagerInternalTLSSecretName, common.OperatorNamespace()), nil, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret %s in namespace %s to be available", render.ManagerInternalTLSSecretName, request.TruthNamespace()), nil, logc)
 			return reconcile.Result{}, err
 		} else if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.ManagerInternalTLSSecretName, common.OperatorNamespace()), err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.ManagerInternalTLSSecretName, request.TruthNamespace()), err, logc)
 			return reconcile.Result{}, nil
 		}
+
 		// Es-proxy needs to trust Voltron for cross-cluster requests.
 		trustedBundle.AddCertificates(internalTrafficSecret)
 	}
 
 	keyValidatorConfig, err := utils.GetKeyValidatorConfig(ctx, r.client, authenticationCR, r.clusterDomain)
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceValidationError, "Failed to process the authentication CR.", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "Failed to process the authentication CR.", err, logc)
 		return reconcile.Result{}, err
 	}
 
 	var elasticLicenseType render.ElasticsearchLicenseType
 	if managementClusterConnection == nil {
-		if elasticLicenseType, err = utils.GetElasticLicenseType(ctx, r.client, reqLogger); err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch license", err, reqLogger)
+		if elasticLicenseType, err = utils.GetElasticLicenseType(ctx, r.client, logc); err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch license", err, logc)
 			return reconcile.Result{}, err
 		}
 	}
 
 	// Create a component handler to manage the rendered component.
-	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
+	handler := utils.NewComponentHandler(log, r.client, r.scheme, args.Manager)
 
 	// Set replicas to 1 for management or managed clusters.
 	// TODO Remove after MCM tigera-manager HA deployment is supported.
-	var replicas *int32 = installation.ControlPlaneReplicas
+	var replicas *int32 = args.Installation.ControlPlaneReplicas
 	if managementCluster != nil || managementClusterConnection != nil {
 		var mcmReplicas int32 = 1
 		replicas = &mcmReplicas
@@ -525,12 +597,12 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		KeyValidatorConfig:      keyValidatorConfig,
 		ESSecrets:               esSecrets,
 		TrustedCertBundle:       trustedBundle,
-		ESClusterConfig:         esClusterConfig,
+		ClusterConfig:           clusterConfig,
 		TLSKeyPair:              tlsSecret,
 		VoltronLinseedKeyPair:   linseedVoltronSecret,
 		PullSecrets:             pullSecrets,
 		Openshift:               r.provider == operatorv1.ProviderOpenShift,
-		Installation:            installation,
+		Installation:            args.Installation,
 		ManagementCluster:       managementCluster,
 		TunnelSecret:            tunnelSecret,
 		InternalTrafficSecret:   internalTrafficSecret,
@@ -540,26 +612,42 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		Compliance:              complianceCR,
 		ComplianceLicenseActive: complianceLicenseFeatureActive,
 		UsePSP:                  r.usePSP,
+		Namespace:               request.InstallNamespace(),
+		MultiTenant:             r.multiTenant,
 	}
 
 	// Render the desired objects from the CRD and create or update them.
 	component, err := render.Manager(managerCfg)
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceRenderingError, "Error rendering Manager", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceRenderingError, "Error rendering Manager", err, logc)
+		return reconcile.Result{}, err
+	}
+	clusterScopedComponent, err := render.ManagerClusterScoped(managerCfg, []string{request.InstallNamespace()}) // TODO: All namespaces.
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceRenderingError, "Error rendering Manager", err, logc)
 		return reconcile.Result{}, err
 	}
 
-	if err = imageset.ApplyImageSet(ctx, r.client, variant, component); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
+	if err = imageset.ApplyImageSet(ctx, r.client, args.Variant, component); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, logc)
 		return reconcile.Result{}, err
 	}
 
 	components := []render.Component{
 		component,
+		clusterScopedComponent,
 		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       render.ManagerNamespace,
+			Namespace:       request.InstallNamespace(),
+			TruthNamespace:  request.TruthNamespace(),
 			ServiceAccounts: []string{render.ManagerServiceAccount},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+				// We need to render the certificate manager CA cert again in case we're running in multi-tenant mode.
+				// For single-tenant, this cert is created once by the core controller. For multi-tenant, we
+				// provision a unique CA per-tenant, and so we need to make sure to create it here.
+				//
+				// TODO: We probably want a separate tenant controller managing the creation of of this instead, so
+				// that individual controllers don't need to do this.
+				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
 				rcertificatemanagement.NewKeyPairOption(tlsSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(linseedVoltronSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(internalTrafficSecret, false, true),
@@ -570,16 +658,16 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 	for _, component := range components {
 		if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
-			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, logc)
 			return reconcile.Result{}, err
 		}
 	}
 
 	// Clear the degraded bit if we've reached this far.
 	r.status.ClearDegraded()
-	instance.Status.State = operatorv1.TigeraStatusReady
+	args.Manager.Status.State = operatorv1.TigeraStatusReady
 	if r.status.IsAvailable() {
-		if err = r.client.Status().Update(ctx, instance); err != nil {
+		if err = r.client.Status().Update(ctx, args.Manager); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -257,7 +257,7 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	}
 
-	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain)
+	certificateManager, err := certificatemanager.Create(r.client, install, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -34,6 +34,11 @@ type AddOptions struct {
 	ManageCRDs          bool
 	ShutdownContext     context.Context
 
+	// Whether or not the operator is running in multi-tenant mode.
+	// When true, this means some CRDs are installed as namespace scoped
+	// instead of cluster scoped.
+	MultiTenant bool
+
 	// Whether or not the cluster supports PodSecurityPolicies.
 	UsePSP bool
 }

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -99,7 +99,6 @@ func newReconciler(
 	licenseAPIReady *utils.ReadyFlag,
 	tierWatchReady *utils.ReadyFlag,
 ) reconcile.Reconciler {
-
 	r := &ReconcilePolicyRecommendation{
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
@@ -366,7 +365,7 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 	}
 
 	if !isManagedCluster {
-		certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain)
+		certificateManager, err := certificatemanager.Create(r.client, network, r.clusterDomain, common.OperatorNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/controller/request.go
+++ b/pkg/controller/request.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"github.com/tigera/operator/pkg/common"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func NewRequest(r types.NamespacedName, mt bool, defaultNS string) Request {
+	return Request{
+		NamespacedName:        r,
+		multiTenant:           mt,
+		singleTenantNamespace: defaultNS,
+	}
+}
+
+// Request wraps a standard request and provides utilities to support both
+// single and multi-tenant operator modes.
+type Request struct {
+	// The name and namespace of the object that triggered this request.
+	types.NamespacedName
+
+	// Whether the operator is running in multi-tenant or single-tenant mode.
+	multiTenant bool
+
+	// The namespace to use for single-tenant installations of this component.
+	singleTenantNamespace string
+}
+
+// InstallNamespace returns the namespace that components will be installed into.
+// for single-tenant clusters, this is tigera-manager. For multi-tenancy, this
+// will be the tenant's namespace.
+func (r *Request) InstallNamespace() string {
+	if !r.multiTenant {
+		return r.singleTenantNamespace
+	}
+	return r.NamespacedName.Namespace
+}
+
+// TruthNamespace returns the namespace to use as the source of truth for storing data.
+// For single-tenant installs, this is the tigera-operator namespace.
+// For multi-tenant installs, this is tenant's namespace.
+func (r *Request) TruthNamespace() string {
+	if !r.multiTenant {
+		return common.OperatorNamespace()
+	}
+	return r.NamespacedName.Namespace
+}

--- a/pkg/controller/utils/auth.go
+++ b/pkg/controller/utils/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import (
 func GetKeyValidatorConfig(ctx context.Context, cli client.Client, authenticationCR *operatorv1.Authentication, clusterDomain string) (rauth.KeyValidatorConfig, error) {
 	var keyValidatorConfig rauth.KeyValidatorConfig
 	if authenticationCR != nil {
-		idpSecret, err := GetIdpSecret(ctx, cli, authenticationCR)
+		idpSecret, err := GetIDPSecret(ctx, cli, authenticationCR)
 		if err != nil {
 			return nil, err
 		}
@@ -73,9 +73,9 @@ func GetKeyValidatorConfig(ctx context.Context, cli client.Client, authenticatio
 	return keyValidatorConfig, nil
 }
 
-// GetIdpSecret retrieves the Secret containing sensitive information for the configuration IdP specified in the given
+// GetIDPSecret retrieves the Secret containing sensitive information for the configuration IdP specified in the given
 // operatorv1.Authentication CR.
-func GetIdpSecret(ctx context.Context, client client.Client, authentication *operatorv1.Authentication) (*corev1.Secret, error) {
+func GetIDPSecret(ctx context.Context, client client.Client, authentication *operatorv1.Authentication) (*corev1.Secret, error) {
 	var secretName string
 	var requiredFields []string
 	if authentication.Spec.OIDC != nil {

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -136,7 +136,7 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 		logCtx.Info("Ignoring annotated object")
 		return nil
 	}
-	logCtx.V(1).Info("Resource already exists, update it")
+	logCtx.V(2).Info("Resource already exists, update it")
 
 	// if mergeState returns nil we don't want to update the object
 	if mobj := mergeState(obj, cur); mobj != nil {

--- a/pkg/controller/utils/elasticsearch.go
+++ b/pkg/controller/utils/elasticsearch.go
@@ -80,7 +80,7 @@ func ElasticsearchSecrets(ctx context.Context, userSecretNames []string, cli cli
 		esUserSecret := &corev1.Secret{}
 		err := cli.Get(ctx, types.NamespacedName{
 			Name:      userSecretName,
-			Namespace: common.OperatorNamespace(),
+			Namespace: common.OperatorNamespace(), // TODO
 		}, esUserSecret)
 		if err != nil {
 			return nil, err
@@ -341,7 +341,7 @@ func extractPolicyDetails(policy map[string]interface{}) (string, string, string
 
 func getTotalEsDisk(ls *operatorv1.LogStorage) int64 {
 	defaultStorage := resource.MustParse(fmt.Sprintf("%dGi", render.DefaultElasticStorageGi))
-	var totalEsStorage = defaultStorage.Value()
+	totalEsStorage := defaultStorage.Value()
 	if ls.Spec.Nodes.ResourceRequirements != nil {
 		if val, ok := ls.Spec.Nodes.ResourceRequirements.Requests["storage"]; ok {
 			totalEsStorage = val.Value()

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -57,9 +57,11 @@ const (
 	unsupportedIgnoreAnnotation = "unsupported.operator.tigera.io/ignore"
 )
 
-var DefaultInstanceKey = client.ObjectKey{Name: "default"}
-var DefaultTSEEInstanceKey = client.ObjectKey{Name: "tigera-secure"}
-var OverlayInstanceKey = client.ObjectKey{Name: "overlay"}
+var (
+	DefaultInstanceKey     = client.ObjectKey{Name: "default"}
+	DefaultTSEEInstanceKey = client.ObjectKey{Name: "tigera-secure"}
+	OverlayInstanceKey     = client.ObjectKey{Name: "overlay"}
+)
 
 // ContextLoggerForResource provides a logger instance with context set for the provided object.
 func ContextLoggerForResource(log logr.Logger, obj client.Object) logr.Logger {
@@ -180,9 +182,6 @@ func WaitToAddTierWatch(tierName string, controller controller.Controller, c kub
 // will be generated.
 func AddNamespacedWatch(c controller.Controller, obj client.Object, metaMatches ...MetaMatch) error {
 	objMeta := obj.(metav1.ObjectMetaAccessor).GetObjectMeta()
-	if objMeta.GetNamespace() == "" {
-		return fmt.Errorf("No namespace provided for namespaced watch")
-	}
 	pred := createPredicateForObject(objMeta)
 	return c.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}, pred)
 }
@@ -493,17 +492,23 @@ func WaitToAddResourceWatch(controller controller.Controller, c kubernetes.Inter
 			duration = maxDuration
 		}
 		ticker.Reset(duration)
+
 		for obj := range resourcesToWatch {
 			objLog := resourcesToWatch[obj].logger
 			predicateFn := resourcesToWatch[obj].predicate
 			if ok, err := isCalicoResourceReady(c, obj.GetObjectKind().GroupVersionKind().Kind); err != nil {
-				objLog.WithValues("Error", err).Info("Failed to check if resource is ready - will retry")
+				msg := "Failed to check if resource is ready - will retry"
+				if errors.IsNotFound(err) {
+					objLog.WithValues("Error", err).V(2).Info(msg)
+				} else {
+					objLog.WithValues("Error", err).Info(msg)
+				}
 			} else if !ok {
 				objLog.Info("Waiting for resource to be ready - will retry")
 			} else if err := controller.Watch(&source.Kind{Type: obj}, &handler.EnqueueRequestForObject{}, predicateFn); err != nil {
 				objLog.WithValues("Error", err).Info("Failed to watch resource - will retry")
 			} else {
-				objLog.Info("Successfully watching resource")
+				objLog.V(2).Info("Successfully watching resource")
 				delete(resourcesToWatch, obj)
 			}
 		}

--- a/pkg/render/certificatemanagement/certificatemanagement.go
+++ b/pkg/render/certificatemanagement/certificatemanagement.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package certificatemanagement
 
 import (
@@ -13,6 +27,11 @@ import (
 func CertificateManagement(
 	cfg *Config,
 ) render.Component {
+	if cfg.TruthNamespace == "" {
+		// Default to the "tigera-operator" namespace, that has
+		// been traditionally used as the source-of-truth for secrets.
+		cfg.TruthNamespace = common.OperatorNamespace()
+	}
 	return &component{
 		cfg: cfg,
 	}
@@ -24,21 +43,26 @@ type Config struct {
 	ServiceAccounts []string
 	KeyPairOptions  []KeyPairOption
 	Namespace       string
+	TruthNamespace  string
 	TrustedBundle   certificatemanagement.TrustedBundle
 }
 
-func NewKeyPairOption(keyPair certificatemanagement.KeyPairInterface, renderInOperatorNamespace, renderInNamespace bool) KeyPairOption {
+func NewKeyPairOption(keyPair certificatemanagement.KeyPairInterface, renderInTruthNS, renderInAppNS bool) KeyPairOption {
 	return KeyPairOption{
-		keyPair:                   keyPair,
-		renderInOperatorNamespace: renderInOperatorNamespace,
-		renderInNamespace:         renderInNamespace,
+		keyPair:                keyPair,
+		renderInTruthNamespace: renderInTruthNS,
+		renderInAppNamespace:   renderInAppNS,
 	}
 }
 
 type KeyPairOption struct {
-	keyPair                   certificatemanagement.KeyPairInterface
-	renderInOperatorNamespace bool
-	renderInNamespace         bool
+	keyPair certificatemanagement.KeyPairInterface
+
+	// Whether or not we should install this in the "source of truth" namespace.
+	renderInTruthNamespace bool
+
+	// Whether or not we should install this into the application namespace.
+	renderInAppNamespace bool
 }
 
 type component struct {
@@ -51,30 +75,38 @@ func (c component) ResolveImages(*operatorv1.ImageSet) error {
 
 func (c component) Objects() (objsToCreate, objsToDelete []client.Object) {
 	if c.cfg.TrustedBundle != nil {
+		// Create the trusted bundle in the namespace that we're installing into.
 		objsToCreate = append(objsToCreate, c.cfg.TrustedBundle.ConfigMap(c.cfg.Namespace))
 	}
+
+	// Iterate each KeyPair and create it where needed. A KeyPair may need to be installed one or more of:
+	// - The "source of truth" namespace, commonly tigera-operator.
+	// - The target namespace that we're installing into.
 	var needsCSRRoleAndBinding bool
 	for _, keyPairCreator := range c.cfg.KeyPairOptions {
 		keyPair := keyPairCreator.keyPair
-		if keyPair != nil {
-			if keyPair.UseCertificateManagement() {
-				if keyPairCreator.renderInOperatorNamespace {
-					objsToDelete = append(objsToDelete, keyPair.Secret(common.OperatorNamespace()))
-				}
-				if keyPairCreator.renderInNamespace {
-					objsToDelete = append(objsToDelete, keyPair.Secret(c.cfg.Namespace))
-				}
-				needsCSRRoleAndBinding = true
-			} else {
-				if keyPairCreator.renderInOperatorNamespace && (!keyPair.BYO() || keyPair.GetName() == certificatemanagement.CASecretName) {
-					objsToCreate = append(objsToCreate, keyPair.Secret(common.OperatorNamespace()))
-				}
-				if keyPairCreator.renderInNamespace {
-					objsToCreate = append(objsToCreate, keyPair.Secret(c.cfg.Namespace))
-				}
+		if keyPair == nil {
+			continue
+		}
+
+		if keyPair.UseCertificateManagement() {
+			if keyPairCreator.renderInTruthNamespace {
+				objsToDelete = append(objsToDelete, keyPair.Secret(c.cfg.TruthNamespace))
+			}
+			if keyPairCreator.renderInAppNamespace {
+				objsToDelete = append(objsToDelete, keyPair.Secret(c.cfg.Namespace))
+			}
+			needsCSRRoleAndBinding = true
+		} else {
+			if keyPairCreator.renderInTruthNamespace && (!keyPair.BYO() || keyPair.GetName() == certificatemanagement.CASecretName) {
+				objsToCreate = append(objsToCreate, keyPair.Secret(c.cfg.TruthNamespace))
+			}
+			if keyPairCreator.renderInAppNamespace {
+				objsToCreate = append(objsToCreate, keyPair.Secret(c.cfg.Namespace))
 			}
 		}
 	}
+
 	if needsCSRRoleAndBinding {
 		for _, sa := range c.cfg.ServiceAccounts {
 			objsToCreate = append(objsToCreate, certificatemanagement.CSRClusterRoleBinding(sa, c.cfg.Namespace))

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -125,11 +125,12 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		c.service(),
 		secret.CopyToNamespace(GuardianNamespace, c.cfg.TunnelSecret)[0],
 		c.cfg.TrustedCertBundle.ConfigMap(GuardianNamespace),
-		// Add tigera-manager service account for impersonation
+		// Add tigera-manager service account for impersonation. In managed clusters, the tigera-manager
+		// service account is always within the tigera-manager namespace - regardless of (multi)tenancy mode.
 		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
-		managerServiceAccount(),
+		managerServiceAccount(ManagerNamespace),
 		managerClusterRole(false, true, c.cfg.UsePSP),
-		managerClusterRoleBinding(),
+		managerClusterRoleBinding([]string{ManagerNamespace}),
 		managerClusterWideSettingsGroup(),
 		managerUserSpecificSettingsGroup(),
 		managerClusterWideTigeraLayer(),

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -87,10 +87,45 @@ const (
 )
 
 var (
-	ManagerEntityRule       = networkpolicy.CreateEntityRule(ManagerNamespace, ManagerDeploymentName, managerPort)
-	ManagerSourceEntityRule = networkpolicy.CreateSourceEntityRule(ManagerNamespace, ManagerDeploymentName)
+	// TODO: NetworkPolicy rules will need to be generated dynamically for each namespace.
+	// Each tenant will need its own policies to ensure only its own components within its namespace can talk.
+	ManagerEntityRule       = networkpolicy.CreateEntityRule("tigera-manager", ManagerDeploymentName, managerPort)
+	ManagerSourceEntityRule = networkpolicy.CreateSourceEntityRule("tigera-manager", ManagerDeploymentName)
 )
 
+// ManagerClusterScoped returns a component for rendering cluster-scoped manager resources.
+func ManagerClusterScoped(cfg *ManagerConfiguration, namespaces []string) (Component, error) {
+	return &managerClusterScopedComponent{
+		cfg:        cfg,
+		namespaces: namespaces,
+	}, nil
+}
+
+type managerClusterScopedComponent struct {
+	cfg        *ManagerConfiguration
+	namespaces []string
+}
+
+func (m *managerClusterScopedComponent) ResolveImages(is *operatorv1.ImageSet) error {
+	return nil
+}
+
+func (m *managerClusterScopedComponent) Objects() (objsToCreate []client.Object, objsToDelete []client.Object) {
+	objs := []client.Object{
+		managerClusterRoleBinding(m.namespaces),
+	}
+	return objs, nil
+}
+
+func (m *managerClusterScopedComponent) Ready() bool {
+	return true
+}
+
+func (m *managerClusterScopedComponent) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeLinux
+}
+
+// Manager returns a component for rendering namespaced manager resources.
 func Manager(cfg *ManagerConfiguration) (Component, error) {
 	var tlsSecrets []*corev1.Secret
 	tlsAnnotations := cfg.TrustedCertBundle.HashAnnotations()
@@ -101,7 +136,7 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 	}
 
 	if cfg.KeyValidatorConfig != nil {
-		tlsSecrets = append(tlsSecrets, cfg.KeyValidatorConfig.RequiredSecrets(ManagerNamespace)...)
+		tlsSecrets = append(tlsSecrets, cfg.KeyValidatorConfig.RequiredSecrets(cfg.Namespace)...)
 		for key, value := range cfg.KeyValidatorConfig.RequiredAnnotations() {
 			tlsAnnotations[key] = value
 		}
@@ -111,6 +146,7 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 		tlsAnnotations[cfg.InternalTrafficSecret.HashAnnotationKey()] = cfg.InternalTrafficSecret.HashAnnotationValue()
 		tlsAnnotations[cfg.TunnelSecret.HashAnnotationKey()] = cfg.InternalTrafficSecret.HashAnnotationValue()
 	}
+
 	return &managerComponent{
 		cfg:            cfg,
 		tlsSecrets:     tlsSecrets,
@@ -122,7 +158,7 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 type ManagerConfiguration struct {
 	KeyValidatorConfig authentication.KeyValidatorConfig
 	ESSecrets          []*corev1.Secret
-	ESClusterConfig    *relasticsearch.ClusterConfig
+	ClusterConfig      *relasticsearch.ClusterConfig
 	PullSecrets        []*corev1.Secret
 	Openshift          bool
 	Installation       *operatorv1.InstallationSpec
@@ -153,7 +189,11 @@ type ManagerConfiguration struct {
 	ComplianceLicenseActive bool
 
 	// Whether the cluster supports pod security policies.
-	UsePSP bool
+	UsePSP    bool
+	Namespace string
+
+	// Whether or not to run the rendered components in multi-tenant mode.
+	MultiTenant bool
 }
 
 type managerComponent struct {
@@ -198,16 +238,17 @@ func (c *managerComponent) SupportedOSType() rmeta.OSType {
 
 func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{
-		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
+		// TODO: The namespace should be pre-created in multi-tenant environments.
+		// Maybe we should do this for single-tenant as well, to keep them more similar?
+		CreateNamespace(c.cfg.Namespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 		c.managerAllowTigeraNetworkPolicy(),
-		networkpolicy.AllowTigeraDefaultDeny(ManagerNamespace),
+		networkpolicy.AllowTigeraDefaultDeny(c.cfg.Namespace),
 	}
-	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ManagerNamespace, c.cfg.PullSecrets...)...)...)
+	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(c.cfg.Namespace, c.cfg.PullSecrets...)...)...)
 
 	objs = append(objs,
-		managerServiceAccount(),
+		managerServiceAccount(c.cfg.Namespace),
 		managerClusterRole(c.cfg.ManagementCluster != nil, false, c.cfg.UsePSP),
-		managerClusterRoleBinding(),
 		managerClusterWideSettingsGroup(),
 		managerUserSpecificSettingsGroup(),
 		managerClusterWideTigeraLayer(),
@@ -226,10 +267,10 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	if c.cfg.UsePSP {
 		objs = append(objs, c.managerPodSecurityPolicy())
 	}
-	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ManagerNamespace, c.cfg.ESSecrets...)...)...)
+	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(c.cfg.Namespace, c.cfg.ESSecrets...)...)...)
 	objs = append(objs, c.managerDeployment())
 	if c.cfg.KeyValidatorConfig != nil {
-		objs = append(objs, configmap.ToRuntimeObjects(c.cfg.KeyValidatorConfig.RequiredConfigMaps(ManagerNamespace)...)...)
+		objs = append(objs, configmap.ToRuntimeObjects(c.cfg.KeyValidatorConfig.RequiredConfigMaps(c.cfg.Namespace)...)...)
 	}
 
 	// The following secret is read by kube controllers and sent to managed clusters so that linseed clients in the managed cluster
@@ -253,13 +294,22 @@ func (c *managerComponent) Ready() bool {
 func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 	var initContainers []corev1.Container
 	if c.cfg.TLSKeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(ManagerNamespace))
+		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(c.cfg.Namespace))
+	}
+
+	// Containers for the manager pod.
+	managerContainer := c.managerContainer()
+	esProxyContainer := c.managerEsProxyContainer()
+	if !c.cfg.MultiTenant {
+		// If we're running in multi-tenant mode, we don't need ES credentials as these are used for Kibana login. Otherwise, add them.
+		managerContainer = relasticsearch.ContainerDecorate(managerContainer, c.cfg.ClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.cfg.ClusterDomain, c.SupportedOSType())
+		esProxyContainer = relasticsearch.ContainerDecorate(esProxyContainer, c.cfg.ClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.cfg.ClusterDomain, c.SupportedOSType())
 	}
 
 	podTemplate := relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ManagerDeploymentName,
-			Namespace:   ManagerNamespace,
+			Namespace:   c.cfg.Namespace,
 			Annotations: c.tlsAnnotations,
 		},
 		Spec: corev1.PodSpec{
@@ -268,24 +318,20 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 			Tolerations:        c.managerTolerations(),
 			ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 			InitContainers:     initContainers,
-			Containers: []corev1.Container{
-				relasticsearch.ContainerDecorate(c.managerContainer(), c.cfg.ESClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.cfg.ClusterDomain, c.SupportedOSType()),
-				relasticsearch.ContainerDecorate(c.managerEsProxyContainer(), c.cfg.ESClusterConfig.ClusterName(), ElasticsearchManagerUserSecret, c.cfg.ClusterDomain, c.SupportedOSType()),
-				c.voltronContainer(),
-			},
-			Volumes: c.managerVolumes(),
+			Containers:         []corev1.Container{managerContainer, esProxyContainer, c.voltronContainer()},
+			Volumes:            c.managerVolumes(),
 		},
-	}, c.cfg.ESClusterConfig, c.cfg.ESSecrets).(*corev1.PodTemplateSpec)
+	}, c.cfg.ClusterConfig, c.cfg.ESSecrets).(*corev1.PodTemplateSpec)
 
 	if c.cfg.Replicas != nil && *c.cfg.Replicas > 1 {
-		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity("tigera-manager", ManagerNamespace)
+		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity("tigera-manager", c.cfg.Namespace)
 	}
 
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ManagerDeploymentName,
-			Namespace: ManagerNamespace,
+			Namespace: c.cfg.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: c.cfg.Replicas,
@@ -371,12 +417,27 @@ func (c *managerComponent) managerProxyProbe() *corev1.Probe {
 	}
 }
 
+func (c *managerComponent) kibanaEnabled() bool {
+	enableKibana := !operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode)
+	if c.cfg.MultiTenant {
+		enableKibana = false
+	}
+	return enableKibana
+}
+
 // managerEnvVars returns the envvars for the manager container.
 func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
+	// Prepare conditional env vars up-front.
+	queryURL := "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy"
+	if c.cfg.MultiTenant {
+		queryURL = ""
+	}
+
 	envs := []corev1.EnvVar{
+		// TODO: Prometheus URL will need to change.
 		{Name: "CNX_PROMETHEUS_API_URL", Value: fmt.Sprintf("/api/v1/namespaces/%s/services/calico-node-prometheus:9090/proxy/api/v1", common.TigeraPrometheusNamespace)},
 		{Name: "CNX_COMPLIANCE_REPORTS_API_URL", Value: "/compliance/reports"},
-		{Name: "CNX_QUERY_API_URL", Value: "/api/v1/namespaces/tigera-system/services/https:tigera-api:8080/proxy"},
+		{Name: "CNX_QUERY_API_URL", Value: queryURL},
 		{Name: "CNX_ELASTICSEARCH_API_URL", Value: "/tigera-elasticsearch"},
 		{Name: "CNX_ELASTICSEARCH_KIBANA_URL", Value: fmt.Sprintf("/%s", KibanaBasePath)},
 		{Name: "CNX_ENABLE_ERROR_TRACKING", Value: "false"},
@@ -384,8 +445,7 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 		{Name: "CNX_CLUSTER_NAME", Value: "cluster"},
 		{Name: "CNX_POLICY_RECOMMENDATION_SUPPORT", Value: "true"},
 		{Name: "ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
-		// Kibana does not have a FIPS compatible mode, therefore we disable the button in the UI.
-		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(!operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode))},
+		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(c.kibanaEnabled())},
 		// Currently, we do not support anomaly detection when FIPS mode is enabled, therefore we disable the button in the UI.
 		{Name: "ENABLE_ANOMALY_DETECTION", Value: strconv.FormatBool(!operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode))},
 		// The manager supports two states of a product feature being unavailable: the product feature being feature-flagged off,
@@ -456,6 +516,12 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 	if c.cfg.VoltronLinseedKeyPair != nil {
 		linseedKeyPath, linseedCertPath = c.cfg.VoltronLinseedKeyPair.VolumeMountKeyFilePath(), c.cfg.VoltronLinseedKeyPair.VolumeMountCertificateFilePath()
 	}
+	defaultForwardServer := "tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"
+	if c.cfg.MultiTenant {
+		// Use the local namespace instead of tigera-elasticsearch.
+		defaultForwardServer = fmt.Sprintf("tigera-secure-es-gateway-http.%s.svc:9200", c.cfg.Namespace)
+	}
+
 	env := []corev1.EnvVar{
 		{Name: "VOLTRON_PORT", Value: defaultVoltronPort},
 		{Name: "VOLTRON_COMPLIANCE_ENDPOINT", Value: fmt.Sprintf("https://compliance.%s.svc.%s", ComplianceNamespace, c.cfg.ClusterDomain)},
@@ -478,7 +544,7 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		{Name: "VOLTRON_INTERNAL_HTTPS_CERT", Value: intCertPath},
 		{Name: "VOLTRON_ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
-		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: "tigera-secure-es-gateway-http.tigera-elasticsearch.svc:9200"},
+		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: defaultForwardServer},
 		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(c.cfg.Compliance != nil && c.cfg.ComplianceLicenseActive)},
 		{Name: "VOLTRON_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 	}
@@ -527,6 +593,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
+		{Name: "ELASTIC_KIBANA_DISABLED", Value: strconv.FormatBool(!c.kibanaEnabled())},
 	}
 
 	volumeMounts := append(
@@ -563,7 +630,7 @@ func (c *managerComponent) managerService() *corev1.Service {
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ManagerServiceName,
-			Namespace: ManagerNamespace,
+			Namespace: c.cfg.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -581,14 +648,15 @@ func (c *managerComponent) managerService() *corev1.Service {
 }
 
 // managerServiceAccount creates the serviceaccount used by the Tigera Secure web app.
-func managerServiceAccount() *corev1.ServiceAccount {
+func managerServiceAccount(ns string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: ManagerServiceAccount, Namespace: ManagerNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: ManagerServiceAccount, Namespace: ns},
 	}
 }
 
 // managerClusterRole returns a clusterrole that allows authn/authz review requests.
+// TODO: This is global. It should be moved to the cluster scoped manager component.
 func managerClusterRole(managementCluster, managedCluster, usePSP bool) *rbacv1.ClusterRole {
 	cr := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
@@ -749,7 +817,15 @@ func managerClusterRole(managementCluster, managedCluster, usePSP bool) *rbacv1.
 
 // managerClusterRoleBinding returns a clusterrolebinding that gives the tigera-manager serviceaccount
 // the permissions in the tigera-manager-role.
-func managerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+func managerClusterRoleBinding(namespaces []string) *rbacv1.ClusterRoleBinding {
+	subjects := []rbacv1.Subject{}
+	for _, ns := range namespaces {
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      ManagerServiceAccount,
+			Namespace: ns,
+		})
+	}
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: ManagerClusterRoleBinding},
@@ -758,13 +834,7 @@ func managerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 			Kind:     "ClusterRole",
 			Name:     ManagerClusterRole,
 		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      ManagerServiceAccount,
-				Namespace: ManagerNamespace,
-			},
-		},
+		Subjects: subjects,
 	}
 }
 
@@ -773,7 +843,7 @@ func (c *managerComponent) securityContextConstraints() *ocsv1.SecurityContextCo
 	privilegeEscalation := false
 	return &ocsv1.SecurityContextConstraints{
 		TypeMeta:                 metav1.TypeMeta{Kind: "SecurityContextConstraints", APIVersion: "security.openshift.io/v1"},
-		ObjectMeta:               metav1.ObjectMeta{Name: ManagerNamespace},
+		ObjectMeta:               metav1.ObjectMeta{Name: c.cfg.Namespace},
 		AllowHostDirVolumePlugin: true,
 		AllowHostIPC:             false,
 		AllowHostNetwork:         false,
@@ -786,7 +856,7 @@ func (c *managerComponent) securityContextConstraints() *ocsv1.SecurityContextCo
 		ReadOnlyRootFilesystem:   false,
 		SELinuxContext:           ocsv1.SELinuxContextStrategyOptions{Type: ocsv1.SELinuxStrategyMustRunAs},
 		SupplementalGroups:       ocsv1.SupplementalGroupsStrategyOptions{Type: ocsv1.SupplementalGroupsStrategyRunAsAny},
-		Users:                    []string{fmt.Sprintf("system:serviceaccount:%s:tigera-manager", ManagerNamespace)},
+		Users:                    []string{fmt.Sprintf("system:serviceaccount:%s:tigera-manager", c.cfg.Namespace)},
 		Volumes:                  []ocsv1.FSType{"*"},
 	}
 }
@@ -800,11 +870,13 @@ func (c *managerComponent) getTLSObjects() []client.Object {
 	return objs
 }
 
+// TODO: Global resource, might need to be namespaced or moved to the cluster-scoped component.
 func (c *managerComponent) managerPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
 	return podsecuritypolicy.NewBasePolicy("tigera-manager")
 }
 
 // Allow users to access Calico Enterprise Manager.
+// TODO: This will need major rework for multi-tenant
 func (c *managerComponent) managerAllowTigeraNetworkPolicy() *v3.NetworkPolicy {
 	egressRules := []v3.Rule{
 		{
@@ -896,7 +968,7 @@ func (c *managerComponent) managerAllowTigeraNetworkPolicy() *v3.NetworkPolicy {
 		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ManagerPolicyName,
-			Namespace: ManagerNamespace,
+			Namespace: c.cfg.Namespace,
 		},
 		Spec: v3.NetworkPolicySpec{
 			Order:    &networkpolicy.HighPrecedenceOrder,
@@ -912,6 +984,7 @@ func (c *managerComponent) managerAllowTigeraNetworkPolicy() *v3.NetworkPolicy {
 // managerClusterWideSettingsGroup returns a UISettingsGroup with the description "cluster-wide settings"
 //
 // Calico Enterprise only
+// TODO: Global resource, might need to be namespaced or moved to the cluster-scoped component.
 func managerClusterWideSettingsGroup() *v3.UISettingsGroup {
 	return &v3.UISettingsGroup{
 		TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"},
@@ -927,6 +1000,7 @@ func managerClusterWideSettingsGroup() *v3.UISettingsGroup {
 // managerUserSpecificSettingsGroup returns a UISettingsGroup with the description "user settings"
 //
 // Calico Enterprise only
+// TODO: Global resource, might need to be namespaced or moved to the cluster-scoped component.
 func managerUserSpecificSettingsGroup() *v3.UISettingsGroup {
 	return &v3.UISettingsGroup{
 		TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"},
@@ -944,6 +1018,7 @@ func managerUserSpecificSettingsGroup() *v3.UISettingsGroup {
 // all of the tigera namespaces.
 //
 // Calico Enterprise only
+// TODO: Global resource, might need to be namespaced or moved to the cluster-scoped component.
 func managerClusterWideTigeraLayer() *v3.UISettings {
 	namespaces := []string{
 		"tigera-compliance",
@@ -998,6 +1073,7 @@ func managerClusterWideTigeraLayer() *v3.UISettings {
 // everything and uses the tigera-infrastructure layer.
 //
 // Calico Enterprise only
+// TODO: Global resource, might need to be namespaced or moved to the cluster-scoped component.
 func managerClusterWideDefaultView() *v3.UISettings {
 	return &v3.UISettings{
 		TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"},

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -50,8 +50,7 @@ const (
 	PacketCapturePodSecurityPolicyName  = PacketCaptureName
 	PacketCapturePolicyName             = networkpolicy.TigeraComponentPolicyPrefix + PacketCaptureName
 	PacketCapturePort                   = 8444
-
-	PacketCaptureCertSecret = "tigera-packetcapture-server-tls"
+	PacketCaptureServerCert             = "tigera-packetcapture-server-tls"
 )
 
 var (

--- a/pkg/render/tiers/tiers.go
+++ b/pkg/render/tiers/tiers.go
@@ -32,6 +32,7 @@ const (
 	NodeLocalDNSPolicyName = networkpolicy.TigeraComponentPolicyPrefix + "node-local-dns"
 )
 
+// TODO: Needs to be updated for multi-tenancy.
 var TigeraNamespaceSelector = createNamespaceSelector(
 	common.CalicoNamespace,
 	render.GuardianNamespace,


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR starts work on adding operator support for multi-tenant
management clusters for Calico Cloud.

For the initial implementation, the operator will have a "namespaced"
mode that allows installation of multiple copies of certain key components in isolated namespaces,
allowing for multiple side-by-side instances of the control plane in a
single Kubernetes cluster.

This PR starts that process for the "manager" component.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.