### PR TITLE
replace value of FELIX_HEALTHPORT instead of appending it

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1656,7 +1656,12 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 	switch c.cfg.Installation.KubernetesProvider {
 	case operatorv1.ProviderOpenShift:
 		// For Openshift, we need special configuration since our default port is already in use.
-		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_HEALTHPORT", Value: "9199"})
+		for i := range nodeEnv {
+			if nodeEnv[i].Name == "FELIX_HEALTHPORT" {
+				nodeEnv[i].Value = "9199"
+				break
+			}
+		}
 	// For AKS/AzureVNET and EKS/VPCCNI, we must explicitly ask felix to add host IP's to wireguard ifaces
 	case operatorv1.ProviderAKS:
 		if c.cfg.Installation.CNI.Type == operatorv1.PluginAzureVNET {


### PR DESCRIPTION
## Description
As described in https://github.com/tigera/operator/issues/2783, when installing Calico with Tigera operator on Openshift, the environment variable `FELIX_HEALTHPORT` is duplicated in calico-node pods, which can cause problems on specific Openshift clusters that are affected by a Kubernetes bug described at https://github.com/kubernetes/kubernetes/issues/118261.
This PR aims to fix this by overwriting the value for `FELIX_HEALTHPORT` instead of appending a new version of it (in case of Openshift).

For more details, please take a look at https://github.com/tigera/operator/issues/2783.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
