### PR TITLE
CORE-8617 BPF Without Disruption

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -747,6 +747,14 @@ type Installation struct {
 	Status InstallationStatus `json:"status,omitempty"`
 }
 
+// BPFEnabled is an extension method that returns true if the Installation resource
+// has Calico Network Linux Dataplane set and equal to value "BPF" otherwise false.
+func (installation *InstallationSpec) BPFEnabled() bool {
+	return installation.CalicoNetwork != nil &&
+		installation.CalicoNetwork.LinuxDataplane != nil &&
+		*installation.CalicoNetwork.LinuxDataplane == LinuxDataplaneBPF
+}
+
 // +kubebuilder:object:root=true
 
 // InstallationList contains a list of Installation

--- a/pkg/controller/installation/bpf.go
+++ b/pkg/controller/installation/bpf.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+
+	"github.com/tigera/operator/pkg/controller/utils"
+
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// updateBPFEnabledAllowed validate Felix Configuration annotations match BPF Enabled spec for all scenarios.
+func updateBPFEnabledAllowed(fc *crdv1.FelixConfiguration) error {
+	var annotationValue *bool
+	if fc.Annotations[render.BPFOperatorAnnotation] != "" {
+		v, err := strconv.ParseBool(fc.Annotations[render.BPFOperatorAnnotation])
+		annotationValue = &v
+		if err != nil {
+			return err
+		}
+	}
+
+	// The values are considered matching if one of the following is true:
+	// - Both values are nil
+	// - Neither are nil and they have the same value.
+	// Otherwise, the we consider the annotation to not match the spec field.
+	match := annotationValue == nil && fc.Spec.BPFEnabled == nil
+	match = match || annotationValue != nil && fc.Spec.BPFEnabled != nil && *annotationValue == *fc.Spec.BPFEnabled
+
+	if !match {
+		return errors.New(`Unable to set bpfEnabled: FelixConfiguration "default" has been modified by someone else, refusing to override potential user configuration.`)
+	}
+
+	return nil
+}
+
+// If the Installation resource has been patched to dataplane: BPF then the
+// calico-node daemonset will be re-created with BPF infrastructure such as
+// the "bpffs" volumne mount etc. which will cause the DS to do a rolling update.
+// Therefore, one way to check that the daemonset rolling update is complete is
+// to compare the DS status current scheduled pods equals the updated number and
+// the current scheduled pods also equals the number available.  When all these
+// checks are reconciled then FelixConfig can be patched as bpfEnabled: true.
+func isRolloutComplete(ds *appsv1.DaemonSet) bool {
+	for _, volume := range ds.Spec.Template.Spec.Volumes {
+		if volume.Name == render.BPFVolumeName {
+			return ds.Status.CurrentNumberScheduled == ds.Status.UpdatedNumberScheduled && ds.Status.CurrentNumberScheduled == ds.Status.NumberAvailable
+		}
+	}
+
+	return false
+}
+
+func setBPFEnabled(fc *crdv1.FelixConfiguration, bpfEnabled bool) error {
+	err := updateBPFEnabledAllowed(fc)
+	if err != nil {
+		return err
+	}
+
+	text := strconv.FormatBool(bpfEnabled)
+
+	// Add an annotation matching the field value. This allows the operator to compare the annotation to the field
+	// when performing an update to determine if another entity has modified the value since the last write.
+	var fcAnnotations map[string]string
+	if fc.Annotations == nil {
+		fcAnnotations = make(map[string]string)
+	} else {
+		fcAnnotations = fc.Annotations
+	}
+	fcAnnotations[render.BPFOperatorAnnotation] = text
+	fc.SetAnnotations(fcAnnotations)
+	fc.Spec.BPFEnabled = &bpfEnabled
+
+	return nil
+}
+
+func bpfEnabledOnDaemonSet(ds *appsv1.DaemonSet) (bool, error) {
+	bpfEnabledStatus := false
+	var err error
+
+	if ds != nil &&
+		!reflect.DeepEqual(ds.Spec, appsv1.DaemonSetSpec{}) &&
+		!reflect.DeepEqual(ds.Spec.Template, corev1.PodTemplateSpec{}) &&
+		!reflect.DeepEqual(ds.Spec.Template.Spec, corev1.PodSpec{}) {
+		bpfEnabledEnvVar := utils.GetPodEnvVar(ds.Spec.Template.Spec, common.NodeDaemonSetName, "FELIX_BPFENABLED")
+		if bpfEnabledEnvVar != nil {
+			bpfEnabledStatus, err = strconv.ParseBool(*bpfEnabledEnvVar)
+		}
+	}
+
+	return bpfEnabledStatus, err
+}
+
+func bpfEnabledOnFelixConfig(fc *crdv1.FelixConfiguration) bool {
+	return fc.Spec.BPFEnabled != nil && *fc.Spec.BPFEnabled
+}

