### PR TITLE
[RS-1574] Linseed misconfiguration for Webhooks in MCM configuration

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -793,7 +793,15 @@ func (c *intrusionDetectionComponent) webhooksControllerContainer() corev1.Conta
 
 	volumeMounts := c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType())
 	volumeMounts = append(volumeMounts, c.cfg.IntrusionDetectionCertSecret.VolumeMount(c.SupportedOSType()))
+
+	// additional settings required for the managed cluster:
 	if c.cfg.ManagedCluster {
+		envVars = append(envVars,
+			corev1.EnvVar{
+				Name:  "LINSEED_CLUSTER",
+				Value: c.cfg.ESClusterConfig.ClusterName(),
+			},
+		)
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
 				Name:      LinseedTokenVolumeName,

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -789,19 +789,15 @@ func (c *intrusionDetectionComponent) webhooksControllerContainer() corev1.Conta
 			Name:  "LINSEED_TOKEN",
 			Value: GetLinseedTokenPath(c.cfg.ManagedCluster),
 		},
+		{
+			Name:  "LINSEED_CLUSTER",
+			Value: c.cfg.ESClusterConfig.ClusterName(),
+		},
 	}
 
 	volumeMounts := c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType())
 	volumeMounts = append(volumeMounts, c.cfg.IntrusionDetectionCertSecret.VolumeMount(c.SupportedOSType()))
-
-	// additional settings required for the managed cluster:
 	if c.cfg.ManagedCluster {
-		envVars = append(envVars,
-			corev1.EnvVar{
-				Name:  "LINSEED_CLUSTER",
-				Value: c.cfg.ESClusterConfig.ClusterName(),
-			},
-		)
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
 				Name:      LinseedTokenVolumeName,


### PR DESCRIPTION
This PR fixes the issue with missing `LINSEED_CLUSTER` environment variable set for the `webhooks-processor` in the IDC deployment for managed clusters.

Original Jira ticket + before/after fix details: https://tigera.atlassian.net/browse/RS-1574