### PR TITLE
[cherry-pick][v1.30]Relax Linseed Policy in case we have DPI installed (#2831)

### DIFF
--- a/pkg/controller/logstorage/logstorage_controller.go
+++ b/pkg/controller/logstorage/logstorage_controller.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/tigera/operator/pkg/render/intrusiondetection/dpi"
 
 	"github.com/go-logr/logr"
@@ -84,7 +86,8 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	// Create the reconciler
 	tierWatchReady := &utils.ReadyFlag{}
-	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage", opts.KubernetesVersion), opts, utils.NewElasticClient, tierWatchReady)
+	dpiAPIReady := &utils.ReadyFlag{}
+	r, err := newReconciler(mgr.GetClient(), mgr.GetScheme(), status.New(mgr.GetClient(), "log-storage", opts.KubernetesVersion), opts, utils.NewElasticClient, tierWatchReady, dpiAPIReady)
 	if err != nil {
 		return err
 	}
@@ -99,6 +102,10 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if err != nil {
 		return fmt.Errorf("log-storage-controller failed to establish a connection to k8s: %w", err)
 	}
+
+	// Start the watch for DPI
+	go utils.WaitToAddResourceWatch(c, k8sClient, log, dpiAPIReady,
+		[]client.Object{&v3.DeepPacketInspection{TypeMeta: metav1.TypeMeta{Kind: v3.KindDeepPacketInspection}}})
 
 	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, tierWatchReady)
 	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
