### PR TITLE
EV-4126 Add watch for tenant controller

### DIFF
--- a/pkg/controller/secrets/tenant_controller.go
+++ b/pkg/controller/secrets/tenant_controller.go
@@ -76,7 +76,16 @@ func AddTenantController(mgr manager.Manager, opts options.AddOptions) error {
 		return fmt.Errorf("tenant-secrets-controller failed to watch Tenant resource: %w", err)
 	}
 
-	// TODO Watch all the secrets created by this controller so we can regenerate any that are deleted
+	if err = c.Watch(&source.Kind{Type: &operatorv1.Installation{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("tenant-controller failed to watch Installation resource: %w", err)
+	}
+	if err = utils.AddSecretsWatch(c, certificatemanagement.CASecretName, common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("tenant-controller failed to watch cluster scoped CA secret %s: %w", certificatemanagement.CASecretName, err)
+	}
+
+	if err = utils.AddSecretsWatch(c, certificatemanagement.TenantCASecretName, ""); err != nil {
+		return fmt.Errorf("tenant-controller failed to watch tenant CA Secret %s in all namespace: %w", certificatemanagement.TenantCASecretName, err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

Added watch to 
- watch installations 
- tenant CA secret in all tenant Namespace - (tigera-ca-private-tenant)
- watch cluster scoped CA certificate

Testing

```
vara@vara:~/bzprofiles/Clusters/tc_mt$ k get secrets -n tenant-a
NAME                                          TYPE     DATA   AGE
tigera-ca-private-tenant                      Opaque   2      11m
tigera-ee-linseed-elasticsearch-user-secret   Opaque   2      3h49m
tigera-secure-linseed-cert                    Opaque   2      3h49m
tigera-secure-linseed-token-tls               Opaque   2      3h49m

vara@vara:~/bzprofiles/Clusters/tc_mt$ k delete secrets tigera-ca-private-tenant -n tenant-a
secret "tigera-ca-private-tenant" deleted

vara@vara:~/bzprofiles/Clusters/tc_mt$ k get secrets -n tenant-a
NAME                                          TYPE     DATA   AGE
tigera-ca-private-tenant                      Opaque   2      **2s**
tigera-ee-linseed-elasticsearch-user-secret   Opaque   2      3h49m
tigera-secure-linseed-cert                    Opaque   2      3h49m
tigera-secure-linseed-token-tls               Opaque   2      3h49m

vara@vara:~/bzprofiles/Clusters/tc_mt$ 
```



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author


- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
