### PR TITLE
Fix! Tenant CA secrets needs to be rendered

### DIFF
--- a/pkg/render/certificatemanagement/certificatemanagement.go
+++ b/pkg/render/certificatemanagement/certificatemanagement.go
@@ -98,7 +98,7 @@ func (c component) Objects() (objsToCreate, objsToDelete []client.Object) {
 			}
 			needsCSRRoleAndBinding = true
 		} else {
-			if keyPairCreator.renderInTruthNamespace && (!keyPair.BYO() || keyPair.GetName() == certificatemanagement.CASecretName) {
+			if keyPairCreator.renderInTruthNamespace && (!keyPair.BYO() || keyPair.GetName() == certificatemanagement.CASecretName || keyPair.GetName() == certificatemanagement.TenantCASecretName) {
 				objsToCreate = append(objsToCreate, keyPair.Secret(c.cfg.TruthNamespace))
 			}
 			if keyPairCreator.renderInAppNamespace {


### PR DESCRIPTION
## Description

We need this in order to allow tenant controller to create the secrets that are not `tigera-ca-private` in the tenant namespace.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
