### PR TITLE
Automated cherry pick of #2790: Certs: Returning specific error type when key usage is

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -249,7 +249,15 @@ var _ = Describe("Test CertificateManagement suite", func() {
 
 				_, err = certificateManager.GetCertificate(cli, secret.Name, secret.Namespace)
 				Expect(err).To(HaveOccurred())
-				kp, err := certificateManager.GetOrCreateKeyPair(cli, secret.Name, secret.Namespace, []string{appSecretName})
+				// Error from GetCertificate with secret that only has server usage should
+				// be a cert error.
+				Expect(certificatemanager.IsCertExtKeyUsageError(err)).To(BeTrue())
+				Expect(err.Error()).To(ContainSubstring("ExtKeyUsageServerAuth"))
+				Expect(err.Error()).To(ContainSubstring("ExtKeyUsageClientAuth"))
+				kp, err := certificateManager.GetKeyPair(cli, secret.Name, secret.Namespace)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(kp).To(BeNil())
+				kp, err = certificateManager.GetOrCreateKeyPair(cli, secret.Name, secret.Namespace, []string{appSecretName})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(kp.GetCertificatePEM()).NotTo(Equal(secret.Data[corev1.TLSCertKey]))
 			})

--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -464,10 +464,25 @@ func (r *ReconcileLogStorage) generateSecrets(
 	for _, certName := range certs {
 		cert, err := cm.GetCertificate(r.client, certName, common.OperatorNamespace())
 		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, log)
-			return nil, err
+			// This check is needed because there is a circular dependency between the certs/secrets
+			// used here and with the linseed cert that is created by this controller.
+			// Typically this circular dependency does not cause an issue because the missing certs
+			// are ignored so the linseed cert is created which unblocks the other controllers to
+			// update their certificates.
+			// This comes into play during an upgrade when certificates need to be updated and
+			// the linseed cert needs to be created because it previously did not exist.
+			// This works around that dependency by ignoring any certs that need updated by a
+			// different controller but are blocked on updating the certs because the other controllers
+			// are also waiting on linseed certs.
+			if certificatemanager.IsCertExtKeyUsageError(err) {
+				msg := fmt.Sprintf("skipping %s/%s secret it will be added when it is updated: %s", common.OperatorNamespace(), certName, err)
+				log.Info(msg)
+			} else {
+				r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, log)
+				return nil, err
+			}
 		} else if cert == nil {
-			msg := fmt.Sprintf("tigera-operator/%s secret not available yet, will add it if/when it becomes available", certName)
+			msg := fmt.Sprintf("%s/%s secret not available yet, will add it if/when it becomes available", common.OperatorNamespace(), certName)
 			log.Info(msg)
 		} else {
 			collection.upstreamCerts = append(collection.upstreamCerts, cert)


### PR DESCRIPTION
Cherry pick of #2790 on release-v1.30.

#2790: Certs: Returning specific error type when key usage is