### PR TITLE
[RS-1431] Create webhooks-secret and allow UI admin user to patch it

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -157,6 +157,10 @@ func (c componentHandler) createOrUpdateObject(ctx context.Context, obj client.O
 			}
 			return nil
 		case *v1.Secret:
+			if IgnoreSecretData(cur) {
+				logCtx.Info("Ignoring secret data of annotated object")
+				return nil
+			}
 			objSecret := obj.(*v1.Secret)
 			curSecret := cur.(*v1.Secret)
 			// Secret types are immutable, we need to delete the old version if the type has changed. If the

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -53,6 +53,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/secret"
 )
 
 const (
@@ -88,6 +89,14 @@ func ContextLoggerForResource(log logr.Logger, obj client.Object) logr.Logger {
 func IgnoreObject(obj runtime.Object) bool {
 	a := obj.(metav1.ObjectMetaAccessor).GetObjectMeta().GetAnnotations()
 	if val, ok := a[unsupportedIgnoreAnnotation]; ok && val == "true" {
+		return true
+	}
+	return false
+}
+
+func IgnoreSecretData(obj runtime.Object) bool {
+	a := obj.(metav1.ObjectMetaAccessor).GetObjectMeta().GetAnnotations()
+	if val, ok := a[secret.IgnoreSecretDataAnnotation]; ok && val == "true" {
 		return true
 	}
 	return false

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1771,6 +1771,17 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			Resources: []string{"felixconfigurations"},
 			Verbs:     []string{"get", "list"},
 		},
+		// Allow the user to patch webhooks-secret secret.
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"secrets",
+			},
+			ResourceNames: []string{
+				"webhooks-secret",
+			},
+			Verbs: []string{"patch"},
+		},
 	}
 
 	// Privileges for lma.tigera.io have no effect on managed clusters.

--- a/pkg/render/common/secret/secrets.go
+++ b/pkg/render/common/secret/secrets.go
@@ -30,6 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	IgnoreSecretDataAnnotation = "operator.tigera.io/ignore-secret-data"
+)
+
 // CreateTLSSecret Creates a new TLS secret with the information passed
 //
 //	ca: The ca to use for creating the Cert/Key pair. This is required.

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -205,6 +205,7 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(IntrusionDetectionNamespace, c.cfg.ESSecrets...)...)...)
 	objs = append(objs, c.globalAlertTemplates()...)
+	objs = append(objs, c.webhooksSecret())
 
 	var objsToDelete []client.Object
 
@@ -1474,5 +1475,22 @@ func (c *intrusionDetectionComponent) adDetectorAllowTigeraPolicy() *v3.NetworkP
 			Name:      ADDetectorPolicyName,
 			Namespace: IntrusionDetectionNamespace,
 		},
+	}
+}
+
+func (c *intrusionDetectionComponent) webhooksSecret() *corev1.Secret {
+	// This secret is created empty as a placeholder for user-supplied credentials for webhooks.
+	// As a result, we don't want the operator to keep the content of the secret in sync...
+	annotations := make(map[string]string)
+	annotations[secret.IgnoreSecretDataAnnotation] = "true"
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "webhooks-secret",
+			Namespace:   IntrusionDetectionNamespace,
+			Annotations: annotations,
+		},
+		Data: make(map[string][]byte),
+		Type: corev1.SecretTypeOpaque,
 	}
 }


### PR DESCRIPTION
## Description

This adds and empty secret (`webhooks-secret`) in the `tigera-intrusion-detection` namespace to store user's Jira credentials for webhooks that interact with Jira.

The webhook definitions (and secrets) live in the managed clusters. When creating webhooks with `kubectl`, users can store various configs in the webhook itself, or reference config maps and secrets for more sensitive information. 

In our UI, we allow admin users to easily create/update/delete webhooks. When creating a Jira webhook, we store the Jira credentials they provide (email + token) into a secret. When we delete a webhook through the UI, it also cleans up the information in the secret.

In the initial [poc](https://github.com/tigera/ui-modules/pull/220), we allowed admin users to view and edit those credentials through the UI, which would require adding `create/view/update/delete` permissions for `secrets` in `tigera-netwok-admin` cluster role. This felt like too much permissions (even for admin users) so we decided to:

 - Only specify Jira credentials when creating a webhook, no way to view them ("UI" does not read secrets). If creds need to change, delete webhook and create a new one.
 - Have 1 secret that contains Jira credentials for all the webhooks of a managedcluster created through the UI, with key in secret data using format `<webhok-name>.username` 
 - Let the UI `patch` the required secret when secret when creating/adding a jira webhook (update/remove secret key accordingly).
 - Only allow admin users to `patch` `webhooks-secret` secret using the `ResourceNames` parameter. 
 - Annotate the secret with new annotation so that the operator ignores the secret's data, but re-creates an empty secret if it does not exists.

This PR implements the required changes for this in the operator.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
