### PR TITLE
Make fix: remove extra newlines from imports and fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,8 +430,10 @@ static-checks:
 ## Fix static checks
 fix:
 	$(CONTAINERIZED) $(CALICO_BUILD) \
-	sh -c '$(GIT_CONFIG_SSH) \
-	goimports -w $(SRC_FILES)'
+	sh -c '\
+	for x in $(SRC_FILES); do sed -i $$x -e "/import (/,/)/{ /^[ \t]*$$/d}"; done; \
+	$(GIT_CONFIG_SSH) \
+	goimports -w -local github.com/projectcalico/calico/,github.com/tigera/operator $(SRC_FILES)'
 
 .PHONY: format-check
 format-check:


### PR DESCRIPTION
## Description

This creates 3 groups of imports:
1. built-in go packages
2. 3rd party packages
3. tigera/projectcalico packages

each with a newline between each group

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
