### PR TITLE
Ev 4104 csr controller

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -143,6 +143,13 @@ func AddToManager(mgr ctrl.Manager, options options.AddOptions) error {
 	}).SetupWithManager(mgr, options); err != nil {
 		return fmt.Errorf("failed to create controller Windows: %v", err)
 	}
+	if err := (&CSRReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("CertificateSigningRequest"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr, options); err != nil {
+		return fmt.Errorf("failed to create controller %s: %v", "CSR", err)
+	}
 	// +kubebuilder:scaffold:builder
 	return nil
 }

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/tigera/operator/pkg/controller/csr"
+	"github.com/tigera/operator/pkg/controller/options"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CSRReconciler reconciles CSRs.
+type CSRReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+func (r *CSRReconciler) SetupWithManager(mgr ctrl.Manager, opts options.AddOptions) error {
+	return csr.Add(mgr, opts)
+}

--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -43,6 +43,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// OperatorCSRSignerName when this value is set as a signer on a CSR, the CSR controller will handle
+// the request.
+const OperatorCSRSignerName = "tigera.io/operator-signer"
+
 var log = logf.Log.WithName("tls")
 
 func ErrInvalidCertDNSNames(secretName, secretNamespace string) error {

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -92,7 +92,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	for _, secretName := range []string{
 		render.PacketCaptureServerCert,
-		monitor.PrometheusTLSSecretName,
+		monitor.PrometheusServerTLSSecretName,
 		render.ProjectCalicoAPIServerTLSSecretName(operatorv1.TigeraSecureEnterprise),
 		render.ProjectCalicoAPIServerTLSSecretName(operatorv1.Calico),
 	} {
@@ -150,8 +150,8 @@ func add(mgr manager.Manager, c controller.Controller) error {
 		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, render.PacketCaptureServerCert, err)
 	}
 	// Watch for changes to the secrets associated with Prometheus.
-	if err = utils.AddSecretsWatch(c, monitor.PrometheusTLSSecretName, common.OperatorNamespace()); err != nil {
-		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, monitor.PrometheusTLSSecretName, err)
+	if err = utils.AddSecretsWatch(c, monitor.PrometheusServerTLSSecretName, common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("%s failed to watch Secret resource %s: %w", controllerName, monitor.PrometheusServerTLSSecretName, err)
 	}
 
 	if err = utils.AddSecretsWatch(c, certificatemanagement.CASecretName, common.OperatorNamespace()); err != nil {
@@ -288,7 +288,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		trustedCertBundle = certificateManager.CreateTrustedBundle()
 	}
 
-	for _, secretName := range []string{render.PacketCaptureServerCert, monitor.PrometheusTLSSecretName, render.ProjectCalicoAPIServerTLSSecretName(instl.Variant)} {
+	for _, secretName := range []string{render.PacketCaptureServerCert, monitor.PrometheusServerTLSSecretName, render.ProjectCalicoAPIServerTLSSecretName(instl.Variant)} {
 		secret, err := certificateManager.GetCertificate(r.Client, secretName, common.OperatorNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve %s", secretName), err, reqLogger)

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/dns"
-
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/test"
@@ -101,7 +100,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		pcSecret, err := certificateManager.GetOrCreateKeyPair(c, render.PacketCaptureServerCert, common.OperatorNamespace(), []string{"a"})
 		Expect(err).NotTo(HaveOccurred())
 
-		promSecret, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusTLSSecretName, common.OperatorNamespace(), []string{"a"})
+		promSecret, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusServerTLSSecretName, common.OperatorNamespace(), []string{"a"})
 		Expect(err).NotTo(HaveOccurred())
 
 		queryServerSecret, err := certificateManager.GetOrCreateKeyPair(c, render.ProjectCalicoAPIServerTLSSecretName(operatorv1.TigeraSecureEnterprise), common.OperatorNamespace(), []string{"a"})

--- a/pkg/controller/compliance/compliance_controller_test.go
+++ b/pkg/controller/compliance/compliance_controller_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Compliance controller tests", func() {
 		testCA := test.MakeTestCA("compliance-test")
 		newSecret, err := secret.CreateTLSSecret(testCA,
 			render.ComplianceServerCertSecret, common.OperatorNamespace(), corev1.TLSPrivateKeyKey,
-			corev1.TLSCertKey, rmeta.DefaultCertificateDuration, nil, oldDNSNames...,
+			corev1.TLSCertKey, tls.DefaultCertificateDuration, nil, oldDNSNames...,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.Create(ctx, newSecret)).NotTo(HaveOccurred())
@@ -266,7 +266,7 @@ var _ = Describe("Compliance controller tests", func() {
 		dnsNames := append(expectedDNSNames, "compliance.example.com", "192.168.10.13")
 		newSecret, err := secret.CreateTLSSecret(nil,
 			render.ComplianceServerCertSecret, common.OperatorNamespace(), corev1.TLSPrivateKeyKey,
-			corev1.TLSCertKey, rmeta.DefaultCertificateDuration, nil, dnsNames...,
+			corev1.TLSCertKey, tls.DefaultCertificateDuration, nil, dnsNames...,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.Create(ctx, newSecret)).NotTo(HaveOccurred())
@@ -299,7 +299,7 @@ var _ = Describe("Compliance controller tests", func() {
 		testCA := test.MakeTestCA("compliance-test")
 		complianceSecret, err := secret.CreateTLSSecret(testCA,
 			render.ComplianceServerCertSecret, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey,
-			rmeta.DefaultCertificateDuration, nil, dnsNames...,
+			tls.DefaultCertificateDuration, nil, dnsNames...,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.Create(ctx, complianceSecret)).NotTo(HaveOccurred())

--- a/pkg/controller/csr/csr_controller.go
+++ b/pkg/controller/csr/csr_controller.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package csr
 
 import (
@@ -336,7 +350,7 @@ func (r *reconcileCSR) getPod(ctx context.Context, csr *certificatesv1.Certifica
 		}
 		return nil, err
 	}
-	if podUIDs[0] == fmt.Sprintf("%s", pod.UID) && serviceaccountName == pod.Spec.ServiceAccountName {
+	if podUIDs[0] == string(pod.UID) && serviceaccountName == pod.Spec.ServiceAccountName {
 		return pod, nil
 	}
 

--- a/pkg/controller/csr/csr_controller.go
+++ b/pkg/controller/csr/csr_controller.go
@@ -116,9 +116,9 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions) (reconcile.Reco
 func allowedAssets(clusterDomain string) map[string]tlsAsset {
 	return map[string]tlsAsset{
 		rmonitor.PrometheusServerTLSSecretName: {
-			rmonitor.PrometheusServiceAccountName,
-			rmonitor.TigeraPrometheusObjectName,
-			monitor.PrometheusTLSServerDNSNames(clusterDomain),
+			serviceaccountName:      rmonitor.PrometheusServiceAccountName,
+			serviceaccountNamespace: rmonitor.TigeraPrometheusObjectName,
+			validDNSNames:           monitor.PrometheusTLSServerDNSNames(clusterDomain),
 		},
 	}
 }

--- a/pkg/controller/csr/csr_controller.go
+++ b/pkg/controller/csr/csr_controller.go
@@ -1,0 +1,321 @@
+package csr
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"strings"
+	"time"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/controller/monitor"
+	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/render"
+	rmonitor "github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
+	typedcertificatesv1 "k8s.io/client-go/kubernetes/typed/certificates/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var log = logf.Log.WithName("controller_csr")
+var controllerName = "csr-controller"
+
+// LabelName label that we set on our CSRs, this helps us exclude irrelevant CSRs.
+const LabelName = "operator.tigera.io/csr"
+
+var extKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+
+// relevantCSR returns true if a csr is relevant to this controller.
+func relevantCSR(csr *certificatesv1.CertificateSigningRequest) bool {
+	if _, found := csr.Labels[LabelName]; !found {
+		return false
+	}
+	for _, condition := range csr.Status.Conditions {
+		if (condition.Type == certificatesv1.CertificateDenied || condition.Type == certificatesv1.CertificateFailed) && condition.Status == corev1.ConditionTrue {
+			// These request statuses are deterministic/non-recoverable.
+			return false
+		}
+	}
+	// We are only interested in CSRs that have not been signed. This also excludes
+	// us from watching our own updates and reconciling for no reason.
+	return csr.Status.Certificate == nil
+}
+
+// Add creates a new CSR Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+	if !opts.EnterpriseCRDExists {
+		// No need to start this controller (currently).
+		return nil
+	}
+	reconciler, err := newReconciler(mgr, opts)
+	if err != nil {
+		return err
+	}
+
+	ctrl, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconciler})
+	if err != nil {
+		return err
+	}
+
+	return utils.AddCSRWatchWithRelevancyFn(ctrl, relevantCSR)
+}
+
+type tlsAsset struct {
+	serviceaccountName      string
+	serviceaccountNamespace string
+	validDNSNames           []string
+}
+
+// newReconciler returns a new *reconcile.Reconciler
+func newReconciler(mgr manager.Manager, opts options.AddOptions) (reconcile.Reconciler, error) {
+	// We need to construct a certificatesV1 client, as this API has methods we rely upon that are not present in the generic client.
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	r := &ReconcileCSR{
+		client:             mgr.GetClient(),
+		scheme:             mgr.GetScheme(),
+		provider:           opts.DetectedProvider,
+		clusterDomain:      opts.ClusterDomain,
+		certificatesClient: clientset.CertificatesV1(),
+		allowedTLSAssets:   allowedAssets(opts.ClusterDomain),
+	}
+	return r, nil
+}
+
+func allowedAssets(clusterDomain string) map[string]tlsAsset {
+	return map[string]tlsAsset{
+		rmonitor.PrometheusServerTLSSecretName: {
+			rmonitor.PrometheusServiceAccountName,
+			rmonitor.TigeraPrometheusObjectName,
+
+			monitor.PrometheusTLSServerDNSNames(clusterDomain),
+		},
+	}
+}
+
+// blank assignment to verify that ReconcileCompliance implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileCSR{}
+
+// ReconcileCSR reconciles CSRs objects
+type ReconcileCSR struct {
+	client             client.Client
+	scheme             *runtime.Scheme
+	provider           operatorv1.Provider
+	clusterDomain      string
+	certificatesClient typedcertificatesv1.CertificatesV1Interface
+	allowedTLSAssets   map[string]tlsAsset
+}
+
+func (r ReconcileCSR) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling CSR Controller")
+	csrList := &certificatesv1.CertificateSigningRequestList{}
+
+	// Filter out unnecessary CSRs. (Calico CSRs are guaranteed to have this label).
+	requirement, err := labels.NewRequirement(LabelName, selection.Exists, []string{})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if err := r.client.List(ctx, csrList, &client.ListOptions{LabelSelector: labels.NewSelector().Add(*requirement)}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	instance := &operatorv1.Installation{}
+	if err := r.client.Get(ctx, utils.DefaultInstanceKey, instance); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	certificateManager, err := certificatemanager.Create(r.client, &instance.Spec, r.clusterDomain, common.OperatorNamespace(), certificatemanager.WithLogger(reqLogger))
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	for _, csr := range csrList.Items {
+		if csr.Spec.SignerName != utils.OperatorCSRSignerName || csr.Status.Certificate != nil || !relevantCSR(&csr) {
+			// Not for us, or already signed.
+			continue
+		}
+		reqLogger.Info("Inspecting CSR with name : %v.", csr.Name)
+		certificateTemplate, err := r.validate(ctx, &csr)
+		if err != nil {
+			if errors.As(err, &systemError{}) {
+				// Validation failed due to an error unrelated to the CSR itself.
+				return reconcile.Result{}, err
+			}
+
+			csr.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{
+				{
+					Type:    certificatesv1.CertificateDenied,
+					Message: err.Error(),
+					Reason:  err.Error(),
+					Status:  corev1.ConditionTrue,
+				},
+			}
+			reqLogger.Error(err, "Rejecting the CSR.")
+			_, err = r.certificatesClient.CertificateSigningRequests().UpdateStatus(ctx, &csr, metav1.UpdateOptions{})
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			continue
+		}
+		csr.Status.Conditions = []certificatesv1.CertificateSigningRequestCondition{
+			{
+				Type:    certificatesv1.CertificateApproved,
+				Message: "Approved",
+				Reason:  "Approved",
+				Status:  corev1.ConditionTrue,
+			},
+		}
+		reqs := r.certificatesClient.CertificateSigningRequests()
+		updatedCSR, err := reqs.UpdateApproval(ctx, csr.Name, &csr, metav1.UpdateOptions{})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		reqLogger.Info("Approved CSR with name : %v.", csr.Name)
+
+		certificatePEM, err := certificateManager.SignCertificate(certificateTemplate, certificateTemplate.PublicKey)
+		if err != nil {
+			reqLogger.Error(err, "error signing certificate request")
+			return reconcile.Result{}, err
+		}
+		updatedCSR.Status.Certificate = certificatePEM
+
+		_, err = r.certificatesClient.CertificateSigningRequests().UpdateStatus(ctx, updatedCSR, metav1.UpdateOptions{})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		reqLogger.Info("Signed CSR with name : %v.", csr.Name)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+type systemError struct {
+	message string
+}
+
+func (v systemError) Error() string {
+	return v.message
+}
+
+func (r ReconcileCSR) validate(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) (*x509.Certificate, error) {
+	firstBlock, restBlocks := pem.Decode(csr.Spec.Request)
+	if firstBlock == nil {
+		return nil, fmt.Errorf("cannot parse certificate request for CSR with name %s", csr.Name)
+	}
+	if len(restBlocks) != 0 {
+		return nil, fmt.Errorf("unexpected (multiple) pem blocks for CSR with name %s", csr.Name)
+	}
+
+	certificateRequest, err := x509.ParseCertificateRequest(firstBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	if err = certificateRequest.CheckSignature(); err != nil {
+		return nil, err
+	}
+
+	// The CSRName is formatted as "<secretName>:<podName>".
+	secretName := strings.Split(csr.Name, ":")[0]
+
+	// Validate whether this is a CSR we monitor at all.
+	asset, ok := r.allowedTLSAssets[secretName]
+	if !ok {
+		return nil, fmt.Errorf("this controller is not configured to sign secretName: %s", secretName)
+	}
+
+	// Validate whether the requestor of the CSR is registered for the given CSR
+	if fmt.Sprintf("system:serviceaccount:%s:%s", asset.serviceaccountNamespace, asset.serviceaccountName) != csr.Spec.Username {
+		return nil, fmt.Errorf("invalid requestor %s for CSR with name %s", csr.Spec.Username, csr.Name)
+	}
+
+	// Validate whether the DNS names are permitted for the request.
+	for _, name := range append(certificateRequest.DNSNames, certificateRequest.Subject.CommonName) {
+		var found bool
+		for _, valid := range asset.validDNSNames {
+			if valid == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("invalid dns name \"%s\" found in CSR with name %s", name, csr.Name)
+		}
+	}
+
+	if len(certificateRequest.IPAddresses) == 1 {
+		// Validate the IP address that is requested in the CSR matches the pod IP of the requestor.
+		label, ok := csr.Labels[render.AppLabelName]
+		if !ok {
+			return nil, fmt.Errorf("unable to find expected k8s-app label for CSR with name %s", csr.Name)
+		}
+		podList := &corev1.PodList{}
+		err = r.client.List(ctx, podList, &client.ListOptions{
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				render.AppLabelName: label,
+			}),
+			Namespace: asset.serviceaccountNamespace})
+		if err != nil {
+			return nil, systemError{fmt.Sprintf("unexpected server error while listing pods by label for CSR %s", csr.Name)}
+		}
+		var foundIp bool
+		for _, pod := range podList.Items {
+			if pod.Status.PodIP == certificateRequest.IPAddresses[0].String() {
+				foundIp = true
+				break
+			}
+		}
+		if !foundIp {
+			return nil, fmt.Errorf("invalid pod IP for CSR with name %s", csr.Name)
+		}
+	} else if len(certificateRequest.IPAddresses) > 1 {
+		return nil, fmt.Errorf("unable request more than 1 IP for CSR with name %s", csr.Name)
+	}
+
+	bigint, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	certTemplate := &x509.Certificate{
+		// We don't rely on any other part of the subject. Common name is validated already.
+		Subject:            pkix.Name{CommonName: certificateRequest.Subject.CommonName},
+		SerialNumber:       bigint,
+		Version:            3,
+		PublicKeyAlgorithm: certificateRequest.PublicKeyAlgorithm,
+		PublicKey:          certificateRequest.PublicKey,
+		NotBefore:          time.Now(),
+		// We currently don't implement the Duration for certificate requests.
+		NotAfter: time.Now().Add(tls.DefaultCertificateDuration),
+		// For the time being we simply issue the standard usages. There are very few, if any, exceptions in our product.
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: extKeyUsage,
+		DNSNames:    certificateRequest.DNSNames,
+		IPAddresses: certificateRequest.IPAddresses,
+	}
+	return certTemplate, nil
+}

--- a/pkg/controller/csr/csr_controller_suite_test.go
+++ b/pkg/controller/csr/csr_controller_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csr
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/ut/csr_controller_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/controller/CSR Controller Suite", []Reporter{junitReporter})
+}

--- a/pkg/controller/csr/csr_controller_test.go
+++ b/pkg/controller/csr/csr_controller_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package csr
 
 import (
@@ -9,7 +23,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
-	"fmt"
 	"net"
 
 	. "github.com/onsi/ginkgo"
@@ -242,7 +255,7 @@ func validCSR(cr *x509.CertificateRequest, pod *corev1.Pod) *certificatesv1.Cert
 			Username:   "system:serviceaccount:tigera-prometheus:prometheus",
 			Extra: map[string]certificatesv1.ExtraValue{
 				"authentication.kubernetes.io/pod-name": []string{pod.Name},
-				"authentication.kubernetes.io/pod-uid":  []string{fmt.Sprintf("%s", pod.UID)},
+				"authentication.kubernetes.io/pod-uid":  []string{string(pod.UID)},
 			},
 		},
 		Status: certificatesv1.CertificateSigningRequestStatus{},

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -292,8 +292,8 @@ func add(c controller.Controller, r *ReconcileInstallation) error {
 			return fmt.Errorf("tigera-installation-controller failed to watch primary resource: %v", err)
 		}
 
-		if err = utils.AddSecretsWatch(c, monitor.PrometheusTLSSecretName, common.TigeraPrometheusNamespace); err != nil {
-			return fmt.Errorf("tigera-installation-controller failed to watch secret '%s' in '%s' namespace: %w", monitor.PrometheusTLSSecretName, common.OperatorNamespace(), err)
+		if err = utils.AddSecretsWatch(c, monitor.PrometheusServerTLSSecretName, common.TigeraPrometheusNamespace); err != nil {
+			return fmt.Errorf("tigera-installation-controller failed to watch secret '%s' in '%s' namespace: %w", monitor.PrometheusServerTLSSecretName, common.OperatorNamespace(), err)
 		}
 
 		// watch for change to primary resource LogCollector

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls"
@@ -399,7 +398,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			r.typhaAutoscaler.start(ctx)
 			certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
-			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusClientTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
@@ -812,7 +811,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			certificateManager, err = certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))) // Persist the root-ca in the operator namespace.
-			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
@@ -859,7 +858,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			nodeSecret, err := secret.CreateTLSSecret(testCA,
 				render.NodeTLSSecretName, common.OperatorNamespace(), "key.key",
-				"cert.crt", rmeta.DefaultCertificateDuration, nil, render.FelixCommonName,
+				"cert.crt", tls.DefaultCertificateDuration, nil, render.FelixCommonName,
 			)
 			nodeSecret.Data[render.CommonName] = []byte(render.FelixCommonName)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -867,7 +866,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			typhaSecret, err := secret.CreateTLSSecret(testCA,
 				render.TyphaTLSSecretName, common.OperatorNamespace(), "key.key",
-				"cert.crt", rmeta.DefaultCertificateDuration, nil, render.TyphaCommonName,
+				"cert.crt", tls.DefaultCertificateDuration, nil, render.TyphaCommonName,
 			)
 			typhaSecret.Data[render.CommonName] = []byte(render.TyphaCommonName)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -995,7 +994,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			}
 			certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
