### PR TITLE
Fix! LogStorage name for tigera-status cannot contain special characters

### DIFF
--- a/pkg/controller/logstorage/elastic/elastic_controller.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller.go
@@ -69,7 +69,7 @@ var log = logf.Log.WithName("controller_logstorage_elastic")
 
 const (
 	LogStorageFinalizer = "tigera.io/eck-cleanup"
-	tigeraStatusName    = "log-storage=-elastic"
+	tigeraStatusName    = "log-storage-elastic"
 )
 
 // ElasticSubController is a sub-controller of the main LogStorage controller


### PR DESCRIPTION
## Description

```
tigera-operator-5c447d9bd8-nv6pz {"level":"info","ts":1694029499.3821063,"logger":"status_manager","msg":"Failed to create tigera status","reason":"TigeraStatus.operator.tigera.io \"log-storage=-elastic\" is invalid: metadata.name: Invali
d value: \"log-storage=-elastic\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-
z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"}
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
