### PR TITLE
Fix! Delete Rolebind from toDelete objects

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -309,7 +309,7 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	if c.cfg.ManagedCluster {
 		objs = append(objs, c.externalLinseedRoleBinding())
 	} else {
-		toDelete = append(objs, c.externalLinseedRoleBinding())
+		toDelete = append(toDelete, c.externalLinseedRoleBinding())
 	}
 
 	// Windows PSP does not support allowedHostPaths yet.


### PR DESCRIPTION
## Description

Deleting rolebinding together with objects toDelete

Error logs:
```
{"level":"error","ts":"2023-12-01T22:29:35Z","logger":"controller_logcollector","msg":"Error creating / updating resource","Request.Namespace":"","Request.Name":"ip-192-168-0-60.us-west-2.compute.internal","reason":"ResourceUpdateError","error":"networkpolicies.projectcalico.org \"allow-tigera.allow-fluentd-node\" is forbidden: unable to create new content in namespace tigera-fluentd because it is being terminated","stacktrace":"github.com/tigera/operator/pkg/controller/status.(*statusManager).SetDegraded\n\t/go/src/github.com/tigera/operator/pkg/controller/status/status.go:356\ngithub.com/tigera/operator/pkg/controller/logcollector.(*ReconcileLogCollector).Reconcile\n\t/go/src/github.com/tigera/operator/pkg/controller/logcollector/logcollector_controller.go:604\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235"}
```


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
