### PR TITLE
Automated cherry pick of #3081: Only watch the monitor CR if the CRD exists.

### DIFF
--- a/pkg/controller/csr/csr_controller.go
+++ b/pkg/controller/csr/csr_controller.go
@@ -90,8 +90,10 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return err
 	}
 
-	if err = ctrl.Watch(&source.Kind{Type: &operatorv1.Monitor{}}, &handler.EnqueueRequestForObject{}); err != nil {
-		return fmt.Errorf("monitor-controller failed to watch primary resource: %w", err)
+	if opts.EnterpriseCRDExists {
+		if err = ctrl.Watch(&source.Kind{Type: &operatorv1.Monitor{}}, &handler.EnqueueRequestForObject{}); err != nil {
+			return fmt.Errorf("monitor-controller failed to watch primary resource: %w", err)
+		}
 	}
 
 	if err = ctrl.Watch(&source.Kind{Type: &operatorv1.Installation{}}, &handler.EnqueueRequestForObject{}); err != nil {

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -118,6 +118,13 @@ spec:
                   Loose]'
                 pattern: ^(?i)(Disabled|Strict|Loose)?$
                 type: string
+              bpfExcludeCIDRsFromNAT:
+                description: BPFExcludeCIDRsFromNAT is a list of CIDRs that are to
+                  be excluded from NAT resolution so that host can handle them. A
+                  typical usecase is node local DNS cache.
+                items:
+                  type: string
+                type: array
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
                   mark that is set on connections from an external client to a local


### PR DESCRIPTION
Cherry pick of #3081 on release-v1.33.

#3081: Only watch the monitor CR if the CRD exists.