### PR TITLE
[release-v1.32] Auto pick #2949: Make windowsDataplane disabled by default in providerAKS (as

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -541,17 +541,10 @@ func fillDefaults(instance *operator.Installation) error {
 		instance.Spec.CalicoNetwork.LinuxDataplane = &dpIptables
 	}
 
-	// Default Windows dataplane is disabled, unless provider is AKS
+	// Default Windows dataplane is disabled
 	winDataplaneDisabled := operator.WindowsDataplaneDisabled
-	winDataplaneHNS := operator.WindowsDataplaneHNS
 	if instance.Spec.CalicoNetwork.WindowsDataplane == nil {
-		if instance.Spec.KubernetesProvider == operator.ProviderAKS {
-			// On AKS, we had the windows upgrade daemonset, which is replaced by the
-			// calico-node-windows daemonset, so default to HNS dataplane in this case.
-			instance.Spec.CalicoNetwork.WindowsDataplane = &winDataplaneHNS
-		} else {
-			instance.Spec.CalicoNetwork.WindowsDataplane = &winDataplaneDisabled
-		}
+		instance.Spec.CalicoNetwork.WindowsDataplane = &winDataplaneDisabled
 	}
 
 	// If Windows is enabled, populate CNI bin, config and log dirs with defaults

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -531,15 +531,6 @@ var _ = Describe("Defaulting logic tests", func() {
 			Expect(instance.Spec.CNI.Type).To(Equal(plugin))
 			iptables := operator.LinuxDataplaneIptables
 			winDataplane := operator.WindowsDataplaneDisabled
-			// if provider == operator.ProviderAKS {
-			// 	winDataplane = operator.WindowsDataplaneHNS
-			// 	instance.Spec.ServiceCIDRs = []string{"10.96.0.0/12"}
-			// 	// Populate the k8s service endpoint (required for windows)
-			// 	k8sapi.Endpoint = k8sapi.ServiceEndpoint{
-			// 		Host: "1.2.3.4",
-			// 		Port: "6443",
-			// 	}
-			// }
 			bgpDisabled := operator.BGPDisabled
 			Expect(instance.Spec.CalicoNetwork).To(Equal(&operator.CalicoNetworkSpec{
 				LinuxDataplane:   &iptables,

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -29,7 +29,6 @@ import (
 
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/render"
 )
 
@@ -532,15 +531,15 @@ var _ = Describe("Defaulting logic tests", func() {
 			Expect(instance.Spec.CNI.Type).To(Equal(plugin))
 			iptables := operator.LinuxDataplaneIptables
 			winDataplane := operator.WindowsDataplaneDisabled
-			if provider == operator.ProviderAKS {
-				winDataplane = operator.WindowsDataplaneHNS
-				instance.Spec.ServiceCIDRs = []string{"10.96.0.0/12"}
-				// Populate the k8s service endpoint (required for windows)
-				k8sapi.Endpoint = k8sapi.ServiceEndpoint{
-					Host: "1.2.3.4",
-					Port: "6443",
-				}
-			}
+			// if provider == operator.ProviderAKS {
+			// 	winDataplane = operator.WindowsDataplaneHNS
+			// 	instance.Spec.ServiceCIDRs = []string{"10.96.0.0/12"}
+			// 	// Populate the k8s service endpoint (required for windows)
+			// 	k8sapi.Endpoint = k8sapi.ServiceEndpoint{
+			// 		Host: "1.2.3.4",
+			// 		Port: "6443",
+			// 	}
+			// }
 			bgpDisabled := operator.BGPDisabled
 			Expect(instance.Spec.CalicoNetwork).To(Equal(&operator.CalicoNetworkSpec{
 				LinuxDataplane:   &iptables,


### PR DESCRIPTION
Cherry pick of #2949 on release-v1.32.

#2949: Make windowsDataplane disabled by default in providerAKS (as

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.