### PR TITLE
Cherry-pick #3018 Add Linseed RBAC,envvars for eks log forwarding

### DIFF
--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -571,33 +571,28 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 	}
 	// Render the fluentd component for Linux
 	comp := render.Fluentd(fluentdCfg)
-	components := []render.Component{
-		comp,
-		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       render.LogCollectorNamespace,
-			ServiceAccounts: []string{render.FluentdNodeName},
-			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
-				rcertificatemanagement.NewKeyPairOption(fluentdKeyPair, true, true),
-			},
-			TrustedBundle: trustedBundle,
-		}),
+
+	certificateComponent := rcertificatemanagement.Config{
+		Namespace:       render.LogCollectorNamespace,
+		ServiceAccounts: []string{render.FluentdNodeName},
+		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+			rcertificatemanagement.NewKeyPairOption(fluentdKeyPair, true, true),
+		},
+		TrustedBundle: trustedBundle,
 	}
 
 	if installation.KubernetesProvider == operatorv1.ProviderEKS {
 		if instance.Spec.AdditionalSources != nil {
 			if instance.Spec.AdditionalSources.EksCloudwatchLog != nil {
-				components = append(components,
-					rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-						Namespace:       render.LogCollectorNamespace,
-						ServiceAccounts: []string{render.EKSLogForwarderName},
-						KeyPairOptions: []rcertificatemanagement.KeyPairOption{
-							rcertificatemanagement.NewKeyPairOption(eksLogForwarderKeyPair, true, true),
-						},
-						TrustedBundle: trustedBundle,
-					}),
-				)
+				certificateComponent.ServiceAccounts = append(certificateComponent.ServiceAccounts, render.EKSLogForwarderName)
+				certificateComponent.KeyPairOptions = append(certificateComponent.KeyPairOptions, rcertificatemanagement.NewKeyPairOption(eksLogForwarderKeyPair, true, true))
 			}
 		}
+	}
+
+	components := []render.Component{
+		comp,
+		rcertificatemanagement.CertificateManagement(&certificateComponent),
 	}
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, comp); err != nil {

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -396,13 +396,6 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	// eksLogForwarderKeyPair is the key pair eks-log-forwarder presents to identify itself
-	eksLogForwarderKeyPair, err := certificateManager.GetOrCreateKeyPair(r.client, render.EKSLogForwarderTLSSecretName, common.OperatorNamespace(), []string{render.EKSLogForwarderTLSSecretName})
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating eks log forwarder TLS certificate", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
 	prometheusCertificate, err := certificateManager.GetCertificate(r.client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, reqLogger)
@@ -529,6 +522,7 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 	}
 
 	var eksConfig *render.EksCloudwatchLogConfig
+	var eksLogForwarderKeyPair certificatemanagement.KeyPairInterface
 	if installation.KubernetesProvider == operatorv1.ProviderEKS {
 		log.Info("Managed kubernetes EKS found, getting necessary credentials and config")
 		if instance.Spec.AdditionalSources != nil {
@@ -540,6 +534,13 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 					instance.Spec.AdditionalSources.EksCloudwatchLog.StreamPrefix)
 				if err != nil {
 					r.status.SetDegraded(operatorv1.ResourceReadError, "Error retrieving EKS Cloudwatch Logs configuration", err, reqLogger)
+					return reconcile.Result{}, err
+				}
+
+				// eksLogForwarderKeyPair is the key pair eks-log-forwarder presents to identify itself
+				eksLogForwarderKeyPair, err = certificateManager.GetOrCreateKeyPair(r.client, render.EKSLogForwarderTLSSecretName, common.OperatorNamespace(), []string{render.EKSLogForwarderTLSSecretName})
+				if err != nil {
+					r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating eks log forwarder TLS certificate", err, reqLogger)
 					return reconcile.Result{}, err
 				}
 			}
@@ -580,14 +581,23 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 			},
 			TrustedBundle: trustedBundle,
 		}),
