### PR TITLE
Automated cherry pick of #2796: Remove duplicate Felix Health Port for Openshift

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1482,8 +1482,6 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 	// Configure provider specific environment variables here.
 	switch c.cfg.Installation.KubernetesProvider {
 	case operatorv1.ProviderOpenShift:
-		// For Openshift, we need special configuration since our default port is already in use.
-		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_HEALTHPORT", Value: "9199"})
 		if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 			// We also need to configure a non-default trusted DNS server, since there's no kube-dns.
 			nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"})

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1731,8 +1731,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					// The OpenShift envvar overrides.
-					{Name: "FELIX_HEALTHPORT", Value: "9199"},
 					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -1823,9 +1821,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_FLOWLOGSCOLLECTPROCESSINFO", Value: "true"},
 					{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 					{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
-
-					// The OpenShift envvar overrides.
-					{Name: "FELIX_HEALTHPORT", Value: "9199"},
 					{Name: "MULTI_INTERFACE_MODE", Value: operatorv1.MultiInterfaceModeNone.Value()},
 					{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"},
 					{Name: "FIPS_MODE_ENABLED", Value: "false"},


### PR DESCRIPTION
Cherry pick of #2796 on release-v1.28.

#2796: Remove duplicate Felix Health Port for Openshift