### PR TITLE
[cherry-pick][v.32] Allow linseed to query managed clusters and set REQUIRE_TENANT_CLAIM

### DIFF
--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -49,14 +49,15 @@ import (
 )
 
 const (
-	DeploymentName        = "tigera-linseed"
-	ServiceAccountName    = "tigera-linseed"
-	PodSecurityPolicyName = "tigera-linseed"
-	PolicyName            = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
-	PortName              = "tigera-linseed"
-	TargetPort            = 8444
-	Port                  = 443
-	ClusterRoleName       = "tigera-linseed"
+	DeploymentName                                  = "tigera-linseed"
+	ServiceAccountName                              = "tigera-linseed"
+	PodSecurityPolicyName                           = "tigera-linseed"
+	PolicyName                                      = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
+	PortName                                        = "tigera-linseed"
+	TargetPort                                      = 8444
+	Port                                            = 443
+	ClusterRoleName                                 = "tigera-linseed"
+	MultiTenantManagedClustersAccessClusterRoleName = "tigera-linseed-managed-cluster-access"
 )
 
 func Linseed(c *Config) render.Component {
@@ -147,6 +148,9 @@ func (l *linseed) Objects() (toCreate, toDelete []client.Object) {
 	toCreate = append(toCreate, l.linseedService())
 	toCreate = append(toCreate, l.linseedClusterRole())
 	toCreate = append(toCreate, l.linseedClusterRoleBinding(l.cfg.BindNamespaces))
+	if l.cfg.Tenant != nil {
+		toCreate = append(toCreate, l.multiTenantManagedClustersAccess()...)
+	}
 	toCreate = append(toCreate, l.linseedServiceAccount())
 	toCreate = append(toCreate, l.linseedDeployment())
 	if l.cfg.UsePSP {
@@ -236,6 +240,50 @@ func (l *linseed) linseedClusterRole() *rbacv1.ClusterRole {
 
 func (l *linseed) linseedClusterRoleBinding(namespaces []string) client.Object {
 	return rcomponents.ClusterRoleBinding(ClusterRoleName, ClusterRoleName, ServiceAccountName, namespaces)
+}
+
+func (l *linseed) multiTenantManagedClustersAccess() []client.Object {
+	var objects []client.Object
+	objects = append(objects, &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"managedclusters"},
+				Verbs: []string{
+					// The Authentication Proxy in Voltron checks if Linseed (either using impersonation headers for
+					// tigera-linseed service in tigera-elasticsearch namespace or the actual account in a single tenant
+					// setup) can get a managed clusters before sending the request down the tunnel
+					"get",
+				},
+			},
+		},
+	})
+
+	// In a single tenant setup we want to create a cluster role that binds using service account
+	// tigera-linseed from tigera-elasticsearch namespace. In a multi-tenant setup Linseed from the tenant's
+	// namespace impersonates service tigera-linseed from tigera-elasticsearch namespace
+	objects = append(objects, &rbacv1.ClusterRoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     MultiTenantManagedClustersAccessClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			// requests for Linseed to managed clusters are done using service account tigera-linseed
+			// from tigera-elasticsearch namespace regardless of tenancy mode (single tenant or multi-tenant)
+			{
+				Kind:      "ServiceAccount",
+				Name:      ServiceAccountName,
+				Namespace: render.ElasticsearchNamespace,
+			},
+		},
+	})
+
+	return objects
 }
 
 func (l *linseed) linseedPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -367,6 +367,7 @@ var _ = Describe("Linseed rendering tests", func() {
 				ESClusterConfig: esClusterConfig,
 				Namespace:       "tenant-test-tenant",
 				Tenant:          tenant,
+				BindNamespaces:  []string{tenant.Namespace, "tigera-elasticsearch"},
 			}
 		})
 
@@ -394,6 +395,33 @@ var _ = Describe("Linseed rendering tests", func() {
 				},
 			}
 			Expect(cr.Rules).To(ContainElements(expectedRules))
+		})
+
+		It("should render managed cluster permissions as part of tigera-linseed-managed-clusters-acess ClusterRole", func() {
+			component := Linseed(cfg)
+			Expect(component).NotTo(BeNil())
+			resources, _ := component.Objects()
+			cr := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			expectedRules := []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"projectcalico.org"},
+					Resources: []string{"managedclusters"},
+					Verbs: []string{
+						"get",
+					},
+				},
+			}
+			Expect(cr.Rules).To(ContainElements(expectedRules))
+			rb := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+			Expect(rb.RoleRef.Name).To(Equal(MultiTenantManagedClustersAccessClusterRoleName))
+			Expect(rb.Subjects).To(ContainElements([]rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      ServiceAccountName,
+					Namespace: "tigera-elasticsearch",
+				},
+			}))
 		})
 
 		It("should render multi-tenant environment variables", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -536,6 +536,9 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_TENANT_NAMESPACE", Value: c.cfg.Tenant.Namespace})
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_TENANT_ID", Value: c.cfg.Tenant.Spec.ID})
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc", c.cfg.Tenant.Namespace)})
+		// Always configure the Tenant Claim for all multi-tenancy setups (single tenant and multi tenant)
+		// This will check the tenant claim when a Bearer token is presented to Voltron
+		env = append(env, corev1.EnvVar{Name: "VOLTRON_REQUIRE_TENANT_CLAIM", Value: "true"})
 	}
 
 	return corev1.Container{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -990,6 +990,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			esProxyEnv := d.Spec.Template.Spec.Containers[1].Env
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_TENANT_NAMESPACE", Value: tenantANamespace}))
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_TENANT_ID", Value: "tenant-a"}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_REQUIRE_TENANT_CLAIM", Value: "true"}))
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc", tenantANamespace)}))
 			Expect(esProxyEnv).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_URL", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", tenantANamespace)}))
 		})


### PR DESCRIPTION
## Description

Cherry-pick https://github.com/tigera/operator/pull/3020 and https://github.com/tigera/operator/pull/3023

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
