### PR TITLE
Change rollout settings for Fluentd to speed up rollout, while avoidi…

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -487,8 +487,9 @@ func (c *fluentdComponent) packetCaptureApiRoleBinding() *rbacv1.RoleBinding {
 // managerDeployment creates a deployment for the Tigera Secure manager component.
 func (c *fluentdComponent) daemonset() *appsv1.DaemonSet {
 	var terminationGracePeriod int64 = 0
-	// It is not required that Fluentd runs at all times. It is able to catch up from temporary downtime.
-	maxUnavailable := intstr.FromString("100%")
+	// The rationale for this setting is that while there is no need for fluentd to be available, we want to avoid
+	// potentially negative consequences of an immediate roll-out on huge clusters.
+	maxUnavailable := intstr.FromInt(10)
 
 	annots := c.cfg.TrustedBundle.HashAnnotations()
 


### PR DESCRIPTION
…ng too much contention on huge clusters.
