### PR TITLE
Various fixes for multi-tenancy

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -360,7 +360,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	// Get or create a certificate for the manager pod to use within the cluster.
-	dnsNames := dns.GetServiceDNSNames(render.ManagerServiceName, helper.TruthNamespace(), r.clusterDomain)
+	dnsNames := dns.GetServiceDNSNames(render.ManagerServiceName, helper.InstallNamespace(), r.clusterDomain)
 	internalTrafficSecret, err := certificateManager.GetOrCreateKeyPair(
 		r.client,
 		render.ManagerInternalTLSSecretName,

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -360,7 +360,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	// Get or create a certificate for the manager pod to use within the cluster.
-	dnsNames := dns.GetServiceDNSNames(render.ManagerServiceName, render.ManagerNamespace, r.clusterDomain)
+	dnsNames := dns.GetServiceDNSNames(render.ManagerServiceName, helper.TruthNamespace(), r.clusterDomain)
 	internalTrafficSecret, err := certificateManager.GetOrCreateKeyPair(
 		r.client,
 		render.ManagerInternalTLSSecretName,

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -88,7 +88,7 @@ func CreateEntityRule(namespace string, deploymentName string, ports ...uint16) 
 func CreateSourceEntityRule(namespace string, deploymentName string) v3.EntityRule {
 	return v3.EntityRule{
 		Selector:          fmt.Sprintf("k8s-app == '%s'", deploymentName),
-		NamespaceSelector: fmt.Sprintf("name == '%s'", namespace),
+		NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", namespace),
 	}
 }
 

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -17,7 +17,6 @@ package render
 import (
 	"crypto/x509"
 	"fmt"
-	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -147,11 +146,13 @@ type EksCloudwatchLogConfig struct {
 
 // FluentdConfiguration contains all the config information needed to render the component.
 type FluentdConfiguration struct {
-	LogCollector    *operatorv1.LogCollector
+	LogCollector   *operatorv1.LogCollector
+	S3Credential   *S3Credential
+	SplkCredential *SplunkCredential
+	Filters        *FluentdFilters
+	// ESClusterConfig is only populated for when EKSConfig
+	// is also defined
 	ESClusterConfig *relasticsearch.ClusterConfig
-	S3Credential    *S3Credential
-	SplkCredential  *SplunkCredential
-	Filters         *FluentdFilters
 	EKSConfig       *EksCloudwatchLogConfig
 	PullSecrets     []*corev1.Secret
 	Installation    *operatorv1.InstallationSpec
@@ -790,24 +791,7 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		}
 	}
 
-	envs = append(envs,
-		corev1.EnvVar{Name: "ELASTIC_FLOWS_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
-		corev1.EnvVar{Name: "ELASTIC_DNS_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
-		corev1.EnvVar{Name: "ELASTIC_AUDIT_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
-		corev1.EnvVar{Name: "ELASTIC_BGP_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
-		corev1.EnvVar{Name: "ELASTIC_WAF_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
-		corev1.EnvVar{Name: "ELASTIC_L7_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
-		corev1.EnvVar{Name: "ELASTIC_RUNTIME_INDEX_REPLICAS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Replicas())},
-
-		corev1.EnvVar{Name: "ELASTIC_FLOWS_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.FlowShards())},
-		corev1.EnvVar{Name: "ELASTIC_DNS_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
-		corev1.EnvVar{Name: "ELASTIC_AUDIT_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
-		corev1.EnvVar{Name: "ELASTIC_BGP_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
-		corev1.EnvVar{Name: "ELASTIC_WAF_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
-		corev1.EnvVar{Name: "ELASTIC_L7_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
-		corev1.EnvVar{Name: "ELASTIC_RUNTIME_INDEX_SHARDS", Value: strconv.Itoa(c.cfg.ESClusterConfig.Shards())},
-		corev1.EnvVar{Name: "CA_CRT_PATH", Value: c.trustedBundlePath()},
-	)
+	envs = append(envs, corev1.EnvVar{Name: "CA_CRT_PATH", Value: c.trustedBundlePath()})
 
 	return envs
 }

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -41,7 +41,6 @@ import (
 )
 
 var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
-	var esConfigMap *relasticsearch.ClusterConfig
 	var cfg *render.FluentdConfiguration
 
 	expectedFluentdPolicyForUnmanaged := testutils.GetExpectedPolicyFromFile("testutils/expected_policies/fluentd_unmanaged.json")
@@ -51,7 +50,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 	BeforeEach(func() {
 		// Initialize a default instance to use. Each test can override this to its
 		// desired configuration.
-		esConfigMap = relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
+		//esConfigMap = relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
 		scheme := runtime.NewScheme()
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -62,10 +61,9 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		metricsSecret, err := certificateManager.GetOrCreateKeyPair(cli, render.FluentdPrometheusTLSSecretName, common.OperatorNamespace(), []string{""})
 		Expect(err).NotTo(HaveOccurred())
 		cfg = &render.FluentdConfiguration{
-			LogCollector:    &operatorv1.LogCollector{},
-			ESClusterConfig: esConfigMap,
-			ClusterDomain:   dns.DefaultClusterDomain,
-			OSType:          rmeta.OSTypeLinux,
+			LogCollector:  &operatorv1.LogCollector{},
+			ClusterDomain: dns.DefaultClusterDomain,
+			OSType:        rmeta.OSTypeLinux,
 			Installation: &operatorv1.InstallationSpec{
 				KubernetesProvider: operatorv1.ProviderNone,
 			},
@@ -823,6 +821,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			GroupName:     "dummy-eks-cluster-cloudwatch-log-group",
 			FetchInterval: fetchInterval,
 		}
+		cfg.ESClusterConfig = relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
 		t := corev1.Toleration{
 			Key:      "foo",
 			Operator: corev1.TolerationOpEqual,

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -50,7 +50,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 	BeforeEach(func() {
 		// Initialize a default instance to use. Each test can override this to its
 		// desired configuration.
-		//esConfigMap = relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
 		scheme := runtime.NewScheme()
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 		cli := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -309,6 +309,7 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 		// If a tenant was provided, set the expected tenant ID and enable the shared index backend.
 		envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_EXPECTED_TENANT_ID", Value: l.cfg.Tenant.Spec.ID})
 		envVars = append(envVars, corev1.EnvVar{Name: "BACKEND", Value: "elastic-single-index"})
+		envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", l.cfg.Tenant.Namespace)})
 	}
 
 	var initContainers []corev1.Container

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Linseed rendering tests", func() {
 			Expect(cr.Rules).To(ContainElements(expectedRules))
 		})
 
-		It("should render MANAGEMENT_OPERATOR_NS environment variable", func() {
+		It("should render MULTI-TENANT environment variables", func() {
 			cfg.ManagementCluster = true
 			component := Linseed(cfg)
 			Expect(component).NotTo(BeNil())
@@ -350,6 +350,9 @@ var _ = Describe("Linseed rendering tests", func() {
 			d := rtest.GetResource(resources, DeploymentName, cfg.Namespace, appsv1.GroupName, "v1", "Deployment").(*appsv1.Deployment)
 			envs := d.Spec.Template.Spec.Containers[0].Env
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "MANAGEMENT_OPERATOR_NS", Value: "tigera-operator"}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "BACKEND", Value: "elastic-single-index"}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "LINSEED_EXPECTED_TENANT_ID", Value: cfg.Tenant.Spec.ID}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "LINSEED_MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", cfg.Tenant.Namespace)}))
 		})
 	})
 })

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Linseed rendering tests", func() {
 			Expect(cr.Rules).To(ContainElements(expectedRules))
 		})
 
-		It("should render MULTI-TENANT environment variables", func() {
+		It("should render multi-tenant environment variables", func() {
 			cfg.ManagementCluster = true
 			component := Linseed(cfg)
 			Expect(component).NotTo(BeNil())

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -534,6 +534,7 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 
 	if c.cfg.Tenant != nil {
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_TENANT_NAMESPACE", Value: c.cfg.Tenant.Namespace})
+		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc.cluster.local", c.cfg.Tenant.Namespace)})
 	}
 
 	return corev1.Container{

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -534,7 +534,8 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 
 	if c.cfg.Tenant != nil {
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_TENANT_NAMESPACE", Value: c.cfg.Tenant.Namespace})
-		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc.cluster.local", c.cfg.Tenant.Namespace)})
+		env = append(env, corev1.EnvVar{Name: "VOLTRON_TENANT_ID", Value: c.cfg.Tenant.Spec.ID})
+		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc", c.cfg.Tenant.Namespace)})
 	}
 
 	return corev1.Container{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -965,6 +965,21 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				},
 			}))
 		})
+
+		It("should render MULTI-TENANT environment variables", func() {
+			tenantAResources := renderObjects(renderConfig{
+				oidc:                    false,
+				managementCluster:       nil,
+				installation:            installation,
+				compliance:              compliance,
+				complianceFeatureActive: true,
+				ns:                      tenantANamespace,
+			})
+			d := rtest.GetResource(tenantAResources, "tigera-manager", tenantANamespace, appsv1.GroupName, "v1", "Deployment").(*appsv1.Deployment)
+			envs := d.Spec.Template.Spec.Containers[0].Env
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_TENANT_NAMESPACE", Value: tenantANamespace}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc.cluster.local", tenantANamespace)}))
+		})
 	})
 })
 

