### PR TITLE
Apiserver render, protect against uninitialized Installation resource

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1023,6 +1023,7 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 func (c *apiServerComponent) hostNetwork() bool {
 	hostNetwork := c.cfg.ForceHostNetwork
 	if c.cfg.Installation.KubernetesProvider == operatorv1.ProviderEKS &&
+		c.cfg.Installation.CNI != nil &&
 		c.cfg.Installation.CNI.Type == operatorv1.PluginCalico {
 		// Workaround the fact that webhooks don't work for non-host-networked pods
 		// when in this networking mode on EKS, because the control plane nodes don't run

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1805,6 +1805,15 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", "calico-apiserver")))
 	})
 
+	It("should render with EKS provider without CNI.Type", func() {
+		cfg.Installation.KubernetesProvider = operatorv1.ProviderEKS
+
+		component, err := render.APIServer(cfg)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		_, _ = component.Objects()
+	})
+
 	Context("With APIServer Deployment overrides", func() {
 		rr1 := corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{


### PR DESCRIPTION
## Description

Fixes https://github.com/projectcalico/calico/issues/7748

I'm guessing this probably isn't a persistent issue and that once the main core/installation controller runs and defaults the CNI struct in the Installation resource this would no longer panic.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