@@ -126,6 +133,7 @@ func newReconciler(
 	opts options.AddOptions,
 	esCliCreator utils.ElasticsearchClientCreator,
 	tierWatchReady *utils.ReadyFlag,
+	dpiAPIReady *utils.ReadyFlag,
 ) (*ReconcileLogStorage, error) {
 	c := &ReconcileLogStorage{
 		client:         cli,
@@ -135,6 +143,7 @@ func newReconciler(
 		esCliCreator:   esCliCreator,
 		clusterDomain:  opts.ClusterDomain,
 		tierWatchReady: tierWatchReady,
+		dpiAPIReady:    dpiAPIReady,
 		usePSP:         opts.UsePSP,
 	}
 
@@ -243,6 +252,10 @@ func add(mgr manager.Manager, c controller.Controller) error {
 		return fmt.Errorf("logstorage-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
 
+	if err = utils.AddAPIServerWatch(c); err != nil {
+		return fmt.Errorf("logstorage-controller failed to watch APIServer resource: %v", err)
+	}
+
 	return nil
 }
 
@@ -260,6 +273,7 @@ type ReconcileLogStorage struct {
 	esCliCreator   utils.ElasticsearchClientCreator
 	clusterDomain  string
 	tierWatchReady *utils.ReadyFlag
+	dpiAPIReady    *utils.ReadyFlag
 	usePSP         bool
 }
 
@@ -627,9 +641,20 @@ func (r *ReconcileLogStorage) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	if !utils.IsAPIServerReady(r.client, reqLogger) {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tigera API server to be ready", nil, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
 	if !r.tierWatchReady.IsReady() {
 		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tier watch to be established", nil, reqLogger)
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	if !r.dpiAPIReady.IsReady() {
+		log.Info("Waiting for DeepPacketInspection API to be ready")
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for DeepPacketInspection API to be ready", nil, reqLogger)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 

--- a/pkg/controller/logstorage/logstorage_controller_test.go
+++ b/pkg/controller/logstorage/logstorage_controller_test.go
@@ -98,7 +98,8 @@ var _ = Describe("LogStorage controller", func() {
 	var (
 		cli                client.Client
 		mockStatus         *status.MockStatus
-		readyFlag          *utils.ReadyFlag
+		tierReadyFlag      *utils.ReadyFlag
+		dpiReadyFlag       *utils.ReadyFlag
 		scheme             *runtime.Scheme
 		ctx                context.Context
 		certificateManager certificatemanager.CertificateManager
@@ -123,8 +124,10 @@ var _ = Describe("LogStorage controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
-		readyFlag = &utils.ReadyFlag{}
-		readyFlag.MarkAsReady()
+		tierReadyFlag = &utils.ReadyFlag{}
+		tierReadyFlag.MarkAsReady()
+		dpiReadyFlag = &utils.ReadyFlag{}
+		dpiReadyFlag.MarkAsReady()
 	})
 	Context("Reconcile", func() {
 		Context("Check default logstorage settings", func() {
@@ -255,7 +258,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("SetMetaData", mock.Anything).Return()
 					})
 					DescribeTable("tests that the ExternalService is setup with the default service name", func(clusterDomain, expectedSvcName string) {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, clusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 						_, err = r.Reconcile(ctx, reconcile.Request{})
 						Expect(err).ShouldNot(HaveOccurred())
@@ -280,7 +283,7 @@ var _ = Describe("LogStorage controller", func() {
 					})
 
 					It("returns an error if the LogStorage resource exists and is not marked for deletion", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", operatorv1.ResourceValidationError, "LogStorage validation failed - cluster type is managed but LogStorage CR still exists", mock.Anything, mock.Anything).Return()
 						result, err := r.Reconcile(ctx, reconcile.Request{})
@@ -300,7 +303,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("ReadyToMonitor")
 						mockStatus.On("SetMetaData", mock.Anything).Return()
 
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						ls := &operatorv1.LogStorage{}
@@ -412,7 +415,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
@@ -532,7 +535,7 @@ var _ = Describe("LogStorage controller", func() {
 						ObjectMeta: metav1.ObjectMeta{Namespace: render.ElasticsearchNamespace, Name: render.OIDCUsersEsSecreteName},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
@@ -657,7 +660,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Elasticsearch and kibana secrets are good.
@@ -696,7 +699,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
@@ -793,7 +796,7 @@ var _ = Describe("LogStorage controller", func() {
 						},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
@@ -835,7 +838,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(cli.Create(ctx, kbSecret)).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
@@ -909,7 +912,7 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
 					}
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for curator secrets to become available", mock.Anything, mock.Anything).Return()
@@ -989,7 +992,7 @@ var _ = Describe("LogStorage controller", func() {
 						Expect(cli.Create(ctx, rec)).ShouldNot(HaveOccurred())
 					}
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for curator secrets to become available", mock.Anything, mock.Anything).Return()
@@ -1027,7 +1030,7 @@ var _ = Describe("LogStorage controller", func() {
 						Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 					})).ShouldNot(HaveOccurred())
 
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
@@ -1078,7 +1081,7 @@ var _ = Describe("LogStorage controller", func() {
 							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
 							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 						})).ShouldNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
@@ -1132,7 +1135,7 @@ var _ = Describe("LogStorage controller", func() {
 							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
 							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 						})).ShouldNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
 						result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
@@ -1201,7 +1204,7 @@ var _ = Describe("LogStorage controller", func() {
 							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
 							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 						})).ShouldNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
 						result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
@@ -1288,7 +1291,7 @@ var _ = Describe("LogStorage controller", func() {
 							ObjectMeta: metav1.ObjectMeta{Namespace: render.ECKOperatorNamespace, Name: render.ECKLicenseConfigMapName},
 							Data:       map[string]string{"eck_license_level": string(render.ElasticsearchLicenseTypeEnterprise)},
 						})).ShouldNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 						mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, "Waiting for Elasticsearch cluster to be operational", mock.Anything, mock.Anything).Return()
 						result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
@@ -1381,7 +1384,7 @@ var _ = Describe("LogStorage controller", func() {
 						}
 					})
 					It("should use default images", func() {
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						esAdminUserSecret := &corev1.Secret{
@@ -1499,7 +1502,7 @@ var _ = Describe("LogStorage controller", func() {
 								},
 							},
 						})).ToNot(HaveOccurred())
-						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						esAdminUserSecret := &corev1.Secret{
@@ -1652,7 +1655,7 @@ var _ = Describe("LogStorage controller", func() {
 						mockStatus.On("SetMetaData", mock.Anything).Return()
 
 						var err error
-						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 					})
 
@@ -1662,10 +1665,18 @@ var _ = Describe("LogStorage controller", func() {
 
 					It("should wait if tier watch is not ready", func() {
 						var err error
-						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, &utils.ReadyFlag{})
+						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, &utils.ReadyFlag{}, dpiReadyFlag)
 						Expect(err).ShouldNot(HaveOccurred())
 
 						utils.ExpectWaitForTierWatch(ctx, r, mockStatus)
+					})
+
+					It("should wait if dpi watch is not ready", func() {
+						var err error
+						r, err = NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, &utils.ReadyFlag{})
+						Expect(err).ShouldNot(HaveOccurred())
+
+						utils.ExpectWaitForWatch(ctx, r, mockStatus, "Waiting for DeepPacketInspection API to be ready")
 					})
 				})
 			})
@@ -1717,12 +1728,12 @@ var _ = Describe("LogStorage controller", func() {
 					mockStatus.On("OnCRFound").Return()
 					mockStatus.On("ReadyToMonitor")
 					mockStatus.On("SetMetaData", mock.Anything).Return()
-					readyFlag = &utils.ReadyFlag{}
-					readyFlag.MarkAsReady()
+					tierReadyFlag = &utils.ReadyFlag{}
+					tierReadyFlag.MarkAsReady()
 				})
 
 				It("deletes Elasticsearch and Kibana then removes the finalizers on the LogStorage CR", func() {
-					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, readyFlag)
+					r, err := NewReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, mockEsCliCreator, dns.DefaultClusterDomain, tierReadyFlag, dpiReadyFlag)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					esAdminUserSecret := &corev1.Secret{

--- a/pkg/controller/logstorage/shim_test.go
+++ b/pkg/controller/logstorage/shim_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020,2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,8 @@ func NewReconcilerWithShims(
 	provider operatorv1.Provider,
 	esCliCreator utils.ElasticsearchClientCreator,
 	clusterDomain string,
-	tierWatchReady *utils.ReadyFlag) (*ReconcileLogStorage, error) {
+	tierWatchReady *utils.ReadyFlag,
+	dpiAPIReady *utils.ReadyFlag) (*ReconcileLogStorage, error) {
 
 	opts := options.AddOptions{
 		DetectedProvider: provider,
@@ -42,5 +43,5 @@ func NewReconcilerWithShims(
 		ShutdownContext:  context.TODO(),
 	}
 
-	return newReconciler(cli, schema, status, opts, esCliCreator, tierWatchReady)
+	return newReconciler(cli, schema, status, opts, esCliCreator, tierWatchReady, dpiAPIReady)
 }

--- a/pkg/controller/utils/test_utils.go
+++ b/pkg/controller/utils/test_utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,14 @@ func DeleteAllowTigeraTierAndExpectWait(ctx context.Context, c client.Client, r 
 // Assumes that mockStatus has any required initial status progression expectations set, and that the Reconciler utilizes
 // the mockStatus object.
 func ExpectWaitForTierWatch(ctx context.Context, r reconcile.Reconciler, mockStatus *status.MockStatus) {
-	mockStatus.On("SetDegraded", operator.ResourceNotReady, "Waiting for Tier watch to be established", mock.Anything, mock.Anything).Return()
+	ExpectWaitForWatch(ctx, r, mockStatus, "Waiting for Tier watch to be established")
+}
+
+// ExpectWaitForWatch expects the Reconciler issues a degraded status, waiting for a watch to be established.
+// Assumes that mockStatus has any required initial status progression expectations set, and that the Reconciler utilizes
+// the mockStatus object.
+func ExpectWaitForWatch(ctx context.Context, r reconcile.Reconciler, mockStatus *status.MockStatus, message string) {
+	mockStatus.On("SetDegraded", operator.ResourceNotReady, message, mock.Anything, mock.Anything).Return()
 	_, err := r.Reconcile(ctx, reconcile.Request{})
 	Expect(err).ShouldNot(HaveOccurred())
 	mockStatus.AssertExpectations(GinkgoT())

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -47,8 +47,6 @@ const (
 	DefaultCPURequest              = "100m"
 )
 
-var DPISourceEntityRule = networkpolicy.CreateSourceEntityRule(DeepPacketInspectionNamespace, DeepPacketInspectionName)
-
 type DPIConfig struct {
 	IntrusionDetection *operatorv1.IntrusionDetection
 	Installation       *operatorv1.InstallationSpec

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -40,7 +40,6 @@ import (
 	"github.com/tigera/operator/pkg/render/common/podsecuritypolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
-	"github.com/tigera/operator/pkg/render/intrusiondetection/dpi"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
@@ -456,16 +455,10 @@ func (e *esGateway) esGatewayAllowTigeraPolicy() *v3.NetworkPolicy {
 				{
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
-					Source:      dpi.DPISourceEntityRule,
-					Destination: esgatewayIngressDestinationEntityRule,
-				},
-				{
-					Action:      v3.Allow,
-					Protocol:    &networkpolicy.TCPProtocol,
 					Destination: esgatewayIngressDestinationEntityRule,
 					// The operator needs access to Elasticsearch and Kibana (through ES Gateway), however, since the
 					// operator is on the hostnetwork it's hard to create specific network policies for it.
-					// Allow all sources, as node CIDRs are not known.
+					// Allow all sources, as node CIDRs are not known. This also applies to DPI, which is host networked
 				},
 			},
 			Egress: egressRules,

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -63,7 +63,9 @@ var _ = Describe("Linseed rendering tests", func() {
 		var cfg *Config
 		clusterDomain := "cluster.local"
 		expectedPolicy := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/linseed.json")
+		expectedPolicyWithDPI := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/linseed_dpi_enabled.json")
 		expectedPolicyForOpenshift := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/linseed_ocp.json")
+		expectedPolicyForOpenshiftWithDPI := testutils.GetExpectedPolicyFromFile("../../testutils/expected_policies/linseed_ocp_dpi_enabled.json")
 		esClusterConfig := relasticsearch.NewClusterConfig("", 1, 1, 1)
 
 		expectedResources := []resourceTestObj{
@@ -201,6 +203,10 @@ var _ = Describe("Linseed rendering tests", func() {
 					return nil
 				}
 
+				if scenario.DPIEnabled {
+					return testutils.SelectPolicyByProvider(scenario, expectedPolicyWithDPI, expectedPolicyForOpenshiftWithDPI)
+				}
+
 				return testutils.SelectPolicyByProvider(scenario, expectedPolicy, expectedPolicyForOpenshift)
 			}
 
@@ -211,6 +217,7 @@ var _ = Describe("Linseed rendering tests", func() {
 					} else {
 						cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
 					}
+					cfg.HasDPIResource = scenario.DPIEnabled
 					component := Linseed(cfg)
 					resources, _ := component.Objects()
 
@@ -221,7 +228,9 @@ var _ = Describe("Linseed rendering tests", func() {
 				// Linseed only renders in the presence of an LogStorage CR and absence of a ManagementClusterConnection CR, therefore
 				// does not have a config option for managed clusters.
 				Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false}),
+				Entry("for management/standalone, kube-dns with dpi", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: false, DPIEnabled: true}),
 				Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true}),
+				Entry("for management/standalone, openshift-dns with dpi", testutils.AllowTigeraScenario{ManagedCluster: false, Openshift: true, DPIEnabled: true}),
 			)
 		})
 		It("should set the right env when FIPS mode is enabled", func() {

--- a/pkg/render/testutils/expected_policies/es-gateway.json
+++ b/pkg/render/testutils/expected_policies/es-gateway.json
@@ -190,19 +190,6 @@
             5554
           ]
         },
-        "protocol": "TCP",
-        "source": {
-          "selector": "k8s-app == 'tigera-dpi'",
-          "namespaceSelector": "name == 'tigera-dpi'"
-        }
-      },
-      {
-        "action": "Allow",
-        "destination": {
-          "ports": [
-            5554
-          ]
-        },
         "protocol": "TCP"
       }
     ],

--- a/pkg/render/testutils/expected_policies/linseed.json
+++ b/pkg/render/testutils/expected_policies/linseed.json
@@ -192,19 +192,6 @@
         },
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-dpi'",
-          "namespaceSelector": "name == 'tigera-dpi'"
-        }
-      },
-      {
-        "action": "Allow",
-        "destination": {
-          "ports": [
-            8444
-          ]
-        },
-        "protocol": "TCP",
-        "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
           "namespaceSelector": "name == 'tigera-policy-recommendation'"
         }

--- a/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
@@ -2,13 +2,13 @@
   "apiVersion": "projectcalico.org/v3",
   "kind": "NetworkPolicy",
   "metadata": {
-    "name": "allow-tigera.es-gateway-access",
+    "name": "allow-tigera.linseed-access",
     "namespace": "tigera-elasticsearch"
   },
   "spec": {
     "order": 1,
     "tier": "allow-tigera",
-    "selector": "k8s-app == 'tigera-secure-es-gateway'",
+    "selector": "k8s-app == 'tigera-linseed'",
     "types": [
       "Ingress",
       "Egress"
@@ -23,7 +23,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -36,7 +36,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -49,7 +49,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -62,7 +62,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -75,7 +75,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -83,7 +83,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -96,7 +96,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -109,7 +109,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -122,7 +122,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -135,7 +135,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -148,7 +148,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -161,7 +161,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -174,7 +174,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -187,7 +187,20 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-policy-recommendation'",
+          "namespaceSelector": "name == 'tigera-policy-recommendation'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            8444
           ]
         },
         "protocol": "TCP"
@@ -198,32 +211,10 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app == 'kube-dns'",
           "ports": [
-            5353
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
-          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
-          "ports": [
-            5353
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
-          "selector": "k8s-app == 'tigera-dex'",
-          "ports": [
-            5556
+            53
           ]
         }
       },
@@ -245,17 +236,6 @@
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
-          "selector": "k8s-app == 'tigera-secure'",
-          "ports": [
-            5601
           ]
         }
       }

--- a/pkg/render/testutils/expected_policies/linseed_ocp.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp.json
@@ -192,19 +192,6 @@
         },
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-dpi'",
-          "namespaceSelector": "name == 'tigera-dpi'"
-        }
-      },
-      {
-        "action": "Allow",
-        "destination": {
-          "ports": [
-            8444
-          ]
-        },
-        "protocol": "TCP",
-        "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
           "namespaceSelector": "name == 'tigera-policy-recommendation'"
         }

