### PR TITLE
Break infinite reconciliation loop

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -483,6 +483,12 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 			// on the new object.
 			dsa.Secrets = csa.Secrets
 		}
+		if len(csa.ImagePullSecrets) != 0 && len(dsa.ImagePullSecrets) == 0 {
+			// For example on OCP, the service account gets ImagePullSecrets added. If we don't merge this into the
+			// object, we will create a version update, immediately followed by another update by their controller,
+			// and then again our controllers watching the service account will reconcile again, causing a loop.
+			dsa.ImagePullSecrets = csa.ImagePullSecrets
+		}
 		return dsa
 	case *esv1.Elasticsearch:
 		// Only update if the spec has changed

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -486,7 +486,7 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 		if len(csa.ImagePullSecrets) != 0 && len(dsa.ImagePullSecrets) == 0 {
 			// For example on OCP, the service account gets ImagePullSecrets added. If we don't merge this into the
 			// object, we will create a version update, immediately followed by another update by their controller,
-			// and then again our controllers watching the service account will reconcile again, causing a loop.
+			// and then our controllers watching the service account will reconcile again, causing a loop.
 			dsa.ImagePullSecrets = csa.ImagePullSecrets
 		}
 		return dsa


### PR DESCRIPTION
Without this change, the core_controller stays in an infinite loop. The old and new service account objects are not recognized as being equivalents.

![image](https://github.com/tigera/operator/assets/15924949/15de5ebd-32b2-411f-b7a0-dff35d251766)

Since I don't see any related release notes in controller-runtime, I think opening a PR is the best way forward.