--- a/pkg/render/testutils/expected_policies/compliance-server.json
+++ b/pkg/render/testutils/expected_policies/compliance-server.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [

--- a/pkg/render/testutils/expected_policies/compliance-server_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance-server_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [

--- a/pkg/render/testutils/expected_policies/dex.json
+++ b/pkg/render/testutils/expected_policies/dex.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -50,7 +50,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-packetcapture'",
-          "namespaceSelector": "name == 'tigera-packetcapture'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/dex_ocp.json
+++ b/pkg/render/testutils/expected_policies/dex_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -50,7 +50,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-packetcapture'",
-          "namespaceSelector": "name == 'tigera-packetcapture'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/elasticsearch.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure'",
-          "namespaceSelector": "name == 'tigera-kibana'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -64,7 +64,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure'",
-          "namespaceSelector": "name == 'tigera-kibana'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/es-gateway.json
+++ b/pkg/render/testutils/expected_policies/es-gateway.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "name == 'tigera-fluentd'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'"
         },
         "destination": {
           "ports": [
@@ -58,7 +58,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-curator'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -71,7 +71,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-benchmarker'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-controller'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -115,7 +115,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -128,7 +128,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-snapshotter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -141,7 +141,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-reporter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -167,7 +167,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {
@@ -180,7 +180,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/es-gateway_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-gateway_ocp.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "name == 'tigera-fluentd'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'"
         },
         "destination": {
           "ports": [
@@ -58,7 +58,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-curator'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -71,7 +71,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-benchmarker'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-controller'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -115,7 +115,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -128,7 +128,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-snapshotter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -141,7 +141,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-reporter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -167,7 +167,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {
@@ -180,7 +180,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/guardian.json
+++ b/pkg/render/testutils/expected_policies/guardian.json
@@ -36,7 +36,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-benchmarker'"
         }
       },
@@ -49,7 +49,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-reporter'"
         }
       },