--- a/pkg/controller/installation/bpf_test.go
+++ b/pkg/controller/installation/bpf_test.go
@@ -1,0 +1,523 @@
+// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	operator "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/test"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	schedv1 "k8s.io/api/scheduling/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Testing BPF Upgrade without disruption during core-controller installation", func() {
+	var c client.Client
+	var cs *kfake.Clientset
+	var ctx context.Context
+	var cancel context.CancelFunc
+	var r ReconcileInstallation
+	var scheme *runtime.Scheme
+	var mockStatus *status.MockStatus
+	var reqLogger logr.Logger
+
+	ready := &utils.ReadyFlag{}
+	ready.MarkAsReady()
+
+	Context("Reconcile tests BPF Upgrade without disruption", func() {
+		BeforeEach(func() {
+			// The schema contains all objects that should be known to the fake client when the test runs.
+			scheme = runtime.NewScheme()
+			Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+			Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(schedv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(operator.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+			Expect(storagev1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+			// Create a client that will have a crud interface of k8s objects.
+			c = fake.NewClientBuilder().WithScheme(scheme).Build()
+			ctx, cancel = context.WithCancel(context.Background())
+
+			// Create a fake clientset for the autoscaler.
+			var replicas int32 = 1
+			objs := []runtime.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node1",
+						Labels: map[string]string{"kubernetes.io/os": "linux"},
+					},
+					Spec: corev1.NodeSpec{},
+				},
+				&appsv1.Deployment{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+				},
+			}
+			cs = kfake.NewSimpleClientset(objs...)
+
+			// Create an object we can use throughout the test to do the core reconcile loops.
+			mockStatus = &status.MockStatus{}
+			mockStatus.On("AddDaemonsets", mock.Anything).Return()
+			mockStatus.On("AddDeployments", mock.Anything).Return()
+			mockStatus.On("IsAvailable").Return(true)
+			mockStatus.On("OnCRFound").Return()
+			mockStatus.On("ClearDegraded")
+			mockStatus.On("AddCertificateSigningRequests", mock.Anything)
+			mockStatus.On("ReadyToMonitor")
+			mockStatus.On("SetMetaData", mock.Anything).Return()
+
+			// Create the indexer and informer used by the typhaAutoscaler
+			nlw := test.NewNodeListWatch(cs)
+			nodeIndexInformer := cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
+
+			go nodeIndexInformer.Run(ctx.Done())
+			for nodeIndexInformer.HasSynced() {
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
+			r = ReconcileInstallation{
+				config:               nil, // there is no fake for config
+				client:               c,
+				scheme:               scheme,
+				autoDetectedProvider: operator.ProviderNone,
+				status:               mockStatus,
+				typhaAutoscaler:      newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus),
+				namespaceMigration:   &fakeNamespaceMigration{},
+				amazonCRDExists:      true,
+				enterpriseCRDsExist:  true,
+				migrationChecked:     true,
+				tierWatchReady:       ready,
+			}
+
+			r.typhaAutoscaler.start(ctx)
+			certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
+			Expect(err).NotTo(HaveOccurred())
+			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
+
+			// Create the logger
+			reqLogger = log.WithValues("Request.Namespace", "test-namespace", "Request.Name", "test-name")
+		})
+
+		AfterEach(func() {
+			cancel()
+		})
+
+		It("should query calico-node DS and if FELIX_BPFENABLED true and FelixConfig unset then set BPF enabled true to be patched", func() {
+			// Arrange.
+			// FELIX_BPFENABLED env var only set in BPF datatplane.
+			cr := createInstallation(c, ctx, operator.LinuxDataplaneBPF)
+			cr.Spec.CNI = &operator.CNISpec{}
+
+			// Create calico-node Daemonset with FELIX_BPFENABLED env var set.
+			envVars := []corev1.EnvVar{{Name: "FELIX_BPFENABLED", Value: "true"}}
+			container := corev1.Container{
+				Name: common.NodeDaemonSetName,
+				Env:  envVars,
+			}
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: common.NodeDaemonSetName, Namespace: common.CalicoNamespace},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{container},
+						},
+					},
+				},
+			}
+			Expect(c.Create(ctx, ds)).NotTo(HaveOccurred())
+
+			// Create felix config
+			healthPort := 9099
+			vxlanVNI := 4096
+			fc := &crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       crdv1.FelixConfigurationSpec{HealthPort: &healthPort, VXLANVNI: &vxlanVNI},
+			}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+
+			// Act.
+			_, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
+				return r.setDefaultsOnFelixConfiguration(cr, ds, fc, reqLogger)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert.
+			bpfEnabled := true
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
+			Expect(fc.Spec.BPFEnabled).To(Equal(&bpfEnabled))
+			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("true"))
+		})
+
+		It("should query FelixConfig annotation is nil and spec is nil then outcome is valid", func() {
+			fc := &crdv1.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+			Expect(updateBPFEnabledAllowed(fc)).ShouldNot(HaveOccurred())
+		})
+
+		It("should query FelixConfig annotation is nil and spec is not nil then outcome is invalid", func() {
+			bpfEnabled := false
+			fc := &crdv1.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}, Spec: crdv1.FelixConfigurationSpec{BPFEnabled: &bpfEnabled}}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+			Expect(updateBPFEnabledAllowed(fc)).Should(HaveOccurred())
+		})
+
+		It("should query FelixConfig annotation is set but is invalid then outcome is invalid", func() {
+			fcAnnotations := make(map[string]string)
+			fcAnnotations[render.BPFOperatorAnnotation] = "foo"
+			fc := &crdv1.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default", Annotations: fcAnnotations}}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+			Expect(updateBPFEnabledAllowed(fc)).Should(HaveOccurred())
+		})
+
+		It("should query FelixConfig annotation is set but spec is nil then outcome is invalid", func() {
+			fcAnnotations := make(map[string]string)
+			fcAnnotations[render.BPFOperatorAnnotation] = "true"
+			fc := &crdv1.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default", Annotations: fcAnnotations}}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+			Expect(updateBPFEnabledAllowed(fc)).Should(HaveOccurred())
+		})
+
+		It("should query FelixConfig annotation is set and spec is set and matches then outcome is valid", func() {
+			bpfEnabled := true
+			fcAnnotations := make(map[string]string)
+			fcAnnotations[render.BPFOperatorAnnotation] = "true"
+			fc := &crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default",
+					Annotations: fcAnnotations,
+				},
+				Spec: crdv1.FelixConfigurationSpec{
+					BPFEnabled: &bpfEnabled,
+				},
+			}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+			Expect(updateBPFEnabledAllowed(fc)).ShouldNot(HaveOccurred())
+		})
+
+		It("should query FelixConfig annotation is set and spec is set but does not match then outcome is invalid", func() {
+			bpfEnabled := false
+			fcAnnotations := make(map[string]string)
+			fcAnnotations[render.BPFOperatorAnnotation] = "true"
+			fc := &crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default",
+					Annotations: fcAnnotations,
+				},
+				Spec: crdv1.FelixConfigurationSpec{
+					BPFEnabled: &bpfEnabled,
+				},
+			}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+			Expect(updateBPFEnabledAllowed(fc)).Should(HaveOccurred())
+		})
+
+		It("should query calico-node DS in BPF dataplane and if DS status not set then verify rollout not complete", func() {
+			// Arrange.
+			// Upgrade cluster from IP Tables to BPF dataplane.
+			cr := createInstallation(c, ctx, operator.LinuxDataplaneBPF)
+
+			// Create calico-node Daemonset annotation to indicate update rollout complete.
+			container := corev1.Container{Name: common.NodeDaemonSetName}
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeDaemonSetName,
+					Namespace: common.CalicoNamespace,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{container}},
+					},
+				},
+			}
+			Expect(c.Create(ctx, ds)).NotTo(HaveOccurred())
+
+			// Create felix config
+			fc := &crdv1.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+
+			// Act.
+			_, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
+				return r.setBPFUpdatesOnFelixConfiguration(cr, ds, fc, reqLogger)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert.
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.BPFEnabled).To(BeNil())
+		})
+
+		It("should query calico-node DS in BPF dataplane and if DS status rolling out then verify rollout not complete", func() {
+			// Arrange.
+			// Upgrade cluster from IP Tables to BPF dataplane.
+			cr := createInstallation(c, ctx, operator.LinuxDataplaneBPF)
+
+			// Create calico-node Daemonset status updating to indicate rollout not complete.
+			volume := corev1.Volume{
+				Name: "bpffs",
+			}
+			container := corev1.Container{Name: common.NodeDaemonSetName}
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeDaemonSetName,
+					Namespace: common.CalicoNamespace,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Volumes:    []corev1.Volume{volume},
+							Containers: []corev1.Container{container},
+						},
+					},
+				},
+				Status: appsv1.DaemonSetStatus{
+					CurrentNumberScheduled: 2,
+					UpdatedNumberScheduled: 2,
+					NumberAvailable:        1,
+				},
+			}
+			Expect(c.Create(ctx, ds)).NotTo(HaveOccurred())
+
+			// Create felix config
+			fc := &crdv1.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+
+			// Act.
+			_, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
+				return r.setBPFUpdatesOnFelixConfiguration(cr, ds, fc, reqLogger)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert.
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.BPFEnabled).To(BeNil())
+		})
+
+		It("should query calico-node DS in BPF dataplane and if DS status rolling out complete then patch Felix Config", func() {
+			// Arrange.
+			// Upgrade cluster from BPF to IP Tables dataplane.
+			cr := createInstallation(c, ctx, operator.LinuxDataplaneBPF)
+
+			// Create calico-node Daemonset status updaetd to indicate rollout is complete.
+			volume := corev1.Volume{
+				Name: "bpffs",
+			}
+			container := corev1.Container{Name: common.NodeDaemonSetName}
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeDaemonSetName,
+					Namespace: common.CalicoNamespace,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Volumes:    []corev1.Volume{volume},
+							Containers: []corev1.Container{container},
+						},
+					},
+				},
+				Status: appsv1.DaemonSetStatus{
+					CurrentNumberScheduled: 4,
+					UpdatedNumberScheduled: 4,
+					NumberAvailable:        4,
+				},
+			}
+			Expect(c.Create(ctx, ds)).NotTo(HaveOccurred())
+
+			// Create felix config
+			bpfEnabled := false
+			fcAnnotations := make(map[string]string)
+			fcAnnotations[render.BPFOperatorAnnotation] = "false"
+			fc := &crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default",
+					Annotations: fcAnnotations,
+				},
+				Spec: crdv1.FelixConfigurationSpec{
+					BPFEnabled: &bpfEnabled,
+				},
+			}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+
+			// Act.
+			_, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
+				return r.setBPFUpdatesOnFelixConfiguration(cr, ds, fc, reqLogger)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert.
+			bpfEnabled = true
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
+			Expect(fc.Spec.BPFEnabled).To(Equal(&bpfEnabled))
+			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("true"))
+		})
+
+		It("should query calico-node DS in Iptables dataplane and patch Felix Config when bpfEnabled empty", func() {
+			// Arrange.
+			// Upgrade cluster from BPF to IP Tables dataplane.
+			cr := createInstallation(c, ctx, operator.LinuxDataplaneIptables)
+
+			// Create calico-node Daemonset annotation to indicate update rollout complete.
+			container := corev1.Container{Name: common.NodeDaemonSetName}
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeDaemonSetName,
+					Namespace: common.CalicoNamespace,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{container}},
+					},
+				},
+			}
+			Expect(c.Create(ctx, ds)).NotTo(HaveOccurred())
+
+			// Create felix config
+			fc := &crdv1.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+
+			// Act.
+			_, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
+				return r.setBPFUpdatesOnFelixConfiguration(cr, ds, fc, reqLogger)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert.
+			bpfEnabled := false
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
+			Expect(fc.Spec.BPFEnabled).To(Equal(&bpfEnabled))
+			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("false"))
+		})
+
+		It("should query calico-node DS in Iptables dataplane and steer Felix Config when bpfEnabled false", func() {
+			// Arrange.
+			// Upgrade cluster from BPF to IP Tables dataplane.
+			cr := createInstallation(c, ctx, operator.LinuxDataplaneIptables)
+
+			// Create calico-node Daemonset annotation to indicate update rollout complete.
+			container := corev1.Container{Name: common.NodeDaemonSetName}
+			ds := &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.NodeDaemonSetName,
+					Namespace: common.CalicoNamespace,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{container}},
+					},
+				},
+			}
+			Expect(c.Create(ctx, ds)).NotTo(HaveOccurred())
+
+			// Create felix config
+			bpfEnabled := false
+			fcAnnotations := make(map[string]string)
+			fcAnnotations[render.BPFOperatorAnnotation] = "false"
+			fc := &crdv1.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default",
+					Annotations: fcAnnotations,
+				},
+				Spec: crdv1.FelixConfigurationSpec{
+					BPFEnabled: &bpfEnabled,
+				},
+			}
+			Expect(c.Create(ctx, fc)).NotTo(HaveOccurred())
+
+			// Act.
+			_, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
+				return r.setBPFUpdatesOnFelixConfiguration(cr, ds, fc, reqLogger)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Assert.
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
+			Expect(fc.Spec.BPFEnabled).To(Equal(&bpfEnabled))
+		})
+	})
+})
+
+func createInstallation(c client.Client, ctx context.Context, dp operator.LinuxDataplaneOption) *operator.Installation {
+	ca, err := tls.MakeCA("test")
+	Expect(err).NotTo(HaveOccurred())
+	cert, _, _ := ca.Config.GetPEMBytes() // create a valid pem block
+
+	//We start off with a 'standard' installation, with nothing special except setting the dataplane.
+	cr := &operator.Installation{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: operator.InstallationSpec{
+			Variant:               operator.Calico,
+			Registry:              "some.registry.org/",
+			CertificateManagement: &operator.CertificateManagement{CACert: cert},
+			CalicoNetwork: &operator.CalicoNetworkSpec{
+				LinuxDataplane: &dp,
+			},
+		},
+	}
+
+	Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+	return cr
+}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1146,9 +1146,18 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
+	// BPF Upgrade env var initial check:
+	var calicoNodeDaemonset appsv1.DaemonSet
+	calicoNodeDaemonset = appsv1.DaemonSet{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: common.CalicoNamespace, Name: common.NodeDaemonSetName}, &calicoNodeDaemonset)
+	if err != nil {
+		r.status.SetDegraded(operator.ResourceReadError, "Error getting Daemonset", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	// Set any non-default FelixConfiguration values that we need.
 	felixConfiguration, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
-		return r.setDefaultsOnFelixConfiguration(instance, fc)
+		return r.setDefaultsOnFelixConfiguration(instance, &calicoNodeDaemonset, fc, reqLogger)
 	})
 	if err != nil {
 		return reconcile.Result{}, err
@@ -1422,8 +1431,8 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	// TODO: We handle too many components in this controller at the moment. Once we are done consolidating,
 	// we can have the CreateOrUpdate logic handle this for us.
-	r.status.AddDaemonsets([]types.NamespacedName{{Name: "calico-node", Namespace: "calico-system"}})
-	r.status.AddDeployments([]types.NamespacedName{{Name: "calico-kube-controllers", Namespace: "calico-system"}})
+	r.status.AddDaemonsets([]types.NamespacedName{{Name: common.NodeDaemonSetName, Namespace: common.CalicoNamespace}})
+	r.status.AddDeployments([]types.NamespacedName{{Name: common.KubeControllersDeploymentName, Namespace: common.CalicoNamespace}})
 	certificateManager.AddToStatusManager(r.status, render.CSRLabelCalicoSystem)
 
 	// Run this after we have rendered our components so the new (operator created)
@@ -1491,6 +1500,24 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	// Tell the status manager that we're ready to monitor the resources we've told it about and receive statuses.
 	r.status.ReadyToMonitor()
+
+	// BPF Upgrade without disruption:
+	// First get the calico-node daemonset.
+	calicoNodeDaemonset = appsv1.DaemonSet{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: common.CalicoNamespace, Name: common.NodeDaemonSetName}, &calicoNodeDaemonset)
+	if err != nil {
+		r.status.SetDegraded(operator.ResourceReadError, "Error getting Daemonset", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	// Next, delegate logic implementation here using the state of the installation and dependent resources.
+	_, err = utils.PatchFelixConfiguration(ctx, r.client, func(fc *crdv1.FelixConfiguration) bool {
+		return r.setBPFUpdatesOnFelixConfiguration(instance, &calicoNodeDaemonset, felixConfiguration, reqLogger)
+	})
+	if err != nil {
+		r.status.SetDegraded(operator.ResourceUpdateError, "Error updating resource", err, reqLogger)
+		return reconcile.Result{}, err
+	}
 
 	// We can clear the degraded state now since as far as we know everything is in order.
 	r.status.ClearDegraded()
@@ -1621,7 +1648,7 @@ func getOrCreateTyphaNodeTLSConfig(cli client.Client, certificateManager certifi
 
 // setDefaultOnFelixConfiguration will take the passed in fc and add any defaulting needed
 // based on the install config.
-func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(install *operator.Installation, fc *crdv1.FelixConfiguration) bool {
+func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(install *operator.Installation, ds *appsv1.DaemonSet, fc *crdv1.FelixConfiguration, reqLogger logr.Logger) bool {
 	updated := false
 
 	switch install.Spec.CNI.Type {
@@ -1699,6 +1726,52 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(install *operato
 			}
 		}
 	}
+
+	// If BPF is enabled, but not set on FelixConfiguration, do so here. Older versions of the operator
+	// used an environment variable to enable BPF, but we no longer do so. In order to prevent disruption
+	// when the environment variable is removed by the render code, make sure
+	// FelixConfiguration has the correct value set.
+	bpfEnabledOnDaemonSet, err := bpfEnabledOnDaemonSet(ds)
+	if err != nil {
+		reqLogger.Error(err, "An error occurred when querying the Daemonset resource")
+	} else if bpfEnabledOnDaemonSet && !bpfEnabledOnFelixConfig(fc) {
+		err = setBPFEnabled(fc, true)
+		if err != nil {
+			reqLogger.Error(err, "Unable to enable eBPF data plane")
+		} else {
+			updated = true
+		}
+	}
+
+	return updated
+}
+
+// setBPFUpdatesOnFelixConfiguration will take the passed in fc and update any BPF properties needed
+// based on the install config and the daemonset.
+func (r *ReconcileInstallation) setBPFUpdatesOnFelixConfiguration(install *operator.Installation, ds *appsv1.DaemonSet, fc *crdv1.FelixConfiguration, reqLogger logr.Logger) bool {
+	updated := false
+
+	bpfEnabledOnInstall := install.Spec.BPFEnabled()
+	if bpfEnabledOnInstall {
+		if (fc.Spec.BPFEnabled == nil || !(*fc.Spec.BPFEnabled)) && isRolloutComplete(ds) {
+			err := setBPFEnabled(fc, bpfEnabledOnInstall)
+			if err != nil {
+				reqLogger.Error(err, "Unable to enable eBPF data plane")
+			} else {
+				updated = true
+			}
+		}
+	} else {
+		if fc.Spec.BPFEnabled == nil || *fc.Spec.BPFEnabled {
+			err := setBPFEnabled(fc, bpfEnabledOnInstall)
+			if err != nil {
+				reqLogger.Error(err, "Unable to enable eBPF data plane")
+			} else {
+				updated = true
+			}
+		}
+	}
+
 	return updated
 }
 

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -82,6 +82,16 @@ func (f *fakeNamespaceMigration) CleanupMigration(ctx context.Context) error {
 }
 
 var _ = Describe("Testing core-controller installation", func() {
+
+	var c client.Client
+	var cs *kfake.Clientset
+	var ctx context.Context
+	var cancel context.CancelFunc
+	var r ReconcileInstallation
+	var cr *operator.Installation
+	var scheme *runtime.Scheme
+	var mockStatus *status.MockStatus
+
 	table.DescribeTable("checking rendering configuration",
 		func(detectedProvider, configuredProvider operator.Provider, expectedErr error) {
 			configuredInstallation := &operator.Installation{}
@@ -317,13 +327,6 @@ var _ = Describe("Testing core-controller installation", func() {
 	ready.MarkAsReady()
 
 	Context("image reconciliation tests", func() {
-		var c client.Client
-		var cs *kfake.Clientset
-		var ctx context.Context
-		var cancel context.CancelFunc
-		var r ReconcileInstallation
-		var scheme *runtime.Scheme
-		var mockStatus *status.MockStatus
 
 		BeforeEach(func() {
 			// The schema contains all objects that should be known to the fake client when the test runs.
@@ -420,6 +423,20 @@ var _ = Describe("Testing core-controller installation", func() {
 							Registry: "my-reg",
 							// The test is provider agnostic.
 							KubernetesProvider: operator.ProviderNone,
+						},
+					},
+				})).NotTo(HaveOccurred())
+
+			Expect(c.Create(
+				ctx,
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{Name: common.NodeDaemonSetName, Namespace: common.CalicoNamespace},
+					Spec: appsv1.DaemonSetSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: render.CalicoNodeObjectName}},
+							},
 						},
 					},
 				})).NotTo(HaveOccurred())
@@ -694,15 +711,6 @@ var _ = Describe("Testing core-controller installation", func() {
 	)
 
 	Context("management cluster exists", func() {
-		var c client.Client
-		var cs *kfake.Clientset
-		var ctx context.Context
-		var cancel context.CancelFunc
-		var r ReconcileInstallation
-		var cr *operator.Installation
-
-		var scheme *runtime.Scheme
-		var mockStatus *status.MockStatus
 
 		var expectedDNSNames []string
 		var certificateManager certificatemanager.CertificateManager
@@ -816,6 +824,20 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
+
+			Expect(c.Create(
+				ctx,
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{Name: common.NodeDaemonSetName, Namespace: common.CalicoNamespace},
+					Spec: appsv1.DaemonSetSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: render.CalicoNodeObjectName}},
+							},
+						},
+					},
+				})).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {
 			cancel()
@@ -885,15 +907,6 @@ var _ = Describe("Testing core-controller installation", func() {
 	})
 
 	Context("Reconcile tests", func() {
-		var c client.Client
-		var cs *kfake.Clientset
-		var ctx context.Context
-		var cancel context.CancelFunc
-		var r ReconcileInstallation
-		var scheme *runtime.Scheme
-		var mockStatus *status.MockStatus
-
-		var cr *operator.Installation
 
 		BeforeEach(func() {
 			// The schema contains all objects that should be known to the fake client when the test runs.
@@ -999,6 +1012,20 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
+
+			Expect(c.Create(
+				ctx,
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{Name: common.NodeDaemonSetName, Namespace: common.CalicoNamespace},
+					Spec: appsv1.DaemonSetSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: render.CalicoNodeObjectName}},
+							},
+						},
+					},
+				})).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {
 			cancel()

--- a/pkg/controller/migration/convert/bpf_test.go
+++ b/pkg/controller/migration/convert/bpf_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ var _ = Describe("convert bpf config", func() {
 		Expect(data).To(Equal(cmData))
 	})
 
-	It("converts bpfenabled env var set to true", func() {
+	It("converts dataplane to BPF given bpfenabled env var set to true", func() {
 		comps.client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(endPointCM, f).Build()
 		comps.node.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{
 			Name:  "FELIX_BPFENABLED",
@@ -125,12 +125,26 @@ var _ = Describe("convert bpf config", func() {
 		Expect(data).To(Equal(cmData))
 	})
 
-	It("converts bpfenabled env var set to false", func() {
+	It("converts dataplane to empty given bpfenabled env var set to false", func() {
 		comps.client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(endPointCM, f).Build()
 		comps.node.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{
 			Name:  "FELIX_BPFENABLED",
 			Value: "false",
 		}}
+		err := handleBPF(&comps, i)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(i.Spec.CalicoNetwork).To(BeNil())
+		err, data := getEndPointCM(&comps, "kube-system")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal(cmData))
+		err, data = getEndPointCM(&comps, common.OperatorNamespace())
+		Expect(err).To(HaveOccurred())
+		Expect(data).To(BeNil())
+	})
+
+	It("converts dataplane to empty given bpfenabled env var set not set", func() {
+		comps.client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(endPointCM, f).Build()
+		comps.node.Spec.Template.Spec.Containers[0].Env = nil
 		err := handleBPF(&comps, i)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(i.Spec.CalicoNetwork).To(BeNil())

--- a/pkg/controller/migration/convert/felix_vars_test.go
+++ b/pkg/controller/migration/convert/felix_vars_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -137,18 +137,14 @@ var _ = Describe("felix env parser", func() {
 			c.client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(emptyFelixConfig()).Build()
 		})
 
-		It("sets a boolean", func() {
-			c.node.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{
-				Name:  "FELIX_BPFENABLED",
-				Value: "true",
-			}}
+		It("handle empty BPF Enabled environment variable", func() {
+			c.node.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{}
 
 			Expect(handleFelixVars(&c)).ToNot(HaveOccurred())
 
 			f := crdv1.FelixConfiguration{}
 			Expect(c.client.Get(ctx, types.NamespacedName{Name: "default"}, &f)).ToNot(HaveOccurred())
-			Expect(f.Spec.BPFEnabled).ToNot(BeNil())
-			Expect(*f.Spec.BPFEnabled).To(BeTrue())
+			Expect(f.Spec.BPFEnabled).To(BeNil())
 		})
 
 		It("handles 'none' failsafe inbound ports", func() {

--- a/pkg/controller/migration/convert/k8s.go
+++ b/pkg/controller/migration/convert/k8s.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -779,3 +779,29 @@ func GetDNSServiceName(provider operatorv1.Provider) types.NamespacedName {
 	}
 	return kubeDNSServiceName
 }
+
+func GetPodEnvVar(spec corev1.PodSpec, name, key string) *string {
+	c := getContainer(spec, name)
+	for _, e := range c.Env {
+		if e.Name == key {
+			if e.ValueFrom == nil {
+				return &e.Value
+			}
+		}
+	}
+	return nil
+}
+
+func getContainer(spec corev1.PodSpec, name string) *corev1.Container {
+	for _, container := range spec.Containers {
+		if container.Name == name {
+			return &container
+		}
+	}
+	for _, container := range spec.InitContainers {
+		if container.Name == name {
+			return &container
+		}
+	}
+	return nil
+}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -45,11 +45,14 @@ import (
 )
 
 const (
-	BirdTemplatesConfigMapName        = "bird-templates"
-	birdTemplateHashAnnotation        = "hash.operator.tigera.io/bird-templates"
-	nodeCniConfigAnnotation           = "hash.operator.tigera.io/cni-config"
-	bgpLayoutHashAnnotation           = "hash.operator.tigera.io/bgp-layout"
-	bgpBindModeHashAnnotation         = "hash.operator.tigera.io/bgp-bind-mode"
+	BirdTemplatesConfigMapName = "bird-templates"
+	birdTemplateHashAnnotation = "hash.operator.tigera.io/bird-templates"
+	BPFOperatorAnnotation      = "operator.tigera.io/bpfEnabled"
+
+	nodeCniConfigAnnotation   = "hash.operator.tigera.io/cni-config"
+	bgpLayoutHashAnnotation   = "hash.operator.tigera.io/bgp-layout"
+	bgpBindModeHashAnnotation = "hash.operator.tigera.io/bgp-bind-mode"
+
 	CSRLabelCalicoSystem              = "calico-system"
 	BGPLayoutConfigMapName            = "bgp-layout"
 	BGPLayoutConfigMapKey             = "earlyNetworkConfiguration"
@@ -63,6 +66,7 @@ const (
 	NodePrometheusTLSServerSecret = "calico-node-prometheus-server-tls"
 	CalicoNodeObjectName          = "calico-node"
 	CalicoCNIPluginObjectName     = "calico-cni-plugin"
+	BPFVolumeName                 = "bpffs"
 )
 
 var (
@@ -890,7 +894,7 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 		initContainers = append(initContainers, c.flexVolumeContainer())
 	}
 
-	if c.bpfDataplaneEnabled() {
+	if c.cfg.Installation.BPFEnabled() {
 		initContainers = append(initContainers, c.bpffsInitContainer())
 	}
 
@@ -1029,7 +1033,7 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 		)
 	}
 
-	if c.bpfDataplaneEnabled() {
+	if c.cfg.Installation.BPFEnabled() {
 		volumes = append(volumes,
 			// Volume for the containing directory so that the init container can mount the child bpf directory if needed.
 			corev1.Volume{Name: "sys-fs", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/sys/fs", Type: &dirOrCreate}}},
@@ -1107,12 +1111,6 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 	}
 
 	return volumes
-}
-
-func (c *nodeComponent) bpfDataplaneEnabled() bool {
-	return c.cfg.Installation.CalicoNetwork != nil &&
-		c.cfg.Installation.CalicoNetwork.LinuxDataplane != nil &&
-		*c.cfg.Installation.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneBPF
 }
 
 func (c *nodeComponent) vppDataplaneEnabled() bool {
@@ -1297,8 +1295,8 @@ func (c *nodeComponent) nodeVolumeMounts() []corev1.VolumeMount {
 			corev1.VolumeMount{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
 		)
 	}
-	if c.bpfDataplaneEnabled() {
-		nodeVolumeMounts = append(nodeVolumeMounts, corev1.VolumeMount{MountPath: "/sys/fs/bpf", Name: "bpffs"})
+	if c.cfg.Installation.BPFEnabled() {
+		nodeVolumeMounts = append(nodeVolumeMounts, corev1.VolumeMount{MountPath: "/sys/fs/bpf", Name: BPFVolumeName})
 	}
 	if c.vppDataplaneEnabled() {
 		nodeVolumeMounts = append(nodeVolumeMounts, corev1.VolumeMount{MountPath: "/usr/local/bin/felix-plugins", Name: "felix-plugins", ReadOnly: true})
@@ -1495,9 +1493,6 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		}
 	}
 
-	if c.bpfDataplaneEnabled() {
-		nodeEnv = append(nodeEnv, corev1.EnvVar{Name: "FELIX_BPFENABLED", Value: "true"})
-	}
 	if c.vppDataplaneEnabled() {
 		nodeEnv = append(nodeEnv, corev1.EnvVar{
 			Name:  "FELIX_USEINTERNALDATAPLANEDRIVER",

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -556,7 +556,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "CALICO_MANAGE_CNI", Value: "true"},
 					{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "false"},
 					{Name: "CLUSTER_TYPE", Value: "k8s,operator,bgp"},
-					{Name: "FELIX_BPFENABLED", Value: "true"},
 					{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 					{Name: "FELIX_HEALTHENABLED", Value: "true"},
 					{Name: "FELIX_HEALTHPORT", Value: "9099"},


### PR DESCRIPTION
## Description
Currently, transitioning from iptables to ebpf mode with the operator is disruptive.  This is because the operator enables BPF mode using a rolling update of the calico-node daemonset (to add the relevant environment variable).  However, clusters with some nodes in iptbales mode and some in BPF mode have broken networking.  Therefore, when enabling eBPF mode, all should nodes transition at the same time so that there is minimal iptables/eBPF mode crossover.
Note: [as outlined in epic] 
_Once roll out is finished, cluster quickly transitions to eBPF mode.  Some small disruption may occur as nodes transition within a few seconds of each other._

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
