### PR TITLE
update dns svc discovery for rke2 (#2895)

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -645,3 +645,22 @@ func AddNodeLocalDNSWatch(c controller.Controller) error {
 	}
 	return c.Watch(&source.Kind{Type: &appsv1.DaemonSet{}}, &handler.EnqueueRequestForObject{}, createPredicateForObject(ds))
 }
+
+func GetDNSServiceIPs(ctx context.Context, client client.Client, provider operatorv1.Provider) ([]string, error) {
+	// Discover the DNS Service's cluster IP address:
+	// Default kubernetes dns service is named "kube-dns", but RKE2 is using a different name for the default
+	// dns service i.e. "rke2-coredns-rke2-coredns".
+	dnsServiceName := "kube-dns"
+	if provider == operatorv1.ProviderRKE2 {
+		dnsServiceName = "rke2-coredns-rke2-coredns"
+	}
+
+	kubeDNSService := &corev1.Service{}
+
+	err := client.Get(ctx, types.NamespacedName{Name: dnsServiceName, Namespace: "kube-system"}, kubeDNSService)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeDNSService.Spec.ClusterIPs, nil
+}


### PR DESCRIPTION
dns service is named differently on rke2. default dns service is called "kube-dns" and on rke2 it is called "rke2-coredns-rke2-coredns". Thus, we need to retrieve dns service using the appropriate name based on the platform.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
