### PR TITLE
Add .PHONY for ut target and ignore ut folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ cscope.*
 .idea/
 # Test reports
 pkg/report
+ut/

--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ FV_DIR?=./test
 GINKGO_ARGS?= -v
 GINKGO_FOCUS?=.*
 
+.PHONY: ut
 ut:
 	-mkdir -p .go-pkg-cache report
 	$(CONTAINERIZED) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \


### PR DESCRIPTION
## Description

Fix subsequent `make ut` doesn't run issue and ignore `ut` folder in `.gitignore`.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
