### PR TITLE
Add fluentd-windows prometheus metrics support

### DIFF
--- a/pkg/controller/installation/windows_controller.go
+++ b/pkg/controller/installation/windows_controller.go
@@ -372,7 +372,7 @@ func (r *ReconcileWindows) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 
 		// The key pair is created by the core controller, so if it isn't set, requeue to wait until it is
-		nodePrometheusTLS, err = certificateManager.GetKeyPair(r.client, render.NodePrometheusTLSServerSecret, common.OperatorNamespace(), dns.GetServiceDNSNames(render.CalicoNodeMetricsService, common.CalicoNamespace, r.clusterDomain))
+		nodePrometheusTLS, err = certificateManager.GetKeyPair(r.client, render.NodePrometheusTLSServerSecret, common.OperatorNamespace(), dns.GetServiceDNSNames(render.WindowsNodeMetricsService, common.CalicoNamespace, r.clusterDomain))
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceCreateError, "Error getting TLS certificate", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -56,6 +56,7 @@ const (
 	// use-case for this credential. However, it is used on all TLS connections served by fluentd.
 	FluentdPrometheusTLSSecretName           = "tigera-fluentd-prometheus-tls"
 	FluentdMetricsService                    = "fluentd-metrics"
+	FluentdMetricsServiceWindows             = "fluentd-metrics-windows"
 	FluentdMetricsPortName                   = "fluentd-metrics-port"
 	FluentdMetricsPort                       = 9081
 	FluentdPolicyName                        = networkpolicy.TigeraComponentPolicyPrefix + "allow-fluentd-node"
@@ -212,6 +213,13 @@ func (c *fluentdComponent) fluentdNodeName() string {
 		return fluentdNodeWindowsName
 	}
 	return FluentdNodeName
+}
+
+func (c *fluentdComponent) fluentdMetricsService() string {
+	if c.cfg.OSType == rmeta.OSTypeWindows {
+		return FluentdMetricsServiceWindows
+	}
+	return FluentdMetricsService
 }
 
 func (c *fluentdComponent) readinessCmd() []string {
@@ -584,12 +592,12 @@ func (c *fluentdComponent) metricsService() *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      FluentdMetricsService,
+			Name:      c.fluentdMetricsService(),
 			Namespace: LogCollectorNamespace,
-			Labels:    map[string]string{"k8s-app": FluentdNodeName},
+			Labels:    map[string]string{"k8s-app": c.fluentdNodeName()},
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{"k8s-app": FluentdNodeName},
+			Selector: map[string]string{"k8s-app": c.fluentdNodeName()},
 			// Important: "None" tells Kubernetes that we want a headless service with
 			// no kube-proxy load balancer.  If we omit this then kube-proxy will render
 			// a huge set of iptables rules for this service since there's an instance
@@ -795,13 +803,9 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		corev1.EnvVar{Name: "ELASTIC_WAF_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
 		corev1.EnvVar{Name: "ELASTIC_L7_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
 		corev1.EnvVar{Name: "ELASTIC_RUNTIME_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
+		corev1.EnvVar{Name: "CA_CRT_PATH", Value: c.trustedBundlePath()},
 	)
 
-	if c.SupportedOSType() != rmeta.OSTypeWindows {
-		envs = append(envs,
-			corev1.EnvVar{Name: "CA_CRT_PATH", Value: c.cfg.TrustedBundle.MountPath()},
-		)
-	}
 	return envs
 }
 

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -215,7 +215,10 @@ func (c *fluentdComponent) fluentdNodeName() string {
 	return FluentdNodeName
 }
 
-func (c *fluentdComponent) fluentdMetricsService() string {
+// Use different service names depending on the OS type ("fluentd-metrics"
+// vs "fluentd-metrics-windows") in order to help identify which OS daemonset
+// we are referring to.
+func (c *fluentdComponent) fluentdMetricsServiceName() string {
 	if c.cfg.OSType == rmeta.OSTypeWindows {
 		return FluentdMetricsServiceWindows
 	}
@@ -592,7 +595,7 @@ func (c *fluentdComponent) metricsService() *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.fluentdMetricsService(),
+			Name:      c.fluentdMetricsServiceName(),
 			Namespace: LogCollectorNamespace,
 			Labels:    map[string]string{"k8s-app": c.fluentdNodeName()},
 		},

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}{
 			{name: "tigera-fluentd", ns: "", group: "", version: "v1", kind: "Namespace"},
 			{name: render.FluentdPolicyName, ns: render.LogCollectorNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-			{name: render.FluentdMetricsService, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
+			{name: render.FluentdMetricsServiceWindows, ns: render.LogCollectorNamespace, group: "", version: "v1", kind: "Service"},
 			{name: "tigera-fluentd-windows", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-fluentd-windows", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "fluentd-node-windows", ns: "tigera-fluentd", group: "", version: "v1", kind: "ServiceAccount"},

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -743,7 +743,13 @@ func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMoni
 			Labels:    map[string]string{"team": "network-operators"},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
-			Selector:          metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "calico-node"}},
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "k8s-app",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"calico-node", "calico-node-windows"}},
+				},
+			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{"calico-system"}},
 			Endpoints: []monitoringv1.Endpoint{
 				{
@@ -815,7 +821,13 @@ func (mc *monitorComponent) serviceMonitorFluentd() *monitoringv1.ServiceMonitor
 			Labels:    map[string]string{"team": "network-operators"},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
-			Selector:          metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "fluentd-node"}},
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "k8s-app",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"fluentd-node", "fluentd-node-windows"}},
+				},
+			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{render.LogCollectorNamespace}},
 			Endpoints: []monitoringv1.Endpoint{
 				{

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -745,9 +745,11 @@ func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMoni
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: "k8s-app",
+					{
+						Key:      "k8s-app",
 						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{"calico-node", "calico-node-windows"}},
+						Values:   []string{"calico-node", "calico-node-windows"},
+					},
 				},
 			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{"calico-system"}},