-		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       render.LogCollectorNamespace,
-			ServiceAccounts: []string{render.EKSNodeName},
-			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
-				rcertificatemanagement.NewKeyPairOption(eksLogForwarderKeyPair, true, true),
-			},
-			TrustedBundle: trustedBundle,
-		}),
+	}
+
+	if installation.KubernetesProvider == operatorv1.ProviderEKS {
+		if instance.Spec.AdditionalSources != nil {
+			if instance.Spec.AdditionalSources.EksCloudwatchLog != nil {
+				components = append(components,
+					rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
+						Namespace:       render.LogCollectorNamespace,
+						ServiceAccounts: []string{render.EKSLogForwarderName},
+						KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+							rcertificatemanagement.NewKeyPairOption(eksLogForwarderKeyPair, true, true),
+						},
+						TrustedBundle: trustedBundle,
+					}),
+				)
+			}
+		}
 	}
 
 	if err = imageset.ApplyImageSet(ctx, r.client, variant, comp); err != nil {

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -151,6 +151,7 @@ func add(mgr manager.Manager, c controller.Controller) error {
 		render.FluentdPrometheusTLSSecretName,
 		render.NodePrometheusTLSServerSecret,
 		kubecontrollers.KubeControllerPrometheusTLSSecret,
+		render.EKSLogForwarderTLSSecretName,
 	} {
 		if err = utils.AddSecretsWatch(c, secret, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("monitor-controller failed to watch secret: %w", err)

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -1044,13 +1044,6 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 		eksCloudwatchLogCredentialHashAnnotation: rmeta.AnnotationHash(c.cfg.EKSConfig),
 	}
 
-	// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
-	// namespace. For multi-tenant management clusters, this may vary.
-	linseedNS := ElasticsearchNamespace
-	if c.cfg.Tenant.MultiTenant() {
-		linseedNS = c.cfg.Tenant.Namespace
-	}
-
 	envVars := []corev1.EnvVar{
 		// Meta flags.
 		{Name: "LOG_LEVEL", Value: "info"},
@@ -1067,16 +1060,12 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 		{Name: "AWS_ACCESS_KEY_ID", ValueFrom: secret.GetEnvVarSource(EksLogForwarderSecret, EksLogForwarderAwsId, false)},
 		{Name: "AWS_SECRET_ACCESS_KEY", ValueFrom: secret.GetEnvVarSource(EksLogForwarderSecret, EksLogForwarderAwsKey, false)},
 		{Name: "LINSEED_ENABLED", Value: "true"},
-		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, linseedNS)},
+		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain)},
 		{Name: "LINSEED_CA_PATH", Value: c.trustedBundlePath()},
 		{Name: "TLS_CRT_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountCertificateFilePath()},
 		{Name: "TLS_KEY_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountKeyFilePath()},
 		{Name: "LINSEED_TOKEN", Value: c.path(GetLinseedTokenPath(c.cfg.ManagedCluster))},
 	}
-	if c.cfg.Tenant != nil {
-		envVars = append(envVars, corev1.EnvVar{Name: "TENANT_ID", Value: c.cfg.Tenant.Spec.ID})
-	}
-
 	var eksLogForwarderReplicas int32 = 1
 
 	return &appsv1.Deployment{

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -104,7 +104,9 @@ const (
 	FluentdNodeName        = "fluentd-node"
 	fluentdNodeWindowsName = "fluentd-node-windows"
 
-	eksLogForwarderName = "eks-log-forwarder"
+	EKSNodeName                  = "eks-log-forwarder-node"
+	eksLogForwarderName          = "eks-log-forwarder"
+	EKSLogForwarderTLSSecretName = "tigera-eks-log-forwarder-tls"
 
 	PacketCaptureAPIRole        = "packetcapture-api-role"
 	PacketCaptureAPIRoleBinding = "packetcapture-api-role-binding"
@@ -120,6 +122,7 @@ var EKSLogForwarderEntityRule = networkpolicy.CreateSourceEntityRule(LogCollecto
 // Register secret/certs that need Server and Client Key usage
 func init() {
 	certkeyusage.SetCertKeyUsage(FluentdPrometheusTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
+	certkeyusage.SetCertKeyUsage(EKSLogForwarderTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
 }
 
 type FluentdFilters struct {
@@ -182,6 +185,8 @@ type FluentdConfiguration struct {
 	UsePSP bool
 	// Whether to use User provided certificate or not.
 	UseSyslogCertificate bool
+
+	EKSLogForwarderKeyPair certificatemanagement.KeyPairInterface
 }
 
 type fluentdComponent struct {
@@ -291,12 +296,12 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, c.filtersConfigMap())
 	}
 	if c.cfg.EKSConfig != nil && c.cfg.OSType == rmeta.OSTypeLinux {
+		objs = append(objs,
+			c.eksLogForwarderClusterRole(c.cfg.UsePSP),
+			c.eksLogForwarderClusterRoleBinding())
+
 		if c.cfg.UsePSP {
-			objs = append(objs,
-				c.eksLogForwarderClusterRole(),
-				c.eksLogForwarderClusterRoleBinding(),
-				c.eksLogForwarderPodSecurityPolicy(),
-			)
+			objs = append(objs, c.eksLogForwarderPodSecurityPolicy())
 		}
 		objs = append(objs, c.eksLogForwarderServiceAccount(),
 			c.eksLogForwarderSecret(),
@@ -1039,6 +1044,13 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 		eksCloudwatchLogCredentialHashAnnotation: rmeta.AnnotationHash(c.cfg.EKSConfig),
 	}
 
+	// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
+	// namespace. For multi-tenant management clusters, this may vary.
+	linseedNS := ElasticsearchNamespace
+	if c.cfg.Tenant != nil {
+		linseedNS = c.cfg.Tenant.Namespace
+	}
+
 	envVars := []corev1.EnvVar{
 		// Meta flags.
 		{Name: "LOG_LEVEL", Value: "info"},
@@ -1054,6 +1066,15 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 		{Name: "AWS_REGION", Value: c.cfg.EKSConfig.AwsRegion},
 		{Name: "AWS_ACCESS_KEY_ID", ValueFrom: secret.GetEnvVarSource(EksLogForwarderSecret, EksLogForwarderAwsId, false)},
 		{Name: "AWS_SECRET_ACCESS_KEY", ValueFrom: secret.GetEnvVarSource(EksLogForwarderSecret, EksLogForwarderAwsKey, false)},
+		{Name: "LINSEED_ENABLED", Value: "true"},
+		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, linseedNS)},
+		{Name: "LINSEED_CA_PATH", Value: c.trustedBundlePath()},
+		{Name: "TLS_CRT_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountCertificateFilePath()},
+		{Name: "TLS_KEY_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountKeyFilePath()},
+		{Name: "LINSEED_TOKEN", Value: c.path(GetLinseedTokenPath(c.cfg.ManagedCluster))},
+	}
+	if c.cfg.Tenant != nil {
+		envVars = append(envVars, corev1.EnvVar{Name: "TENANT_ID", Value: c.cfg.Tenant.Spec.ID})
 	}
 
 	var eksLogForwarderReplicas int32 = 1
@@ -1090,21 +1111,21 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 					Tolerations:        c.cfg.Installation.ControlPlaneTolerations,
 					ServiceAccountName: eksLogForwarderName,
 					ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
-					InitContainers: []corev1.Container{relasticsearch.ContainerDecorateENVVars(corev1.Container{
+					InitContainers: []corev1.Container{{
 						Name:            eksLogForwarderName + "-startup",
 						Image:           c.image,
 						Command:         []string{c.path("/bin/eks-log-forwarder-startup")},
 						Env:             envVars,
 						SecurityContext: c.securityContext(false),
 						VolumeMounts:    c.eksLogForwarderVolumeMounts(),
-					}, c.cfg.ESClusterConfig.ClusterName(), ElasticsearchEksLogForwarderUserSecret, c.cfg.ClusterDomain, c.cfg.OSType)},
-					Containers: []corev1.Container{relasticsearch.ContainerDecorateENVVars(corev1.Container{
+					}},
+					Containers: []corev1.Container{{
 						Name:            eksLogForwarderName,
 						Image:           c.image,
 						Env:             envVars,
 						SecurityContext: c.securityContext(false),
 						VolumeMounts:    c.eksLogForwarderVolumeMounts(),
-					}, c.cfg.ESClusterConfig.ClusterName(), ElasticsearchEksLogForwarderUserSecret, c.cfg.ClusterDomain, c.cfg.OSType)},
+					}},
 					Volumes: c.eksLogForwarderVolumes(),
 				},
 			},
@@ -1124,8 +1145,8 @@ func trustedBundleVolume(bundle certificatemanagement.TrustedBundle) corev1.Volu
 }
 
 func (c *fluentdComponent) eksLogForwarderVolumeMounts() []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		relasticsearch.DefaultVolumeMount(c.cfg.OSType),
+
+	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "plugin-statefile-dir",
 			MountPath: c.path("/fluentd/cloudwatch-logs/"),
@@ -1135,10 +1156,24 @@ func (c *fluentdComponent) eksLogForwarderVolumeMounts() []corev1.VolumeMount {
 			MountPath: c.path("/etc/fluentd/elastic/"),
 		},
 	}
+	volumeMounts = append(volumeMounts, c.cfg.TrustedBundle.VolumeMounts(c.SupportedOSType())...)
+	if c.cfg.EKSLogForwarderKeyPair != nil {
+		volumeMounts = append(volumeMounts, c.cfg.EKSLogForwarderKeyPair.VolumeMount(c.SupportedOSType()))
+	}
+
+	if c.cfg.ManagedCluster {
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      LinseedTokenVolumeName,
+				MountPath: c.path(LinseedVolumeMountPath),
+			})
+	}
+	return volumeMounts
 }
 
 func (c *fluentdComponent) eksLogForwarderVolumes() []corev1.Volume {
-	return []corev1.Volume{
+
+	volumes := []corev1.Volume{
 		trustedBundleVolume(c.cfg.TrustedBundle),
 		{
 			Name: "plugin-statefile-dir",
@@ -1147,6 +1182,23 @@ func (c *fluentdComponent) eksLogForwarderVolumes() []corev1.Volume {
 			},
 		},
 	}
+	if c.cfg.EKSLogForwarderKeyPair != nil {
+		volumes = append(volumes, c.cfg.EKSLogForwarderKeyPair.Volume())
+	}
+
+	if c.cfg.ManagedCluster {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: LinseedTokenVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: fmt.Sprintf(LinseedTokenSecret, eksLogForwarderName),
+						Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
+					},
+				},
+			})
+	}
+	return volumes
 }
 
 func (c *fluentdComponent) eksLogForwarderPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
