### PR TITLE
Update apiserver controller to handle old voltron cert format

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -350,7 +350,7 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 		}
 		return nil, nil, err
 	}
-	keyPEM, certPEM := GetKeyCertPEM(secret)
+	keyPEM, certPEM := certificatemanagement.GetKeyCertPEM(secret)
 	if !readCertOnly {
 		if len(keyPEM) == 0 {
 			return nil, nil, errNoPrivateKeyPEM(secretName, secretNamespace)
@@ -452,36 +452,6 @@ func (cm *certificateManager) GetKeyPair(cli client.Client, secretName, secretNa
 // CertificateManagement returns the CertificateManagement object or nil if it is not configured.
 func (cm *certificateManager) CertificateManagement() *operatorv1.CertificateManagement {
 	return cm.keyPair.CertificateManagement
-}
-
-func GetKeyCertPEM(secret *corev1.Secret) ([]byte, []byte) {
-	const (
-		legacySecretCertName  = "cert" // Formerly known as certificatemanagement.ManagerSecretCertName
-		legacySecretKeyName   = "key"  // Formerly known as certificatemanagement.ManagerSecretKeyName
-		legacySecretKeyName2  = "apiserver.key"
-		legacySecretCertName2 = "apiserver.crt"
-		legacySecretKeyName3  = "key.key"             // Formerly used for Felix and Typha.
-		legacySecretCertName3 = "cert.crt"            // Formerly used for Felix and Typha.
-		legacySecretKeyName4  = "managed-cluster.key" // Used for tunnel secrets
-		legacySecretCertName4 = "managed-cluster.crt"
-		legacySecretKeyName5  = "management-cluster.key"
-		legacySecretCertName5 = "management-cluster.crt"
-	)
-	data := secret.Data
-	for keyField, certField := range map[string]string{
-		corev1.TLSPrivateKeyKey: corev1.TLSCertKey,
-		legacySecretKeyName:     legacySecretCertName,
-		legacySecretKeyName2:    legacySecretCertName2,
-		legacySecretKeyName3:    legacySecretCertName3,
-		legacySecretKeyName4:    legacySecretCertName4,
-		legacySecretKeyName5:    legacySecretCertName5,
-	} {
-		key, cert := data[keyField], data[certField]
-		if len(cert) > 0 {
-			return key, cert
-		}
-	}
-	return nil, nil
 }
 
 // certificateManagementKeyPair returns a KeyPair for to be used when certificate management is used to provide a key pair to a pod.

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -607,7 +607,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 })
 
 func x509FromSecret(secret *corev1.Secret) (*x509.Certificate, error) {
-	_, certPEM := certificatemanager.GetKeyCertPEM(secret)
+	_, certPEM := certificatemanagement.GetKeyCertPEM(secret)
 	x509Cert, err := certificatemanagement.ParseCertificate(certPEM)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Fix issue introduced with #2802 where the old format used in tigera-management-cluster-connection secret was not handled anymore.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
