### PR TITLE
EV-4413 configure Linux OS affinity for policy-recommendation

### DIFF
--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -181,6 +181,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 			res := test.GetResource(c, &d)
 			Expect(res).To(BeNil())
 			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(d.Spec.Template.Spec.NodeSelector).To((Equal(map[string]string{"kubernetes.io/os": "linux"})))
 			controller := test.GetContainer(d.Spec.Template.Spec.Containers, "policy-recommendation-controller")
 			Expect(controller).ToNot(BeNil())
 			Expect(controller.Image).To(Equal(fmt.Sprintf("some.registry.org/%s:%s",

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -100,7 +100,7 @@ func (pr *policyRecommendationComponent) ResolveImages(is *operatorv1.ImageSet) 
 }
 
 func (pr *policyRecommendationComponent) SupportedOSType() rmeta.OSType {
-	return rmeta.OSTypeAny
+	return rmeta.OSTypeLinux
 }
 
 func (pr *policyRecommendationComponent) Objects() ([]client.Object, []client.Object) {


### PR DESCRIPTION

```
vara@vara:~/bzprofiles/Clusters/tc_windows$ k get deployment.apps/tigera-policy-recommendation -n tigera-policy-recommendation -o yaml|grep -A 3 -B 3 nodeSelector
      dnsPolicy: ClusterFirst
      imagePullSecrets:
      - name: tigera-pull-secret
      nodeSelector:
        kubernetes.io/os: linux
      restartPolicy: Always
      schedulerName: default-scheduler

```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