@@ -1176,22 +1228,45 @@ func (c *fluentdComponent) eksLogForwarderClusterRoleBinding() *rbacv1.ClusterRo
 	}
 }
 
-func (c *fluentdComponent) eksLogForwarderClusterRole() *rbacv1.ClusterRole {
+func (c *fluentdComponent) eksLogForwarderClusterRole(usePSP bool) *rbacv1.ClusterRole {
+
+	rules := []rbacv1.PolicyRule{
+		{
+			// Add read access to Linseed APIs.
+			APIGroups: []string{"linseed.tigera.io"},
+			Resources: []string{
+				"auditlogs",
+			},
+			Verbs: []string{"get"},
+		},
+		{
+			// Add write access to Linseed APIs to flush eks kube audit logs.
+			APIGroups: []string{"linseed.tigera.io"},
+			Resources: []string{
+				"kube_auditlogs",
+			},
+			Verbs: []string{"create"},
+		}}
+
+	if usePSP {
+		rules = append(rules, rbacv1.PolicyRule{
+
+			// Allow access to the pod security policy in case this is enforced on the cluster
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{eksLogForwarderName},
+		})
+	}
+
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: eksLogForwarderName,
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				// Allow access to the pod security policy in case this is enforced on the cluster
-				APIGroups:     []string{"policy"},
-				Resources:     []string{"podsecuritypolicies"},
-				Verbs:         []string{"use"},
-				ResourceNames: []string{eksLogForwarderName},
-			},
-		},
+		Rules: rules,
 	}
