### PR TITLE
Cluster name will be set by Voltron for a managed cluster

### DIFF
--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -240,7 +240,6 @@ func (d *dpiComponent) dpiEnvVars() []corev1.EnvVar {
 		{Name: "DPI_TYPHACAFILE", Value: d.cfg.TyphaNodeTLS.TrustedBundle.MountPath()},
 		{Name: "DPI_TYPHACERTFILE", Value: d.cfg.TyphaNodeTLS.NodeSecret.VolumeMountCertificateFilePath()},
 		{Name: "DPI_TYPHAKEYFILE", Value: d.cfg.TyphaNodeTLS.NodeSecret.VolumeMountKeyFilePath()},
-		{Name: "CLUSTER_NAME", Value: d.cfg.ESClusterConfig.ClusterName()},
 		{Name: "LINSEED_CLIENT_CERT", Value: d.cfg.DPICertSecret.VolumeMountCertificateFilePath()},
 		{Name: "LINSEED_CLIENT_KEY", Value: d.cfg.DPICertSecret.VolumeMountKeyFilePath()},
 		{Name: "LINSEED_TOKEN", Value: render.GetLinseedTokenPath(d.cfg.ManagedCluster)},

--- a/pkg/render/intrusiondetection/dpi/dpi_test.go
+++ b/pkg/render/intrusiondetection/dpi/dpi_test.go
@@ -230,7 +230,6 @@ var _ = Describe("DPI rendering tests", func() {
 
 		ds := rtest.GetResource(resources, dpi.DeepPacketInspectionName, dpi.DeepPacketInspectionNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
-			corev1.EnvVar{Name: "CLUSTER_NAME", Value: "clusterTestName"},
 			corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: "/deep-packet-inspection-tls/tls.crt"},
 			corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: "/deep-packet-inspection-tls/tls.key"},
 			corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "false"},


### PR DESCRIPTION
## Description

For managed cluster, x-cluster-id will be set by Voltron when making calls to linseed. In a management cluster, an empty cluster name will default to value "cluster" by Linseed.

```
kubectl logs tigera-manager-cc4f6864-jbl8l -ntigera-manager -ctigera-voltron -f | grep "inner_handler"
2023-09-15 21:13:43.784 [WARNING][1] inner_handler.go 46: Unexpected cluster ID url=/api/v1/events/bulk x-cluster-id="bm2l8d9i.saba-test" x-tenant-id=""
2023-09-15 21:16:27.264 [WARNING][1] inner_handler.go 46: Unexpected cluster ID url=/api/v1/events/bulk x-cluster-id="bm2l8d9i.saba-test" x-tenant-id=""
```

```
Environment:                                                                                                                                                                                        │
│       DPI_NODENAME:              (v1:spec.nodeName)                                                                                                                                                     │
│       DPI_TYPHAK8SNAMESPACE:    calico-system                                                                                                                                                           │
│       DPI_TYPHAK8SSERVICENAME:  calico-typha                                                                                                                                                            │
│       DPI_TYPHACAFILE:          /etc/pki/tls/certs/tigera-ca-bundle.crt                                                                                                                                 │
│       DPI_TYPHACERTFILE:        /node-certs/tls.crt                                                                                                                                                     │
│       DPI_TYPHAKEYFILE:         /node-certs/tls.key                                                                                                                                                     │
│       CLUSTER_NAME:             bm2l8d9i.saba-test                                                                                                                                                      │
│       LINSEED_CLIENT_CERT:      /deep-packet-inspection-tls/tls.crt                                                                                                                                     │
│       LINSEED_CLIENT_KEY:       /deep-packet-inspection-tls/tls.key                                                                                                                                     │
│       LINSEED_TOKEN:            /var/run/secrets/tigera.io/linseed/token                                                                                                                                │
│       FIPS_MODE_ENABLED:        false                                                                                                                                                                   │
│       DPI_TYPHACN:              typha-server                     
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
