### PR TITLE
Fix windows_controller/core_controller race condition

### DIFF
--- a/pkg/controller/installation/windows_controller.go
+++ b/pkg/controller/installation/windows_controller.go
@@ -292,7 +292,12 @@ func (r *ReconcileWindows) Reconcile(ctx context.Context, request reconcile.Requ
 	// We rely on the core controller for defaulting, so wait until it has done so before continuing
 	if reflect.DeepEqual(instanceStatus, operatorv1.InstallationStatus{}) {
 		err := fmt.Errorf("InstallationStatus is empty")
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "InstallationStatus is empty", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "InstallationStatus is empty", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+	if instance.Spec.WindowsNodes == nil {
+		err := fmt.Errorf("Installation.Spec.WindowsNodes is nil")
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Installation.Spec.WindowsNodes is nil", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
Make windows_controller wait for Installation.Spec.WindowsNodes to be defaulted by core_controller before continuing.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
