### PR TITLE
Automated cherry pick of #2938: Add a label to the prometheus service, so it can be

### DIFF
--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -684,6 +684,9 @@ func (mc *monitorComponent) prometheusServiceService() *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PrometheusServiceServiceName,
 			Namespace: common.TigeraPrometheusNamespace,
+			Labels: map[string]string{
+				"k8s-app": TigeraPrometheusObjectName,
+			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -153,6 +153,9 @@ var _ = Describe("monitor rendering tests", func() {
 		namespace := rtest.GetResource(toCreate, "tigera-prometheus", "", "", "v1", "Namespace").(*corev1.Namespace)
 		Expect(namespace.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("baseline"))
 		Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
+
+		service := rtest.GetResource(toCreate, "prometheus-http-api", "tigera-prometheus", "", "v1", "Service").(*corev1.Service)
+		Expect(service.Labels["k8s-app"]).To(Equal("tigera-prometheus"))
 	})
 
 	It("Should render Prometheus resource Specs correctly", func() {


### PR DESCRIPTION
Cherry pick of #2938 on release-v1.32.

#2938: Add a label to the prometheus service, so it can be