### PR TITLE
Configure manager to properly impersonate when communicating with managed clusters

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -620,6 +620,12 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	if tenant.MultiTenant() {
+		// In a multi-tenant environment, we need to grant access to the canonical tigera-manager:tigera-manager service account
+		// so that es-proxy passes Voltron's authorization checks when accessing managed clusters. This is because per-tenant manager instances
+		// impersonate as this serviceaccount on these flows.
+		namespaces = append(namespaces, render.ManagerNamespace)
+	}
 
 	managerCfg := &render.ManagerConfiguration{
 		KeyValidatorConfig:      keyValidatorConfig,

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -1141,6 +1141,12 @@ var _ = Describe("Manager controller tests", func() {
 						Namespace: tenantBNamespace,
 					},
 				}
+				clusterRoleBinding := rbacv1.ClusterRoleBinding{
+					TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: render.ManagerClusterRoleBinding,
+					},
+				}
 
 				// We called Reconcile without specifying a namespace, so neither of these namespaced deployments should
 				// exist yet
@@ -1183,6 +1189,12 @@ var _ = Describe("Manager controller tests", func() {
 
 				err = test.GetResource(c, &tenantBDeployment)
 				Expect(kerror.IsNotFound(err)).Should(BeFalse())
+
+				// Ensure a cluster role binding was created that binds both tenants, as well as the
+				// canonical manager service account.
+				err = test.GetResource(c, &clusterRoleBinding)
+				Expect(kerror.IsNotFound(err)).Should(BeFalse())
+				Expect(clusterRoleBinding.Subjects).To(HaveLen(3))
 			})
 		})
 	})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -587,6 +587,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 		if c.cfg.Tenant.MultiTenant() {
 			// This cluster supports multiple tenants. Point the manager at the correct Linseed instance for this tenant.
 			env = append(env, corev1.EnvVar{Name: "LINSEED_URL", Value: fmt.Sprintf("https://tigera-linseed.%s.svc", c.cfg.Namespace)})
+			env = append(env, corev1.EnvVar{Name: "TENANT_NAMESPACE", Value: c.cfg.Namespace})
 		}
 	}
 

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -994,6 +994,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_REQUIRE_TENANT_CLAIM", Value: "true"}))
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc", tenantANamespace)}))
 			Expect(esProxyEnv).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_URL", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", tenantANamespace)}))
+			Expect(esProxyEnv).To(ContainElement(corev1.EnvVar{Name: "TENANT_ID", Value: "tenant-a"}))
+			Expect(esProxyEnv).To(ContainElement(corev1.EnvVar{Name: "TENANT_NAMESPACE", Value: tenantANamespace}))
 		})
 
 		It("should not install UISettings / UISettingsGroups", func() {
@@ -1049,11 +1051,15 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_TENANT_ID", Value: "tenant-a"}))
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_REQUIRE_TENANT_CLAIM", Value: "true"}))
 			Expect(esProxyEnv).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_URL", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", render.ManagerNamespace)}))
+			Expect(esProxyEnv).To(ContainElement(corev1.EnvVar{Name: "TENANT_ID", Value: "tenant-a"}))
 
 			// Make sure we don't render multi-tenant environment variables
 			for _, env := range envs {
 				Expect(env.Name).NotTo(Equal("VOLTRON_TENANT_NAMESPACE"))
 				Expect(env.Name).NotTo(Equal("VOLTRON_LINSEED_ENDPOINT"))
+			}
+			for _, env := range esProxyEnv {
+				Expect(env.Name).NotTo(Equal("TENANT_NAMESPACE"))
 			}
 		})
 	})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

tigera-manager needs to be configured with a tenant namespace so that it
can query managed clusters properly in a multi-tenant environment, and
to indicate that it should be using impersonation when talking to
managed clusters via Voltron.

In order to enable that flow, we must also grant
`tigera-manager:tigera-manager` permissions to "get" managed clusters 
in order to pass Voltron's authorization checks.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.