### PR TITLE
[RS-1431] Allow UI admin user to create and patch webhooks-secret

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1783,6 +1783,17 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			Resources: []string{"securityeventwebhooks"},
 			Verbs:     []string{"get", "list", "update", "patch", "create", "delete"},
 		},
+		// Allow the user to create and patch webhooks-secret secret.
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"secrets",
+			},
+			ResourceNames: []string{
+				"webhooks-secret",
+			},
+			Verbs: []string{"create", "patch"},
+		},
 	}
 
 	// Privileges for lma.tigera.io have no effect on managed clusters.

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1510,6 +1510,12 @@ var (
 			Resources: []string{"securityeventwebhooks"},
 			Verbs:     []string{"get", "list", "update", "patch", "create", "delete"},
 		},
+		{
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{"webhooks-secret"},
+			Verbs:         []string{"create", "patch"},
+		},
 	}
 )
 


### PR DESCRIPTION
## Description

In our UI, we allow admin users to easily create/update/delete webhooks. When creating a Jira webhook, we store the Jira credentials they provide (email + token) into a secret. When we delete a webhook through the UI, it also cleans up the information in the secret.

In the initial [poc](https://github.com/tigera/ui-modules/pull/220), we allowed admin users to view and edit those credentials through the UI, which would require adding `create/view/update/delete` permissions for `secrets` in `tigera-netwok-admin` cluster role. This felt like too much permissions (even for admin users) so we decided to:

 - Only specify Jira credentials when creating a webhook, no way to view them ("UI" does not read secrets). If creds need to change, delete webhook and create a new one.
 - Have 1 secret that contains Jira credentials for all the webhooks of a managedcluster created through the UI, with key in secret data using format `<webhok-name>.username` 
 - Let the UI `create` the required secret when needed and `patch` the secret when creating/adding a jira webhook (update/remove secret key accordingly).


## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
