### PR TITLE
[pick #2775] Recreate certificates that are only specified to be used as server certs [r1.31]

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,16 +40,16 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var (
-	log = logf.Log.WithName("tls")
-)
+var log = logf.Log.WithName("tls")
 
 func ErrInvalidCertDNSNames(secretName, secretNamespace string) error {
 	return fmt.Errorf("certificate %s/%s has the wrong DNS names", secretNamespace, secretName)
 }
+
 func errNoPrivateKeyPEM(secretName, secretNamespace string) error {
 	return fmt.Errorf("key pair %s/%s is missing a private key", secretNamespace, secretName)
 }
+
 func errNoCertificatePEM(secretName, secretNamespace string) error {
 	return fmt.Errorf("certificate PEM is missing for %s/%s ", secretNamespace, secretName)
 }
@@ -208,6 +209,7 @@ func (cm *certificateManager) GetOrCreateKeyPair(cli client.Client, secretName, 
 
 // getKeyPair is an internal convenience method to retrieve a keypair or a certificate.
 func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNamespace string, readCertOnly bool) (certificatemanagement.KeyPairInterface, *x509.Certificate, error) {
+
 	secret := &corev1.Secret{}
 	err := cli.Get(context.Background(), types.NamespacedName{
 		Name:      secretName,
@@ -223,7 +225,7 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 		}
 		return nil, nil, err
 	}
-	keyPEM, certPEM := getKeyCertPEM(secret)
+	keyPEM, certPEM := GetKeyCertPEM(secret)
 	if !readCertOnly {
 		if len(keyPEM) == 0 {
 			return nil, nil, errNoPrivateKeyPEM(secretName, secretNamespace)
@@ -237,19 +239,31 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 		return nil, nil, err
 	}
 
-	if x509Cert.NotAfter.Before(time.Now()) || x509Cert.NotBefore.After(time.Now()) {
+	timeInvalid := x509Cert.NotAfter.Before(time.Now()) || x509Cert.NotBefore.After(time.Now())
+	// Get specific usages to check for certs that are utilized for mTLS with Linseed
+	requiredKeyUsages := certkeyusage.GetCertKeyUsage(secretName)
+	invalidKeyUsage := !HasRequiredKeyUsage(x509Cert, requiredKeyUsages)
+	if timeInvalid || invalidKeyUsage {
 		if !readCertOnly && strings.HasPrefix(x509Cert.Issuer.CommonName, rmeta.TigeraOperatorCAIssuerPrefix) {
 			if cm.keyPair.CertificateManagement != nil {
 				// When certificate management is enabled, we can simply return a certificate management key pair;
 				// the old secret will be deleted automatically.
 				return certificateManagementKeyPair(cm, secretName, nil), nil, nil
 			}
+
+			if invalidKeyUsage {
+				log.Info("secret %s/%s must specify ext key usages: %+v", secretNamespace, secretName, requiredKeyUsages)
+			}
 			// We return nil, so a new secret will be created for expired (legacy) operator signed secrets.
 			return nil, nil, nil
 		}
-		// We return an error for byo secrets.
-		return nil, nil, fmt.Errorf("secret %s is not valid at this date", secretName)
+
+		if timeInvalid {
+			return nil, nil, fmt.Errorf("secret %s/%s is not valid at this date", secretNamespace, secretName)
+		}
+		return nil, nil, fmt.Errorf("secret %s/%s must specify ext key usages: %+v", secretNamespace, secretName, requiredKeyUsages)
 	}
+
 	var issuer certificatemanagement.KeyPairInterface
 	if x509Cert.Issuer.CommonName == rmeta.TigeraOperatorCAIssuerPrefix {
 		if cm.keyPair.CertificateManagement != nil {
@@ -274,7 +288,25 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 		CertificatePEM: certPEM,
 		OriginalSecret: secret,
 	}, x509Cert, nil
+}
 
+// HasRequiredKeyUsage returns true if the given certificate is valid
+// for use as both a server certificate, as well as a client certificate for mTLS connections.
+func HasRequiredKeyUsage(cert *x509.Certificate, required []x509.ExtKeyUsage) bool {
+	for _, ku := range required {
+		found := false
+		for _, certKU := range cert.ExtKeyUsage {
+			if certKU == ku {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // GetCertificate returns a Certificate. If the certificate is not found or outdated, a k8s.io NotFound error is returned.
@@ -294,7 +326,7 @@ func (cm *certificateManager) CertificateManagement() *operatorv1.CertificateMan
 	return cm.keyPair.CertificateManagement
 }
 
-func getKeyCertPEM(secret *corev1.Secret) ([]byte, []byte) {
+func GetKeyCertPEM(secret *corev1.Secret) ([]byte, []byte) {
 	const (
 		legacySecretCertName  = "cert" // Formerly known as certificatemanagement.ManagerSecretCertName
 		legacySecretKeyName   = "key"  // Formerly known as certificatemanagement.ManagerSecretKeyName

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -19,6 +19,7 @@ package certificatemanager_test
 
 import (
 	"context"
+	"crypto/x509"
 	"runtime"
 	"strings"
 	"time"
@@ -38,6 +39,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 	"github.com/tigera/operator/test"
 
 	apps "k8s.io/api/apps/v1"
@@ -50,29 +52,31 @@ import (
 )
 
 var _ = Describe("Test CertificateManagement suite", func() {
-
 	const (
 		appSecretName       = "my-app-tls"
 		appSecretName2      = "my-app-tls-2"
+		legacySecretName    = "legacy-secret"
 		appNs               = "my-app"
 		legacyKeyFieldName  = "key"
 		legacyCertFieldName = "cert"
 	)
 
 	var (
-		cli                 client.Client
-		scheme              *k8sruntime.Scheme
-		installation        *operatorv1.InstallationSpec
-		cm                  *operatorv1.CertificateManagement
-		clusterDomain       = "cluster.local"
-		appDNSNames         = []string{appSecretName}
-		ctx                 = context.TODO()
-		certificateManager  certificatemanager.CertificateManager
-		expiredSecret       *corev1.Secret
-		legacySecret        *corev1.Secret
-		expiredLegacySecret *corev1.Secret
-		byoSecret           *corev1.Secret
-		expiredByoSecret    *corev1.Secret
+		cli                      client.Client
+		scheme                   *k8sruntime.Scheme
+		installation             *operatorv1.InstallationSpec
+		cm                       *operatorv1.CertificateManagement
+		clusterDomain            = "cluster.local"
+		appDNSNames              = []string{appSecretName}
+		ctx                      = context.TODO()
+		certificateManager       certificatemanager.CertificateManager
+		expiredSecret            *corev1.Secret
+		legacySecret             *corev1.Secret
+		expiredLegacySecret      *corev1.Secret
+		byoSecret                *corev1.Secret
+		expiredBYOSecret         *corev1.Secret
+		legacyBYOSecret          *corev1.Secret
+		legacyWithClientKeyUsage *corev1.Secret
 	)
 	BeforeEach(func() {
 		// Create a Kubernetes client.
@@ -93,26 +97,39 @@ var _ = Describe("Test CertificateManagement suite", func() {
 		Expect(err).NotTo(HaveOccurred())
 		cm = &operatorv1.CertificateManagement{CACert: keyPair.GetCertificatePEM()}
 
-		// Create a legacy secret (how certs were before v1.24) with non-standardized legacy key and cert name.
-		legacySecret, err = secret.CreateTLSSecret(nil, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, time.Hour, nil, appSecretName)
+		// Configure certs to match legacy operator-generated cert extensions - i.e., only valid for use as a server certificate.
+		legacyOpts := []crypto.CertificateExtensionFunc{tls.SetServerAuth}
+		modernOpts := []crypto.CertificateExtensionFunc{tls.SetServerAuth, tls.SetClientAuth}
+
+		certkeyusage.SetCertKeyUsage(legacySecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+		// Create a legacy secret (how certs were before v1.24) with non-standardized legacy key and cert name, and no CA.
+		// Use a secret
+		legacySecret, err = secret.CreateTLSSecret(nil, legacySecretName, appNs, legacyKeyFieldName, legacyCertFieldName, time.Hour, legacyOpts, legacySecretName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// This is a special case, which may or may not exist in the wild. It's a legacy-style certificate signed by tigera-operator but also with client usage.
+		legacyWithClientKeyUsage, err = secret.CreateTLSSecret(nil, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, time.Hour, modernOpts, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create a byo secret with non-standardized legacy key and cert name (like our docs for felix/typha).
 		cryptoCA, err := tls.MakeCA("byo-ca")
 		Expect(err).NotTo(HaveOccurred())
-		byoSecret, err = secret.CreateTLSSecret(cryptoCA, appSecretName, appNs, "key.key", "cert.crt", time.Hour, nil, appSecretName)
+		byoSecret, err = secret.CreateTLSSecret(cryptoCA, appSecretName, appNs, "key.key", "cert.crt", time.Hour, modernOpts, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
-		expiredByoSecret, err = secret.CreateTLSSecret(cryptoCA, appSecretName, appNs, "key.key", "cert.crt", -time.Hour, nil, appSecretName)
+		legacyBYOSecret, err = secret.CreateTLSSecret(cryptoCA, legacySecretName, appNs, "key.key", "cert.crt", time.Hour, legacyOpts, legacySecretName)
+		Expect(err).NotTo(HaveOccurred())
+		expiredBYOSecret, err = secret.CreateTLSSecret(cryptoCA, appSecretName, appNs, "key.key", "cert.crt", -time.Hour, modernOpts, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
 
+		// Create a CA in the manner of older operator versions.
 		legacyCryptoCA, err := tls.MakeCA(rmeta.TigeraOperatorCAIssuerPrefix + "@some-hash")
 		Expect(err).NotTo(HaveOccurred())
-		expiredLegacySecret, err = secret.CreateTLSSecret(legacyCryptoCA, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, -time.Hour, nil, appSecretName)
+		expiredLegacySecret, err = secret.CreateTLSSecret(legacyCryptoCA, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, -time.Hour, legacyOpts, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
 
 		ca, err := crypto.GetCAFromBytes(certificateManager.KeyPair().GetCertificatePEM(), certificateManager.KeyPair().Secret("").Data[corev1.TLSPrivateKeyKey])
 		Expect(err).NotTo(HaveOccurred())
-		expiredSecret, err = secret.CreateTLSSecret(ca, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, -time.Hour, nil, appSecretName)
+		expiredSecret, err = secret.CreateTLSSecret(ca, appSecretName, appNs, legacyKeyFieldName, legacyCertFieldName, -time.Hour, legacyOpts, appSecretName)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -155,7 +172,6 @@ var _ = Describe("Test CertificateManagement suite", func() {
 		})
 
 		It("should create a KeyPair if it does not exist yet or reconstruct it from secret", func() {
-
 			By("creating a key pair and storing the secret")
 			keyPair, err := certificateManager.GetOrCreateKeyPair(cli, appSecretName, appNs, appDNSNames)
 			Expect(err).NotTo(HaveOccurred())
@@ -169,7 +185,6 @@ var _ = Describe("Test CertificateManagement suite", func() {
 		})
 
 		It("should replace a KeyPair if it was created by an older ca", func() {
-
 			By("creating a key pair and storing the secret")
 			keyPair, err := certificateManager.GetOrCreateKeyPair(cli, appSecretName, appNs, appDNSNames)
 			Expect(err).NotTo(HaveOccurred())
@@ -219,6 +234,40 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			Expect(certificate).NotTo(BeNil())
 		})
 
+		Describe("check ExtKeyUsage", func() {
+			It("should update certificates that are only valid for server use", func() {
+				x509Cert, err := x509FromSecret(legacySecret)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Should not be considered valid.
+				valid := certificatemanager.HasRequiredKeyUsage(x509Cert, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+				Expect(valid).NotTo(BeTrue())
+
+				// Should create a new secret.
+				secret := legacySecret
+				Expect(cli.Create(ctx, secret)).NotTo(HaveOccurred())
+
+				_, err = certificateManager.GetCertificate(cli, secret.Name, secret.Namespace)
+				Expect(err).To(HaveOccurred())
+				kp, err := certificateManager.GetOrCreateKeyPair(cli, secret.Name, secret.Namespace, []string{appSecretName})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(kp.GetCertificatePEM()).NotTo(Equal(secret.Data[corev1.TLSCertKey]))
+			})
+
+			It("should consider a client+server certificate valid", func() {
+				// GetOrCreateKeyPair creates a keypair that is configured to act as both a client and server certificate.
+				kp, err := certificateManager.GetOrCreateKeyPair(cli, "secret", "default", []string{"localhost"})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Get the x509 cert and make sure it is recognized as valid.
+				certPEM := kp.GetCertificatePEM()
+				x509Cert, err := certificatemanagement.ParseCertificate(certPEM)
+				Expect(err).NotTo(HaveOccurred())
+				valid := certificatemanager.HasRequiredKeyUsage(x509Cert, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+				Expect(valid).To(BeTrue())
+			})
+		})
+
 		Describe("test certificate expiry", func() {
 			It("should create a new secret when it has expired", func() {
 				secret := expiredSecret
@@ -237,7 +286,14 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			})
 
 			It("should return an error on byo expired secrets", func() {
-				secret := expiredByoSecret
+				secret := expiredBYOSecret
+				Expect(cli.Create(ctx, secret)).NotTo(HaveOccurred())
+				_, err := certificateManager.GetOrCreateKeyPair(cli, secret.Name, secret.Namespace, []string{appSecretName})
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should return an error on legacy byo secrets without client key usage", func() {
+				secret := legacyBYOSecret
 				Expect(cli.Create(ctx, secret)).NotTo(HaveOccurred())
 				_, err := certificateManager.GetOrCreateKeyPair(cli, secret.Name, secret.Namespace, []string{appSecretName})
 				Expect(err).To(HaveOccurred())
@@ -254,7 +310,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			})
 
 			It("should return an error on byo expired secrets when certificate management is enabled", func() {
-				secret := expiredByoSecret
+				secret := expiredBYOSecret
 				Expect(cli.Create(ctx, secret)).NotTo(HaveOccurred())
 				installation.CertificateManagement = cm
 				certificateManagerCM, err := certificatemanager.Create(cli, installation, clusterDomain)
@@ -276,7 +332,6 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			secret1.Name = "test"
 			secret2 := keyPair.Secret("test")
 			Expect(secret2.Name).NotTo(Equal(secret1.Name))
-
 		})
 
 		It("render the right spec for certificateManager issued key pairs", func() {
@@ -398,9 +453,13 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			Expect(cli.Create(ctx, legacySecret)).NotTo(HaveOccurred())
 			keyPair, err := certificateManager.GetOrCreateKeyPair(cli, appSecretName, appNs, appDNSNames)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Legacy certs don't specify a usage key of client, and so they will be reissued
+			// using the new tigera-operator CA certificate. As such, we expect them to match
+			// the new issuer.
 			Expect(keyPair.UseCertificateManagement()).To(BeFalse())
-			Expect(keyPair.BYO()).To(BeTrue())
-			Expect(keyPair.GetIssuer()).NotTo(Equal(certificateManager.KeyPair()))
+			Expect(keyPair.BYO()).NotTo(BeTrue())
+			Expect(keyPair.GetIssuer()).To(Equal(certificateManager.KeyPair()))
 
 			By("verifying the volume is correct")
 			volume := keyPair.Volume()
@@ -420,17 +479,12 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			By("verifying that the non-standard secret fields have been standardized")
 			Expect(keyPair.Secret(appNs).Data[corev1.TLSPrivateKeyKey]).NotTo(BeNil())
 			Expect(keyPair.Secret(appNs).Data[corev1.TLSCertKey]).NotTo(BeNil())
-
-			By("verifying that the legacy fields have been preserved for certain edge-cases in cluster upgrades")
-			Expect(keyPair.Secret(appNs).Data[legacyKeyFieldName]).NotTo(BeNil())
-			Expect(keyPair.Secret(appNs).Data[legacyCertFieldName]).NotTo(BeNil())
 		})
 	})
 
 	Describe("test TrustedBundle interface", func() {
-
 		It("should add a pem block for each certificate", func() {
-			By("creating four secrets in the datastore")
+			By("creating five secrets in the datastore")
 			keyPair, err := certificateManager.GetOrCreateKeyPair(cli, appSecretName, appNs, appDNSNames)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cli.Create(ctx, keyPair.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
@@ -444,24 +498,36 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			legacySecret.Name, legacySecret.Namespace = "legacy-secret", common.OperatorNamespace()
 			Expect(cli.Create(ctx, legacySecret)).NotTo(HaveOccurred())
 			Expect(err).NotTo(HaveOccurred())
+			legacyWithClientKeyUsage.Name, legacyWithClientKeyUsage.Namespace = "legacy-secret-wcku", common.OperatorNamespace()
+			Expect(cli.Create(ctx, legacyWithClientKeyUsage)).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
-			By("creating and validating the four certificates")
+			By("creating and validating the five certificates")
 			cert, err := certificateManager.GetCertificate(cli, appSecretName, common.OperatorNamespace())
 			Expect(err).NotTo(HaveOccurred())
 			cert2, err := certificateManager.GetCertificate(cli, appSecretName2, common.OperatorNamespace())
 			Expect(err).NotTo(HaveOccurred())
 			byo, err := certificateManager.GetCertificate(cli, byoSecret.Name, common.OperatorNamespace())
 			Expect(err).NotTo(HaveOccurred())
+			lwcku, err := certificateManager.GetCertificate(cli, legacyWithClientKeyUsage.Name, common.OperatorNamespace())
+			Expect(err).NotTo(HaveOccurred())
+
+			kp, err := certificateManager.GetOrCreateKeyPair(cli, legacySecret.Name, common.OperatorNamespace(), []string{appSecretName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cli.Update(ctx, kp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			legacy, err := certificateManager.GetCertificate(cli, legacySecret.Name, common.OperatorNamespace())
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(cert.GetIssuer()).To(Equal(certificateManager.KeyPair()))
 			Expect(cert2.GetIssuer()).To(Equal(certificateManager.KeyPair()))
 			Expect(byo.GetIssuer()).NotTo(Equal(certificateManager.KeyPair()))
-			Expect(legacy.GetIssuer()).NotTo(Equal(certificateManager.KeyPair()))
+			Expect(lwcku.GetIssuer()).NotTo(Equal(certificateManager.KeyPair()))
+
+			// The legacy certificate will have been reissued, and so will match the operator CA.
+			Expect(legacy.GetIssuer()).To(Equal(certificateManager.KeyPair()))
 
 			By("creating and validating a trusted certificate bundle")
-			trustedBundle := certificateManager.CreateTrustedBundle(cert, cert2, byo, legacy)
+			trustedBundle := certificateManager.CreateTrustedBundle(cert, cert2, byo, legacy, lwcku)
 			Expect(trustedBundle.Volume()).To(Equal(corev1.Volume{
 				Name: "tigera-ca-bundle",
 				VolumeSource: corev1.VolumeSource{
@@ -487,12 +553,13 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			// While we have the ca + 4 certs, we expect 3 cert blocks (+ 2):
 			// - the certificateManager: this covers for all certs signed by the tigera root ca
 			// - the byo block (+ its ca block)
-			// - the legacy block (+ its ca block)
+			// - the legacy cert that already has ExtKeyUsageClient configured.
 			Expect(numBlocks).To(Equal(3))
 			Expect(trustedBundle.HashAnnotations()).To(HaveKey("hash.operator.tigera.io/tigera-ca-private"))
 			Expect(trustedBundle.HashAnnotations()).To(HaveKey("hash.operator.tigera.io/byo-secret"))
-			Expect(trustedBundle.HashAnnotations()).To(HaveKey("hash.operator.tigera.io/legacy-secret"))
+			Expect(trustedBundle.HashAnnotations()).To(HaveKey("hash.operator.tigera.io/legacy-secret-wcku"))
 		})
+
 		It("should load the system certificates into the bundle", func() {
 			if runtime.GOOS != "linux" {
 				Skip("Skip for users that run this test outside of a container on incompatible systems.")
@@ -509,3 +576,12 @@ var _ = Describe("Test CertificateManagement suite", func() {
 		})
 	})
 })
+
+func x509FromSecret(secret *corev1.Secret) (*x509.Certificate, error) {
+	_, certPEM := certificatemanager.GetKeyCertPEM(secret)
+	x509Cert, err := certificatemanagement.ParseCertificate(certPEM)
+	if err != nil {
+		return nil, err
+	}
+	return x509Cert, nil
+}

--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -442,6 +442,9 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	reqLogger.V(3).Info("rendering components")
+
+	namespaceComp := render.NewPassthrough(render.CreateNamespace(render.ComplianceNamespace, network.KubernetesProvider, render.PSSPrivileged))
+
 	hasNoLicense := !utils.IsFeatureActive(license, common.ComplianceFeature)
 	openshift := r.provider == operatorv1.ProviderOpenShift
 	complianceCfg := &render.ComplianceConfiguration{
@@ -488,7 +491,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		TrustedBundle: trustedBundle,
 	})
 
-	for _, comp := range []render.Component{comp, certificateComponent} {
+	for _, comp := range []render.Component{namespaceComp, certificateComponent, comp} {
 		if err := handler.CreateOrUpdateOrDelete(ctx, comp, r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating / deleting resource", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/render/common/secret/secrets.go
+++ b/pkg/render/common/secret/secrets.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package secret
 
 import (
@@ -43,10 +57,17 @@ func CreateTLSSecret(
 			return nil, fmt.Errorf("unable to create signed cert pair: %s", err)
 		}
 	}
+
 	// localhost is the default hostname for the generated certificate if none are provided.
 	hostnamesSet := sets.NewString("localhost")
 	if len(hostnames) > 0 {
 		hostnamesSet = sets.NewString(hostnames...)
+	}
+
+	// Default extensions if not provided such that the certificate is valid
+	// for both a server and client certificate.
+	if len(cef) == 0 {
+		cef = []crypto.CertificateExtensionFunc{tls.SetClientAuth, tls.SetServerAuth}
 	}
 
 	cert, err := ca.MakeServerCertForDuration(hostnamesSet, dur, cef...)

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -15,6 +15,7 @@
 package render
 
 import (
+	"crypto/x509"
 	"fmt"
 	"strings"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 )
 
 const (
@@ -84,6 +86,14 @@ var (
 	ComplianceSnapshotterSourceEntityRule = networkpolicy.CreateSourceEntityRule(ComplianceNamespace, ComplianceSnapshotterName)
 	ComplianceReporterSourceEntityRule    = networkpolicy.CreateSourceEntityRule(ComplianceNamespace, ComplianceReporterName)
 )
+
+// Register secret/certs that need Server and Client Key usage
+func init() {
+	certkeyusage.SetCertKeyUsage(ComplianceServerCertSecret, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+	certkeyusage.SetCertKeyUsage(ComplianceSnapshotterSecret, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+	certkeyusage.SetCertKeyUsage(ComplianceBenchmarkerSecret, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+	certkeyusage.SetCertKeyUsage(ComplianceReporterSecret, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+}
 
 func Compliance(cfg *ComplianceConfiguration) (Component, error) {
 	return &complianceComponent{
@@ -171,7 +181,6 @@ func (c *complianceComponent) SupportedOSType() rmeta.OSType {
 
 func (c *complianceComponent) Objects() ([]client.Object, []client.Object) {
 	complianceObjs := []client.Object{
-		CreateNamespace(ComplianceNamespace, c.cfg.Installation.KubernetesProvider, PSSPrivileged),
 		c.complianceAccessAllowTigeraNetworkPolicy(),
 		networkpolicy.AllowTigeraDefaultDeny(ComplianceNamespace),
 	}

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -129,7 +129,6 @@ var _ = Describe("compliance rendering tests", func() {
 				version string
 				kind    string
 			}{
-				{ns, "", "", "v1", "Namespace"},
 				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
@@ -177,11 +176,6 @@ var _ = Describe("compliance rendering tests", func() {
 			rtest.ExpectGlobalReportType(rtest.GetResource(resources, "network-access", "", "projectcalico.org", "v3", "GlobalReportType"), "network-access")
 			rtest.ExpectGlobalReportType(rtest.GetResource(resources, "policy-audit", "", "projectcalico.org", "v3", "GlobalReportType"), "policy-audit")
 			rtest.ExpectGlobalReportType(rtest.GetResource(resources, "cis-benchmark", "", "projectcalico.org", "v3", "GlobalReportType"), "cis-benchmark")
-
-			// Check the namespace.
-			namespace := rtest.GetResource(resources, "tigera-compliance", "", "", "v1", "Namespace").(*corev1.Namespace)
-			Expect(namespace.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("privileged"))
-			Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 
 			clusterRole := rtest.GetResource(resources, "tigera-compliance-server", "", rbac, "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			Expect(clusterRole.Rules).To(ConsistOf([]rbacv1.PolicyRule{
@@ -292,7 +286,6 @@ var _ = Describe("compliance rendering tests", func() {
 				version string
 				kind    string
 			}{
-				{ns, "", "", "v1", "Namespace"},
 				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
@@ -412,7 +405,6 @@ var _ = Describe("compliance rendering tests", func() {
 				version string
 				kind    string
 			}{
-				{ns, "", "", "v1", "Namespace"},
 				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},
@@ -554,7 +546,6 @@ var _ = Describe("compliance rendering tests", func() {
 				version string
 				kind    string
 			}{
-				{ns, "", "", "v1", "Namespace"},
 				{"allow-tigera.compliance-access", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"allow-tigera.default-deny", ns, "projectcalico.org", "v3", "NetworkPolicy"},
 				{"tigera-compliance-controller", ns, "", "v1", "ServiceAccount"},

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -15,6 +15,7 @@
 package render
 
 import (
+	"crypto/x509"
 	"fmt"
 	"strconv"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 	"github.com/tigera/operator/pkg/url"
 )
 
@@ -114,6 +116,11 @@ var FluentdSourceEntityRule = v3.EntityRule{
 }
 
 var EKSLogForwarderEntityRule = networkpolicy.CreateSourceEntityRule(LogCollectorNamespace, eksLogForwarderName)
+
+// Register secret/certs that need Server and Client Key usage
+func init() {
+	certkeyusage.SetCertKeyUsage(FluentdPrometheusTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+}
 
 type FluentdFilters struct {
 	Flow string

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -15,6 +15,7 @@
 package render
 
 import (
+	"crypto/x509"
 	"fmt"
 	"strconv"
 	"strings"
@@ -43,6 +44,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 	"github.com/tigera/operator/pkg/url"
 )
 
@@ -88,6 +90,7 @@ const (
 
 var adAPIReplicas int32 = 1
 
+// Register secret/certs that need Server and Client Key usage
 var (
 	intrusionDetectionNamespaceSelector = fmt.Sprintf("projectcalico.org/name == '%s'", IntrusionDetectionNamespace)
 	IntrusionDetectionSourceEntityRule  = v3.EntityRule{
@@ -99,6 +102,12 @@ var (
 var IntrusionDetectionInstallerSourceEntityRule = v3.EntityRule{
 	NamespaceSelector: intrusionDetectionNamespaceSelector,
 	Selector:          fmt.Sprintf("job-name == '%s'", IntrusionDetectionInstallerJobName),
+}
+
+// Register secret/certs that need Server and Client Key usage
+func init() {
+	certkeyusage.SetCertKeyUsage(AnomalyDetectorTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+	certkeyusage.SetCertKeyUsage(DPITLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
 }
 
 func IntrusionDetection(cfg *IntrusionDetectionConfiguration) Component {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -15,6 +15,7 @@
 package render
 
 import (
+	"crypto/x509"
 	"fmt"
 	"strconv"
 	"strings"
@@ -46,6 +47,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 )
 
 const (
@@ -90,6 +92,11 @@ var (
 	ManagerEntityRule       = networkpolicy.CreateEntityRule(ManagerNamespace, ManagerDeploymentName, managerPort)
 	ManagerSourceEntityRule = networkpolicy.CreateSourceEntityRule(ManagerNamespace, ManagerDeploymentName)
 )
+
+func init() {
+	certkeyusage.SetCertKeyUsage(ManagerTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+	certkeyusage.SetCertKeyUsage(ManagerInternalTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+}
 
 func Manager(cfg *ManagerConfiguration) (Component, error) {
 	var tlsSecrets []*corev1.Secret

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -15,6 +15,7 @@
 package monitor
 
 import (
+	"crypto/x509"
 	_ "embed"
 	"fmt"
 	"strings"
@@ -45,6 +46,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 )
 
 const (
@@ -91,6 +93,11 @@ var alertManagerSelector = fmt.Sprintf(
 	"(app == 'alertmanager' && alertmanager == '%[1]s') || (app.kubernetes.io/name == 'alertmanager' && alertmanager == '%[1]s')",
 	CalicoNodeAlertmanager,
 )
+
+// Register secret/certs that need Server and Client Key usage
+func init() {
+	certkeyusage.SetCertKeyUsage(PrometheusClientTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+}
 
 func Monitor(cfg *Config) render.Component {
 	return &monitorComponent{

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -15,6 +15,8 @@
 package render
 
 import (
+	"crypto/x509"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -33,6 +35,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/pkg/tls/certkeyusage"
 )
 
 // The names of the components related to the PolicyRecommendation APIs related rendered objects.
@@ -48,6 +51,11 @@ const (
 )
 
 var PolicyRecommendationEntityRule = networkpolicy.CreateSourceEntityRule(PolicyRecommendationNamespace, PolicyRecommendationName)
+
+// Register secret/certs that need Server and Client Key usage
+func init() {
+	certkeyusage.SetCertKeyUsage(PolicyRecommendationTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+}
 
 // PolicyRecommendationConfiguration contains all the config information needed to render the component.
 type PolicyRecommendationConfiguration struct {

--- a/pkg/tls/certkeyusage/certkeyusage.go
+++ b/pkg/tls/certkeyusage/certkeyusage.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certkeyusage
+
+import "crypto/x509"
+
+var secretKeyUsage = map[string][]x509.ExtKeyUsage{}
+
+func SetCertKeyUsage(secretName string, usage []x509.ExtKeyUsage) {
+	secretKeyUsage[secretName] = usage
+}
+
+// GetKeyUsage looks up the expected usage for keys by name. Currently these are certs that in a
+// legacy install may have been created with only Server ext key usage but now with linseed they
+// they need to also have client for mTLS.
+// This is a varaible so that we can override this for testing purposes.
+func GetCertKeyUsage(secret string) []x509.ExtKeyUsage {
+	if usage, ok := secretKeyUsage[secret]; ok {
+		return usage
+	}
+	return []x509.ExtKeyUsage{}
+}


### PR DESCRIPTION
- Only require key usage for certain secret certs
- Compliance: order dependencies so certificates are updated before pods are updated.

## Description

Pick #2775 to release-v1.31

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
