### PR TITLE
[EV-4356] createPredicateForObject should react if the generation isn…

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -647,7 +647,9 @@ func createPredicateForObject(objMeta metav1.Object) predicate.Predicate {
 			return e.Object.GetNamespace() == objMeta.GetNamespace() || objMeta.GetNamespace() == ""
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			generationChanged := e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+			// Not all objects use/have a generation, so we can't always rely on that to determine if the
+			// object has changed. The generation will be 0 if it's not set.
+			generationChanged := e.ObjectOld.GetGeneration() == 0 || e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 
 			if objMeta.GetName() == "" && objMeta.GetNamespace() == "" {
 				// No name or namespace match was specified. Match everything, assuming the generation has changed.

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -326,3 +326,109 @@ func (m *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 	args := m.Called(groupVersion)
 	return args.Get(0).(*metav1.APIResourceList), nil
 }
+
+var _ = Describe("CreatePredicateForObject", func() {
+	var (
+		objMeta metav1.Object
+	)
+
+	Context("when the name and namespace were specified with empty strings", func() {
+		BeforeEach(func() {
+			objMeta = &metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "",
+			}
+		})
+
+		It("should match everything", func() {
+			p := createPredicateForObject(objMeta)
+			Expect(p.Create(event.CreateEvent{})).To(BeTrue())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "", Generation: 0}}})).To(BeTrue())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "", Generation: 1}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "", Generation: 2}}})).To(BeTrue())
+			Expect(p.Delete(event.DeleteEvent{})).To(BeTrue())
+		})
+	})
+
+	Context("when a name match was specified, with no namespace", func() {
+		BeforeEach(func() {
+			objMeta = &metav1.ObjectMeta{
+				Name:      "test-object",
+				Namespace: "",
+			}
+		})
+
+		It("should match if the object name matches", func() {
+			p := createPredicateForObject(objMeta)
+			Expect(p.Create(event.CreateEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: ""}}})).To(BeTrue())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "", Generation: 0}}})).To(BeTrue()) // Generation was not specified.
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "", Generation: 3}}})).To(BeTrue())
+			Expect(p.Delete(event.DeleteEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: ""}}})).To(BeTrue())
+		})
+
+		It("should not match if the object name does not match, or the generation hasn't changed", func() {
+			p := createPredicateForObject(objMeta)
+			Expect(p.Create(event.CreateEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: ""}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "", Generation: 0}}})).To(BeFalse()) // Generation was not specified.
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "", Generation: 3}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "", Generation: 2}}})).To(BeFalse()) // Generation didn't change.
+			Expect(p.Delete(event.DeleteEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: ""}}})).To(BeFalse())
+		})
+	})
+
+	Context("when a namespace match was specified", func() {
+		BeforeEach(func() {
+			objMeta = &metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "test-namespace",
+			}
+		})
+
+		It("should match if the object namespace matches", func() {
+			p := createPredicateForObject(objMeta)
+			Expect(p.Create(event.CreateEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace"}}})).To(BeTrue())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace", Generation: 0}}})).To(BeTrue()) // Generation was not specified.
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace", Generation: 3}}})).To(BeTrue())
+			Expect(p.Delete(event.DeleteEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace"}}})).To(BeTrue())
+		})
+
+		It("should not match if the object namespace does not match", func() {
+			p := createPredicateForObject(objMeta)
+			Expect(p.Create(event.CreateEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "other-namespace"}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "other-namespace", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "other-namespace", Generation: 0}}})).To(BeFalse()) // Generation was not specified.
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "other-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "other-namespace", Generation: 3}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "test-namespace", Generation: 2}}})).To(BeFalse()) // Generation didn't change.
+			Expect(p.Delete(event.DeleteEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "other-namespace"}}})).To(BeFalse())
+		})
+	})
+
+	Context("when a name and namespace match were specified", func() {
+		BeforeEach(func() {
+			objMeta = &metav1.ObjectMeta{
+				Name:      "test-object",
+				Namespace: "test-namespace",
+			}
+		})
+
+		It("should match if the object name and namespace match", func() {
+			p := createPredicateForObject(objMeta)
+			Expect(p.Create(event.CreateEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "test-namespace"}}})).To(BeTrue())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "test-namespace", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "test-namespace", Generation: 0}}})).To(BeTrue()) // Generation was not specified.
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "test-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "test-namespace", Generation: 3}}})).To(BeTrue())
+			Expect(p.Delete(event.DeleteEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "test-namespace"}}})).To(BeTrue())
+		})
+
+		It("should not match if the object name or namespace do not match", func() {
+			p := createPredicateForObject(objMeta)
+			Expect(p.Create(event.CreateEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "other-namespace"}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "other-namespace", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "other-namespace", Generation: 0}}})).To(BeFalse()) // Generation was not specified.
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "other-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "other-namespace", Generation: 3}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "other-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "test-namespace", Generation: 2}}})).To(BeFalse()) // Generation didn't change.
+			Expect(p.Delete(event.DeleteEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-object", Namespace: "other-namespace"}}})).To(BeFalse())
+			Expect(p.Create(event.CreateEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace"}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace", Generation: 0}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace", Generation: 0}}})).To(BeFalse()) // Generation was not specified.
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace", Generation: 3}}})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace", Generation: 2}}, ObjectNew: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace", Generation: 2}}})).To(BeFalse()) // Generation didn't change.
+			Expect(p.Delete(event.DeleteEvent{Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other-object", Namespace: "test-namespace"}}})).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
…'t set

## Description

Updates to watched objects do not propagate a call to the `Reconcile`, if the `ObjectMeta::Generation` isn't defined. The change checks the old object in an update and if that is zero sets `generationChanged` to 0.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
