### PR TITLE
Allow get managed clusters for a cluster id for tigera-linseed using …

### DIFF
--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -50,15 +50,15 @@ import (
 )
 
 const (
-	DeploymentName                = "tigera-linseed"
-	ServiceAccountName            = "tigera-linseed"
-	PodSecurityPolicyName         = "tigera-linseed"
-	PolicyName                    = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
-	PortName                      = "tigera-linseed"
-	TargetPort                    = 8444
-	Port                          = 443
-	ClusterRoleName               = "tigera-linseed"
-	ClusterRoleNameExtraRBACCloud = "tigera-linseed-impersonated"
+	DeploymentName                                  = "tigera-linseed"
+	ServiceAccountName                              = "tigera-linseed"
+	PodSecurityPolicyName                           = "tigera-linseed"
+	PolicyName                                      = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
+	PortName                                        = "tigera-linseed"
+	TargetPort                                      = 8444
+	Port                                            = 443
+	ClusterRoleName                                 = "tigera-linseed"
+	MultiTenantManagedClustersAccessClusterRoleName = "tigera-linseed-managed-cluster-access"
 )
 
 func Linseed(c *Config) render.Component {
@@ -156,7 +156,9 @@ func (l *linseed) Objects() (toCreate, toDelete []client.Object) {
 	toCreate = append(toCreate, l.linseedService())
 	toCreate = append(toCreate, l.linseedClusterRole())
 	toCreate = append(toCreate, l.linseedClusterRoleBinding(l.cfg.BindNamespaces))
-	toCreate = append(toCreate, l.extraLinseedRBACForCloud()...)
+	if l.cfg.Tenant != nil {
+		toCreate = append(toCreate, l.multiTenantManagedClustersAccess()...)
+	}
 	toCreate = append(toCreate, l.linseedServiceAccount())
 	toCreate = append(toCreate, l.linseedDeployment())
 	if l.cfg.UsePSP {
@@ -255,17 +257,11 @@ func (l *linseed) linseedClusterRoleBinding(namespaces []string) client.Object {
 	return rcomponents.ClusterRoleBinding(ClusterRoleName, ClusterRoleName, ServiceAccountName, namespaces)
 }
 
-func (l *linseed) extraLinseedRBACForCloud() []client.Object {
-	if l.cfg.Tenant == nil {
-		return nil
-	}
-
-	var extraRBAC []client.Object
-	extraRBAC = append(extraRBAC, &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ClusterRoleNameExtraRBACCloud,
-		},
+func (l *linseed) multiTenantManagedClustersAccess() []client.Object {
+	var objects []client.Object
+	objects = append(objects, &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -283,26 +279,26 @@ func (l *linseed) extraLinseedRBACForCloud() []client.Object {
 	// In a single tenant setup we want to create a cluster role that binds using service account
 	// tigera-linseed from tigera-elasticsearch namespace. In a multi-tenant setup Linseed from the tenant's
 	// namespace impersonates service tigera-linseed from tigera-elasticsearch namespace
-	extraRBAC = append(extraRBAC, &rbacv1.ClusterRoleBinding{
+	objects = append(objects, &rbacv1.ClusterRoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: ClusterRoleNameExtraRBACCloud},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     ClusterRoleNameExtraRBACCloud,
+			Name:     MultiTenantManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{
-			// requests for Linseed are done using service account tigera-linseed
-			// from tigera-elasticsearch namespace
+			// requests for Linseed to managed clusters are done using service account tigera-linseed
+			// from tigera-elasticsearch namespace regardless of tenancy mode (single tenant or multi-tenant)
 			{
 				Kind:      "ServiceAccount",
 				Name:      ServiceAccountName,
-				Namespace: "tigera-elasticsearch",
+				Namespace: render.ElasticsearchNamespace,
 			},
 		},
 	})
 
-	return extraRBAC
+	return objects
 }
 
 func (l *linseed) linseedPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -459,11 +459,11 @@ var _ = Describe("Linseed rendering tests", func() {
 			Expect(cr.Rules).To(ContainElements(expectedRules))
 		})
 
-		It("should render managed cluster permissions as part of tigera-linseed-managedclusters ClusterRole", func() {
+		It("should render managed cluster permissions as part of tigera-linseed-managed-clusters-acess ClusterRole", func() {
 			component := Linseed(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			cr := rtest.GetResource(resources, ClusterRoleNameExtraRBACCloud, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			cr := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			expectedRules := []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"projectcalico.org"},
@@ -474,9 +474,9 @@ var _ = Describe("Linseed rendering tests", func() {
 				},
 			}
 			Expect(cr.Rules).To(ContainElements(expectedRules))
-			rb := rtest.GetResource(resources, ClusterRoleNameExtraRBACCloud, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			rb := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
 			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
-			Expect(rb.RoleRef.Name).To(Equal(ClusterRoleNameExtraRBACCloud))
+			Expect(rb.RoleRef.Name).To(Equal(MultiTenantManagedClustersAccessClusterRoleName))
 			Expect(rb.Subjects).To(ContainElements([]rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",


### PR DESCRIPTION
…tigera-elasticsearch namespace

## Description

Voltron checks for access to get a managed cluster in the authentication proxy. (https://github.com/tigera/calico-private/blob/master/voltron/internal/pkg/server/server.go#L548-L554). 

In a multi-tenant environment, Linseed will send requests using impersonation headers, impersonating as tigera-linseed service account within tigera-elasticsearch namespace.

```
"ts":"2023-11-28T18:42:29.631Z","tls":{"proto":"h2","version":771,"serverName":"tigera-manager.tenant-w99surc9.svc","cipherSuite":"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},"req":{"time":"2023-11-28T18:42:29.232Z","remoteAddr":"10.117.80.213:35566","proto":"HTTP/2.0","method":"GET","host":"tigera-manager.tenant-w99surc9.svc:9443","path":"/api/v1/namespaces/tigera-fluentd/secrets/fluentd-node-tigera-linseed-token","query":"timeout=15s","xClusterID":"mihaela-test-create","userAgent":"linseed/v0.0.0 (linux/amd64) kubernetes/$Format","impersonateUser":"system:serviceaccount:tigera-elasticsearch:tigera-linseed","impersonateGroup":"system:serviceaccounts","auth":{"iss":"https://container.googleapis.com/v1/projects/tigera-cc-dev/locations/us-west1/clusters/vo4pfdmz-management","sub":"system:serviceaccount:tenant-w99surc9:tigera-linseed"}},"resp":{"status":403,"bytes":35,"duration":0.398690421,"body":"not authorized for managed cluster\n"}
```


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
