### PR TITLE
[RS-1431] Allow tigera-network-admin to create secrets

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1783,7 +1783,15 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			Resources: []string{"securityeventwebhooks"},
 			Verbs:     []string{"get", "list", "update", "patch", "create", "delete"},
 		},
-		// Allow the user to create and patch webhooks-secret secret.
+		// Allow the user to create secrets.
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"secrets",
+			},
+			Verbs: []string{"create"},
+		},
+		// Allow the user to patch webhooks-secret secret.
 		{
 			APIGroups: []string{""},
 			Resources: []string{
@@ -1792,7 +1800,7 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			ResourceNames: []string{
 				"webhooks-secret",
 			},
-			Verbs: []string{"create", "patch"},
+			Verbs: []string{"patch"},
 		},
 	}
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1511,10 +1511,15 @@ var (
 			Verbs:     []string{"get", "list", "update", "patch", "create", "delete"},
 		},
 		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"create"},
+		},
+		{
 			APIGroups:     []string{""},
 			Resources:     []string{"secrets"},
 			ResourceNames: []string{"webhooks-secret"},
-			Verbs:         []string{"create", "patch"},
+			Verbs:         []string{"patch"},
 		},
 	}
 )


### PR DESCRIPTION
## Description

This builds up on top of changes made in #3014. We want to limit patching and creating secrets to a single secret `webhooks-secret`. While this works for `patch`, it doesn't work for `create` as `create` is applied on `/secrets` resources whereas `patch` is aplied on `secrets/webhooks-secret` and the `ResourceName` parameter can be enforced.

To make this work, we now allow creating any secret while keeping the restrinction on `patch` in place.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