+
 }
 
 func (c *fluentdComponent) allowTigeraPolicy() *v3.NetworkPolicy {

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -297,7 +297,7 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	}
 	if c.cfg.EKSConfig != nil && c.cfg.OSType == rmeta.OSTypeLinux {
 		objs = append(objs,
-			c.eksLogForwarderClusterRole(c.cfg.UsePSP),
+			c.eksLogForwarderClusterRole(),
 			c.eksLogForwarderClusterRoleBinding())
 
 		if c.cfg.UsePSP {
@@ -1047,7 +1047,7 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 	// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
 	// namespace. For multi-tenant management clusters, this may vary.
 	linseedNS := ElasticsearchNamespace
-	if c.cfg.Tenant != nil {
+	if c.cfg.Tenant.MultiTenant() {
 		linseedNS = c.cfg.Tenant.Namespace
 	}
 
@@ -1228,7 +1228,7 @@ func (c *fluentdComponent) eksLogForwarderClusterRoleBinding() *rbacv1.ClusterRo
 	}
 }
 
-func (c *fluentdComponent) eksLogForwarderClusterRole(usePSP bool) *rbacv1.ClusterRole {
+func (c *fluentdComponent) eksLogForwarderClusterRole() *rbacv1.ClusterRole {
 
 	rules := []rbacv1.PolicyRule{
 		{
@@ -1248,7 +1248,7 @@ func (c *fluentdComponent) eksLogForwarderClusterRole(usePSP bool) *rbacv1.Clust
 			Verbs: []string{"create"},
 		}}
 
-	if usePSP {
+	if c.cfg.UsePSP {
 		rules = append(rules, rbacv1.PolicyRule{
 
 			// Allow access to the pod security policy in case this is enforced on the cluster


### PR DESCRIPTION
operator: https://github.com/tigera/operator/pull/3039
calico-private:https://github.com/tigera/calico-private/pull/6977 
fluent-docker: https://github.com/tigera/fluentd-docker/pull/407

Master PRs:

Related PR:
fluentd-docker: https://github.com/tigera/fluentd-docker/pull/402

For token generation:
Linseed:https://github.com/tigera/calico-private/pull/6946

RBAC, env variable to connect to linseed
https://github.com/tigera/operator/pull/3018

Tested in 3.17 eks cluster:
![image](https://github.com/tigera/operator/assets/102720382/101bb700-f2a9-4dc9-a95d-2085cdead799)


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
