### PR TITLE
[release-v1.29] Add SecurityContext for Prometheus service container

### DIFF
--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -499,6 +499,7 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 							},
 						},
 					},
+					SecurityContext: securitycontext.NewNonRootContext(),
 				},
 			},
 			// ListenLocal makes the Prometheus server listen on loopback, so that it

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -316,6 +316,22 @@ var _ = Describe("monitor rendering tests", func() {
 			&corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			}))
+		Expect(prometheusObj.Spec.Containers).To(HaveLen(1))
+		Expect(prometheusObj.Spec.Containers[0].Name).To(Equal("authn-proxy"))
+		Expect(*prometheusObj.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+		Expect(*prometheusObj.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
+		Expect(*prometheusObj.Spec.Containers[0].SecurityContext.RunAsGroup).To(BeEquivalentTo(10001))
+		Expect(*prometheusObj.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
+		Expect(*prometheusObj.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(10001))
+		Expect(prometheusObj.Spec.Containers[0].SecurityContext.Capabilities).To(Equal(
+			&corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		))
+		Expect(prometheusObj.Spec.Containers[0].SecurityContext.SeccompProfile).To(Equal(
+			&corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			}))
 
 		// Prometheus ServiceAccount
 		_, ok = rtest.GetResource(toCreate, "prometheus", common.TigeraPrometheusNamespace, "", "v1", "ServiceAccount").(*corev1.ServiceAccount)


### PR DESCRIPTION
## Description

Pick https://github.com/tigera/operator/pull/2784 into release v1.29 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
