### PR TITLE
PolicyRecommendation needs to access resource within a tenant namespace

### DIFF
--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -335,12 +335,12 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, policyRecommendation)
 
 	// Determine the namespaces to which we must bind the cluster role.
-	var bindNamespaces = []string{ResourceName}
-	if tenant.MultiTenant() {
-		bindNamespaces, err = helper.TenantNamespaces(r.client)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
+	// For multi-tenant, the cluster role will be bind to the service account in the tenant namespace
+	// For single-tenant or zero-tenant, the cluster role will be bind to the service account in the tigera-policy-recommendation
+	// namespace
+	bindNamespaces, err := helper.TenantNamespaces(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
 	logc.V(3).Info("rendering components")

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -334,16 +334,23 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, policyRecommendation)
 
+	// Determine the namespaces to which we must bind the cluster role.
+	bindNamespaces, err := helper.TenantNamespaces(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	logc.V(3).Info("rendering components")
 	policyRecommendationCfg := &render.PolicyRecommendationConfiguration{
-		ClusterDomain:  r.clusterDomain,
-		Installation:   installation,
-		ManagedCluster: isManagedCluster,
-		PullSecrets:    pullSecrets,
-		Openshift:      r.provider == operatorv1.ProviderOpenShift,
-		UsePSP:         r.usePSP,
-		Namespace:      helper.InstallNamespace(),
-		Tenant:         tenant,
+		ClusterDomain:     r.clusterDomain,
+		Installation:      installation,
+		ManagedCluster:    isManagedCluster,
+		PullSecrets:       pullSecrets,
+		Openshift:         r.provider == operatorv1.ProviderOpenShift,
+		UsePSP:            r.usePSP,
+		Namespace:         helper.InstallNamespace(),
+		Tenant:            tenant,
+		BindingNamespaces: bindNamespaces,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -335,9 +335,12 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, policyRecommendation)
 
 	// Determine the namespaces to which we must bind the cluster role.
-	bindNamespaces, err := helper.TenantNamespaces(r.client)
-	if err != nil {
-		return reconcile.Result{}, err
+	var bindNamespaces = []string{ResourceName}
+	if tenant.MultiTenant() {
+		bindNamespaces, err = helper.TenantNamespaces(r.client)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	logc.V(3).Info("rendering components")

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tigera/operator/pkg/render"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -257,7 +255,7 @@ func (h *NetworkPolicyHelper) ManagerSourceEntityRule() v3.EntityRule {
 }
 
 func (h *NetworkPolicyHelper) PolicyRecommendationSourceEntityRule() v3.EntityRule {
-	return CreateSourceEntityRule(h.namespace(render.PolicyRecommendationNamespace), render.PolicyRecommendationName)
+	return CreateSourceEntityRule(h.namespace("tigera-policy-recommendation"), "tigera-policy-recommendation")
 }
 
 const PrometheusSelector = "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')"

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tigera/operator/pkg/render"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -252,6 +254,10 @@ func (h *NetworkPolicyHelper) ManagerEntityRule() v3.EntityRule {
 
 func (h *NetworkPolicyHelper) ManagerSourceEntityRule() v3.EntityRule {
 	return CreateSourceEntityRule(h.namespace("tigera-manager"), "tigera-manager")
+}
+
+func (h *NetworkPolicyHelper) PolicyRecommendationSourceEntityRule() v3.EntityRule {
+	return CreateSourceEntityRule(h.namespace(render.PolicyRecommendationNamespace), render.PolicyRecommendationName)
 }
 
 const PrometheusSelector = "(app == 'prometheus' && prometheus == 'calico-node-prometheus') || (app.kubernetes.io/name == 'prometheus' && prometheus == 'calico-node-prometheus')"

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -656,13 +656,11 @@ func (c *fluentdComponent) metricsService() *corev1.Service {
 }
 
 func (c *fluentdComponent) envvars() []corev1.EnvVar {
-	// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
-	// namespace. For multi-tenant management clusters, this may vary.
-	linseedNS := LinseedNamespace(c.cfg.Tenant)
-
 	envs := []corev1.EnvVar{
 		{Name: "LINSEED_ENABLED", Value: "true"},
-		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, linseedNS)},
+		// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
+		// namespace. For multi-tenant management clusters, this may vary.
+		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant))},
 		{Name: "LINSEED_CA_PATH", Value: c.trustedBundlePath()},
 		{Name: "TLS_KEY_PATH", Value: c.keyPath()},
 		{Name: "TLS_CRT_PATH", Value: c.certPath()},
@@ -1058,10 +1056,6 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 		eksCloudwatchLogCredentialHashAnnotation: rmeta.AnnotationHash(c.cfg.EKSConfig),
 	}
 
