### PR TITLE
Enable OIDC for multi-tenant setup

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -386,7 +386,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	// Build a trusted bundle containing all of the certificates of components that communicate with the manager pod.
 	// This bundle contains the root CA used to sign all operator-generated certificates, as well as the explicitly named
 	// certificates, in case the user has provided their own cert in lieu of the default certificate.
-	var authenticationCR *operatorv1.Authentication
+
 	var trustedSecretNames []string
 	if !r.multiTenant {
 		// For multi-tenant systems, we don't support user-provided certs for all components. So, we don't need to include these,
@@ -408,19 +408,21 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 			}
 			trustedSecretNames = append(trustedSecretNames, render.ComplianceServerCertSecret)
 		}
+	}
 
-		// Fetch the Authentication spec. If present, we use to configure user authentication.
-		authenticationCR, err = utils.GetAuthentication(ctx, r.client)
-		if err != nil && !errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error while fetching Authentication", err, logc)
-			return reconcile.Result{}, err
-		}
-		if authenticationCR != nil && authenticationCR.Status.State != operatorv1.TigeraStatusReady {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Authentication is not ready authenticationCR status: %s", authenticationCR.Status.State), nil, logc)
-			return reconcile.Result{}, nil
-		} else if authenticationCR != nil {
-			trustedSecretNames = append(trustedSecretNames, render.DexTLSSecretName)
-		}
+	var authenticationCR *operatorv1.Authentication
+	// Fetch the Authentication spec. If present, we use to configure user authentication.
+	authenticationCR, err = utils.GetAuthentication(ctx, r.client)
+	if err != nil && !errors.IsNotFound(err) {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error while fetching Authentication", err, logc)
+		return reconcile.Result{}, err
+	}
+	if authenticationCR != nil && authenticationCR.Status.State != operatorv1.TigeraStatusReady {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Authentication is not ready authenticationCR status: %s", authenticationCR.Status.State), nil, logc)
+		return reconcile.Result{}, nil
+	} else if authenticationCR != nil && !utils.IsDexDisabled(authenticationCR) {
+		// Do not include DEX TLS Secret Name is authentication CR does not have type Dex
+		trustedSecretNames = append(trustedSecretNames, render.DexTLSSecretName)
 	}
 
 	bundleMaker := certificateManager.CreateTrustedBundle()

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -836,3 +836,11 @@ func compareMap(m1, m2 map[string]string) bool {
 	}
 	return true
 }
+
+func IsDexDisabled(authentication *operatorv1.Authentication) bool {
+	disableDex := false
+	if authentication.Spec.OIDC != nil && authentication.Spec.OIDC.Type == operatorv1.OIDCTypeTigera {
+		disableDex = true
+	}
+	return disableDex
+}


### PR DESCRIPTION
## Description

Enable OIDC when configuring a multi-tenant management cluster.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
