### PR TITLE
Change rollout settings for Fluentd to speed up rollout.

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -458,7 +458,8 @@ func (c *fluentdComponent) packetCaptureApiRoleBinding() *rbacv1.RoleBinding {
 // managerDeployment creates a deployment for the Tigera Secure manager component.
 func (c *fluentdComponent) daemonset() *appsv1.DaemonSet {
 	var terminationGracePeriod int64 = 0
-	maxUnavailable := intstr.FromInt(1)
+	// It is not required that Fluentd runs at all times. It is able to catch up from temporary downtime.
+	maxUnavailable := intstr.FromString("100%")
 
 	annots := c.cfg.TrustedBundle.HashAnnotations()
 


### PR DESCRIPTION
Fluentd takes ~1m to boot. With the old settings, a rollout of fluentd on a large cluster can take very long, while there is no need for fluentd to be available.

```
tigera-fluentd                 fluentd-node-nlf7f                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-r22cf                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-lx65p                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-x6b4f                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-nlf7f                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-r22cf                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-lx65p                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-x6b4f                              1/1     Terminating       8 (24m ago)     15d
tigera-fluentd                 fluentd-node-9j85c                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-rgcpr                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-x5hwr                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-9j85c                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-rgcpr                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-tpms6                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-x5hwr                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-tpms6                              0/1     Pending           0               0s
tigera-fluentd                 fluentd-node-9j85c                              0/1     ContainerCreating   0               0s
tigera-fluentd                 fluentd-node-rgcpr                              0/1     ContainerCreating   0               0s
tigera-fluentd                 fluentd-node-x5hwr                              0/1     ContainerCreating   0               1s
tigera-fluentd                 fluentd-node-tpms6                              0/1     ContainerCreating   0               1s
tigera-fluentd                 fluentd-node-9j85c                              0/1     ContainerCreating   0               1s
tigera-fluentd                 fluentd-node-rgcpr                              0/1     ContainerCreating   0               1s
tigera-fluentd                 fluentd-node-x5hwr                              0/1     ContainerCreating   0               1s
...
tigera-fluentd                 fluentd-node-s7cr8                              0/1     Running     0               45s
tigera-fluentd                 fluentd-node-tzwwh                              0/1     Running     0               45s
tigera-fluentd                 fluentd-node-v5qcs                              0/1     Running     0               45s
tigera-fluentd                 fluentd-node-wqjj9                              0/1     Running     0               45s
...
```