### PR TITLE
Automated cherry pick of #2802: Create internal manager tls inside of manager_controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,7 @@ FV_DIR?=./test
 GINKGO_ARGS?= -v
 GINKGO_FOCUS?=.*
 
+.PHONY: ut
 ut:
 	-mkdir -p .go-pkg-cache report
 	$(CONTAINERIZED) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -329,7 +329,7 @@ func add(c controller.Controller, r *ReconcileInstallation) error {
 
 		// Watch the internal manager TLS secret in the calico namespace, where it's copied for kube-controllers.
 		if err = utils.AddSecretsWatch(c, monitor.PrometheusTLSSecretName, common.TigeraPrometheusNamespace); err != nil {
-			return fmt.Errorf("tigera-installation-controller failed to watch secret '%s' in '%s' namespace: %w", render.ManagerInternalTLSSecretName, common.OperatorNamespace(), err)
+			return fmt.Errorf("tigera-installation-controller failed to watch secret '%s' in '%s' namespace: %w", monitor.PrometheusTLSSecretName, common.OperatorNamespace(), err)
 		}
 
 		// watch for change to primary resource LogCollector
@@ -1059,20 +1059,22 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		r.status.SetDegraded(operator.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err
 	}
-	var managerInternalTLSSecret certificatemanagement.KeyPairInterface
-	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
-		managerInternalTLSSecret, err = certificateManager.GetKeyPair(r.client, render.ManagerInternalTLSSecretName, common.OperatorNamespace())
-		if err != nil {
-			r.status.SetDegraded(operator.ResourceReadError, fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.ManagerInternalTLSSecretName, common.OperatorNamespace()), err, reqLogger)
-			return reconcile.Result{}, nil
-		}
-	}
 
 	typhaNodeTLS, err := GetOrCreateTyphaNodeTLSConfig(r.client, certificateManager)
 	if err != nil {
 		log.Error(err, "Error with Typha/Felix secrets")
 		r.status.SetDegraded(operator.CertificateError, "Error with Typha/Felix secrets", err, reqLogger)
 		return reconcile.Result{}, err
+	}
+
+	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
+		managerInternalTLSSecret, err := certificateManager.GetCertificate(r.client, render.ManagerInternalTLSSecretName, common.OperatorNamespace())
+		if err != nil {
+			r.status.SetDegraded(operator.ResourceReadError, fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.ManagerInternalTLSSecretName, common.OperatorNamespace()), err, reqLogger)
+			return reconcile.Result{}, nil
+		} else if managerInternalTLSSecret != nil {
+			typhaNodeTLS.TrustedBundle.AddCertificates(managerInternalTLSSecret)
+		}
 	}
 
 	birdTemplates, err := getBirdTemplates(r.client)
@@ -1278,7 +1280,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
 				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
-				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, false, true),
 				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(kubeControllerTLS, true, true),
 			},
@@ -1364,7 +1365,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		ManagementClusterConnection: managementClusterConnection,
 		ClusterDomain:               r.clusterDomain,
 		MetricsPort:                 kubeControllersMetricsPort,
-		ManagerInternalSecret:       managerInternalTLSSecret,
 		Terminating:                 terminating,
 		UsePSP:                      r.usePSP,
 		MetricsServerTLS:            kubeControllerTLS,

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1061,11 +1061,10 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	}
 	var managerInternalTLSSecret certificatemanagement.KeyPairInterface
 	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
-		dnsNames := append(dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain), render.ManagerServiceIP)
-		managerInternalTLSSecret, err = certificateManager.GetOrCreateKeyPair(r.client, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), dnsNames)
+		managerInternalTLSSecret, err = certificateManager.GetKeyPair(r.client, render.ManagerInternalTLSSecretName, common.OperatorNamespace())
 		if err != nil {
-			r.status.SetDegraded(operator.CertificateError, fmt.Sprintf("Error ensuring internal manager TLS certificate %q exists and has valid DNS names", render.ManagerInternalTLSSecretName), err, reqLogger)
-			return reconcile.Result{}, err
+			r.status.SetDegraded(operator.ResourceReadError, fmt.Sprintf("Error fetching TLS secret %s in namespace %s", render.ManagerInternalTLSSecretName, common.OperatorNamespace()), err, reqLogger)
+			return reconcile.Result{}, nil
 		}
 	}
 
@@ -1279,7 +1278,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 				rcertificatemanagement.NewKeyPairOption(certificateManager.KeyPair(), true, false),
 				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(nodePrometheusTLS, true, true),
