### PR TITLE
Automated cherry pick of #3075: Avoid endless reconcile loop when image pull secrets are

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -483,6 +483,12 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 			// on the new object.
 			dsa.Secrets = csa.Secrets
 		}
+		if len(csa.ImagePullSecrets) != 0 && len(dsa.ImagePullSecrets) == 0 {
+			// For example on OCP, the service account gets ImagePullSecrets added. If we don't merge this into the
+			// object, we will create a version update, immediately followed by another update by their controller,
+			// and then again our controllers watching the service account will reconcile again, causing a loop.
+			dsa.ImagePullSecrets = csa.ImagePullSecrets
+		}
 		return dsa
 	case *esv1.Elasticsearch:
 		// Only update if the spec has changed

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -486,7 +486,7 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 		if len(csa.ImagePullSecrets) != 0 && len(dsa.ImagePullSecrets) == 0 {
 			// For example on OCP, the service account gets ImagePullSecrets added. If we don't merge this into the
 			// object, we will create a version update, immediately followed by another update by their controller,
-			// and then again our controllers watching the service account will reconcile again, causing a loop.
+			// and then our controllers watching the service account will reconcile again, causing a loop.
 			dsa.ImagePullSecrets = csa.ImagePullSecrets
 		}
 		return dsa


### PR DESCRIPTION
Cherry pick of #3075 on release-v1.33.

#3075: Avoid endless reconcile loop when image pull secrets are