### PR TITLE
[release-v1.30] Adjust linseed probe timeout and period seconds

### DIFF
--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -322,7 +322,8 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 							},
 						},
 						InitialDelaySeconds: 10,
-						PeriodSeconds:       5,
+						PeriodSeconds:       30,
+						TimeoutSeconds:      10,
 					},
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
@@ -331,7 +332,8 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 							},
 						},
 						InitialDelaySeconds: 10,
-						PeriodSeconds:       5,
+						PeriodSeconds:       60,
+						TimeoutSeconds:      10,
 					},
 				},
 			},

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -415,7 +415,8 @@ func expectedContainers() []corev1.Container {
 					},
 				},
 				InitialDelaySeconds: 10,
-				PeriodSeconds:       5,
+				PeriodSeconds:       30,
+				TimeoutSeconds:      10,
 			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
@@ -424,7 +425,8 @@ func expectedContainers() []corev1.Container {
 					},
 				},
 				InitialDelaySeconds: 10,
-				PeriodSeconds:       5,
+				PeriodSeconds:       60,
+				TimeoutSeconds:      10,
 			},
 			Env: []corev1.EnvVar{
 				{


### PR DESCRIPTION
## Description

This changeset adjusts linseed readiness and liveness probes to a bigger value so that it won't be restarted prematurely under a loaded cluster.

This change is v1.30 release branch only and we are working on [another patch](https://github.com/tigera/operator/pull/2746) to apply these settings to all other Calico components.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