-				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, true, true),
+				rcertificatemanagement.NewKeyPairOption(managerInternalTLSSecret, false, true),
 				rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(kubeControllerTLS, true, true),
 			},

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/dns"
-	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/kubecontrollers"
@@ -49,11 +48,10 @@ import (
 
 var _ = Describe("kube-controllers rendering tests", func() {
 	var (
-		instance                 *operatorv1.InstallationSpec
-		k8sServiceEp             k8sapi.ServiceEndpoint
-		cfg                      kubecontrollers.KubeControllersConfiguration
-		internalManagerTLSSecret certificatemanagement.KeyPairInterface
-		cli                      client.Client
+		instance     *operatorv1.InstallationSpec
+		k8sServiceEp k8sapi.ServiceEndpoint
+		cfg          kubecontrollers.KubeControllersConfiguration
+		cli          client.Client
 	)
 
 	esEnvs := []corev1.EnvVar{
@@ -127,8 +125,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 		cli = fake.NewClientBuilder().WithScheme(scheme).Build()
 		certificateManager, err := certificatemanager.Create(cli, nil, dns.DefaultClusterDomain)
-		Expect(err).NotTo(HaveOccurred())
-		internalManagerTLSSecret, err = certificateManager.GetOrCreateKeyPair(cli, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), []string{render.ManagerInternalTLSSecretName})
 		Expect(err).NotTo(HaveOccurred())
 		cfg = kubecontrollers.KubeControllersConfiguration{
 			K8sServiceEp:  k8sServiceEp,
@@ -240,7 +236,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		}
 
 		instance.Variant = operatorv1.TigeraSecureEnterprise
-		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
 
 		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
@@ -264,13 +259,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			Name: "ENABLED_CONTROLLERS", Value: "node,service,federatedservices",
 		}))
 
-		Expect(len(dp.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(2))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/internal-manager-tls"))
-
-		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(2))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
+		Expect(len(dp.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
+		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(len(clusterRole.Rules)).To(Equal(19))
@@ -329,7 +319,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		instance.Variant = operatorv1.TigeraSecureEnterprise
 		cfg.LogStorageExists = true
 		cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
-		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
 
 		component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
@@ -354,17 +343,13 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		}))
 		Expect(envs).To(ContainElements(esEnvs))
 
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/internal-manager-tls"))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal("tigera-ca-bundle"))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal("/etc/pki/tls/certs"))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(1))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("tigera-ca-bundle"))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/etc/pki/tls/certs"))
 
-		Expect(dp.Spec.Template.Spec.Volumes).To(HaveLen(2))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Volumes[1].Name).To(Equal("tigera-ca-bundle"))
-		Expect(dp.Spec.Template.Spec.Volumes[1].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
+		Expect(dp.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal("tigera-ca-bundle"))
+		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(len(clusterRole.Rules)).To(Equal(19))
@@ -395,7 +380,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		// Override configuration to match expected Enterprise config.
 		instance.Variant = operatorv1.TigeraSecureEnterprise
 		cfg.ManagementCluster = &operatorv1.ManagementCluster{}
-		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
 
 		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
@@ -419,14 +403,9 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			Value: "node,service,federatedservices",
 		}))
 
