### PR TITLE
Automated cherry pick of #2740: Don't use subPath on windows:

### DIFF
--- a/pkg/tls/certificatemanagement/certificatebundle.go
+++ b/pkg/tls/certificatemanagement/certificatebundle.go
@@ -134,7 +134,7 @@ func (t *trustedBundle) VolumeMounts(osType rmeta.OSType) []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 	}
-	if len(t.systemCertificates) > 0 {
+	if len(t.systemCertificates) > 0 && osType != rmeta.OSTypeWindows {
 		// apps linking libssl need this file (SSL_CERT_FILE)
 		mounts = append(mounts,
 			corev1.VolumeMount{


### PR DESCRIPTION
Cherry pick of #2740 on release-v1.30.

#2740: Don't use subPath on windows: