### PR TITLE
[release-v1.31] Use default non-root SecurityContext for manager

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -34,7 +34,6 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render/common/authentication"
 	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
 	"github.com/tigera/operator/pkg/render/common/configmap"
@@ -410,21 +409,15 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 
 // managerContainer returns the manager container.
 func (c *managerComponent) managerContainer() corev1.Container {
-	// UID 999 is used in the manager Dockerfile.
-	sc := securitycontext.NewNonRootContext()
-	sc.RunAsUser = ptr.Int64ToPtr(999)
-	sc.RunAsGroup = ptr.Int64ToPtr(0)
-
-	tm := corev1.Container{
+	return corev1.Container{
 		Name:            "tigera-manager",
 		Image:           c.managerImage,
 		ImagePullPolicy: ImagePullPolicy(),
 		Env:             c.managerEnvVars(),
 		LivenessProbe:   c.managerProbe(),
-		SecurityContext: sc,
+		SecurityContext: securitycontext.NewNonRootContext(),
 		VolumeMounts:    c.managerVolumeMounts(),
 	}
-	return tm
 }
 
 // managerOAuth2EnvVars returns the OAuth2/OIDC envvars depending on the authentication type.

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -119,9 +119,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		// manager container
 		Expect(*manager.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
 		Expect(*manager.SecurityContext.Privileged).To(BeFalse())
-		Expect(*manager.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
+		Expect(*manager.SecurityContext.RunAsGroup).To(BeEquivalentTo(10001))
 		Expect(*manager.SecurityContext.RunAsNonRoot).To(BeTrue())
-		Expect(*manager.SecurityContext.RunAsUser).To(BeEquivalentTo(999))
+		Expect(*manager.SecurityContext.RunAsUser).To(BeEquivalentTo(10001))
 		Expect(manager.SecurityContext.Capabilities).To(Equal(
 			&corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},


### PR DESCRIPTION
## Description

Pick https://github.com/tigera/operator/pull/2809 into release v1.31 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