@@ -62,7 +62,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-snapshotter'"
         }
       },
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-controller'"
         }
       },

--- a/pkg/render/testutils/expected_policies/guardian_ocp.json
+++ b/pkg/render/testutils/expected_policies/guardian_ocp.json
@@ -36,7 +36,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-benchmarker'"
         }
       },
@@ -49,7 +49,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-reporter'"
         }
       },
@@ -62,7 +62,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-snapshotter'"
         }
       },
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "name == 'tigera-compliance'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'",
           "selector": "k8s-app == 'compliance-controller'"
         }
       },

--- a/pkg/render/testutils/expected_policies/kibana.json
+++ b/pkg/render/testutils/expected_policies/kibana.json
@@ -47,7 +47,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -65,7 +65,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       }
     ],

--- a/pkg/render/testutils/expected_policies/kibana_ocp.json
+++ b/pkg/render/testutils/expected_policies/kibana_ocp.json
@@ -47,7 +47,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -65,7 +65,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       }
     ],

--- a/pkg/render/testutils/expected_policies/linseed.json
+++ b/pkg/render/testutils/expected_policies/linseed.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "name == 'tigera-fluentd'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'"
         },
         "destination": {
           "ports": [
@@ -58,7 +58,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-curator'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -71,7 +71,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-benchmarker'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-controller'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -115,7 +115,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -128,7 +128,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-snapshotter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -141,7 +141,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-reporter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -167,7 +167,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {
@@ -180,7 +180,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -193,7 +193,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "name == 'tigera-policy-recommendation'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-policy-recommendation'"
         }
       }
     ],

