### PR TITLE
Automate updating operator version for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@
 # TODO: Add in the necessary variables, etc, to make this Makefile work.
 # TODO: Add in multi-arch stuff.
 
+GIT_CMD           = git
+
+ifdef CONFIRM
+GIT           = $(GIT_CMD)
+else
+GIT           = echo [DRY RUN] $(GIT_CMD)
+endif
+
 
 # Shortcut targets
 default: build
@@ -558,6 +566,41 @@ ifdef LOCAL_BUILD
 	$(error LOCAL_BUILD must not be set for a release)
 endif
 
+release-prep: var-require-all-VERSION-CALICO_VERSION-COMMON_VERSION
+ifdef CNX
+	$(MAKE) var-require-all-CALICO_ENTERPRISE_VERSION
+	yq e ".title = \"$(CALICO_ENTERPRISE_VERSION)\" | .components |= with_entries(select(.key | test(\"^(eck-|coreos-).*\") | not)) |= with(.[]; .version = \"$(CALICO_ENTERPRISE_VERSION)\")" -i config/enterprise_versions.yml
+endif
+	yq e ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
+	yq e ".title = \"$(COMMON_VERSION)\" | .components.key-cert-provisioner.version = \"$(COMMON_VERSION)\"" -i config/common_versions.yml
+	sed -i "s/\"gcr.io.*\"/\"quay.io\/\"/g" pkg/components/images.go
+	sed -i "s/\"gcr.io.*\"/\"quay.io\"/g" hack/gen-versions/main.go
+	$(MAKE) gen-versions release-prep/create-and-push-branch release-prep/create-pr release-prep/set-merge-when-ready-on-pr
+
+GIT_REMOTE?=origin
+GIT_PR_BRANCH_BASE?=$(SEMAPHORE_GIT_BRANCH)
+GIT_REPO_SLUG?=$(SEMAPHORE_GIT_REPO_SLUG)
+RELEASE_UPDATE_BRANCH?=semaphore-auto-build-updates-$(VERSION)
+GIT_PR_BRANCH_HEAD?=$(RELEASE_UPDATE_BRANCH)
+release-prep/create-and-push-branch:
+ifeq ($(shell git rev-parse --abbrev-ref HEAD),$(GIT_PR_BRANCH_HEAD))
+	$(error Current branch is pull request head, cannot set it up.)
+endif
+	-git branch -D $(GIT_PR_BRANCH_HEAD)
+	-$(GIT) push $(GIT_REMOTE) --delete $(GIT_PR_BRANCH_HEAD)
+	git checkout -b $(GIT_PR_BRANCH_HEAD)
+	$(GIT) add config/*_versions.yml hack/gen-versions/main.go pkg/components/* pkg/crds/*
+	$(GIT) commit -m "Automatic version updates for $(VERSION) release"
+	$(GIT) push $(GIT_REMOTE) $(GIT_PR_BRANCH_HEAD)
+
+release-prep/create-pr:
+	$(call github_pr_create,$(GIT_REPO_SLUG),[$(GIT_PR_BRANCH_BASE)] Semaphore Auto $(VERSION) Release Update,$(GIT_PR_BRANCH_HEAD),$(GIT_PR_BRANCH_BASE))
+	echo 'Created release update pull request for $(VERSION): $(PR_NUMBER)'
+
+release-prep/set-merge-when-ready-on-pr:
+	$(call github_pr_add_comment,$(GIT_REPO_SLUG),$(PR_NUMBER),/merge-when-ready delete-branch)
+	echo "Added '/merge-when-ready' comment command to pull request $(PR_NUMBER)"
+
 ###############################################################################
 # Utilities
 ###############################################################################
@@ -866,3 +909,56 @@ install-git-hooks:
 .PHONY: pre-commit
 pre-commit:
 	$(CONTAINERIZED) $(CALICO_BUILD) git-hooks/pre-commit-in-container
+
+# var-set-% checks if there is a non empty variable for the value describe by %. If FAIL_NOT_SET is set, then var-set-%
+# fails with an error message. If FAIL_NOT_SET is not set, then var-set-% appends a 1 to VARSET if the variable isn't
+# set.
+var-set-%:
+	$(if $($*),$(eval VARSET+=1),$(if $(FAIL_NOT_SET),$(error $* is required but not set),))
+
+# var-require is used to check if one or all of the variables are set in REQUIRED_VARS, and fails if not. The variables
+# in REQUIRE_VARS are hyphen separated.
+#
+# If FAIL_NOT_SET is set, then all variables described in REQUIRED_VARS must be set for var-require to not fail,
+# otherwise only one variable needs to be set for var-require to not fail.
+var-require: $(addprefix var-set-,$(subst -, ,$(REQUIRED_VARS)))
+	$(if $(VARSET),,$(error one of $(subst -, ,$(REQUIRED_VARS)) is not set or empty, but at least one is required))
+
+# var-require-all-% checks if the there are non empty variables set for the hyphen separated values in %, and fails if
+# there isn't a non empty variable for each given value. For instance, to require FOO and BAR both must be set you would
+# call var-require-all-FOO-BAR.
+var-require-all-%:
+	$(MAKE) var-require REQUIRED_VARS=$* FAIL_NOT_SET=true
+
+# var-require-one-of-% checks if the there are non empty variables set for the hyphen separated values in %, and fails
+# there isn't a non empty variable for at least one of the given values. For instance, to require either FOO or BAR both
+# must be set you would call var-require-all-FOO-BAR.
+var-require-one-of-%:
+	$(MAKE) var-require REQUIRED_VARS=$*
+
+# Call the github API. $(1) is the http method type for the https request, $(2) is the repo slug, and is $(3) is for json
+# data (if omitted then no data is set for the request). If GITHUB_API_EXIT_ON_FAILURE is set then the macro exits with 1
+# on failure. On success, the ENV variable GITHUB_API_RESPONSE will contain the response from github
+define github_call_api
+	$(eval CMD := curl -fL -X $(1) \
+		-H "Content-Type: application/json"\
+		-H "Authorization: Bearer ${GITHUB_TOKEN}"\
+		https://api.github.com/repos/$(2) $(if $(3),--data '$(3)',))
+	$(eval GITHUB_API_RESPONSE := $(shell $(CMD) | sed -e 's/#/\\\#/g'))
+	$(if $(GITHUB_API_EXIT_ON_FAILURE), $(if $(GITHUB_API_RESPONSE),,exit 1),)
+endef
+
+# Create the pull request. $(1) is the repo slug, $(2) is the title, $(3) is the head branch and $(4) is the base branch.
+# If the call was successful then the ENV variable PR_NUMBER will contain the pull request number of the created pull request.
+define github_pr_create
+	$(eval JSON := {"title": "$(2)", "head": "$(3)", "base": "$(4)"})
+	$(call github_call_api,POST,$(1)/pulls,$(JSON))
+	$(eval PR_NUMBER := $(filter-out null,$(shell echo '$(GITHUB_API_RESPONSE)' | jq '.number')))
+endef
+
+# Create a comment on a pull request. $(1) is the repo slug, $(2) is the pull request number, and $(3) is the comment
+# body.
+define github_pr_add_comment
+	$(eval JSON := {"body":"$(3)"})
+	$(call github_call_api,POST,$(1)/issues/$(2)/comments,$(JSON))
+endef

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,20 @@
 # TODO: Add in the necessary variables, etc, to make this Makefile work.
 # TODO: Add in multi-arch stuff.
 
-GIT_CMD           = git
+define yq_cmd
+	$(shell yq --version | grep v$1.* >/dev/null && which yq || echo docker run --rm --user="root" -i -v "$(shell pwd)":/workdir mikefarah/yq:$1 $(if $(shell [ $1 -lt 4 ] && echo "true"), yq,))
+endef
+YQ_V4 = $(call yq_cmd,4)
+
+GIT_CMD   = git
+CURL_CMD  = curl -fL
 
 ifdef CONFIRM
-GIT           = $(GIT_CMD)
+GIT       = $(GIT_CMD)
+CURL      = $(CURL_CMD)
 else
-GIT           = echo [DRY RUN] $(GIT_CMD)
+GIT       = echo [DRY RUN] $(GIT_CMD)
+CURL      = echo [DRY RUN] $(CURL_CMD)
 endif
 
 
@@ -566,35 +574,35 @@ ifdef LOCAL_BUILD
 	$(error LOCAL_BUILD must not be set for a release)
 endif
 
-release-prep: var-require-all-VERSION-CALICO_VERSION-COMMON_VERSION
-ifdef CNX
-	$(MAKE) var-require-all-CALICO_ENTERPRISE_VERSION
-	yq e ".title = \"$(CALICO_ENTERPRISE_VERSION)\" | .components |= with_entries(select(.key | test(\"^(eck-|coreos-).*\") | not)) |= with(.[]; .version = \"$(CALICO_ENTERPRISE_VERSION)\")" -i config/enterprise_versions.yml
-endif
-	yq e ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
-	yq e ".title = \"$(COMMON_VERSION)\" | .components.key-cert-provisioner.version = \"$(COMMON_VERSION)\"" -i config/common_versions.yml
+release-prep: var-require-all-GIT_PR_BRANCH_BASE-GIT_REPO_SLUG-VERSION-CALICO_VERSION-COMMON_VERSION-CALICO_ENTERPRISE_VERSION
+	$(YQ_V4) ".title = \"$(CALICO_ENTERPRISE_VERSION)\" | .components |= with_entries(select(.key | test(\"^(eck-|coreos-).*\") | not)) |= with(.[]; .version = \"$(CALICO_ENTERPRISE_VERSION)\")" -i config/enterprise_versions.yml
+	$(YQ_V4) ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
+	$(YQ_V4) ".title = \"$(COMMON_VERSION)\" | .components.key-cert-provisioner.version = \"$(COMMON_VERSION)\"" -i config/common_versions.yml
 	sed -i "s/\"gcr.io.*\"/\"quay.io\/\"/g" pkg/components/images.go
 	sed -i "s/\"gcr.io.*\"/\"quay.io\"/g" hack/gen-versions/main.go
 	$(MAKE) gen-versions release-prep/create-and-push-branch release-prep/create-pr release-prep/set-merge-when-ready-on-pr
 
 GIT_REMOTE?=origin
-GIT_PR_BRANCH_BASE?=$(SEMAPHORE_GIT_BRANCH)
-GIT_REPO_SLUG?=$(SEMAPHORE_GIT_REPO_SLUG)
-RELEASE_UPDATE_BRANCH?=semaphore-auto-build-updates-$(VERSION)
-GIT_PR_BRANCH_HEAD?=$(RELEASE_UPDATE_BRANCH)
+ifneq ($(if $(GIT_REPO_SLUG),$(shell dirname $(GIT_REPO_SLUG)),), $(shell dirname `git config remote.$(GIT_REMOTE).url | cut -d: -f2`))
+GIT_FORK_USER:=$(shell dirname `git config remote.$(GIT_REMOTE).url | cut -d: -f2`)
+endif
+GIT_PR_BRANCH_BASE?=$(if $(SEMAPHORE),$(SEMAPHORE_GIT_BRANCH),)
+GIT_REPO_SLUG?=$(if $(SEMAPHORE),$(SEMAPHORE_GIT_REPO_SLUG),)
+RELEASE_UPDATE_BRANCH?=$(if $(SEMAPHORE),semaphore-,)auto-build-updates-$(VERSION)
+GIT_PR_BRANCH_HEAD?=$(if $(GIT_FORK_USER),$(GIT_FORK_USER):$(RELEASE_UPDATE_BRANCH),$(RELEASE_UPDATE_BRANCH))
 release-prep/create-and-push-branch:
-ifeq ($(shell git rev-parse --abbrev-ref HEAD),$(GIT_PR_BRANCH_HEAD))
+ifeq ($(shell git rev-parse --abbrev-ref HEAD),$(RELEASE_UPDATE_BRANCH))
 	$(error Current branch is pull request head, cannot set it up.)
 endif
-	-git branch -D $(GIT_PR_BRANCH_HEAD)
-	-$(GIT) push $(GIT_REMOTE) --delete $(GIT_PR_BRANCH_HEAD)
-	git checkout -b $(GIT_PR_BRANCH_HEAD)
+	-git branch -D $(RELEASE_UPDATE_BRANCH)
+	-$(GIT) push $(GIT_REMOTE) --delete $(RELEASE_UPDATE_BRANCH)
+	git checkout -b $(RELEASE_UPDATE_BRANCH)
 	$(GIT) add config/*_versions.yml hack/gen-versions/main.go pkg/components/* pkg/crds/*
 	$(GIT) commit -m "Automatic version updates for $(VERSION) release"
-	$(GIT) push $(GIT_REMOTE) $(GIT_PR_BRANCH_HEAD)
+	$(GIT) push $(GIT_REMOTE) $(RELEASE_UPDATE_BRANCH)
 
 release-prep/create-pr:
-	$(call github_pr_create,$(GIT_REPO_SLUG),[$(GIT_PR_BRANCH_BASE)] Semaphore Auto $(VERSION) Release Update,$(GIT_PR_BRANCH_HEAD),$(GIT_PR_BRANCH_BASE))
+	$(call github_pr_create,$(GIT_REPO_SLUG),[$(GIT_PR_BRANCH_BASE)] $(if $(SEMAPHORE), Semaphore,) Auto Release Update for $(VERSION),$(GIT_PR_BRANCH_HEAD),$(GIT_PR_BRANCH_BASE))
 	echo 'Created release update pull request for $(VERSION): $(PR_NUMBER)'
 
 release-prep/set-merge-when-ready-on-pr:
@@ -936,11 +944,12 @@ var-require-all-%:
 var-require-one-of-%:
 	$(MAKE) var-require REQUIRED_VARS=$*
 
+GITHUB_API_EXIT_ON_FAILURE?=1
 # Call the github API. $(1) is the http method type for the https request, $(2) is the repo slug, and is $(3) is for json
 # data (if omitted then no data is set for the request). If GITHUB_API_EXIT_ON_FAILURE is set then the macro exits with 1
 # on failure. On success, the ENV variable GITHUB_API_RESPONSE will contain the response from github
 define github_call_api
-	$(eval CMD := curl -fL -X $(1) \
+	$(eval CMD := $(CURL) -X $(1) \
 		-H "Content-Type: application/json"\
 		-H "Authorization: Bearer ${GITHUB_TOKEN}"\
 		https://api.github.com/repos/$(2) $(if $(3),--data '$(3)',))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,30 +16,37 @@ operator version for the version of Calico or Calient that you are releasing. If
 check [the releases page](https://github.com/tigera/operator/releases) to find the most
 recent Operator release for your Calico or Calient minor version.
 
-Update the image versions and the title field with the appropriate versions in the
+Make sure pins are updated in `go.mod`
+
+Run the following command:
+
+```sh
+make release-prep GIT_PR_BRANCH_BASE=<RELEASE_BRANCH> GIT_REPO_SLUG=tigera/operator CONFIRM=true \
+  VERSION=<OPERATOR_VERSION> CALICO_VERSION=<CALICO_VERSION> CALICO_ENTERPRISE_VERSION=<CALICO_ENTERPRISE_VERSION> COMMON_VERSION=<COMMON_VERSION>
+```
+
+The command does the following:
+
+- It updates the image version and the title field with the appropriate versions in the
 format `vX.Y.Z` for each of the following files:
+  1. `config/calico_versions.yml` (Calico OSS version)
+  2. `config/enterprise_versions.yml` (Calico Enterprise version)
+  3. `config/common_versions.yaml` (components common to both)
 
-1. `config/calico_versions.yml` (Calico OSS version)
-2. `config/enterprise_versions.yml` (Calico Enterprise version)
-3. `config/common_versions.yaml` (components common to both)
+- It updates the registry reference to `quay.io` from `gcr.io` for each of the following files:
 
-For the first build of a new minor version (e.g. v1.31.0), also update
-the following values to reference `quay.io` instead of `gcr.io`:
+  1. `TigeraRegistry` in `pkg/components/images.go`
+  2. `defaultEnterpriseRegistry` in `hack/gen-versions/main.go`
 
-1. `TigeraRegistry` in `pkg/components/images.go`
-2. `defaultEnterpriseRegistry` in `hack/gen-versions/main.go`
+- It ensures `make gen-versions` is run and the resulting updates committed.
+- It creates a PR with all the changes
 
-Then ensure `make gen-versions` has been ran and the resulting updates have been committed.
+Go to the PR created and:
 
-Make sure the branch is in a good state: 
+1. Ensure tests pass
+2. Update the labels in the PR  to include `docs-not-required` and `release-note-not-required`
 
-1. Update any pins in go.mod
-2. Create a PR for all of the local changes (versions updates, gen-versions, etc)
-3. Ensure tests pass
-
-You should have no local changes and tests should be passing.
-
-## Releasing 
+## Releasing
 
 1. Merge your PR to the release branch
 

--- a/hack/gen-versions/main.go
+++ b/hack/gen-versions/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
@@ -45,6 +45,8 @@ spec:
                       type: string
                     cidr:
                       type: string
+                    interface:
+                      type: string
                     matchOperator:
                       type: string
                     source:
@@ -63,6 +65,8 @@ spec:
                     action:
                       type: string
                     cidr:
+                      type: string
+                    interface:
                       type: string
                     matchOperator:
                       type: string
@@ -83,6 +87,8 @@ spec:
                       type: string
                     cidr:
                       type: string
+                    interface:
+                      type: string
                     matchOperator:
                       type: string
                     source:
@@ -101,6 +107,8 @@ spec:
                     action:
                       type: string
                     cidr:
+                      type: string
+                    interface:
                       type: string
                     matchOperator:
                       type: string


### PR DESCRIPTION
## Description

This handles [updating versions](https://github.com/tigera/operator/blob/master/RELEASING.md#updating-versions) when preparing for an operator release resulting in a PR similar to [this](https://github.com/tigera/operator/pull/2845/files#diff-224df6cb23a4afa3cbf26bfce45376e99e0f8db6b76e4b88191788ceea3d09e3)

## For PR author

- [x] Tests for change: Tested with private fork: https://github.com/tigera/operator/pull/2963
 
 ```sh
  git o release-v1.31 # checkout release branch
  make release-prep GIT_PR_BRANCH_BASE=master GIT_REPO_SLUG=tigera/operator CONFIRM=true   VERSION=v1.32.0 CALICO_VERSION=v3.26.1 CALICO_ENTERPRISE_VERSION=v3.18.0 COMMON_VERSION=v1.1.15
  ```

- [ ] ~If changing pkg/apis/, run `make gen-files`~
- [ ] ~If changing versions, run `make gen-versions`~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [x] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