-			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())

--- a/pkg/controller/installation/windows_controller_test.go
+++ b/pkg/controller/installation/windows_controller_test.go
@@ -160,7 +160,7 @@ var _ = Describe("windows-controller installation tests", func() {
 			Expect(updateInstallationWithDefaults(ctx, r.client, cr, r.autoDetectedProvider)).NotTo(HaveOccurred())
 			certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
-			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
@@ -604,7 +604,7 @@ var _ = Describe("windows-controller installation tests", func() {
 
 					certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 					Expect(err).NotTo(HaveOccurred())
-					prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+					prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 					Expect(c.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -142,7 +142,7 @@ func add(mgr manager.Manager, c controller.Controller) error {
 	for _, secretName := range []string{
 		render.ElasticsearchEksLogForwarderUserSecret,
 		relasticsearch.PublicCertSecret, render.S3FluentdSecretName, render.EksLogForwarderSecret,
-		render.SplunkFluentdTokenSecretName, render.SplunkFluentdCertificateSecretName, monitor.PrometheusTLSSecretName,
+		render.SplunkFluentdTokenSecretName, render.SplunkFluentdCertificateSecretName, monitor.PrometheusServerTLSSecretName,
 		render.FluentdPrometheusTLSSecretName, render.TigeraLinseedSecret, render.VoltronLinseedPublicCert, render.EKSLogForwarderTLSSecretName,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -143,7 +143,7 @@ var _ = Describe("LogCollector controller tests", func() {
 			},
 		})).NotTo(HaveOccurred())
 
-		prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+		prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 

--- a/pkg/controller/logstorage/elastic/elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller_test.go
@@ -54,9 +54,9 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/test"
 )
 
@@ -132,7 +132,7 @@ var _ = Describe("LogStorage controller", func() {
 		certificateManager, err = certificatemanager.Create(cli, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))) // Persist the root-ca in the operator namespace.
-		prometheusTLS, err := certificateManager.GetOrCreateKeyPair(cli, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+		prometheusTLS, err := certificateManager.GetOrCreateKeyPair(cli, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
@@ -550,7 +550,7 @@ var _ = Describe("LogStorage controller", func() {
 				testCA := test.MakeTestCA("logstorage-test")
 				esSecret, err := secret.CreateTLSSecret(testCA,
 					render.TigeraElasticsearchGatewaySecret, common.OperatorNamespace(), "tls.key", "tls.crt",
-					rmeta.DefaultCertificateDuration, nil, esDNSNames...,
+					tls.DefaultCertificateDuration, nil, esDNSNames...,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -560,7 +560,7 @@ var _ = Describe("LogStorage controller", func() {
 
 				kbDNSNames = []string{"kb.example.com", "192.168.10.11"}
 				kbSecret, err := secret.CreateTLSSecret(testCA,
-					render.TigeraKibanaCertSecret, common.OperatorNamespace(), "tls.key", "tls.crt", rmeta.DefaultCertificateDuration, nil, kbDNSNames...,
+					render.TigeraKibanaCertSecret, common.OperatorNamespace(), "tls.key", "tls.crt", tls.DefaultCertificateDuration, nil, kbDNSNames...,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(cli.Update(ctx, kbSecret)).ShouldNot(HaveOccurred())
@@ -630,7 +630,7 @@ var _ = Describe("LogStorage controller", func() {
 				testCA := test.MakeTestCA("logstorage-test")
 				kbSecret, err := secret.CreateTLSSecret(testCA,
 					render.TigeraKibanaCertSecret, common.OperatorNamespace(), "tls.key", "tls.crt",
-					rmeta.DefaultCertificateDuration, nil, "tigera-secure-kb-http.tigera-elasticsearch.svc",
+					tls.DefaultCertificateDuration, nil, "tigera-secure-kb-http.tigera-elasticsearch.svc",
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(cli.Update(ctx, kbSecret)).ShouldNot(HaveOccurred())
@@ -710,7 +710,7 @@ var _ = Describe("LogStorage controller", func() {
 				dnsNames := dns.GetServiceDNSNames(render.ElasticsearchServiceName, render.ElasticsearchNamespace, dns.DefaultClusterDomain)
 				kbSecret, err := secret.CreateTLSSecret(testCA,
 					render.TigeraElasticsearchGatewaySecret, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey,
-					rmeta.DefaultCertificateDuration, nil, dnsNames...,
+					tls.DefaultCertificateDuration, nil, dnsNames...,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 				resources = append(resources, kbSecret)

--- a/pkg/controller/logstorage/elastic/external_elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/external_elastic_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/render/logstorage"
+	"github.com/tigera/operator/pkg/tls"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
 
 	. "github.com/onsi/ginkgo"
@@ -90,7 +90,7 @@ var _ = Describe("External ES Controller", func() {
 		bundle := certificateManager.CreateTrustedBundle(esKeyPair)
 		Expect(cli.Create(ctx, bundle.ConfigMap(render.ElasticsearchNamespace))).NotTo(HaveOccurred())
 
-		prometheusTLS, err := certificateManager.GetOrCreateKeyPair(cli, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+		prometheusTLS, err := certificateManager.GetOrCreateKeyPair(cli, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(cli.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
@@ -126,7 +126,7 @@ var _ = Describe("External ES Controller", func() {
 			common.OperatorNamespace(),
 			"tls.key",
 			"tls.crt",
-			rmeta.DefaultCertificateDuration,
+			tls.DefaultCertificateDuration,
 			nil,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -138,7 +138,7 @@ var _ = Describe("External ES Controller", func() {
 			common.OperatorNamespace(),
 			"tls.key",
 			"tls.crt",
-			rmeta.DefaultCertificateDuration,
+			tls.DefaultCertificateDuration,
 			nil,
 		)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/controller/logstorage/secrets/secret_controller_test.go
+++ b/pkg/controller/logstorage/secrets/secret_controller_test.go
@@ -47,10 +47,10 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
+	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	"github.com/tigera/operator/test"
 )
@@ -217,7 +217,7 @@ var _ = Describe("LogStorage Secrets controller", func() {
 		testCA := test.MakeTestCA("logstorage-test")
 		esSecret, err := secret.CreateTLSSecret(testCA,
 			render.TigeraElasticsearchGatewaySecret, common.OperatorNamespace(), "tls.key", "tls.crt",
-			rmeta.DefaultCertificateDuration, nil, esDNSNames...,
+			tls.DefaultCertificateDuration, nil, esDNSNames...,
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -232,7 +232,7 @@ var _ = Describe("LogStorage Secrets controller", func() {
 			common.OperatorNamespace(),
 			"tls.key",
 			"tls.crt",
-			rmeta.DefaultCertificateDuration,
+			tls.DefaultCertificateDuration,
 			nil,
 			kbDNSNames...,
 		)
@@ -310,7 +310,7 @@ var _ = Describe("LogStorage Secrets controller", func() {
 			common.OperatorNamespace(),
 			"tls.key",
 			"tls.crt",
-			rmeta.DefaultCertificateDuration,
+			tls.DefaultCertificateDuration,
 			nil,
 			"tigera-secure-kb-http.tigera-elasticsearch.svc",
 		)
@@ -384,7 +384,7 @@ var _ = Describe("LogStorage Secrets controller", func() {
 			common.OperatorNamespace(),
 			"tls.key",
 			"tls.crt",
-			rmeta.DefaultCertificateDuration,
+			tls.DefaultCertificateDuration,
 			nil,
 			"tigera-secure-kb-http.tigera-elasticsearch.svc",
 		)
@@ -426,7 +426,7 @@ var _ = Describe("LogStorage Secrets controller", func() {
 			common.OperatorNamespace(),
 			corev1.TLSPrivateKeyKey,
 			corev1.TLSCertKey,
-			rmeta.DefaultCertificateDuration,
+			tls.DefaultCertificateDuration,
 			nil,
 			dnsNames...,
 		)

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -147,7 +147,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		for _, secretName := range []string{
 			render.ManagerTLSSecretName, relasticsearch.PublicCertSecret, render.ElasticsearchManagerUserSecret,
 			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret, render.PacketCaptureServerCert,
-			render.ManagerInternalTLSSecretName, monitor.PrometheusTLSSecretName, certificatemanagement.CASecretName,
+			render.ManagerInternalTLSSecretName, monitor.PrometheusServerTLSSecretName, certificatemanagement.CASecretName,
 		} {
 			if err = utils.AddSecretsWatch(managerController, secretName, namespace); err != nil {
 				return fmt.Errorf("manager-controller failed to watch the secret '%s' in '%s' namespace: %w", secretName, namespace, err)
@@ -394,7 +394,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		// any of them haven't been signed by the root CA.
 		trustedSecretNames = []string{
 			render.PacketCaptureServerCert,
-			monitor.PrometheusTLSSecretName,
+			monitor.PrometheusServerTLSSecretName,
 			relasticsearch.PublicCertSecret,
 			render.ProjectCalicoAPIServerTLSSecretName(installation.Variant),
 			render.TigeraLinseedSecret,

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -51,10 +51,10 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	rsecret "github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/monitor"
+	tigeratls "github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/test"
 )
 
@@ -215,7 +215,7 @@ var _ = Describe("Manager controller tests", func() {
 			pcapKp, err := certificateManager.GetOrCreateKeyPair(c, render.PacketCaptureServerCert, common.OperatorNamespace(), []string{render.PacketCaptureServerCert})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, pcapKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
-			promKp, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+			promKp, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusServerTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, promKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			gwKp, err := certificateManager.GetOrCreateKeyPair(c, relasticsearch.PublicCertSecret, common.OperatorNamespace(), []string{relasticsearch.PublicCertSecret})
@@ -302,7 +302,7 @@ var _ = Describe("Manager controller tests", func() {
 			dnsNames := []string{"manager.example.com", "192.168.10.22"}
 			testCA := test.MakeTestCA("manager-test")
 			userSecret, err := secret.CreateTLSSecret(
-				testCA, render.ManagerTLSSecretName, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, nil, dnsNames...)
+				testCA, render.ManagerTLSSecretName, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey, tigeratls.DefaultCertificateDuration, nil, dnsNames...)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(c.Create(ctx, userSecret)).NotTo(HaveOccurred())
 
@@ -340,7 +340,7 @@ var _ = Describe("Manager controller tests", func() {
 			dnsNames := []string{"manager.example.com", "192.168.10.22"}
 			testCA := test.MakeTestCA("manager-test")
 			userSecret, err := secret.CreateTLSSecret(
-				testCA, render.ManagerTLSSecretName, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, nil, dnsNames...)
+				testCA, render.ManagerTLSSecretName, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey, tigeratls.DefaultCertificateDuration, nil, dnsNames...)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(c.Create(ctx, userSecret)).NotTo(HaveOccurred())
 
@@ -382,7 +382,7 @@ var _ = Describe("Manager controller tests", func() {
 			dnsNames := []string{"manager.example.com", "192.168.10.22"}
 			testCA := test.MakeTestCA("manager-test")
 			customSecret, err := rsecret.CreateTLSSecret(
-				testCA, render.ManagerTLSSecretName, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey, rmeta.DefaultCertificateDuration, nil, dnsNames...)
+				testCA, render.ManagerTLSSecretName, common.OperatorNamespace(), corev1.TLSPrivateKeyKey, corev1.TLSCertKey, tigeratls.DefaultCertificateDuration, nil, dnsNames...)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Update the existing operator managed cert secret with bytes from
@@ -521,7 +521,7 @@ var _ = Describe("Manager controller tests", func() {
 			pcapKp, err := certificateManager.GetOrCreateKeyPair(c, render.PacketCaptureServerCert, common.OperatorNamespace(), []string{render.PacketCaptureServerCert})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, pcapKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
-			promKp, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusTLSSecretName})
+			promKp, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusServerTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusServerTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, promKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 			gwKp, err := certificateManager.GetOrCreateKeyPair(c, relasticsearch.PublicCertSecret, common.OperatorNamespace(), []string{relasticsearch.PublicCertSecret})

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -146,7 +146,7 @@ func add(mgr manager.Manager, c controller.Controller) error {
 	for _, secret := range []string{
 		certificatemanagement.CASecretName,
 		esmetrics.ElasticsearchMetricsServerTLSSecret,
-		monitor.PrometheusTLSSecretName,
+		monitor.PrometheusServerTLSSecretName,
 		render.FluentdPrometheusTLSSecretName,
 		render.NodePrometheusTLSServerSecret,
 		kubecontrollers.KubeControllerPrometheusTLSSecret,
@@ -262,7 +262,7 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err
 	}
-	serverTLSSecret, err := certificateManager.GetOrCreateKeyPair(r.client, monitor.PrometheusTLSSecretName, common.OperatorNamespace(), dns.GetServiceDNSNames(monitor.PrometheusServiceServiceName, common.TigeraPrometheusNamespace, r.clusterDomain))
+	serverTLSSecret, err := certificateManager.GetOrCreateKeyPair(r.client, monitor.PrometheusServerTLSSecretName, common.OperatorNamespace(), PrometheusTLSServerDNSNames(r.clusterDomain))
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating TLS certificate", err, reqLogger)
 		return reconcile.Result{}, err
@@ -413,6 +413,11 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// PrometheusTLSServerDNSNames returns all the DNS names valid for the prometheus server TLS asset.
+func PrometheusTLSServerDNSNames(clusterDomain string) []string {
+	return dns.GetServiceDNSNames(monitor.PrometheusServiceServiceName, common.TigeraPrometheusNamespace, clusterDomain)
 }
 
 //go:embed alertmanager-config.yaml

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -22,19 +22,19 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/fields"
-
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -60,6 +60,9 @@ const (
 	// This is for development and testing purposes only. Do not use this annotation
 	// for production, as this will cause problems with upgrade.
 	unsupportedIgnoreAnnotation = "unsupported.operator.tigera.io/ignore"
+	// OperatorCSRSignerName when this value is set as a signer on a CSR, the CSR controller will handle
+	// the request.
+	OperatorCSRSignerName = "tigera.io/operator-signer"
 )
 
 var (
@@ -174,6 +177,27 @@ func AddSecretWatchWithLabel(c controller.Controller, ns, label string) error {
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			_, hasLabel := e.Object.GetLabels()[label]
 			return (ns == "" || e.Object.GetNamespace() == ns) && hasLabel
+		},
+	})
+}
+
+// AddCSRWatchWithRelevancyFn adds a watch for CSRs with the given label. isRelevantFn is a function that returns true for
+// items that are relevant to the caller.
+func AddCSRWatchWithRelevancyFn(c controller.Controller, isRelevantFn func(*certificatesv1.CertificateSigningRequest) bool) error {
+	return c.Watch(&source.Kind{Type: &certificatesv1.CertificateSigningRequest{}}, &handler.EnqueueRequestForObject{}, &predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			csr, ok := e.Object.(*certificatesv1.CertificateSigningRequest)
+			return ok && isRelevantFn(csr)
+
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			csr, ok := e.ObjectNew.(*certificatesv1.CertificateSigningRequest)
+			return ok && isRelevantFn(csr)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// If a CSR is deleted, then the need for a certificate is no longer there and there is no need to sign anything.
+			// Therefore, we discard this event. It is up to the issuer to re-issue a new CSR if needed.
+			return false
 		},
 	})
 }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -60,9 +60,6 @@ const (
 	// This is for development and testing purposes only. Do not use this annotation
 	// for production, as this will cause problems with upgrade.
 	unsupportedIgnoreAnnotation = "unsupported.operator.tigera.io/ignore"
-	// OperatorCSRSignerName when this value is set as a signer on a CSR, the CSR controller will handle
-	// the request.
-	OperatorCSRSignerName = "tigera.io/operator-signer"
 )
 
 var (

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -28,14 +28,12 @@ import (
 type OSType string
 
 const (
-	DefaultCertificateDuration = 825 * 24 * time.Hour
-
 	OSTypeAny     OSType = "any"
 	OSTypeLinux   OSType = "linux"
 	OSTypeWindows OSType = "windows"
 
-	// The name prefix used for the CA issuer, which is used for self-signed
-	// certificates issued for operator-managed certificates.
+	// TigeraOperatorCAIssuerPrefix The name prefix used for the CA issuer, which is used
+	// for self-signed certificates issued for operator-managed certificates.
 	// NOTE: Do not change this field since we use this value to identify
 	// certificates managed by this operator.
 	TigeraOperatorCAIssuerPrefix = "tigera-operator-signer"

--- a/pkg/render/common/test/testing.go
+++ b/pkg/render/common/test/testing.go
@@ -237,7 +237,7 @@ func ExpectVolumeMount(vms []v1.VolumeMount, name, path string) {
 // operator secrets or secrets that are brought to the cluster by the customer.
 func CreateCertSecret(name, namespace string, dnsNames ...string) *corev1.Secret {
 	cryptoCA, _ := tls.MakeCA(rmeta.TigeraOperatorCAIssuerPrefix + "@some-hash")
-	cfg, _ := cryptoCA.MakeServerCertForDuration(sets.NewString(dnsNames...), rmeta.DefaultCertificateDuration, tls.SetServerAuth, tls.SetClientAuth)
+	cfg, _ := cryptoCA.MakeServerCertForDuration(sets.NewString(dnsNames...), tls.DefaultCertificateDuration, tls.SetServerAuth, tls.SetClientAuth)
 	keyContent, crtContent := &bytes.Buffer{}, &bytes.Buffer{}
 	_ = cfg.WriteCertConfig(crtContent, keyContent)
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -703,6 +703,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 		// Add the init container that will issue a CSR for transport and mount it in an emptyDir.
 		csrInitContainerTransport := certificatemanagement.CreateCSRInitContainer(
 			es.cfg.Installation.CertificateManagement,
+			csrVolumeNameTransport,
 			es.csrImage,
 			csrVolumeNameTransport,
 			ElasticsearchServiceName,
@@ -1326,6 +1327,7 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 		automountToken = true
 		csrInitContainer := certificatemanagement.CreateCSRInitContainer(
 			es.cfg.Installation.CertificateManagement,
+			csrVolumeNameHTTP,
 			es.csrImage,
 			csrVolumeNameHTTP,
 			ElasticsearchServiceName,

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -72,7 +72,7 @@ const (
 	PrometheusPolicyName          = networkpolicy.TigeraComponentPolicyPrefix + "prometheus"
 	PrometheusProxyPort           = 9095
 	PrometheusServiceAccountName  = "prometheus"
-	PrometheusTLSSecretName       = "calico-node-prometheus-tls"
+	PrometheusServerTLSSecretName = "calico-node-prometheus-tls"
 
 	AlertManagerPolicyName     = networkpolicy.TigeraComponentPolicyPrefix + CalicoNodeAlertmanager
 	AlertmanagerConfigSecret   = "alertmanager-calico-node-alertmanager"
@@ -482,6 +482,11 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				PodMetadata: &monitoringv1.EmbeddedObjectMetadata{
+					Labels: map[string]string{
+						"k8s-app": TigeraPrometheusObjectName,
+					},
+				},
 				Containers: []corev1.Container{
 					{
 						Name:            "authn-proxy",

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -80,7 +80,7 @@ var _ = Describe("monitor rendering tests", func() {
 		certificateManager, err := certificatemanager.Create(cli, nil, dns.DefaultClusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
 
-		prometheusKeyPair, err = certificateManager.GetOrCreateKeyPair(cli, monitor.PrometheusTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
+		prometheusKeyPair, err = certificateManager.GetOrCreateKeyPair(cli, monitor.PrometheusServerTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
 		Expect(err).NotTo(HaveOccurred())
 
 		prometheusClientKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})

--- a/pkg/tls/certificatemanagement/csr.go
+++ b/pkg/tls/certificatemanagement/csr.go
@@ -39,6 +39,7 @@ const (
 // TLS certificates. It uses the provided params and the k8s downward api to be able to specify certificate subject information.
 func CreateCSRInitContainer(
 	certificateManagement *operatorv1.CertificateManagement,
+	secretName,
 	image string,
 	mountName string,
 	commonName string,
@@ -54,6 +55,10 @@ func CreateCSRInitContainer(
 		},
 		Env: []corev1.EnvVar{
 			{Name: "CERTIFICATE_PATH", Value: "/certs-share/"},
+			// SecretName, when defined, is used as a prefix for the CSR name. This avoids CSR name clashes if the same
+			// pod issues more than one CSR. Even though the CSRs are issued and read in sequence, there are edge-cases
+			// where a pod can get stuck in init.
+			{Name: "SECRET_NAME", Value: secretName},
 			{Name: "SIGNER", Value: certificateManagement.SignerName},
 			{Name: "COMMON_NAME", Value: commonName},
 			{Name: "KEY_ALGORITHM", Value: fmt.Sprintf("%v", certificateManagement.KeyAlgorithm)},

--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -32,6 +32,7 @@ type KeyPair struct {
 	CSRImage       string
 	Name           string
 	Namespace      string
+	PrivateKey     any
 	PrivateKeyPEM  []byte
 	CertificatePEM []byte
 	ClusterDomain  string
@@ -131,6 +132,7 @@ func (k *KeyPair) VolumeMount(osType rmeta.OSType) corev1.VolumeMount {
 func (k *KeyPair) InitContainer(namespace string) corev1.Container {
 	initContainer := CreateCSRInitContainer(
 		k.CertificateManagement,
+		k.Name,
 		k.CSRImage,
 		k.GetName(),
 		k.DNSNames[0],

--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -29,9 +29,10 @@ import (
 var ErrInvalidCertNoPEMData = errors.New("cert has no PEM data")
 
 type KeyPair struct {
-	CSRImage       string
-	Name           string
-	Namespace      string
+	CSRImage  string
+	Name      string
+	Namespace string
+	// Golang's x509 package uses the 'any' type for all private and public keys. See x509.CreateCertificate() for more.
 	PrivateKey     any
 	PrivateKeyPEM  []byte
 	CertificatePEM []byte

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -14,6 +14,7 @@
 
 // tls package contains tls related helper functions related to generating and modifying certificates and private keys
 // used for tls.
+
 package tls
 
 import (
@@ -23,6 +24,8 @@ import (
 
 	"github.com/openshift/library-go/pkg/crypto"
 )
+
+const DefaultCertificateDuration = 825 * 24 * time.Hour
 
 func SetClientAuth(x *x509.Certificate) error {
 	if x.ExtKeyUsage == nil {


### PR DESCRIPTION
There will be a hard-coded finite list in the operator of service accounts and the secrets that they are allowed to make. If a CSR is issued by one of these service accounts, we will validate the contents. All other CSRs with signerName tigera.io/operator-signer will be rejected.

For now we only added the prometheus server TLS secret. But once done, all of our TLS secrets will be added this way.

The validation criteria:
- Verify that the service account is allowed to request the common name and/or SANs.
- Verify that the issuer of the CSR (the pod) indeed is the pod that belongs to the IP in the CSR. 
- Verify that the requested key ext usages are valid
- Verify that the CSR was not previously denied or failed
- Verify that the public key matches the signature on the CSR for the provider alg

Other:
- Serial number will be a random int64.
- The validity is currently fixed (825d from current time onwards).
- No info other than CN will be added to the subject of the issued cert (we don’t need it)
- Version field will be set to 3.
