### PR TITLE
FV test improvements

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -144,7 +144,7 @@ blocks:
           commands:
             - make fv
             - make dirty-check
-            - '[[ -f ./report/fv/fv_suite.xml ]] && test-results publish ./report/fv/fv_suite.xml'
+            - '[[ -d ./report/fv ]] && test-results publish ./report/fv'
 
 after_pipeline:
   task:

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(ARCH)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./api -name '*.go')
 SRC_FILES+=$(shell find ./controllers -name '*.go')
+SRC_FILES+=$(shell find ./test -name '*.go')
 SRC_FILES+=main.go
 
 EXTRA_DOCKER_ARGS += -e GO111MODULE=on -e GOPRIVATE=github.com/tigera/*
@@ -299,7 +300,7 @@ ut:
 	ginkgo -trace -r -focus="$(GINKGO_FOCUS)" $(GINKGO_ARGS) "$(UT_DIR)"'
 
 ## Run the functional tests
-fv: cluster-create run-fvs cluster-destroy
+fv: cluster-create load-container-images run-fvs cluster-destroy
 run-fvs:
 	-mkdir -p .go-pkg-cache report
 	$(CONTAINERIZED) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
@@ -324,6 +325,73 @@ cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 
 	# Wait for controller manager to be running and healthy.
 	while ! KUBECONFIG=$(KUBECONFIG) $(BINDIR)/kubectl get serviceaccount default; do echo "Waiting for default serviceaccount to be created..."; sleep 2; done
+
+IMAGE_REGISTRY := docker.io
+VERSION_TAG := master
+NODE_IMAGE := calico/node
+APISERVER_IMAGE := calico/apiserver
+CNI_IMAGE := calico/cni
+FLEXVOL_IMAGE := calico/pod2daemon-flexvol
+KUBECONTROLLERS_IMAGE := calico/kube-controllers
+TYPHA_IMAGE := calico/typha
+CSI_IMAGE := calico/csi
+NODE_DRIVER_REGISTRAR_IMAGE := calico/node-driver-registrar
+
+.PHONY: calico-node.tar
+calico-node.tar:
+	docker pull $(IMAGE_REGISTRY)/$(NODE_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(NODE_IMAGE):$(VERSION_TAG)
+
+.PHONY: calico-apiserver.tar
+calico-apiserver.tar:
+	docker pull $(IMAGE_REGISTRY)/$(APISERVER_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(APISERVER_IMAGE):$(VERSION_TAG)
+
+.PHONY: calico-cni.tar
+calico-cni.tar:
+	docker pull $(IMAGE_REGISTRY)/$(CNI_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(CNI_IMAGE):$(VERSION_TAG)
+
+.PHONY: calico-pod2daemon-flexvol.tar
+calico-pod2daemon-flexvol.tar:
+	docker pull $(IMAGE_REGISTRY)/$(FLEXVOL_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(FLEXVOL_IMAGE):$(VERSION_TAG)
+
+.PHONY: calico-kube-controllers.tar
+calico-kube-controllers.tar:
+	docker pull $(IMAGE_REGISTRY)/$(KUBECONTROLLERS_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(KUBECONTROLLERS_IMAGE):$(VERSION_TAG)
+
+.PHONY: calico-typha.tar
+calico-typha.tar:
+	docker pull $(IMAGE_REGISTRY)/$(TYPHA_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(TYPHA_IMAGE):$(VERSION_TAG)
+
+.PHONY: calico-csi.tar
+calico-csi.tar:
+	docker pull $(IMAGE_REGISTRY)/$(CSI_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(CSI_IMAGE):$(VERSION_TAG)
+
+.PHONY: calico-node-driver-registrar.tar
+calico-node-driver-registrar.tar:
+	docker pull $(IMAGE_REGISTRY)/$(NODE_DRIVER_REGISTRAR_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(NODE_DRIVER_REGISTRAR_IMAGE):$(VERSION_TAG)
+
+IMAGE_TARS := calico-node.tar \
+	calico-apiserver.tar \
+	calico-cni.tar \
+	calico-pod2daemon-flexvol.tar \
+	calico-kube-controllers.tar \
+	calico-typha.tar \
+	calico-csi.tar \
+	calico-node-driver-registrar.tar
+
+load-container-images: ./test/load_images_on_kind_cluster.sh $(IMAGE_TARS)
+	# Load the latest tar files onto the currently running kind cluster.
+	KUBECONFIG=$(KUBECONFIG) ./test/load_images_on_kind_cluster.sh $(IMAGE_TARS)
+	# Restart the Calico containers so they launch with the newly loaded code.
+	# TODO: We should be able to do this without restarting everything in kube-system.
+	KUBECONFIG=$(KUBECONFIG) $(BINDIR)/kubectl delete pods -n kube-system --all
 
 ## Deploy CRDs needed for UTs.  CRDs needed by ECK that we don't use are not deployed.
 ## kubectl create is used for prometheus as a workaround for https://github.com/prometheus-community/helm-charts/issues/1500

--- a/test/active_test.go
+++ b/test/active_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -74,19 +72,8 @@ var _ = Describe("pkg/active with apiserver", func() {
 		}
 		err := c.Delete(context.Background(), ns)
 		Expect(err).NotTo(HaveOccurred())
-		// Validate the calico-system namespace is deleted using an unstructured type.
-		// This hits the API server directly instead of using the client cache.
-		// This should help with flaky tests.
 		Eventually(func() error {
-			u := &unstructured.Unstructured{}
-			u.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "",
-				Version: "v1",
-				Kind:    "Namespace",
-			})
-
-			k := client.ObjectKey{Name: "calico-system"}
-			err := c.Get(context.Background(), k, u)
+			err := GetResource(c, ns)
 			return err
 		}, 240*time.Second).ShouldNot(BeNil())
 		active.OsExitOverride = os.Exit

--- a/test/load_images_on_kind_cluster.sh
+++ b/test/load_images_on_kind_cluster.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function load_image() {
+    local node=${1}
+    for IMAGETAR in ${@:2}
+    do
+      docker cp ./${IMAGETAR} ${node}:/${IMAGETAR}
+      docker exec -t ${node} ctr -n=k8s.io images import /${IMAGETAR}
+      docker exec -t ${node} rm /${IMAGETAR}
+    done
+}
+
+KIND_NODES="kind-control-plane kind-worker kind-worker2 kind-worker3"
+
+for NODE in ${KIND_NODES}
+do
+  load_image ${NODE} ${@:2}
+done

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,10 @@ import (
 	"strings"
 	"time"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
 	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -34,8 +38,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -62,6 +64,7 @@ var _ = Describe("Mainline component function tests", func() {
 	var operatorDone chan struct{}
 	BeforeEach(func() {
 		c, shutdownContext, cancel, mgr = setupManager(ManageCRDsDisable)
+		cleanupResources(c)
 		verifyCRDsExist(c)
 		ns := &corev1.Namespace{
 			TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
@@ -72,19 +75,6 @@ var _ = Describe("Mainline component function tests", func() {
 		if err != nil && !kerror.IsAlreadyExists(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
-		//
-		Eventually(func() error {
-			u := &unstructured.Unstructured{}
-			u.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "operator.tigera.io",
-				Version: "v1",
-				Kind:    "Installation",
-			})
-
-			k := client.ObjectKey{Name: "default"}
-			err := c.Get(context.Background(), k, u)
-			return err
-		}, 20*time.Second).ShouldNot(BeNil())
 	})
 
 	AfterEach(func() {
@@ -97,11 +87,11 @@ var _ = Describe("Mainline component function tests", func() {
 				default:
 					return fmt.Errorf("operator did not shutdown")
 				}
-			}, 60*time.Second).Should(BeNil())
+			}, 60*time.Second).ShouldNot(HaveOccurred())
 		}()
 		removeInstallResourceCR(c, "default", context.Background())
 
-		waitForProductTeardown(c)
+		cleanupResources(c)
 
 		// Clean up Calico data that might be left behind.
 		Eventually(func() error {
@@ -181,6 +171,17 @@ var _ = Describe("Mainline component function tests", func() {
 			By("Deleting CR after its tigera status becomes available")
 			err := c.Delete(context.Background(), instance)
 			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				defaultInstallation := &operator.Installation{
+					TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				}
+				err = GetResource(c, defaultInstallation)
+				if kerror.IsNotFound(err) || kerror.IsGone(err) {
+					return nil
+				}
+				return fmt.Errorf("Default installation still exists")
+			}, 20*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 			By("Verifying the tigera status is removed for deleted CR")
 			Eventually(func() error {
@@ -264,6 +265,10 @@ func assertAvailable(ts *operator.TigeraStatus) error {
 	return nil
 }
 
+func newNonCachingClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+	return client.New(config, options)
+}
+
 func setupManager(manageCRDs bool) (client.Client, context.Context, context.CancelFunc, manager.Manager) {
 	// Create a Kubernetes client.
 	cfg, err := config.GetConfig()
@@ -276,6 +281,9 @@ func setupManager(manageCRDs bool) (client.Client, context.Context, context.Canc
 		// say to replace restmapper but the NewDynamicRestMapper did not satisfy the
 		// MapperProvider interface
 		MapperProvider: func(c *rest.Config) (kmeta.RESTMapper, error) { return apiutil.NewDynamicRESTMapper(c) },
+		// Use a non-caching client because we've had issues with flakes in the past where the cache
+		// was not updating and tests were failing as a result of looking at stale cluster state
+		NewClient: newNonCachingClient,
 	})
 	Expect(err).NotTo(HaveOccurred())
 
@@ -291,6 +299,8 @@ func setupManager(manageCRDs bool) (client.Client, context.Context, context.Canc
 
 	// Setup Scheme for all resources
 	err = apis.AddToScheme(mgr.GetScheme())
+	Expect(err).NotTo(HaveOccurred())
+	err = apiextensionsv1.AddToScheme(mgr.GetScheme())
 	Expect(err).NotTo(HaveOccurred())
 
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -339,6 +349,21 @@ func removeInstallResourceCR(c client.Client, name string, ctx context.Context) 
 	Expect(err).NotTo(HaveOccurred())
 	err = c.Delete(ctx, instance)
 	Expect(err).NotTo(HaveOccurred())
+	// Need to wait here for Installation resource to be fully deleted prior to cancelling the context
+	// which will in turn terminate the operator. Race conditions can occur otherwise that will leave the
+	// Installation resource intact while the operator is no longer running which will result in test failures
+	// that try to create an Installation resource of their own
+	Eventually(func() error {
+		installation := &operator.Installation{
+			TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+		err = GetResource(c, installation)
+		if kerror.IsNotFound(err) || kerror.IsGone(err) {
+			return nil
+		}
+		return fmt.Errorf("\"%s\" installation still exists", name)
+	}, 20*time.Second).ShouldNot(HaveOccurred())
 }
 
 func verifyCalicoHasDeployed(c client.Client) {
@@ -393,15 +418,11 @@ func verifyCRDsExist(c client.Client) {
 	// Eventually all the Enterprise CRDs should be available
 	Eventually(func() error {
 		for _, n := range crdNames {
-			u := &unstructured.Unstructured{}
-			u.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "apiextensions.k8s.io",
-				Version: "v1",
-				Kind:    "CustomResourceDefinition",
-			})
-
-			k := client.ObjectKey{Name: n}
-			err := c.Get(context.Background(), k, u)
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta:   metav1.TypeMeta{Kind: "CustomResourceDefinition", APIVersion: "apiextensions.k8s.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: n},
+			}
+			err := GetResource(c, crd)
 			// If getting any of the CRDs is an error then the CRDs do not exist
 			if err != nil {
 				return err
@@ -412,46 +433,34 @@ func verifyCRDsExist(c client.Client) {
 }
 
 func waitForProductTeardown(c client.Client) {
-	// Validate the calico-system namespace is deleted using an unstructured type. This hits the API server
-	// directly instead of using the client cache. This should help with flaky tests.
 	Eventually(func() error {
-		u := &unstructured.Unstructured{}
-		u.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "",
-			Version: "v1",
-			Kind:    "Namespace",
-		})
-
-		k := client.ObjectKey{Name: "calico-system"}
-		err := c.Get(context.Background(), k, u)
+		ns := &corev1.Namespace{
+			TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "calico-system"},
+		}
+		err := GetResource(c, ns)
 		if err == nil {
 			return fmt.Errorf("Calico namespace still exists")
 		}
 		if !kerror.IsNotFound(err) {
 			return err
 		}
-		u = &unstructured.Unstructured{}
-		u.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "rbac.authorization.k8s.io",
-			Version: "v1",
-			Kind:    "ClusterRoleBinding",
-		})
-		k = client.ObjectKey{Name: "calico-node"}
-		err = c.Get(context.Background(), k, u)
+		crb := &rbacv1.ClusterRoleBinding{
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "calico-node"},
+		}
+		err = GetResource(c, crb)
 		if err == nil {
 			return fmt.Errorf("Node CRB still exists")
 		}
 		if !kerror.IsNotFound(err) {
 			return err
 		}
-		u = &unstructured.Unstructured{}
-		u.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "operator.tigera.io",
-			Version: "v1",
-			Kind:    "Installation",
-		})
-		k = client.ObjectKey{Name: "default"}
-		err = c.Get(context.Background(), k, u)
+		defaultInstallation := &operator.Installation{
+			TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		}
+		err = GetResource(c, defaultInstallation)
 		if err == nil {
 			return fmt.Errorf("default Installation still exists")
 		}
@@ -459,5 +468,10 @@ func waitForProductTeardown(c client.Client) {
 			return err
 		}
 		return nil
-	}, 240*time.Second).Should(BeNil())
+	}, 240*time.Second).ShouldNot(HaveOccurred())
+}
+
+func cleanupResources(c client.Client) {
+	removeInstallResourceCR(c, "default", context.Background())
+	waitForProductTeardown(c)
 }


### PR DESCRIPTION
-Add localized caching of OSS Calico images to speed up performance and improve test reliability by removing variability of image pull timing per test. Also has the added benefit of not ripping through docker pull request limits
-Fix race condition in CRD management tests
-Fix race condition in mainline tests
-Use non-caching k8s client and remove use of unstructured types

Test timing on local laptop went from 25 - 30 minutes to <2.5 minutes.
Ran ~250 iterations with no failures for a failure rate of <0.5%

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

~~- [ ] Tests for change.~~
~~- [ ] If changing pkg/apis/, run `make gen-files`~~
~~- [ ] If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
