### PR TITLE
[CI-1296] Don't use subPath on windows: https://github.com/moby/moby/issues/30555

### DIFF
--- a/pkg/tls/certificatemanagement/certificatebundle.go
+++ b/pkg/tls/certificatemanagement/certificatebundle.go
@@ -134,7 +134,7 @@ func (t *trustedBundle) VolumeMounts(osType rmeta.OSType) []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 	}
-	if len(t.systemCertificates) > 0 {
+	if len(t.systemCertificates) > 0 && osType != rmeta.OSTypeWindows {
 		// apps linking libssl need this file (SSL_CERT_FILE)
 		mounts = append(mounts,
 			corev1.VolumeMount{


### PR DESCRIPTION
When running fluentd on windows nodes, the containers get stuck during creation:
```
 Warning  Failed          9s (x12 over 3m27s)   kubelet            Error: Error response from daemon: invalid volume specification: 'c:\var\lib\kubelet\pods\cb042ed8-f755-4b7b-9bf2-780f6377a29d\volumes\kubernetes.io~configmap\tigera-ca-bundle\ca-bundle.crt:c:/etc/pki/tls/cert.pem:ro': invalid mount config for type "bind": source path must be a directory
```
This is because we are mounting a file under a different name, using the subPath feature of volume mounts. SubPath does not work with runtime = docker on all platforms. See: https://github.com/moby/moby/issues/30555 

This mount is not used on windows, because on windows we don't support uploading data to external sources, so we can simply fix it by not mounting the file in question.

