### PR TITLE
Replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/cloudflare/cfssl v1.6.3
 	github.com/containernetworking/cni v1.0.1
 	github.com/elastic/cloud-on-k8s/v2 v2.0.0-20221014162453-642f9ecd3e2e
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-ldap/ldap v3.0.3+incompatible
 	github.com/go-logr/logr v1.2.3
 	github.com/hashicorp/go-version v1.2.1
@@ -34,6 +33,7 @@ require (
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/kind v0.17.0 // Do not remove, not used by code but used by build
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -120,7 +120,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20230123231816-1cb3ae25d79a // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -321,7 +321,6 @@ github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSy
 github.com/getsentry/raven-go v0.0.0-20190513200303-c977f96e1095/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/cloudflare/cfssl/log"
-	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -39,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/yaml"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -22,10 +22,9 @@ import (
 	"strings"
 	"sync"
 
-	// gopkg.in/yaml.v2 didn't parse all the fields but the ghodss package did
-	"github.com/ghodss/yaml"
 	apiextenv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml" // gopkg.in/yaml.v2 didn't parse all the fields but this package did
 
 	opv1 "github.com/tigera/operator/api/v1"
 )


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The `github.com/ghodss/yaml` package is no longer actively maintained. There are numerous inquiries about the project's status on its issue tracker: https://github.com/ghodss/yaml/issues. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained by Kubernetes SIG and widely used in K8s projects.

Since `sigs.k8s.io/yaml` was already an indirect dependency before this pull request was made, we can remove 1 extra dependency by replacing `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`.

<details><summary>Output of <code>make ut</code> for <code>pkg/crds</code></summary>

```
Running Suite: pkg/crds Suite
=============================
Random Seed: 1689946969
Will run 5 of 5 specs

test crds pkg GetCalicoCRDSource 
  should quickly load calico source CRDs
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:26

• [MEASUREMENT]
test crds pkg
/go/src/github.com/tigera/operator/pkg/crds/crds_test.go:24
  GetCalicoCRDSource
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:25
    should quickly load calico source CRDs
    /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:26

    Ran 50 samples:
    runtime:
      Fastest Time: 0.000s
      Slowest Time: 0.002s
      Average Time: 0.001s ± 0.000s
------------------------------
test crds pkg GetEnterpriseCRDSource 
  should quickly load enterprise source CRDs
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:34

• [MEASUREMENT]
test crds pkg
/go/src/github.com/tigera/operator/pkg/crds/crds_test.go:24
  GetEnterpriseCRDSource
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:33
    should quickly load enterprise source CRDs
    /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:34

    Ran 50 samples:
    runtime:
      Fastest Time: 0.001s
      Slowest Time: 0.002s
      Average Time: 0.001s ± 0.000s
------------------------------
test crds pkg GetOperatorCRDSource 
  should quickly load operator source CRDs
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:42

• [MEASUREMENT]
test crds pkg
/go/src/github.com/tigera/operator/pkg/crds/crds_test.go:24
  GetOperatorCRDSource
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:41
    should quickly load operator source CRDs
    /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:42

    Ran 50 samples:
    runtime:
      Fastest Time: 0.001s
      Slowest Time: 0.002s
      Average Time: 0.001s ± 0.000s
------------------------------
test crds pkg GetCRDs 
  should quickly load calico CRDs
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:50

• [MEASUREMENT]
test crds pkg
/go/src/github.com/tigera/operator/pkg/crds/crds_test.go:24
  GetCRDs
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:49
    should quickly load calico CRDs
    /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:50

    Ran 50 samples:
    runtime:
      Fastest Time: 0.001s
      Slowest Time: 0.162s
      Average Time: 0.007s ± 0.022s
------------------------------
test crds pkg GetCRDs 
  should quickly load enterprise CRDs
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:56

• [MEASUREMENT]
test crds pkg
/go/src/github.com/tigera/operator/pkg/crds/crds_test.go:24
  GetCRDs
  /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:49
    should quickly load enterprise CRDs
    /go/src/github.com/tigera/operator/pkg/crds/crds_test.go:56

    Ran 50 samples:
    runtime:
      Fastest Time: 0.004s
      Slowest Time: 0.199s
      Average Time: 0.009s ± 0.027s
------------------------------

JUnit report was created: /go/src/github.com/tigera/operator/report/ut/crds_suite.xml

Ran 5 of 5 Specs in 0.952 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```

</details> 

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
