### PR TITLE
Panic when attempting to delete operators namespace

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -281,7 +281,13 @@ func (c componentHandler) CreateOrUpdateOrDelete(ctx context.Context, component 
 		}
 	}
 
+	// Name of Namespace where Operator is currently running
+	operatorNamespace := common.OperatorNamespace()
+
 	for _, obj := range objsToDelete {
+		if obj.GetName() == operatorNamespace && obj.GetObjectKind().GroupVersionKind().Kind == "Namespace" {
+			panic(fmt.Sprintf("Attempt to delete Operators Namespace", operatorNamespace))
+		}
 		err := c.client.Delete(ctx, obj)
 		if err != nil && !errors.IsNotFound(err) {
 			logCtx := ContextLoggerForResource(c.log, obj)


### PR DESCRIPTION
## Description

An attempt to delete namespace where the Operator is running should trigger a `panic()` which will allow further tracing of such cases. This change is a consequence of #2912 though the actual fix for a linked issue  will require another PR.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
