### PR TITLE
Fix k8s service endpoint configmap validation in windows_controller

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -360,7 +360,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		}
 	}
 
-	err = utils.GetK8sServiceEndPoint(r.client)
+	err = utils.PopulateK8sServiceEndPoint(r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading services endpoint configmap", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1111,7 +1111,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
-	err = utils.GetK8sServiceEndPoint(r.client)
+	err = utils.PopulateK8sServiceEndPoint(r.client)
 	if err != nil {
 		r.status.SetDegraded(operator.ResourceReadError, "Error reading services endpoint configmap", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/installation/windows_controller.go
+++ b/pkg/controller/installation/windows_controller.go
@@ -249,12 +249,13 @@ func (r *ReconcileWindows) Reconcile(ctx context.Context, request reconcile.Requ
 
 	reqLogger.V(2).Info("Loaded config", "config", instance)
 
-	// The k8s service endpoint configmap must populate k8sapi.Endpoint data before valitating the configuration
-	if err := utils.GetK8sServiceEndPoint(r.client); err != nil {
+	// The k8s service endpoint configmap must populate k8sapi.Endpoint data before validating the configuration.
+	if _, err := utils.GetK8sServiceEndPoint(r.client); err != nil {
+		// PopulateK8sServiceEndPoint() does not return an error if the configmap is not found, check for this with GetK8sServiceEndPoint()
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading services endpoint configmap", err, reqLogger)
 		return reconcile.Result{}, err
-	} else if err := utils.K8sServiceEndPointNotFound(r.client); err != nil {
-		// GetK8sServiceEndPoint() return nil if the configmap is not found, check for this with K8sServiceEndPointExists()
+	}
+	if err := utils.PopulateK8sServiceEndPoint(r.client); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading services endpoint configmap", err, reqLogger)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/installation/windows_controller_test.go
+++ b/pkg/controller/installation/windows_controller_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
-	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/test"
@@ -221,10 +221,17 @@ var _ = Describe("windows-controller installation tests", func() {
 				cr.Spec.ServiceCIDRs = []string{"10.96.0.0/12"}
 
 				// Create the service endpoint configmap for k8s API (required for Calico for Windows)
-				k8sapi.Endpoint = k8sapi.ServiceEndpoint{
-					Host: "1.2.3.4",
-					Port: "6443",
+				endPointCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      render.K8sSvcEndpointConfigMapName,
+						Namespace: common.OperatorNamespace(),
+					},
+					Data: map[string]string{
+						"KUBERNETES_SERVICE_HOST": "1.2.3.4",
+						"KUBERNETES_SERVICE_PORT": "6443",
+					},
 				}
+				Expect(c.Create(ctx, endPointCM)).ToNot(HaveOccurred())
 
 			})
 
@@ -292,6 +299,36 @@ var _ = Describe("windows-controller installation tests", func() {
 				Expect(degradedErr).To(ConsistOf([]string{}))
 			})
 
+			It("should not render the Windows daemonset when the kubernetes-service-endpoint configmap does not exist", func() {
+				hns := operator.WindowsDataplaneHNS
+				cr.Spec.CalicoNetwork.WindowsDataplane = &hns
+
+				// Create the Windows node
+				Expect(c.Create(ctx, winNode)).ToNot(HaveOccurred())
+
+				// Create the installation resource
+				Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+
+				// Delete the configmap
+				endPointCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      render.K8sSvcEndpointConfigMapName,
+						Namespace: common.OperatorNamespace(),
+					},
+				}
+				Expect(c.Delete(ctx, endPointCM)).ToNot(HaveOccurred())
+
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(Equal("configmaps \"kubernetes-services-endpoint\" not found"))
+
+				// The calico-node-windows daemonset should be rendered, but in a degraded state
+				Expect(test.GetResource(c, &dsWin)).To(HaveOccurred())
+				Expect(dsWin.Spec).To(Equal(appsv1.DaemonSetSpec{}))
+				Expect(degradedMsg).To(ConsistOf([]string{"Error reading services endpoint configmap"}))
+				Expect(degradedErr).To(ConsistOf([]string{"configmaps \"kubernetes-services-endpoint\" not found"}))
+			})
+
 			It("should not render the Windows daemonset when the kubernetes-service-endpoint configmap is incomplete", func() {
 				hns := operator.WindowsDataplaneHNS
 				cr.Spec.CalicoNetwork.WindowsDataplane = &hns
@@ -303,9 +340,16 @@ var _ = Describe("windows-controller installation tests", func() {
 				Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 
 				// Have a configmap with no port
-				k8sapi.Endpoint = k8sapi.ServiceEndpoint{
-					Host: "1.2.3.4",
+				endPointCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      render.K8sSvcEndpointConfigMapName,
+						Namespace: common.OperatorNamespace(),
+					},
+					Data: map[string]string{
+						"KUBERNETES_SERVICE_HOST": "1.2.3.4",
+					},
 				}
+				Expect(c.Update(ctx, endPointCM)).ToNot(HaveOccurred())
 
 				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).Should(HaveOccurred())
@@ -549,11 +593,18 @@ var _ = Describe("windows-controller installation tests", func() {
 
 						Expect(c.Create(ctx, node)).ToNot(HaveOccurred())
 
-						// Populate the k8s service endpoint (required for windows)
-						k8sapi.Endpoint = k8sapi.ServiceEndpoint{
-							Host: "1.2.3.4",
-							Port: "6443",
+						// Create the k8s service endpoint configmap (required for windows)
+						endPointCM := &corev1.ConfigMap{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      render.K8sSvcEndpointConfigMapName,
+								Namespace: common.OperatorNamespace(),
+							},
+							Data: map[string]string{
+								"KUBERNETES_SERVICE_HOST": "1.2.3.4",
+								"KUBERNETES_SERVICE_PORT": "6443",
+							},
 						}
+						Expect(c.Create(ctx, endPointCM)).ToNot(HaveOccurred())
 					}
 
 					// Create an object we can use throughout the test to do the compliance reconcile loops.
@@ -584,7 +635,7 @@ var _ = Describe("windows-controller installation tests", func() {
 					}
 					r.ipamConfigWatchReady.MarkAsReady()
 
-					certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
+					certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace())
 					Expect(err).NotTo(HaveOccurred())
 					prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/installation/windows_controller_test.go
+++ b/pkg/controller/installation/windows_controller_test.go
@@ -635,7 +635,7 @@ var _ = Describe("windows-controller installation tests", func() {
 					}
 					r.ipamConfigWatchReady.MarkAsReady()
 
-					certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace())
+					certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 					Expect(err).NotTo(HaveOccurred())
 					prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -328,10 +328,8 @@ func ValidateCertPair(client client.Client, namespace, certPairSecretName, keyNa
 	return secret, nil
 }
 
-// GetK8sServiceEndPoint reads the kubernetes-service-endpoint configmap and pushes
-// KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT to calico-node daemonset, typha
-// apiserver deployments
-func GetK8sServiceEndPoint(client client.Client) error {
+// GetK8sServiceEndPoint returns the kubernetes-service-endpoint configmap
+func GetK8sServiceEndPoint(client client.Client) (*corev1.ConfigMap, error) {
 	cmName := render.K8sSvcEndpointConfigMapName
 	cm := &corev1.ConfigMap{}
 	cmNamespacedName := types.NamespacedName{
@@ -339,30 +337,24 @@ func GetK8sServiceEndPoint(client client.Client) error {
 		Namespace: common.OperatorNamespace(),
 	}
 	if err := client.Get(context.Background(), cmNamespacedName, cm); err != nil {
-		// If the configmap is unavailable, do not return error
+		return nil, err
+	}
+	return cm, nil
+}
+
+// PopulateK8sServiceEndPoint reads the kubernetes-service-endpoint configmap and pushes
+// KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT to calico-node daemonset, typha
+// apiserver deployments
+func PopulateK8sServiceEndPoint(client client.Client) error {
+	cm, err := GetK8sServiceEndPoint(client)
+	if err != nil {
 		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("Failed to read ConfigMap %q: %s", cmName, err)
+			// If the configmap is unavailable, do not return an error
+			return fmt.Errorf("Failed to read ConfigMap %q: %s", render.K8sSvcEndpointConfigMapName, err)
 		}
 	} else {
 		k8sapi.Endpoint.Host = cm.Data["KUBERNETES_SERVICE_HOST"]
 		k8sapi.Endpoint.Port = cm.Data["KUBERNETES_SERVICE_PORT"]
-	}
-	return nil
-}
-
-// Return error if the k8s service endpoint configmap is not found
-func K8sServiceEndPointNotFound(client client.Client) error {
-	cmName := render.K8sSvcEndpointConfigMapName
-	cm := &corev1.ConfigMap{}
-	cmNamespacedName := types.NamespacedName{
-		Name:      cmName,
-		Namespace: common.OperatorNamespace(),
-	}
-	if err := client.Get(context.Background(), cmNamespacedName, cm); err != nil {
-		// If the error is something else other than not found, it means the configmap does exist
-		if kerrors.IsNotFound(err) {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -350,6 +350,23 @@ func GetK8sServiceEndPoint(client client.Client) error {
 	return nil
 }
 
+// Return error if the k8s service endpoint configmap is not found
+func K8sServiceEndPointNotFound(client client.Client) error {
+	cmName := render.K8sSvcEndpointConfigMapName
+	cm := &corev1.ConfigMap{}
+	cmNamespacedName := types.NamespacedName{
+		Name:      cmName,
+		Namespace: common.OperatorNamespace(),
+	}
+	if err := client.Get(context.Background(), cmNamespacedName, cm); err != nil {
+		// If the error is something else other than not found, it means the configmap does exist
+		if kerrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
 func GetNetworkingPullSecrets(i *operatorv1.InstallationSpec, c client.Client) ([]*corev1.Secret, error) {
 	secrets := []*corev1.Secret{}
 	for _, ps := range i.ImagePullSecrets {

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -224,7 +224,7 @@ var _ = Describe("AddPeriodicReconcile", func() {
 	})
 })
 
-var _ = Describe("GetK8sServiceEndpoint", func() {
+var _ = Describe("PopulateK8sServiceEndPoint", func() {
 	var (
 		c      client.Client
 		ctx    context.Context
@@ -256,7 +256,7 @@ var _ = Describe("GetK8sServiceEndpoint", func() {
 
 		Expect(c.Create(ctx, cm)).ShouldNot(HaveOccurred())
 
-		err := GetK8sServiceEndPoint(c)
+		err := PopulateK8sServiceEndPoint(c)
 
 		Expect(err).To(BeNil())
 
@@ -265,7 +265,7 @@ var _ = Describe("GetK8sServiceEndpoint", func() {
 	})
 
 	It("does not return error if ConfigMap is not found.", func() {
-		err := GetK8sServiceEndPoint(c)
+		err := PopulateK8sServiceEndPoint(c)
 
 		Expect(err).To(BeNil())
 	})


### PR DESCRIPTION
Fix validation to populate data before custom resource validation and to check for non-existant configmap.

Refactor utils.GetK8sServiceEndPoint() to retrieve the kubernetes-service-endpoint
configmap and rename old utils.GetK8sServiceEndPoint() into utils.PopulateK8sServiceEndPoint().

Fix tests to use the configmap resource instead of the populated data.

Add test case for non-existant configmap.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