-	// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
-	// namespace. For multi-tenant management clusters, this may vary.
-	linseedNS := LinseedNamespace(c.cfg.Tenant)
-
 	envVars := []corev1.EnvVar{
 		// Meta flags.
 		{Name: "LOG_LEVEL", Value: "info"},
@@ -1078,7 +1072,9 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 		{Name: "AWS_ACCESS_KEY_ID", ValueFrom: secret.GetEnvVarSource(EksLogForwarderSecret, EksLogForwarderAwsId, false)},
 		{Name: "AWS_SECRET_ACCESS_KEY", ValueFrom: secret.GetEnvVarSource(EksLogForwarderSecret, EksLogForwarderAwsKey, false)},
 		{Name: "LINSEED_ENABLED", Value: "true"},
-		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, linseedNS)},
+		// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
+		// namespace. For multi-tenant management clusters, this may vary.
+		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant))},
 		{Name: "LINSEED_CA_PATH", Value: c.trustedBundlePath()},
 		{Name: "TLS_CRT_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountCertificateFilePath()},
 		{Name: "TLS_KEY_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountKeyFilePath()},

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -658,10 +658,7 @@ func (c *fluentdComponent) metricsService() *corev1.Service {
 func (c *fluentdComponent) envvars() []corev1.EnvVar {
 	// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
 	// namespace. For multi-tenant management clusters, this may vary.
-	linseedNS := ElasticsearchNamespace
-	if c.cfg.Tenant.MultiTenant() {
-		linseedNS = c.cfg.Tenant.Namespace
-	}
+	linseedNS := LinseedNamespace(c.cfg.Tenant)
 
 	envs := []corev1.EnvVar{
 		{Name: "LINSEED_ENABLED", Value: "true"},
@@ -1063,10 +1060,7 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 
 	// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
 	// namespace. For multi-tenant management clusters, this may vary.
-	linseedNS := ElasticsearchNamespace
-	if c.cfg.Tenant.MultiTenant() {
-		linseedNS = c.cfg.Tenant.Namespace
-	}
+	linseedNS := LinseedNamespace(c.cfg.Tenant)
 
 	envVars := []corev1.EnvVar{
 		// Meta flags.

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -652,7 +652,7 @@ func (l *linseed) linseedAllowTigeraPolicy() *v3.NetworkPolicy {
 		{
 			Action:      v3.Allow,
 			Protocol:    &networkpolicy.TCPProtocol,
-			Source:      render.PolicyRecommendationEntityRule,
+			Source:      networkpolicy.Helper(l.cfg.Tenant.MultiTenant(), l.cfg.Namespace).PolicyRecommendationSourceEntityRule(),
 			Destination: linseedIngressDestinationEntityRule,
 		},
 	}

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -684,3 +684,13 @@ func (l *linseed) linseedAllowTigeraPolicy() *v3.NetworkPolicy {
 		},
 	}
 }
+
+// LinseedNamespace determine the namespace in which Linseed is running.
+// For management and standalone clusters, this is always the tigera-elasticsearch
+// namespace. For multi-tenant management clusters, this is the tenant namespace
+func LinseedNamespace(tenant *operatorv1.Tenant) string {
+	if tenant.MultiTenant() {
+		return tenant.Namespace
+	}
+	return "tigera-elasticsearch"
+}

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -396,8 +396,8 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 		envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_EXPECTED_TENANT_ID", Value: l.cfg.Tenant.Spec.ID})
 
 		if l.cfg.Tenant.MultiTenant() {
-			// For clusters shared between muliple tenants, we need to configure Linseed with the correct namespace information for its tenant.
-			envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", l.cfg.Tenant.Namespace)})
+			// For clusters shared between multiple tenants, we need to configure Linseed with the correct namespace information for its tenant.
+			envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: render.ManagerService(l.cfg.Tenant)})
 			envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_TENANT_NAMESPACE", Value: l.cfg.Tenant.Namespace})
 
 			// We also use shared indices for multi-tenant clusters.

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -55,8 +55,6 @@ const (
 	PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName = "tigera-policy-recommendation-managed-cluster-access"
 )
 
-var PolicyRecommendationEntityRule = networkpolicy.CreateSourceEntityRule(PolicyRecommendationNamespace, PolicyRecommendationName)
-
 // Register secret/certs that need Server and Client Key usage
 func init() {
 	certkeyusage.SetCertKeyUsage(PolicyRecommendationTLSSecretName, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth})
@@ -260,8 +258,9 @@ func (pr *policyRecommendationComponent) multiTenantManagedClustersAccess() []cl
 	})
 
 	// In a single tenant setup we want to create a cluster role that binds using service account
-	// tigera-linseed from tigera-elasticsearch namespace. In a multi-tenant setup Linseed from the tenant's
-	// namespace impersonates service tigera-linseed from tigera-elasticsearch namespace
+	// tigera-policy-recommendation from tigera-policy-recommendation namespace. In a multi-tenant setup
+	// PolicyRecommendation Controller from the tenant's namespace impersonates service tigera-policy-recommendation
+	// from tigera-policy-recommendation namespace
 	objects = append(objects, &rbacv1.ClusterRoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName},

--- a/pkg/render/utils.go
+++ b/pkg/render/utils.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	"fmt"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+)
+
+// LinseedNamespace determine the namespace in which Linseed is running.
+// For management and standalone clusters, this is always the tigera-elasticsearch
+// namespace. For multi-tenant management clusters, this is the tenant namespace
+func LinseedNamespace(tenant *operatorv1.Tenant) string {
+	if tenant.MultiTenant() {
+		return tenant.Namespace
+	}
+	return ElasticsearchNamespace
+}
+
+// ManagerService determine the name of the tigera manager service.
+// For management and standalone clusters, this is always the tigera-manager.tigera-manager
+// namespace. For multi-tenant management clusters, this is a service that resides within the
+// tenant namespace
+func ManagerService(tenant *operatorv1.Tenant) string {
+	if tenant.MultiTenant() {
+		return fmt.Sprintf("https://tigera-manager.%s.svc:9443", tenant.Namespace)
+	}
+	return fmt.Sprintf("https://tigera-manager.%s.svc:9443", ManagerNamespace)
+}


### PR DESCRIPTION
## Description

Enable access per tenant for PolicyRecommendation:
- Access per tenant Linseed (use the tenant namespace service and modify networkpolicy to access resources in the tenant namespace)
- Access per tenant Manager (use the tenant namespace service and modify networkpolicy to access resources in the tenant namespace)
- Bind RBAC using the tenant service account
- Add impersonation rights for multi-tenant
- Allow to get managed cluster in from tigera-policy-recommendation in a multi-tenant environment

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
