### PR TITLE
Fix for EGW deployment in openshift 4.13

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1353,6 +1353,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		Installation: &instance.Spec,
 		Terminating:  terminating,
 		UsePSP:       r.usePSP,
+		OpenShift:    instance.Spec.KubernetesProvider == operator.ProviderOpenShift,
 	}
 	components = append(components, render.CSI(&csiCfg))
 

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
@@ -295,5 +296,15 @@ var _ = Describe("CSI rendering tests", func() {
 		dsResource := rtest.GetResource(createObjs, "csi-node-driver", common.CalicoNamespace, "apps", "v1", "DaemonSet")
 		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
 		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(ContainSubstring("-fips"))
+	})
+
+	It("should render the labels when the provider is openshift", func() {
+		cfg.OpenShift = true
+		comp := render.CSI(&cfg)
+		Expect(comp.ResolveImages(nil)).To(BeNil())
+		createObjs, _ := comp.Objects()
+		dsResource := rtest.GetResource(createObjs, "csi.tigera.io", "", "storage", "v1", "CSIDriver")
+		Expect(dsResource.(*storagev1.CSIDriver).ObjectMeta.Labels["security.openshift.io/csi-ephemeral-volume-profile"]).To(Equal("restricted"))
+
 	})
 })


### PR DESCRIPTION
## Description
In openshift 4.13, support was added for CSI admission plugin. This restrict pods using csi as a ephemeral volume like we use in EGW. Users can specify ```csi-ephemeral-volume-profile``` label and define the pod security level that needs to be enforced. 

If undefined ```csi-ephemeral-volume-profile``` value will be set to privileged. As a result, only namespaces which enforces ```privileged``` security levels can be used for deploying EGWs. 

```    
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/enforce-version: latest
```
The above labels need to be added to the namespace where EGWs are deployed. To avoid elevating the namespace's security level to privileged, this PR adds ```security.openshift.io/csi-ephemeral-volume-profile: restricted```  to the CSIDriver storage object. As a result all namespaces whose pod security level is ```restricted```, ```privileged``` and ```baseline``` can deploy EGWs. 

Detailed information can be found in https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/ephemeral-storage-csi-inline.html

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