-		Expect(len(dp.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(2))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/internal-manager-tls"))
+		Expect(len(dp.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(1))
 
-		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(2))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
-
+		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 	})
 	It("should render all calico-kube-controllers resources for a default configuration using TigeraSecureEnterprise", func() {
@@ -541,7 +520,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.LogStorageExists = true
 		cfg.ManagementCluster = &operatorv1.ManagementCluster{}
 		cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
-		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
 
 		component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
@@ -565,17 +543,13 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			Value: "authorization,elasticsearchconfiguration,managedcluster",
 		}))
 
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/internal-manager-tls"))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal("tigera-ca-bundle"))
-		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(Equal("/etc/pki/tls/certs"))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(1))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal("tigera-ca-bundle"))
+		Expect(dp.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/etc/pki/tls/certs"))
 
-		Expect(dp.Spec.Template.Spec.Volumes).To(HaveLen(2))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Volumes[0].Secret.SecretName).To(Equal(render.ManagerInternalTLSSecretName))
-		Expect(dp.Spec.Template.Spec.Volumes[1].Name).To(Equal("tigera-ca-bundle"))
-		Expect(dp.Spec.Template.Spec.Volumes[1].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
+		Expect(dp.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(Equal("tigera-ca-bundle"))
+		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
@@ -702,7 +676,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.LogStorageExists = true
 		cfg.ManagementCluster = &operatorv1.ManagementCluster{}
 		cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
-		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
 		cfg.Authentication = &operatorv1.Authentication{Spec: operatorv1.AuthenticationSpec{
 			UsernamePrefix: "uOIDC:",
@@ -951,7 +924,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			cfg.LogStorageExists = true
 			cfg.ManagementCluster = &operatorv1.ManagementCluster{}
 			cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
-			cfg.ManagerInternalSecret = internalManagerTLSSecret
 			cfg.MetricsPort = 9094
 			component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 			resources, _ := component.Objects()
@@ -1035,7 +1007,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 					cfg.ManagementClusterConnection = nil
 				}
 				instance.Variant = operatorv1.TigeraSecureEnterprise
-				cfg.ManagerInternalSecret = internalManagerTLSSecret
 
 				component := kubecontrollers.NewCalicoKubeControllersPolicy(&cfg)
 				resources, _ := component.Objects()
@@ -1083,7 +1054,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				instance.Variant = operatorv1.TigeraSecureEnterprise
 				cfg.LogStorageExists = true
 				cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
-				cfg.ManagerInternalSecret = internalManagerTLSSecret
 
 				component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 				resources, _ := component.Objects()
@@ -1102,7 +1072,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 	It("should render init containers when certificate management is enabled", func() {
 
 		instance.Variant = operatorv1.TigeraSecureEnterprise
-		cfg.ManagerInternalSecret = internalManagerTLSSecret
 		cfg.MetricsPort = 9094
 		ca, _ := tls.MakeCA(rmeta.DefaultOperatorCASignerName())
 		cert, _, _ := ca.Config.GetPEMBytes() // create a valid pem block

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -49,8 +49,6 @@ import (
 const (
 	DeploymentName        = "tigera-linseed"
 	ServiceAccountName    = "tigera-linseed"
-	RoleName              = "tigera-linseed"
-	ServiceName           = "tigera-linseed"
 	PodSecurityPolicyName = "tigera-linseed"
 	PolicyName            = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
 	PortName              = "tigera-linseed"
@@ -287,6 +285,9 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 	var initContainers []corev1.Container
 	if l.cfg.KeyPair.UseCertificateManagement() {
 		initContainers = append(initContainers, l.cfg.KeyPair.InitContainer(l.namespace))
+	}
+	if l.cfg.TokenKeyPair != nil && l.cfg.TokenKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, l.cfg.TokenKeyPair.InitContainer(l.namespace))
 	}
 
 	annotations := l.cfg.TrustedBundle.HashAnnotations()

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -83,13 +83,14 @@ var _ = Describe("Linseed rendering tests", func() {
 				Registry:             "testregistry.com/",
 			}
 			replicas = 2
-			kp, bundle := getTLS(installation)
+			kp, tokenKP, bundle := getTLS(installation)
 			cfg = &Config{
 				Installation: installation,
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
 				KeyPair:         kp,
+				TokenKeyPair:    tokenKP,
 				TrustedBundle:   bundle,
 				ClusterDomain:   clusterDomain,
 				UsePSP:          true,
@@ -120,13 +121,14 @@ var _ = Describe("Linseed rendering tests", func() {
 			secret, err := certificatemanagement.CreateSelfSignedSecret("", "", "", nil)
 			Expect(err).NotTo(HaveOccurred())
 			installation.CertificateManagement = &operatorv1.CertificateManagement{CACert: secret.Data[corev1.TLSCertKey]}
-			kp, bundle := getTLS(installation)
+			kp, tokenKP, bundle := getTLS(installation)
 			cfg = &Config{
 				Installation: installation,
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
 				KeyPair:         kp,
+				TokenKeyPair:    tokenKP,
 				TrustedBundle:   bundle,
 				ClusterDomain:   clusterDomain,
 				UsePSP:          true,
@@ -223,7 +225,7 @@ var _ = Describe("Linseed rendering tests", func() {
 			)
 		})
 		It("should set the right env when FIPS mode is enabled", func() {
-			kp, bundle := getTLS(installation)
+			kp, tokenKP, bundle := getTLS(installation)
 			enabled := operatorv1.FIPSModeEnabled
 			installation.FIPSMode = &enabled
 			component := Linseed(&Config{
@@ -232,6 +234,7 @@ var _ = Describe("Linseed rendering tests", func() {
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
 				KeyPair:         kp,
+				TokenKeyPair:    tokenKP,
 				TrustedBundle:   bundle,
 				ClusterDomain:   clusterDomain,
 				ESClusterConfig: esClusterConfig,
@@ -245,18 +248,20 @@ var _ = Describe("Linseed rendering tests", func() {
 	})
 })
 
-func getTLS(installation *operatorv1.InstallationSpec) (certificatemanagement.KeyPairInterface, certificatemanagement.TrustedBundle) {
+func getTLS(installation *operatorv1.InstallationSpec) (certificatemanagement.KeyPairInterface, certificatemanagement.KeyPairInterface, certificatemanagement.TrustedBundle) {
 	scheme := runtime.NewScheme()
 	Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
 	certificateManager, err := certificatemanager.Create(cli, installation, dns.DefaultClusterDomain)
 	Expect(err).NotTo(HaveOccurred())
 	esDNSNames := dns.GetServiceDNSNames(render.TigeraLinseedSecret, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
-	gwKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TigeraLinseedSecret, render.ElasticsearchNamespace, esDNSNames)
+	linseedKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TigeraLinseedSecret, render.ElasticsearchNamespace, esDNSNames)
 	Expect(err).NotTo(HaveOccurred())
-	trustedBundle := certificateManager.CreateTrustedBundle(gwKeyPair)
+	tokenKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TigeraLinseedTokenSecret, render.ElasticsearchNamespace, esDNSNames)
+	Expect(err).NotTo(HaveOccurred())
+	trustedBundle := certificateManager.CreateTrustedBundle(linseedKeyPair)
 	Expect(cli.Create(context.Background(), certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
-	return gwKeyPair, trustedBundle
+	return linseedKeyPair, tokenKeyPair, trustedBundle
 }
 
 func compareResources(resources []client.Object, expectedResources []resourceTestObj, useCSR bool) {
@@ -299,8 +304,9 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 
 	// Check init containers
 	if useCSR {
-		ExpectWithOffset(1, len(deployment.Spec.Template.Spec.InitContainers)).To(Equal(1))
+		ExpectWithOffset(1, len(deployment.Spec.Template.Spec.InitContainers)).To(Equal(2))
 		ExpectWithOffset(1, deployment.Spec.Template.Spec.InitContainers[0].Name).To(Equal(fmt.Sprintf("%s-key-cert-provisioner", render.TigeraLinseedSecret)))
+		ExpectWithOffset(1, deployment.Spec.Template.Spec.InitContainers[1].Name).To(Equal(fmt.Sprintf("%s-key-cert-provisioner", render.TigeraLinseedTokenSecret)))
 	}
 
 	// Check volumeMounts

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -266,6 +266,9 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 	if c.cfg.InternalTLSKeyPair != nil && c.cfg.InternalTLSKeyPair.UseCertificateManagement() {
 		initContainers = append(initContainers, c.cfg.InternalTLSKeyPair.InitContainer(ManagerNamespace))
 	}
+	if c.cfg.VoltronLinseedKeyPair != nil && c.cfg.VoltronLinseedKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.VoltronLinseedKeyPair.InitContainer(ManagerNamespace))
+	}
 
 	podTemplate := relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -263,6 +263,9 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 	if c.cfg.TLSKeyPair.UseCertificateManagement() {
 		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(ManagerNamespace))
 	}
+	if c.cfg.InternalTLSKeyPair != nil && c.cfg.InternalTLSKeyPair.UseCertificateManagement() {
+		initContainers = append(initContainers, c.cfg.InternalTLSKeyPair.InitContainer(ManagerNamespace))
+	}
 
 	podTemplate := relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -765,9 +765,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 
-		Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
-		csrInitContainer := deployment.Spec.Template.Spec.InitContainers[0]
-		Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ManagerTLSSecretName)))
+		Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(2))
+		managerCSRInitContainer := deployment.Spec.Template.Spec.InitContainers[0]
+		internalManagerCSRInitContainer := deployment.Spec.Template.Spec.InitContainers[1]
+		Expect(managerCSRInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ManagerTLSSecretName)))
+		Expect(internalManagerCSRInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", render.ManagerInternalTLSSecretName)))
 
 		Expect(len(deployment.Spec.Template.Spec.Volumes)).To(Equal(3))
 		Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal(render.ManagerTLSSecretName))

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -107,7 +107,6 @@ func allCalicoComponents(
 		Installation:                cr,
 		ManagementCluster:           managementCluster,
 		ManagementClusterConnection: managementClusterConnection,
-		ManagerInternalSecret:       managerInternalTLSSecret,
 		ClusterDomain:               clusterDomain,
 		MetricsPort:                 kubeControllersMetricsPort,
 		UsePSP:                      true,


### PR DESCRIPTION
Cherry pick of #2802 on release-v1.31.

#2802: Create internal manager tls inside of manager_controller