--- a/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
@@ -2,13 +2,13 @@
   "apiVersion": "projectcalico.org/v3",
   "kind": "NetworkPolicy",
   "metadata": {
-    "name": "allow-tigera.es-gateway-access",
+    "name": "allow-tigera.linseed-access",
     "namespace": "tigera-elasticsearch"
   },
   "spec": {
     "order": 1,
     "tier": "allow-tigera",
-    "selector": "k8s-app == 'tigera-secure-es-gateway'",
+    "selector": "k8s-app == 'tigera-linseed'",
     "types": [
       "Ingress",
       "Egress"
@@ -23,7 +23,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -36,7 +36,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -49,7 +49,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -62,7 +62,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -75,7 +75,7 @@
         },
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         }
       },
@@ -83,7 +83,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -96,7 +96,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -109,7 +109,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -122,7 +122,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -135,7 +135,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -148,7 +148,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -161,7 +161,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -174,7 +174,7 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
           ]
         },
         "protocol": "TCP",
@@ -187,7 +187,20 @@
         "action": "Allow",
         "destination": {
           "ports": [
-            5554
+            8444
+          ]
+        },
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'tigera-policy-recommendation'",
+          "namespaceSelector": "name == 'tigera-policy-recommendation'"
+        }
+      },
+      {
+        "action": "Allow",
+        "destination": {
+          "ports": [
+            8444
           ]
         },
         "protocol": "TCP"
@@ -220,17 +233,6 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
-          "selector": "k8s-app == 'tigera-dex'",
-          "ports": [
-            5556
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "destination": {
           "services": {
             "name": "kubernetes",
             "namespace": "default"
@@ -245,17 +247,6 @@
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
-        "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
-          "selector": "k8s-app == 'tigera-secure'",
-          "ports": [
-            5601
           ]
         }
       }

--- a/pkg/render/testutils/policy.go
+++ b/pkg/render/testutils/policy.go
@@ -33,6 +33,7 @@ import (
 type AllowTigeraScenario struct {
 	ManagedCluster bool
 	Openshift      bool
+	DPIEnabled     bool
 }
 
 type IPMode string


### PR DESCRIPTION
* Relax Linseed Policy in case we have DPI installed

DPI runs on the Host network and it is hard to create a policy that targerts its endpoints. Thus, for Linseed we will relax the ingress policy to allow all traffic in case we have DPI enabled.

* Wait for watch and add tests

* Check dpi resources inside createLinseedhasDPIResource,

* Clean up

## Description

Cherry-pick : #2831

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
