### PR TITLE
feat: new field for image suffix in installation

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -40,7 +40,7 @@ type InstallationSpec struct {
 	// supported to explicitly specify the default registries will be used.
 	//
 	// Image format:
-	//    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+	//    `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
 	//
 	// This option allows configuring the `<registry>` portion of the above format.
 	// +optional
@@ -53,7 +53,7 @@ type InstallationSpec struct {
 	// image path will be used for each image.
 	//
 	// Image format:
-	//    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+	//    `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
 	//
 	// This option allows configuring the `<imagePath>` portion of the above format.
 	// +optional
@@ -66,11 +66,24 @@ type InstallationSpec struct {
 	// image prefix will be used for each image.
 	//
 	// Image format:
-	//    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+	//    `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
 	//
 	// This option allows configuring the `<imagePrefix>` portion of the above format.
 	// +optional
 	ImagePrefix string `json:"imagePrefix,omitempty"`
+
+	// ImageSuffix allows for the suffix part of an image to be specified. If specified
+	// then the given value will be appended to each image name. If not specified, or if
+	// specified value is empty, no suffix will be appended.
+	// A special case value, UseDefault, is supported to explicitly specify the default
+	// image suffix will be used for each image.
+	//
+	// Image format:
+	// 		`<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
+	//
+	// This option allows configuring the `<imageSuffix>` portion of the above format.
+	// +optional
+	ImageSuffix string `json:"imageSuffix,omitempty"`
 
 	// ImagePullSecrets is an array of references to container registry pull secrets to use. These are
 	// applied to all images to be pulled.

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 			cmpnts = append(cmpnts, components.CommonImages...)
 
 			for _, x := range cmpnts {
-				ref, _ := components.GetReference(x, "", "", "", nil)
+				ref, _ := components.GetReference(x, "", "", "", "", nil)
 				fmt.Println(ref)
 			}
 			os.Exit(0)

--- a/pkg/components/images_test.go
+++ b/pkg/components/images_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019,2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ var _ = Describe("test GetReference", func() {
 	Context("No registry override", func() {
 		DescribeTable("should render",
 			func(c component, registry, image string) {
-				Expect(GetReference(c, "", "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
+				Expect(GetReference(c, "", "", "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, CalicoRegistry, "calico/node"),
 			Entry("a tigera image correctly", ComponentTigeraNode, TigeraRegistry, "tigera/cnx-node"),
@@ -42,7 +42,7 @@ var _ = Describe("test GetReference", func() {
 		DescribeTable("should render",
 			func(c component, registry, image string) {
 				ud := "UseDefault"
-				Expect(GetReference(c, ud, ud, "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
+				Expect(GetReference(c, ud, ud, "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, CalicoRegistry, "calico/node"),
 			Entry("a tigera image correctly", ComponentTigeraNode, TigeraRegistry, "tigera/cnx-node"),
@@ -55,7 +55,7 @@ var _ = Describe("test GetReference", func() {
 	Context("registry override", func() {
 		DescribeTable("should render",
 			func(c component, image string) {
-				Expect(GetReference(c, "quay.io/", "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", "quay.io/", image, c.Version)))
+				Expect(GetReference(c, "quay.io/", "", "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", "quay.io/", image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, "calico/node"),
 			Entry("a tigera image correctly", ComponentTigeraNode, "tigera/cnx-node"),
@@ -68,7 +68,7 @@ var _ = Describe("test GetReference", func() {
 	Context("image prefix override", func() {
 		DescribeTable("should render",
 			func(c component, image string) {
-				Expect(GetReference(c, "quay.io/", "", "pref", nil)).To(Equal(fmt.Sprintf("quay.io/%s:%s", image, c.Version)))
+				Expect(GetReference(c, "quay.io/", "", "pref", "", nil)).To(Equal(fmt.Sprintf("quay.io/%s:%s", image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, "calico/prefnode"),
 			Entry("a tigera image correctly", ComponentTigeraNode, "tigera/prefcnx-node"),
@@ -81,7 +81,7 @@ var _ = Describe("test GetReference", func() {
 	Context("imagepath override", func() {
 		DescribeTable("should render",
 			func(c component, registry, image string) {
-				Expect(GetReference(c, "", "userpath", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
+				Expect(GetReference(c, "", "userpath", "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, CalicoRegistry, "userpath/node"),
 			Entry("a tigera image correctly", ComponentTigeraNode, TigeraRegistry, "userpath/cnx-node"),
@@ -93,7 +93,7 @@ var _ = Describe("test GetReference", func() {
 	Context("registry and imagepath override", func() {
 		DescribeTable("should render",
 			func(c component, image string) {
-				Expect(GetReference(c, "quay.io/extra/", "userpath", "", nil)).To(Equal(fmt.Sprintf("quay.io/extra/%s:%s", image, c.Version)))
+				Expect(GetReference(c, "quay.io/extra/", "userpath", "", "", nil)).To(Equal(fmt.Sprintf("quay.io/extra/%s:%s", image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, "userpath/node"),
 			Entry("a tigera image correctly", ComponentTigeraNode, "userpath/cnx-node"),
@@ -116,7 +116,7 @@ var _ = Describe("test GetReference", func() {
 						},
 					},
 				}
-				Expect(GetReference(c, "quay.io/extra/", "userpath", "", is)).To(Equal(fmt.Sprintf("quay.io/extra/%s%s", image, hash)))
+				Expect(GetReference(c, "quay.io/extra/", "userpath", "", "", is)).To(Equal(fmt.Sprintf("quay.io/extra/%s%s", image, hash)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, "userpath/node", "@sha256:caliconodehash"),
 			Entry("a tigera image correctly", ComponentTigeraNode, "userpath/cnx-node", "@sha256:tigeracnxnodehash"),

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -34,7 +34,7 @@ type component struct {
 const UseDefault = "UseDefault"
 
 // GetReference returns the fully qualified image to use, including registry and version.
-func GetReference(c component, registry, imagePath, imagePrefix string, is *operator.ImageSet) (string, error) {
+func GetReference(c component, registry, imagePath, imagePrefix, imageSuffix string, is *operator.ImageSet) (string, error) {
 	// If a user did not supply a registry, use the default registry
 	// based on component
 	if registry == "" || registry == UseDefault {
@@ -80,6 +80,9 @@ func GetReference(c component, registry, imagePath, imagePrefix string, is *oper
 	if imagePath != "" && imagePath != UseDefault {
 		image = ReplaceImagePath(image, imagePath)
 	}
+	if imageSuffix != "" && imageSuffix != UseDefault {
+		image = appendSuffix(image, imageSuffix)
+	}
 
 	if is == nil {
 		return fmt.Sprintf("%s%s:%s", registry, image, c.Version), nil
@@ -110,4 +113,8 @@ func insertPrefix(image, prefix string) string {
 	}
 	subs = append(subs[:len(subs)-1], fmt.Sprintf("%s%s", prefix, subs[len(subs)-1]))
 	return strings.Join(subs, "/")
+}
+
+func appendSuffix(image, suffix string) string {
+	return fmt.Sprintf("%s%s", image, suffix)
 }

--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -161,6 +161,7 @@ func Create(cli client.Client, installation *operatorv1.InstallationSpec, cluste
 			installation.Registry,
 			installation.ImagePath,
 			installation.ImagePrefix,
+			installation.ImageSuffix,
 			imageSet,
 		)
 		if err != nil {

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -407,6 +407,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 				installation.Registry,
 				installation.ImagePath,
 				installation.ImagePrefix,
+				installation.ImageSuffix,
 				imageSet,
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -6974,7 +6974,7 @@ spec:
                   the image path for each image. If not specified or empty, the default
                   for each image will be used. A special case value, UseDefault, is
                   supported to explicitly specify the default image path will be used
-                  for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
                   \n This option allows configuring the `<imagePath>` portion of the
                   above format."
                 type: string
@@ -6984,7 +6984,7 @@ spec:
                   a prefix on each image. If not specified or empty, no prefix will
                   be used. A special case value, UseDefault, is supported to explicitly
                   specify the default image prefix will be used for each image. \n
-                  Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
                   \n This option allows configuring the `<imagePrefix>` portion of
                   the above format."
                 type: string
@@ -7003,6 +7003,14 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              imageSuffix:
+                description: "ImageSuffix allows for the suffix part of an image to
+                  be specified. If specified then the given value will be appended
+                  to each image name. If not specified, or if specified value is empty,
+                  no suffix will be appended. \n Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
+                  \n This option allows configuring the `<imageSuffix>` portion of
+                  the above format."
+                type: string
               kubeletVolumePluginPath:
                 description: 'KubeletVolumePluginPath optionally specifies enablement
                   of Calico CSI plugin. If not specified, CSI will be enabled by default.
@@ -7136,7 +7144,7 @@ spec:
                   slash character (`/`) and all images will be pulled from this registry.
                   If not specified then the default registries will be used. A special
                   case value, UseDefault, is supported to explicitly specify the default
-                  registries will be used. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  registries will be used. \n Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
                   \n This option allows configuring the `<registry>` portion of the
                   above format."
                 type: string
@@ -16481,7 +16489,7 @@ spec:
                       used as the image path for each image. If not specified or empty,
                       the default for each image will be used. A special case value,
                       UseDefault, is supported to explicitly specify the default image
-                      path will be used for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      path will be used for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
                       \n This option allows configuring the `<imagePath>` portion
                       of the above format."
                     type: string
@@ -16491,7 +16499,7 @@ spec:
                       as a prefix on each image. If not specified or empty, no prefix
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default image prefix will be used
-                      for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      for each image. \n Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
                       \n This option allows configuring the `<imagePrefix>` portion
                       of the above format."
                     type: string
@@ -16510,6 +16518,14 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
+                  imageSuffix:
+                    description: "ImageSuffix allows for the suffix part of an image
+                      to be specified. If specified then the given value will be appended
+                      to each image name. If not specified, or if specified value
+                      is empty, no suffix will be appended. \n Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
+                      \n This option allows configuring the `<imageSuffix>` portion
+                      of the above format."
+                    type: string
                   kubeletVolumePluginPath:
                     description: 'KubeletVolumePluginPath optionally specifies enablement
                       of Calico CSI plugin. If not specified, CSI will be enabled
@@ -16649,7 +16665,7 @@ spec:
                       from this registry. If not specified then the default registries
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default registries will be used. \n
-                      Image format: `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      Image format: `<registry><imagePath>/<imagePrefix><imageName><imageSuffix>:<image-tag>`
                       \n This option allows configuring the `<registry>` portion of
                       the above format."
                     type: string

--- a/pkg/render/amazoncloudintegration.go
+++ b/pkg/render/amazoncloudintegration.go
@@ -63,8 +63,9 @@ func (c *amazonCloudIntegrationComponent) ResolveImages(is *operatorv1.ImageSet)
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
-	c.image, err = components.GetReference(components.ComponentCloudControllers, reg, path, prefix, is)
+	c.image, err = components.GetReference(components.ComponentCloudControllers, reg, path, prefix, suffix, is)
 	return err
 }
 

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -133,26 +133,27 @@ func (c *apiServerComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
 	errMsgs := []string{}
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
-		c.apiServerImage, err = components.GetReference(components.ComponentAPIServer, reg, path, prefix, is)
+		c.apiServerImage, err = components.GetReference(components.ComponentAPIServer, reg, path, prefix, suffix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}
-		c.queryServerImage, err = components.GetReference(components.ComponentQueryServer, reg, path, prefix, is)
+		c.queryServerImage, err = components.GetReference(components.ComponentQueryServer, reg, path, prefix, suffix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}
 	} else {
 		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-			c.apiServerImage, err = components.GetReference(components.ComponentCalicoAPIServerFIPS, reg, path, prefix, is)
+			c.apiServerImage, err = components.GetReference(components.ComponentCalicoAPIServerFIPS, reg, path, prefix, suffix, is)
 			if err != nil {
 				errMsgs = append(errMsgs, err.Error())
 			}
 		} else {
-			c.apiServerImage, err = components.GetReference(components.ComponentCalicoAPIServer, reg, path, prefix, is)
+			c.apiServerImage, err = components.GetReference(components.ComponentCalicoAPIServer, reg, path, prefix, suffix, is)
 			if err != nil {
 				errMsgs = append(errMsgs, err.Error())
 			}

--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -114,6 +114,7 @@ func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.config.Installation.Registry
 	path := c.config.Installation.ImagePath
 	prefix := c.config.Installation.ImagePrefix
+	suffix := c.config.Installation.ImageSuffix
 
 	if c.config.OsType != c.SupportedOSType() {
 		return fmt.Errorf("layer 7 features are supported only on %s", c.SupportedOSType())
@@ -122,17 +123,17 @@ func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
 	var err error
 	var errMsgs []string
 
-	c.config.proxyImage, err = components.GetReference(components.ComponentEnvoyProxy, reg, path, prefix, is)
+	c.config.proxyImage, err = components.GetReference(components.ComponentEnvoyProxy, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.config.collectorImage, err = components.GetReference(components.ComponentL7Collector, reg, path, prefix, is)
+	c.config.collectorImage, err = components.GetReference(components.ComponentL7Collector, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.config.dikastesImage, err = components.GetReference(components.ComponentDikastes, reg, path, prefix, is)
+	c.config.dikastesImage, err = components.GetReference(components.ComponentDikastes, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/aws-securitygroup-setup.go
+++ b/pkg/render/aws-securitygroup-setup.go
@@ -51,8 +51,9 @@ func (c *awsSGSetupComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
-	c.image, err = components.GetReference(components.ComponentOperatorInit, reg, path, prefix, is)
+	c.image, err = components.GetReference(components.ComponentOperatorInit, reg, path, prefix, suffix, is)
 	return err
 }
 

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -141,30 +141,31 @@ func (c *complianceComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
-	c.benchmarkerImage, err = components.GetReference(components.ComponentComplianceBenchmarker, reg, path, prefix, is)
+	c.benchmarkerImage, err = components.GetReference(components.ComponentComplianceBenchmarker, reg, path, prefix, suffix, is)
 
 	errMsgs := []string{}
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.snapshotterImage, err = components.GetReference(components.ComponentComplianceSnapshotter, reg, path, prefix, is)
+	c.snapshotterImage, err = components.GetReference(components.ComponentComplianceSnapshotter, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.serverImage, err = components.GetReference(components.ComponentComplianceServer, reg, path, prefix, is)
+	c.serverImage, err = components.GetReference(components.ComponentComplianceServer, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.controllerImage, err = components.GetReference(components.ComponentComplianceController, reg, path, prefix, is)
+	c.controllerImage, err = components.GetReference(components.ComponentComplianceController, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.reporterImage, err = components.GetReference(components.ComponentComplianceReporter, reg, path, prefix, is)
+	c.reporterImage, err = components.GetReference(components.ComponentComplianceReporter, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -357,29 +357,30 @@ func (c *csiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
-		c.csiImage, err = components.GetReference(components.ComponentCSIPrivate, reg, path, prefix, is)
+		c.csiImage, err = components.GetReference(components.ComponentCSIPrivate, reg, path, prefix, suffix, is)
 		if err != nil {
 			return err
 		}
 
-		c.csiRegistrarImage, err = components.GetReference(components.ComponentCSINodeDriverRegistrarPrivate, reg, path, prefix, is)
+		c.csiRegistrarImage, err = components.GetReference(components.ComponentCSINodeDriverRegistrarPrivate, reg, path, prefix, suffix, is)
 	} else {
 		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-			c.csiImage, err = components.GetReference(components.ComponentCalicoCSIFIPS, reg, path, prefix, is)
+			c.csiImage, err = components.GetReference(components.ComponentCalicoCSIFIPS, reg, path, prefix, suffix, is)
 			if err != nil {
 				return err
 			}
-			c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrarFIPS, reg, path, prefix, is)
+			c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrarFIPS, reg, path, prefix, suffix, is)
 		} else {
-			c.csiImage, err = components.GetReference(components.ComponentCalicoCSI, reg, path, prefix, is)
+			c.csiImage, err = components.GetReference(components.ComponentCalicoCSI, reg, path, prefix, suffix, is)
 			if err != nil {
 				return err
 			}
 
-			c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrar, reg, path, prefix, is)
+			c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrar, reg, path, prefix, suffix, is)
 		}
 	}
 

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -87,8 +87,9 @@ func (c *dexComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
-	c.image, err = components.GetReference(components.ComponentDex, reg, path, prefix, is)
+	c.image, err = components.GetReference(components.ComponentDex, reg, path, prefix, suffix, is)
 
 	var errMsgs []string
 	if err != nil {

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -89,13 +89,14 @@ func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.config.Installation.Registry
 	path := c.config.Installation.ImagePath
 	prefix := c.config.Installation.ImagePrefix
+	suffix := c.config.Installation.ImageSuffix
 
 	if c.config.OSType != c.SupportedOSType() {
 		return fmt.Errorf("Egress Gateway is supported only on %s", c.SupportedOSType())
 	}
 
 	var err error
-	c.config.egwImage, err = components.GetReference(components.ComponentEgressGateway, reg, path, prefix, is)
+	c.config.egwImage, err = components.GetReference(components.ComponentEgressGateway, reg, path, prefix, suffix, is)
 	return err
 }
 

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -183,15 +183,16 @@ func (c *fluentdComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 
 	if c.cfg.OSType == rmeta.OSTypeWindows {
 		var err error
-		c.image, err = components.GetReference(components.ComponentFluentdWindows, reg, path, prefix, is)
+		c.image, err = components.GetReference(components.ComponentFluentdWindows, reg, path, prefix, suffix, is)
 		return err
 	}
 
 	var err error
-	c.image, err = components.GetReference(components.ComponentFluentd, reg, path, prefix, is)
+	c.image, err = components.GetReference(components.ComponentFluentd, reg, path, prefix, suffix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -102,8 +102,9 @@ func (c *GuardianComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
-	c.image, err = components.GetReference(components.ComponentGuardian, reg, path, prefix, is)
+	c.image, err = components.GetReference(components.ComponentGuardian, reg, path, prefix, suffix, is)
 	return err
 }
 

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -147,16 +147,17 @@ func (c *intrusionDetectionComponent) ResolveImages(is *operatorv1.ImageSet) err
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var errMsgs []string
 	var err error
 	if !c.cfg.ManagedCluster {
-		c.jobInstallerImage, err = components.GetReference(components.ComponentElasticTseeInstaller, reg, path, prefix, is)
+		c.jobInstallerImage, err = components.GetReference(components.ComponentElasticTseeInstaller, reg, path, prefix, suffix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}
 	}
 
-	c.controllerImage, err = components.GetReference(components.ComponentIntrusionDetectionController, reg, path, prefix, is)
+	c.controllerImage, err = components.GetReference(components.ComponentIntrusionDetectionController, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -79,6 +79,7 @@ func (d *dpiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 		d.cfg.Installation.Registry,
 		d.cfg.Installation.ImagePath,
 		d.cfg.Installation.ImagePrefix,
+		d.cfg.Installation.ImageSuffix,
 		is)
 	if err != nil {
 		return err

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -213,14 +213,15 @@ func (c *kubeControllersComponent) ResolveImages(is *operatorv1.ImageSet) error 
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
-		c.image, err = components.GetReference(components.ComponentTigeraKubeControllers, reg, path, prefix, is)
+		c.image, err = components.GetReference(components.ComponentTigeraKubeControllers, reg, path, prefix, suffix, is)
 	} else {
 		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-			c.image, err = components.GetReference(components.ComponentCalicoKubeControllersFIPS, reg, path, prefix, is)
+			c.image, err = components.GetReference(components.ComponentCalicoKubeControllersFIPS, reg, path, prefix, suffix, is)
 		} else {
-			c.image, err = components.GetReference(components.ComponentCalicoKubeControllers, reg, path, prefix, is)
+			c.image, err = components.GetReference(components.ComponentCalicoKubeControllers, reg, path, prefix, suffix, is)
 		}
 	}
 	return err

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -251,28 +251,29 @@ func (es *elasticsearchComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := es.cfg.Installation.Registry
 	path := es.cfg.Installation.ImagePath
 	prefix := es.cfg.Installation.ImagePrefix
+	suffix := es.cfg.Installation.ImageSuffix
 	var err error
 	if operatorv1.IsFIPSModeEnabled(es.cfg.Installation.FIPSMode) {
-		es.esImage, err = components.GetReference(components.ComponentElasticsearchFIPS, reg, path, prefix, is)
+		es.esImage, err = components.GetReference(components.ComponentElasticsearchFIPS, reg, path, prefix, suffix, is)
 	} else {
-		es.esImage, err = components.GetReference(components.ComponentElasticsearch, reg, path, prefix, is)
+		es.esImage, err = components.GetReference(components.ComponentElasticsearch, reg, path, prefix, suffix, is)
 	}
 	errMsgs := make([]string, 0)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	es.esOperatorImage, err = components.GetReference(components.ComponentElasticsearchOperator, reg, path, prefix, is)
+	es.esOperatorImage, err = components.GetReference(components.ComponentElasticsearchOperator, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	es.kibanaImage, err = components.GetReference(components.ComponentKibana, reg, path, prefix, is)
+	es.kibanaImage, err = components.GetReference(components.ComponentKibana, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	es.curatorImage, err = components.GetReference(components.ComponentEsCurator, reg, path, prefix, is)
+	es.curatorImage, err = components.GetReference(components.ComponentEsCurator, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -91,10 +91,11 @@ func (e *esGateway) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := e.cfg.Installation.Registry
 	path := e.cfg.Installation.ImagePath
 	prefix := e.cfg.Installation.ImagePrefix
+	suffix := e.cfg.Installation.ImageSuffix
 	var err error
 	errMsgs := []string{}
 
-	e.esGatewayImage, err = components.GetReference(components.ComponentESGateway, reg, path, prefix, is)
+	e.esGatewayImage, err = components.GetReference(components.ComponentESGateway, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -81,8 +81,9 @@ func (e *elasticsearchMetrics) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := e.cfg.Installation.Registry
 	path := e.cfg.Installation.ImagePath
 	prefix := e.cfg.Installation.ImagePrefix
+	suffix := e.cfg.Installation.ImageSuffix
 
-	e.esMetricsImage, err = components.GetReference(components.ComponentElasticsearchMetrics, reg, path, prefix, is)
+	e.esMetricsImage, err = components.GetReference(components.ComponentElasticsearchMetrics, reg, path, prefix, suffix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -121,11 +121,12 @@ func (l *linseed) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := l.cfg.Installation.Registry
 	path := l.cfg.Installation.ImagePath
 	prefix := l.cfg.Installation.ImagePrefix
+	suffix := l.cfg.Installation.ImageSuffix
 	var err error
 	errMsgs := []string{}
 
 	// Calculate the image(s) to use for Linseed, given user registry configuration.
-	l.linseedImage, err = components.GetReference(components.ComponentLinseed, reg, path, prefix, is)
+	l.linseedImage, err = components.GetReference(components.ComponentLinseed, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -180,19 +180,20 @@ func (c *managerComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
-	c.managerImage, err = components.GetReference(components.ComponentManager, reg, path, prefix, is)
+	c.managerImage, err = components.GetReference(components.ComponentManager, reg, path, prefix, suffix, is)
 	errMsgs := []string{}
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.proxyImage, err = components.GetReference(components.ComponentManagerProxy, reg, path, prefix, is)
+	c.proxyImage, err = components.GetReference(components.ComponentManagerProxy, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.esProxyImage, err = components.GetReference(components.ComponentEsProxy, reg, path, prefix, is)
+	c.esProxyImage, err = components.GetReference(components.ComponentEsProxy, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -142,21 +142,22 @@ func (mc *monitorComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := mc.cfg.Installation.Registry
 	path := mc.cfg.Installation.ImagePath
 	prefix := mc.cfg.Installation.ImagePrefix
+	suffix := mc.cfg.Installation.ImageSuffix
 
 	errMsgs := []string{}
 	var err error
 
-	mc.alertmanagerImage, err = components.GetReference(components.ComponentPrometheusAlertmanager, reg, path, prefix, is)
+	mc.alertmanagerImage, err = components.GetReference(components.ComponentPrometheusAlertmanager, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	mc.prometheusImage, err = components.GetReference(components.ComponentPrometheus, reg, path, prefix, is)
+	mc.prometheusImage, err = components.GetReference(components.ComponentPrometheus, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	mc.prometheusServiceImage, err = components.GetReference(components.ComponentTigeraPrometheusService, reg, path, prefix, is)
+	mc.prometheusServiceImage, err = components.GetReference(components.ComponentTigeraPrometheusService, reg, path, prefix, suffix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -142,6 +142,7 @@ func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var errMsgs []string
 	appendIfErr := func(imageName string, err error) string {
 		if err != nil {
@@ -152,20 +153,20 @@ func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-			c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNIFIPS, reg, path, prefix, is))
+			c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNIFIPS, reg, path, prefix, suffix, is))
 		} else {
-			c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNI, reg, path, prefix, is))
+			c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNI, reg, path, prefix, suffix, is))
 		}
-		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNode, reg, path, prefix, is))
-		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentFlexVolumePrivate, reg, path, prefix, is))
+		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNode, reg, path, prefix, suffix, is))
+		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentFlexVolumePrivate, reg, path, prefix, suffix, is))
 	} else {
-		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentFlexVolume, reg, path, prefix, is))
+		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentFlexVolume, reg, path, prefix, suffix, is))
 		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-			c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNIFIPS, reg, path, prefix, is))
-			c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNodeFIPS, reg, path, prefix, is))
+			c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNIFIPS, reg, path, prefix, suffix, is))
+			c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNodeFIPS, reg, path, prefix, suffix, is))
 		} else {
-			c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNI, reg, path, prefix, is))
-			c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNode, reg, path, prefix, is))
+			c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNI, reg, path, prefix, suffix, is))
+			c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNode, reg, path, prefix, suffix, is))
 		}
 	}
 

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -92,9 +92,10 @@ func (pc *packetCaptureApiComponent) ResolveImages(is *operatorv1.ImageSet) erro
 	reg := pc.cfg.Installation.Registry
 	path := pc.cfg.Installation.ImagePath
 	prefix := pc.cfg.Installation.ImagePrefix
+	suffix := pc.cfg.Installation.ImageSuffix
 
 	var err error
-	pc.image, err = components.GetReference(components.ComponentPacketCapture, reg, path, prefix, is)
+	pc.image, err = components.GetReference(components.ComponentPacketCapture, reg, path, prefix, suffix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -90,9 +90,10 @@ func (pr *policyRecommendationComponent) ResolveImages(is *operatorv1.ImageSet) 
 	reg := pr.cfg.Installation.Registry
 	path := pr.cfg.Installation.ImagePath
 	prefix := pr.cfg.Installation.ImagePrefix
+	suffix := pr.cfg.Installation.ImageSuffix
 
 	var err error
-	pr.image, err = components.GetReference(components.ComponentPolicyRecommendation, reg, path, prefix, is)
+	pr.image, err = components.GetReference(components.ComponentPolicyRecommendation, reg, path, prefix, suffix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -92,14 +92,15 @@ func (c *typhaComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var err error
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
-		c.typhaImage, err = components.GetReference(components.ComponentTigeraTypha, reg, path, prefix, is)
+		c.typhaImage, err = components.GetReference(components.ComponentTigeraTypha, reg, path, prefix, suffix, is)
 	} else {
 		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-			c.typhaImage, err = components.GetReference(components.ComponentCalicoTyphaFIPS, reg, path, prefix, is)
+			c.typhaImage, err = components.GetReference(components.ComponentCalicoTyphaFIPS, reg, path, prefix, suffix, is)
 		} else {
-			c.typhaImage, err = components.GetReference(components.ComponentCalicoTypha, reg, path, prefix, is)
+			c.typhaImage, err = components.GetReference(components.ComponentCalicoTypha, reg, path, prefix, suffix, is)
 		}
 	}
 	if err != nil {

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -70,6 +70,7 @@ func (c *windowsComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
+	suffix := c.cfg.Installation.ImageSuffix
 	var errMsgs []string
 	appendIfErr := func(imageName string, err error) string {
 		if err != nil {
@@ -79,11 +80,11 @@ func (c *windowsComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	}
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
-		c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNIWindows, reg, path, prefix, is))
-		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNodeWindows, reg, path, prefix, is))
+		c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNIWindows, reg, path, prefix, suffix, is))
+		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNodeWindows, reg, path, prefix, suffix, is))
 	} else {
-		c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNIWindows, reg, path, prefix, is))
-		c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNodeWindows, reg, path, prefix, is))
+		c.cniImage = appendIfErr(components.GetReference(components.ComponentCalicoCNIWindows, reg, path, prefix, suffix, is))
+		c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNodeWindows, reg, path, prefix, suffix, is))
 	}
 
 	if len(errMsgs) != 0 {

--- a/pkg/tls/certificatemanagement/csr.go
+++ b/pkg/tls/certificatemanagement/csr.go
@@ -91,6 +91,7 @@ func ResolveCSRInitImage(inst *operatorv1.InstallationSpec, is *operatorv1.Image
 		inst.Registry,
 		inst.ImagePath,
 		inst.ImagePrefix,
+		inst.ImageSuffix,
 		is,
 	)
 }


### PR DESCRIPTION
## Description

Create a new field `imageSuffix` to allow users to specify a suffix for images deployed. This suffix follows the same rules as the already-existing field `imagePrefix`. This affects the `Installation` resource in the `operator.tigera.io/v1` group/version.

The goal of this change is to enable usage of images with Tigera Operator when the general format is
```none
my.registry/project/<prefix>-<image-name>-<suffix>:<tag>
```
as it is currently not possible to use the operator with images for which names end with a standardized suffix (i.e. `my.registry/project/calico-pod2daemon-flexvol-test`).

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
