### PR TITLE
[release-v1.32] Auto pick #2978: Remove old controller ref for Voltron secret

### DIFF
--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -977,7 +978,68 @@ var _ = Describe("Manager controller tests", func() {
 				Expect(kerror.IsNotFound(err)).Should(BeFalse())
 				assertSANs(&clusterConnectionInManagerNs, "voltron")
 			})
+
+			It("should upgrade a Voltron tunnel secret if previously owned by a different controller", func() {
+				// Older versions of the tigera-operator controlled this secret from the API server controller.
+				// However, only a single controller is allowed as an owner, so we need to properly clear the old
+				// one before setting the Manager CR as the new owner.
+				clusterConnection := corev1.Secret{
+					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      render.VoltronTunnelSecretName,
+						Namespace: common.OperatorNamespace(),
+					},
+				}
+				clusterConnectionInManagerNs := clusterConnection
+				clusterConnectionInManagerNs.Namespace = render.ManagerNamespace
+
+				apiserver := &operatorv1.APIServer{
+					TypeMeta: metav1.TypeMeta{Kind: "APIServer", APIVersion: "operator.tigera.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "tigera-secure",
+						UID:  "1234",
+					},
+				}
+				err := controllerutil.SetControllerReference(apiserver, &clusterConnection, scheme)
+				Expect(err).NotTo(HaveOccurred())
+				err = controllerutil.SetControllerReference(apiserver, &clusterConnectionInManagerNs, scheme)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c.Create(ctx, &clusterConnection)).NotTo(HaveOccurred())
+				Expect(c.Create(ctx, &clusterConnectionInManagerNs)).NotTo(HaveOccurred())
+
+				// Run the controller. It should update the secret to be owned by the Manager CR.
+				// Create the ManagementCluster CR needed to configure
+				// a management cluster for a multi-cluster setup
+				managementCluster := &operatorv1.ManagementCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "tigera-secure",
+					},
+				}
+				Expect(c.Create(ctx, managementCluster)).NotTo(HaveOccurred())
+
+				// Create the Manager CR needed to jumpstart the reconciliation
+				// for the manager
+				manager := &operatorv1.Manager{
+					TypeMeta: metav1.TypeMeta{Kind: "Manager", APIVersion: "operator.tigera.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-secure",
+						Namespace: common.OperatorNamespace(),
+					},
+				}
+				err = c.Create(ctx, manager)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Reconcile Manager
+				_, err = r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Check the owner reference on the secret has updated.
+				Expect(c.Get(ctx, types.NamespacedName{Name: render.VoltronTunnelSecretName, Namespace: common.OperatorNamespace()}, &clusterConnection)).NotTo(HaveOccurred())
+				Expect(len(clusterConnection.OwnerReferences)).To(Equal(1))
+				Expect(clusterConnection.OwnerReferences[0].Kind).To(Equal("Manager"))
+			})
 		})
+
 		Context("Multi-tenant/namespaced reconciliation", func() {
 			tenantANamespace := "tenant-a"
 			tenantBNamespace := "tenant-b"


### PR DESCRIPTION
Cherry pick of #2978 on release-v1.32.

#2978: Remove old controller ref for Voltron secret

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We recently moved ownership of this secret from the APIServer controller
to the Manager controller. However, on upgrade, older versions of this
secret will still have the old owner reference set, resulting in two
owners and thus an error.

If we see this case, simply remove the old owner reference.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.