### PR TITLE
add unit testing for WAF render

### DIFF
--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -33,7 +33,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -419,19 +418,14 @@ func (r *ReconcileApplicationLayer) getModSecurityRuleSet(ctx context.Context) (
 }
 
 func getDefaultCoreRuleset(ctx context.Context) (*corev1.ConfigMap, error) {
-	data, err := embed.AsMap()
+	ruleset, err := embed.AsConfigMap(
+		applicationlayer.ModSecurityRulesetConfigMapName,
+		common.OperatorNamespace(),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	ruleset := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      applicationlayer.ModSecurityRulesetConfigMapName,
-			Namespace: common.OperatorNamespace(),
-		},
-		Data: data,
-	}
 	return ruleset, nil
 }
 

--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -303,8 +303,8 @@ func (c *component) containers() []corev1.Container {
 				"--waf-ruleset-base-dir", ModSecurityRulesetVolumePath,
 				"--waf-directive", "Include modsecdefault.conf",
 				"--waf-directive", "Include crs-setup.conf",
+				"--waf-directive", "Include REQUEST-*.conf",
 				"--waf-directive", "Include tigera.conf",
-				"--waf-directive", "Include rules/*.conf",
 			)
 			volMounts = append(
 				volMounts,

--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -303,7 +303,7 @@ func (c *component) containers() []corev1.Container {
 				"--waf-ruleset-base-dir", ModSecurityRulesetVolumePath,
 				"--waf-directive", "Include modsecdefault.conf",
 				"--waf-directive", "Include crs-setup.conf",
-				"--waf-directive", "Include REQUEST-*.conf",
+				"--waf-directive", "Include rules/*.conf",
 				"--waf-directive", "Include tigera.conf",
 			)
 			volMounts = append(

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -564,7 +564,7 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 			"--waf-ruleset-base-dir", applicationlayer.ModSecurityRulesetVolumePath,
 			"--waf-directive", "Include modsecdefault.conf",
 			"--waf-directive", "Include crs-setup.conf",
-			"--waf-directive", "Include REQUEST-*.conf",
+			"--waf-directive", "Include rules/*.conf",
 			"--waf-directive", "Include tigera.conf",
 		}
 		for _, element := range expectedDikastesArgs {

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -444,7 +444,7 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
 		for i := range expectedResources {
-			rtest.ExpectResource(resources[i], resources)
+			ExpectWithOffset(1, rtest.ExpectResource(resources[i], resources)).ShouldNot(HaveOccurred())
 		}
 
 		ds := rtest.GetResource(resources, applicationlayer.ApplicationLayerDaemonsetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -15,6 +15,8 @@
 package applicationlayer_test
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -25,6 +27,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render/applicationlayer"
+	"github.com/tigera/operator/pkg/render/applicationlayer/embed"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 )
@@ -404,6 +407,178 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		expectedDikastesVolMounts := []corev1.VolumeMount{
 			{Name: applicationlayer.DikastesSyncVolumeName, MountPath: "/var/run/dikastes"},
 			{Name: applicationlayer.FelixSync, MountPath: "/var/run/felix"},
+		}
+		Expect(len(dikastesVolMounts)).To(Equal(len(expectedDikastesVolMounts)))
+		for _, expected := range expectedDikastesVolMounts {
+			Expect(dikastesVolMounts).To(ContainElement(expected))
+		}
+	})
+
+	It("should render with default l7 WAF configuration", func() {
+		expectedResources := []struct {
+			name    string
+			ns      string
+			group   string
+			version string
+			kind    string
+		}{
+			{name: applicationlayer.APLName, ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
+			{name: applicationlayer.ModSecurityRulesetConfigMapName, ns: common.CalicoNamespace, group: "", version: "v1", kind: "ConfigMap"},
+			{name: applicationlayer.EnvoyConfigMapName, ns: common.CalicoNamespace, group: "", version: "v1", kind: "ConfigMap"},
+			{name: applicationlayer.ApplicationLayerDaemonsetName, ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
+		}
+		// Should render the correct resources.
+		cm, err := embed.AsConfigMap(
+			applicationlayer.ModSecurityRulesetConfigMapName,
+			common.OperatorNamespace(),
+		)
+		Expect(err).To(BeNil())
+		component := applicationlayer.ApplicationLayer(&applicationlayer.Config{
+			PullSecrets:          nil,
+			Installation:         installation,
+			OsType:               rmeta.OSTypeLinux,
+			WAFEnabled:           true,
+			ModSecurityConfigMap: cm,
+		})
+		resources, _ := component.Objects()
+		Expect(len(resources)).To(Equal(len(expectedResources)))
+
+		i := 0
+		for _, expectedRes := range expectedResources {
+			rtest.ExpectResourceTypeAndObjectMetadata(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
+			i++
+		}
+
+		ds := rtest.GetResource(resources, applicationlayer.ApplicationLayerDaemonsetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+
+		// Check rendering of daemonset.
+		Expect(ds.Spec.Template.Spec.HostNetwork).To(BeTrue())
+		Expect(ds.Spec.Template.Spec.HostIPC).To(BeTrue())
+		Expect(ds.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirstWithHostNet))
+		Expect(len(ds.Spec.Template.Spec.Containers)).To(Equal(2))
+		Expect(len(ds.Spec.Template.Spec.Tolerations)).To(Equal(3))
+
+		// Ensure each volume rendered correctly.
+		dsVols := ds.Spec.Template.Spec.Volumes
+		hp := corev1.HostPathDirectoryOrCreate
+		expectedVolumes := []corev1.Volume{
+			{
+				Name: applicationlayer.EnvoyLogsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: applicationlayer.EnvoyConfigMapName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: applicationlayer.EnvoyConfigMapName},
+					},
+				},
+			},
+			{
+				Name: applicationlayer.FelixSync,
+				VolumeSource: corev1.VolumeSource{
+					CSI: &corev1.CSIVolumeSource{
+						Driver: "csi.tigera.io",
+					},
+				},
+			},
+			{
+				Name: applicationlayer.DikastesSyncVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: applicationlayer.CalicoLogsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/var/log/calico",
+						Type: &hp,
+					},
+				},
+			},
+			{
+				Name: applicationlayer.ModSecurityRulesetConfigMapName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: applicationlayer.ModSecurityRulesetConfigMapName},
+					},
+				},
+			},
+		}
+
+		Expect(len(ds.Spec.Template.Spec.Volumes)).To(Equal(len(expectedVolumes)))
+		for i, expected := range expectedVolumes {
+			Expect(dsVols[i]).To(Equal(expected))
+		}
+
+		// Ensure that tolerations rendered correctly.
+		dsTolerations := ds.Spec.Template.Spec.Tolerations
+		expectedToleration := rmeta.TolerateAll
+		for _, expected := range expectedToleration {
+			Expect(dsTolerations).To(ContainElement(expected))
+		}
+
+		// Check proxy container rendering.
+		proxyContainer := ds.Spec.Template.Spec.Containers[0]
+
+		proxyEnvs := proxyContainer.Env
+		expectedProxyEnvs := []corev1.EnvVar{
+			{Name: "ENVOY_UID", Value: "0"},
+			{Name: "ENVOY_GID", Value: "0"},
+		}
+		Expect(len(proxyEnvs)).To(Equal(len(expectedProxyEnvs)))
+
+		for _, expected := range expectedProxyEnvs {
+			Expect(proxyEnvs).To(ContainElement(expected))
+		}
+
+		proxyVolMounts := proxyContainer.VolumeMounts
+		expectedProxyVolMounts := []corev1.VolumeMount{
+			{Name: applicationlayer.EnvoyConfigMapName, MountPath: "/etc/envoy"},
+			{Name: applicationlayer.EnvoyLogsVolumeName, MountPath: "/tmp/"},
+			{Name: applicationlayer.DikastesSyncVolumeName, MountPath: "/var/run/dikastes"},
+		}
+		Expect(len(proxyVolMounts)).To(Equal(len(expectedProxyVolMounts)))
+
+		for _, expected := range expectedProxyVolMounts {
+			Expect(proxyVolMounts).To(ContainElement(expected))
+		}
+
+		dikastesContainer := ds.Spec.Template.Spec.Containers[1]
+
+		dikastesEnvs := dikastesContainer.Env
+		expectedDikastesEnvs := []corev1.EnvVar{
+			{Name: "LOG_LEVEL", Value: "Info"},
+			{Name: "DIKASTES_SUBSCRIPTION_TYPE", Value: "per-host-policies"},
+		}
+		Expect(len(dikastesEnvs)).To(Equal(len(expectedDikastesEnvs)))
+		for _, element := range expectedDikastesEnvs {
+			Expect(dikastesEnvs).To(ContainElement(element))
+		}
+
+		dikastesArgs := dikastesContainer.Command
+		expectedDikastesArgs := []string{
+			"--waf-enabled",
+			"--waf-log-file", filepath.Join(applicationlayer.CalicologsVolumePath, "waf", "waf.log"),
+			"--waf-ruleset-base-dir", applicationlayer.ModSecurityRulesetVolumePath,
+			"--waf-directive", "Include modsecdefault.conf",
+			"--waf-directive", "Include crs-setup.conf",
+			"--waf-directive", "Include tigera.conf",
+			"--waf-directive", "Include rules/*.conf",
+		}
+		for _, element := range expectedDikastesArgs {
+			Expect(dikastesArgs).To(ContainElement(element))
+		}
+
+		dikastesVolMounts := dikastesContainer.VolumeMounts
+		expectedDikastesVolMounts := []corev1.VolumeMount{
+			{Name: applicationlayer.DikastesSyncVolumeName, MountPath: "/var/run/dikastes"},
+			{Name: applicationlayer.FelixSync, MountPath: "/var/run/felix"},
+			{Name: applicationlayer.CalicoLogsVolumeName, MountPath: applicationlayer.CalicologsVolumePath},
+			{Name: applicationlayer.ModSecurityRulesetConfigMapName, MountPath: applicationlayer.ModSecurityRulesetVolumePath, ReadOnly: true},
 		}
 		Expect(len(dikastesVolMounts)).To(Equal(len(expectedDikastesVolMounts)))
 		for _, expected := range expectedDikastesVolMounts {

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -443,10 +443,8 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		resources, _ := component.Objects()
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
-		i := 0
-		for _, expectedRes := range expectedResources {
-			rtest.ExpectResourceTypeAndObjectMetadata(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-			i++
+		for i := range expectedResources {
+			rtest.ExpectResource(resources[i], resources)
 		}
 
 		ds := rtest.GetResource(resources, applicationlayer.ApplicationLayerDaemonsetName, common.CalicoNamespace, "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -564,8 +564,8 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 			"--waf-ruleset-base-dir", applicationlayer.ModSecurityRulesetVolumePath,
 			"--waf-directive", "Include modsecdefault.conf",
 			"--waf-directive", "Include crs-setup.conf",
+			"--waf-directive", "Include REQUEST-*.conf",
 			"--waf-directive", "Include tigera.conf",
-			"--waf-directive", "Include rules/*.conf",
 		}
 		for _, element := range expectedDikastesArgs {
 			Expect(dikastesArgs).To(ContainElement(element))

--- a/pkg/render/applicationlayer/embed/embed.go
+++ b/pkg/render/applicationlayer/embed/embed.go
@@ -18,6 +18,9 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -58,4 +61,20 @@ func AsMap() (map[string]string, error) {
 	}
 
 	return res, nil
+}
+
+func AsConfigMap(name, namespace string) (*corev1.ConfigMap, error) {
+	data, err := AsMap()
+	if err != nil {
+		return nil, err
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}, nil
 }


### PR DESCRIPTION
## Description
- add unit-tests for WAF, specifically for flags control and expected vols/volMounts
- added embed.AsConfigMap so that it's simpler to inject a config map, just an dry approach.. possibly an optional change

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