--- a/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "name == 'tigera-fluentd'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'"
         },
         "destination": {
           "ports": [
@@ -58,7 +58,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-curator'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -71,7 +71,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-benchmarker'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-controller'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -115,7 +115,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -128,7 +128,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-snapshotter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -141,7 +141,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-reporter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -167,7 +167,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {
@@ -180,7 +180,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -193,7 +193,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "name == 'tigera-policy-recommendation'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-policy-recommendation'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/linseed_ocp.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "name == 'tigera-fluentd'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'"
         },
         "destination": {
           "ports": [
@@ -58,7 +58,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-curator'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -71,7 +71,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-benchmarker'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-controller'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -115,7 +115,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -128,7 +128,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-snapshotter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -141,7 +141,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-reporter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -167,7 +167,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {
@@ -180,7 +180,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -193,7 +193,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "name == 'tigera-policy-recommendation'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-policy-recommendation'"
         }
       }
     ],

--- a/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "name == 'tigera-fluentd'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-fluentd'"
         },
         "destination": {
           "ports": [
@@ -58,7 +58,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-curator'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -71,7 +71,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-benchmarker'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-controller'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -115,7 +115,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-server'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -128,7 +128,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-snapshotter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -141,7 +141,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'compliance-reporter'",
-          "namespaceSelector": "name == 'tigera-compliance'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-compliance'"
         }
       },
       {
@@ -167,7 +167,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "name == 'tigera-eck-operator'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
         }
       },
       {
@@ -180,7 +180,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "name == 'tigera-elasticsearch'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -193,7 +193,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "name == 'tigera-policy-recommendation'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-policy-recommendation'"
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/packetcapture.json
+++ b/pkg/render/testutils/expected_policies/packetcapture.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [

--- a/pkg/render/testutils/expected_policies/packetcapture_managed.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-guardian'",
-          "namespaceSelector": "name == 'tigera-guardian'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'"
         },
         "destination": {
           "ports": [

--- a/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-guardian'",
-          "namespaceSelector": "name == 'tigera-guardian'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-guardian'"
         },
         "destination": {
           "ports": [

--- a/pkg/render/testutils/expected_policies/packetcapture_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-manager'",
-          "namespaceSelector": "name == 'tigera-manager'"
+          "namespaceSelector": "projectcalico.org/name == 'tigera-manager'"
         },
         "destination": {
           "ports": [


### PR DESCRIPTION
## Description

- Linseed connects to a wrong svc for multi-tenant for tigera-manager (Need to set LINSEED_MULTI_CLUSTER_FORWARDING_ENDPOINT to use tigera-manager from the tenant namespace)
- SSL certificate for internal-manager-tls was a wrong SANs (the service tigera-manager needs to be the one the tenant namespace)
- A managed cluster does not need elastic config map in most installations. (This is currently needed for eks forwarder)
- Voltron needs to talk to the Linseed service from the tenant namespace (Need to set VOLTRON_LINSEED_ENDPOINT to use the linseed service from the tenant namespace)
- Voltron needs VOLTRON_TENANT_ID configured
- Make use of `projectcalico.org/name` for a namespace selector instead of name

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
