### PR TITLE
Use internal manager tls certificate for es-proxy and linseed

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1060,7 +1060,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 	var managerInternalTLSSecret certificatemanagement.KeyPairInterface
-	if instance.Spec.Variant == operator.TigeraSecureEnterprise && managementCluster != nil {
+	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
 		dnsNames := append(dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain), render.ManagerServiceIP)
 		managerInternalTLSSecret, err = certificateManager.GetOrCreateKeyPair(r.client, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), dnsNames)
 		if err != nil {

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -435,11 +435,11 @@ func (r *ReconcileLogStorage) generateSecrets(
 		// Get certificate for TLS on Prometheus metrics endpoints. This is created in the monitor controller.
 		monitor.PrometheusClientTLSSecretName,
 
-		// Get certificate for es-proxy, which Linseed and es-gateway need to trust.
+		// Get certificate for es-proxy, which es-gateway needs to trust.
 		render.ManagerTLSSecretName,
 
 		// Linseed needs the manager internal cert in order to verify the cert presented by Voltron when provisioning
-		// tokens into managed clusters.
+		// tokens into managed clusters or when communicating with ES proxy
 		render.ManagerInternalTLSSecretName,
 
 		// Get certificate for fluentd, which Linseed needs to trust in a standalone or management cluster.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -107,9 +107,9 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 		}
 	}
 
+	tlsAnnotations[cfg.InternalTLSKeyPair.HashAnnotationKey()] = cfg.InternalTLSKeyPair.HashAnnotationValue()
 	if cfg.ManagementCluster != nil {
-		tlsAnnotations[cfg.InternalTrafficSecret.HashAnnotationKey()] = cfg.InternalTrafficSecret.HashAnnotationValue()
-		tlsAnnotations[cfg.TunnelSecret.HashAnnotationKey()] = cfg.InternalTrafficSecret.HashAnnotationValue()
+		tlsAnnotations[cfg.TunnelSecret.HashAnnotationKey()] = cfg.TunnelSecret.HashAnnotationValue()
 	}
 	return &managerComponent{
 		cfg:            cfg,
@@ -139,8 +139,9 @@ type ManagerConfiguration struct {
 	// KeyPair used for establishing mTLS tunnel with Guardian.
 	TunnelSecret certificatemanagement.KeyPairInterface
 
-	// TLS KeyPair used by Voltron within the cluster when operating as a management cluster.
-	InternalTrafficSecret certificatemanagement.KeyPairInterface
+	// TLS KeyPair used by both Voltron and es-proxy, presented by each as part of the mTLS handshake with
+	// other services within the cluster. This is used in both management and standalone clusters.
+	InternalTLSKeyPair certificatemanagement.KeyPairInterface
 
 	// Certificate bundle used by the manager pod to verify certificates presented
 	// by clients as part of mTLS authentication.
@@ -311,10 +312,10 @@ func (c *managerComponent) managerVolumes() []corev1.Volume {
 	v := []corev1.Volume{
 		c.cfg.TLSKeyPair.Volume(),
 		c.cfg.TrustedCertBundle.Volume(),
+		c.cfg.InternalTLSKeyPair.Volume(),
 	}
 	if c.cfg.ManagementCluster != nil {
 		v = append(v,
-			c.cfg.InternalTrafficSecret.Volume(),
 			c.cfg.TunnelSecret.Volume(),
 			c.cfg.VoltronLinseedKeyPair.Volume(),
 		)
@@ -447,8 +448,8 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		// This should never be nil, but we check it anyway just to be safe.
 		keyPath, certPath = c.cfg.TLSKeyPair.VolumeMountKeyFilePath(), c.cfg.TLSKeyPair.VolumeMountCertificateFilePath()
 	}
-	if c.cfg.InternalTrafficSecret != nil {
-		intKeyPath, intCertPath = c.cfg.InternalTrafficSecret.VolumeMountKeyFilePath(), c.cfg.InternalTrafficSecret.VolumeMountCertificateFilePath()
+	if c.cfg.InternalTLSKeyPair != nil {
+		intKeyPath, intCertPath = c.cfg.InternalTLSKeyPair.VolumeMountKeyFilePath(), c.cfg.InternalTLSKeyPair.VolumeMountCertificateFilePath()
 	}
 	if c.cfg.TunnelSecret != nil {
 		tunnelKeyPath, tunnelCertPath = c.cfg.TunnelSecret.VolumeMountKeyFilePath(), c.cfg.TunnelSecret.VolumeMountCertificateFilePath()
@@ -497,7 +498,7 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 	mounts := c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType())
 	mounts = append(mounts, corev1.VolumeMount{Name: ManagerTLSSecretName, MountPath: "/manager-tls", ReadOnly: true})
 	if c.cfg.ManagementCluster != nil {
-		mounts = append(mounts, c.cfg.InternalTrafficSecret.VolumeMount(c.SupportedOSType()))
+		mounts = append(mounts, c.cfg.InternalTLSKeyPair.VolumeMount(c.SupportedOSType()))
 		mounts = append(mounts, c.cfg.TunnelSecret.VolumeMount(c.SupportedOSType()))
 		mounts = append(mounts, c.cfg.VoltronLinseedKeyPair.VolumeMount(c.SupportedOSType()))
 	}
@@ -516,9 +517,9 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 // managerEsProxyContainer returns the ES proxy container
 func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 	var keyPath, certPath string
-	if c.cfg.TLSKeyPair != nil {
+	if c.cfg.InternalTLSKeyPair != nil {
 		// This should never be nil, but we check it anyway just to be safe.
-		keyPath, certPath = c.cfg.TLSKeyPair.VolumeMountKeyFilePath(), c.cfg.TLSKeyPair.VolumeMountCertificateFilePath()
+		keyPath, certPath = c.cfg.InternalTLSKeyPair.VolumeMountKeyFilePath(), c.cfg.InternalTLSKeyPair.VolumeMountCertificateFilePath()
 	}
 
 	env := []corev1.EnvVar{
@@ -531,7 +532,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 
 	volumeMounts := append(
 		c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType()),
-		c.cfg.TLSKeyPair.VolumeMount(c.SupportedOSType()),
+		c.cfg.InternalTLSKeyPair.VolumeMount(c.SupportedOSType()),
 	)
 	if c.cfg.ManagementCluster != nil {
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_CA_PATH", Value: certificatemanagement.TrustedCertBundleMountPath})


### PR DESCRIPTION
communication

## Description

Manager-TLS is configured to also have K8S tigera-manager services as a SAN.

```
X509v3 Subject Alternative Name: 
                DNS:localhost, DNS:tigera-manager, DNS:tigera-manager.tigera-manager, DNS:tigera-manager.tigera-manager.svc, DNS:tigera-manager.tigera-manager.svc.cluster.local
    Signature Algorithm: sha256WithRSAEncryption
```

When users provide their own certificates, they do not have the K8S service declared, which causes errors for communication between Linseed and Es proxy.

This PR proposes that we use the internal manager tls that was created to be used for inter cluster communication (es-proxy and voltron) in MCM use case.


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
