### PR TITLE
[Feature Request] Add podDisruptionBudget in API server

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -17,6 +17,7 @@ package common
 const (
 	CalicoNamespace               = "calico-system"
 	TyphaDeploymentName           = "calico-typha"
+	APIServerDeploymentName       = "calico-apiserver"
 	NodeDaemonSetName             = "calico-node"
 	KubeControllersDeploymentName = "calico-kube-controllers"
 	WindowsDaemonSetName          = "calico-node-windows"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -17,7 +17,6 @@ package common
 const (
 	CalicoNamespace               = "calico-system"
 	TyphaDeploymentName           = "calico-typha"
-	APIServerDeploymentName       = "calico-apiserver"
 	NodeDaemonSetName             = "calico-node"
 	KubeControllersDeploymentName = "calico-kube-controllers"
 	WindowsDaemonSetName          = "calico-node-windows"

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import (
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
@@ -326,7 +325,7 @@ func (c *apiServerComponent) apiServerPodDisruptionBudget() *policyv1.PodDisrupt
 		TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: common.CalicoNamespace,
+			Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -294,12 +294,28 @@ func (c *apiServerComponent) Ready() bool {
 	return true
 }
 
+// Determine names based on the configured variant
+// It takes two name as parameters, enterpriseName and ossName, and returns name and nameToDelete.
+func (c *apiServerComponent) resourceNameBasedOnVariant(enterpriseName, ossName string) (string, string) {
+	var name, nameToDelete string
+	switch c.cfg.Installation.Variant {
+	case operatorv1.TigeraSecureEnterprise:
+		name = enterpriseName
+		nameToDelete = ossName
+	case operatorv1.Calico:
+		name = ossName
+		nameToDelete = enterpriseName
+	}
+	return name, nameToDelete
+}
+
 func (c *apiServerComponent) apiServerPodDisruptionBudget() *policyv1.PodDisruptionBudget {
 	maxUnavailable := intstr.FromInt(1)
+	name, _ := c.resourceNameBasedOnVariant("tigera-apiserver", "calico-apiserver")
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      common.APIServerDeploymentName,
+			Name:      name,
 			Namespace: common.CalicoNamespace,
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
@@ -345,18 +361,7 @@ func (c *apiServerComponent) apiServiceRegistration(cert []byte) *apiregv1.APISe
 // Both Calico and Calico Enterprise, but different names.
 func (c *apiServerComponent) delegateAuthClusterRoleBinding() (client.Object, client.Object) {
 	// Determine names based on the configured variant.
-	var name, nameToDelete string
-	enterpriseName := "tigera-apiserver-delegate-auth"
-	ossName := "calico-apiserver-delegate-auth"
-	switch c.cfg.Installation.Variant {
-	case operatorv1.TigeraSecureEnterprise:
-		name = enterpriseName
-		nameToDelete = ossName
-	case operatorv1.Calico:
-		name = ossName
-		nameToDelete = enterpriseName
-	}
-
+	name, nameToDelete := c.resourceNameBasedOnVariant("tigera-apiserver-delegate-auth", "calico-apiserver-delegate-auth")
 	return &rbacv1.ClusterRoleBinding{
 			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -388,18 +393,7 @@ func (c *apiServerComponent) delegateAuthClusterRoleBinding() (client.Object, cl
 //
 // Both Calico and Calico Enterprise, but different names.
 func (c *apiServerComponent) authReaderRoleBinding() (client.Object, client.Object) {
-	var name, nameToDelete string
-	enterpriseName := "tigera-auth-reader"
-	ossName := "calico-apiserver-auth-reader"
-	switch c.cfg.Installation.Variant {
-	case operatorv1.TigeraSecureEnterprise:
-		name = enterpriseName
-		nameToDelete = ossName
-	case operatorv1.Calico:
-		name = ossName
-		nameToDelete = enterpriseName
-	}
-
+	name, nameToDelete := c.resourceNameBasedOnVariant("tigera-auth-reader", "calico-apiserver-auth-reader")
 	return &rbacv1.RoleBinding{
 			TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -617,18 +611,7 @@ func (c *apiServerComponent) calicoCustomResourcesClusterRoleBinding() *rbacv1.C
 //
 // Both Calico and Calico Enterprise, with different names.
 func (c *apiServerComponent) authClusterRole() (client.Object, client.Object) {
-	var name, nameToDelete string
-	enterpriseName := "tigera-extension-apiserver-auth-access"
-	ossName := "calico-extension-apiserver-auth-access"
-	switch c.cfg.Installation.Variant {
-	case operatorv1.TigeraSecureEnterprise:
-		name = enterpriseName
-		nameToDelete = ossName
-	case operatorv1.Calico:
-		name = ossName
-		nameToDelete = enterpriseName
-	}
-
+	name, nameToDelete := c.resourceNameBasedOnVariant("tigera-extension-apiserver-auth-access", "calico-extension-apiserver-auth-access")
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{
@@ -787,18 +770,7 @@ func (c *apiServerComponent) secretsRBAC() []client.Object {
 //
 // Both Calico and Calico Enterprise, with different names.
 func (c *apiServerComponent) authClusterRoleBinding() (client.Object, client.Object) {
-	var name, nameToDelete string
-	enterpriseName := "tigera-extension-apiserver-auth-access"
-	ossName := "calico-extension-apiserver-auth-access"
-	switch c.cfg.Installation.Variant {
-	case operatorv1.TigeraSecureEnterprise:
-		name = enterpriseName
-		nameToDelete = ossName
-	case operatorv1.Calico:
-		name = ossName
-		nameToDelete = enterpriseName
-	}
-
+	name, nameToDelete := c.resourceNameBasedOnVariant("tigera-extension-apiserver-auth-access", "calico-extension-apiserver-auth-access")
 	return &rbacv1.ClusterRoleBinding{
 			TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -829,18 +801,7 @@ func (c *apiServerComponent) authClusterRoleBinding() (client.Object, client.Obj
 //
 // Both Calico and Calico Enterprise, with different names.
 func (c *apiServerComponent) webhookReaderClusterRole() (client.Object, client.Object) {
-	var name, nameToDelete string
-	enterpriseName := "tigera-webhook-reader"
-	ossName := "calico-webhook-reader"
-	switch c.cfg.Installation.Variant {
-	case operatorv1.TigeraSecureEnterprise:
-		name = enterpriseName
-		nameToDelete = ossName
-	case operatorv1.Calico:
-		name = ossName
-		nameToDelete = enterpriseName
-	}
-
+	name, nameToDelete := c.resourceNameBasedOnVariant("tigera-webhook-reader", "calico-webhook-reader")
 	return &rbacv1.ClusterRole{
 			TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -874,20 +835,14 @@ func (c *apiServerComponent) webhookReaderClusterRole() (client.Object, client.O
 //
 // Both Calico and Calico Enterprise, with different names.
 func (c *apiServerComponent) webhookReaderClusterRoleBinding() (client.Object, client.Object) {
-	var name, nameToDelete, refName string
-	enterpriseName := "tigera-apiserver-webhook-reader"
-	ossName := "calico-apiserver-webhook-reader"
+	name, nameToDelete := c.resourceNameBasedOnVariant("tigera-apiserver-webhook-reader", "calico-apiserver-webhook-reader")
+	var refName string
 	switch c.cfg.Installation.Variant {
 	case operatorv1.TigeraSecureEnterprise:
-		name = enterpriseName
-		nameToDelete = ossName
 		refName = "tigera-webhook-reader"
 	case operatorv1.Calico:
-		name = ossName
-		nameToDelete = enterpriseName
 		refName = "calico-webhook-reader"
 	}
-
 	return &rbacv1.ClusterRoleBinding{
 			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -951,14 +906,7 @@ func (c *apiServerComponent) apiServerService() *corev1.Service {
 
 // apiServer creates a deployment containing the API and query servers.
 func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
-	var name string
-	switch c.cfg.Installation.Variant {
-	case operatorv1.TigeraSecureEnterprise:
-		name = "tigera-apiserver"
-	case operatorv1.Calico:
-		name = "calico-apiserver"
-	}
-
+	name, _ := c.resourceNameBasedOnVariant("tigera-apiserver", "calico-apiserver")
 	hostNetwork := c.hostNetwork()
 	dnsPolicy := corev1.DNSClusterFirst
 	if hostNetwork {
@@ -1250,25 +1198,11 @@ func (c *apiServerComponent) tolerations() []corev1.Toleration {
 //
 // Both Calico and Calico Enterprise, with different names.
 func (c *apiServerComponent) apiServerPodSecurityPolicy() (client.Object, client.Object) {
-	var name, nameToDelete string
-	enterpriseName := "tigera-apiserver"
-	ossName := "calico-apiserver"
-
-	switch c.cfg.Installation.Variant {
-	case operatorv1.TigeraSecureEnterprise:
-		name = enterpriseName
-		nameToDelete = ossName
-	case operatorv1.Calico:
-		name = ossName
-		nameToDelete = enterpriseName
-	}
-
+	name, nameToDelete := c.resourceNameBasedOnVariant("tigera-apiserver", "calico-apiserver")
 	psp := podsecuritypolicy.NewBasePolicy(name)
 	psp.Spec.Volumes = append(psp.Spec.Volumes, policyv1beta1.HostPath)
 	psp.Spec.RunAsUser.Rule = policyv1beta1.RunAsUserStrategyRunAsAny
-
 	pspToDelete := podsecuritypolicy.NewBasePolicy(nameToDelete)
-
 	return psp, pspToDelete
 }
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -132,6 +133,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-uisettingsgroup-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -399,6 +401,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-uisettingsgroup-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -453,6 +456,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-uisettingsgroup-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -528,6 +532,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-uisettingsgroup-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -596,6 +601,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-uisettingsgroup-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -748,6 +754,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-uisettingsgroup-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -817,6 +824,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			&apiregv1.APIService{ObjectMeta: metav1.ObjectMeta{Name: "v3.projectcalico.org"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-apiserver", Namespace: "tigera-system"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tigera-api", Namespace: "tigera-system"}},
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "tigera-apiserver", Namespace: "tigera-system"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-tier-getter"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-tier-getter"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-uisettingsgroup-getter"}},
@@ -900,6 +908,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "tigera-apiserver", ns: "tigera-system", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "tigera-api", ns: "tigera-system", group: "", version: "v1", kind: "Service"},
+			{name: "tigera-apiserver", ns: "tigera-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "tigera-tier-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "tigera-uisettingsgroup-getter", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
@@ -1547,6 +1556,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			{name: "v3.projectcalico.org", ns: "", group: "apiregistration.k8s.io", version: "v1", kind: "APIService"},
 			{name: "calico-apiserver", ns: "calico-apiserver", group: "apps", version: "v1", kind: "Deployment"},
 			{name: "calico-api", ns: "calico-apiserver", group: "", version: "v1", kind: "Service"},
+			{name: "calico-apiserver", ns: "calico-apiserver", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "calico-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 			{name: "calico-apiserver-webhook-reader", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "calico-apiserver", ns: "", group: "policy", version: "v1beta1", kind: "PodSecurityPolicy"},
@@ -1667,6 +1677,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			&apiregv1.APIService{ObjectMeta: metav1.ObjectMeta{Name: "v3.projectcalico.org"}, TypeMeta: metav1.TypeMeta{APIVersion: "apiregistration.k8s.io/v1", Kind: "APIService"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "calico-api", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"}},
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "policy/v1", Kind: "PodDisruptionBudget"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhook-reader"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-webhook-reader"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}},
 			&policyv1beta1.PodSecurityPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "policy/v1beta1", Kind: "PodSecurityPolicy"}},


### PR DESCRIPTION
## Description

Closes https://github.com/tigera/operator/issues/2886

This PR adds `podDisruptionBudget` in the API Server and affects the `calico-apiserver` component. 


## Testing
For testing this feature :
1. Install operator
2. Run `kubectl create -f ./config/samples/operator_v1_apiserver.yaml`
3. Run `kubectl -n calico-system get pdb` 
4. Shows `podDisruptionBudget` for `calico-apiserver` component. 


## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