@@ -823,9 +825,11 @@ func (mc *monitorComponent) serviceMonitorFluentd() *monitoringv1.ServiceMonitor
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{Key: "k8s-app",
+					{
+						Key:      "k8s-app",
 						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{"fluentd-node", "fluentd-node-windows"}},
+						Values:   []string{"fluentd-node", "fluentd-node-windows"},
+					},
 				},
 			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{render.LogCollectorNamespace}},

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -414,8 +414,13 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(ok).To(BeTrue())
 		Expect(servicemonitorObj.ObjectMeta.Labels).To(HaveLen(1))
 		Expect(servicemonitorObj.ObjectMeta.Labels["team"]).To(Equal("network-operators"))
-		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(1))
-		Expect(servicemonitorObj.Spec.Selector.MatchLabels["k8s-app"]).To(Equal("fluentd-node"))
+		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(0))
+		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(HaveLen(1))
+		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(ConsistOf([]metav1.LabelSelectorRequirement{
+			{Key: "k8s-app",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"fluentd-node", "fluentd-node-windows"}},
+		}))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames).To(HaveLen(1))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames[0]).To(Equal("tigera-fluentd"))
 		Expect(servicemonitorObj.Spec.Endpoints).To(HaveLen(1))
@@ -444,8 +449,13 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(ok).To(BeTrue())
 		Expect(servicemonitorObj.ObjectMeta.Labels).To(HaveLen(1))
 		Expect(servicemonitorObj.ObjectMeta.Labels["team"]).To(Equal("network-operators"))
-		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(1))
-		Expect(servicemonitorObj.Spec.Selector.MatchLabels["k8s-app"]).To(Equal("calico-node"))
+		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(0))
+		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(HaveLen(1))
+		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(ConsistOf([]metav1.LabelSelectorRequirement{
+			{Key: "k8s-app",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"calico-node", "calico-node-windows"}},
+		}))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames).To(HaveLen(1))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames[0]).To(Equal("calico-system"))
 		Expect(servicemonitorObj.Spec.Endpoints).To(HaveLen(2))
@@ -475,8 +485,13 @@ var _ = Describe("monitor rendering tests", func() {
 
 		servicemonitorObj, ok = rtest.GetResource(toCreate, "fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
 		Expect(ok).To(BeTrue())
-		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(1))
-		Expect(servicemonitorObj.Spec.Selector.MatchLabels["k8s-app"]).To(Equal("fluentd-node"))
+		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(0))
+		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(HaveLen(1))
+		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(ConsistOf([]metav1.LabelSelectorRequirement{
+			{Key: "k8s-app",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"fluentd-node", "fluentd-node-windows"}},
+		}))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames).To(HaveLen(1))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames[0]).To(Equal("tigera-fluentd"))
 		Expect(servicemonitorObj.Spec.Endpoints).To(HaveLen(1))

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -417,9 +417,11 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(0))
 		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(HaveLen(1))
 		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(ConsistOf([]metav1.LabelSelectorRequirement{
-			{Key: "k8s-app",
+			{
+				Key:      "k8s-app",
 				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{"fluentd-node", "fluentd-node-windows"}},
+				Values:   []string{"fluentd-node", "fluentd-node-windows"},
+			},
 		}))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames).To(HaveLen(1))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames[0]).To(Equal("tigera-fluentd"))
@@ -488,9 +490,11 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Selector.MatchLabels).To(HaveLen(0))
 		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(HaveLen(1))
 		Expect(servicemonitorObj.Spec.Selector.MatchExpressions).To(ConsistOf([]metav1.LabelSelectorRequirement{
-			{Key: "k8s-app",
+			{
+				Key:      "k8s-app",
 				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{"fluentd-node", "fluentd-node-windows"}},
+				Values:   []string{"fluentd-node", "fluentd-node-windows"},
+			},
 		}))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames).To(HaveLen(1))
 		Expect(servicemonitorObj.Spec.NamespaceSelector.MatchNames[0]).To(Equal("tigera-fluentd"))


### PR DESCRIPTION
Also a small fix to calico-node-windows prometheus metrics.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
