### PR TITLE
fix CNI plugin configuration issue

### DIFF
--- a/pkg/controller/migration/convert/network.go
+++ b/pkg/controller/migration/convert/network.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023, 2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -201,8 +201,8 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 	}
 
 	type TuningSpec struct {
-		Sysctl []operatorv1.Sysctl `json:"sysctl,omitempty"`
-		Type   string              `json:"type"`
+		Sysctl *map[string]string `json:"sysctl,omitempty"`
+		Type   string             `json:"type"`
 	}
 
 	// CNI tuning plugin
@@ -219,10 +219,10 @@ func handleCalicoCNI(c *components, install *operatorv1.Installation) error {
 		}
 
 		sysctlTuning := []operatorv1.Sysctl{}
-		for _, setting := range tuningSpecData.Sysctl {
+		for k, v := range *tuningSpecData.Sysctl {
 			sysctl := operatorv1.Sysctl{
-				Key:   setting.Key,
-				Value: setting.Value,
+				Key:   k,
+				Value: v,
 			}
 			sysctlTuning = append(sysctlTuning, sysctl)
 		}

--- a/pkg/controller/migration/convert/network_test.go
+++ b/pkg/controller/migration/convert/network_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023, 2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -782,20 +782,11 @@ var _ = Describe("Convert network tests", func() {
   },
   {
 	"type": "tuning",
-	"sysctl": [
-		  {
-			"key": "net.ipv4.tcp_keepalive_intvl",
-			"value": "15"
-		  },
-		  {
-			"key": "net.ipv4.tcp_keepalive_probes",
-			"value": "6"
-		  },
-		  {
-			"key": "net.ipv4.tcp_keepalive_time",
-			"value": "40"
-		  }
-		]
+	"sysctl": {
+		"net.ipv4.tcp_keepalive_intvl": "15",
+		"net.ipv4.tcp_keepalive_probes": "6",
+		"net.ipv4.tcp_keepalive_time": "40"
+	}
   }
   ]
 }`,
@@ -846,13 +837,10 @@ var _ = Describe("Convert network tests", func() {
 },
 {
 	"type": "tuning",
-	"sysctl": [
-		{
-		  "key": "net.ipv4.not_allowed",
-		  "value": "40"
-		}
-	]
-  }
+	"sysctl": {
+		"net.ipv4.not_allowed": "40"
+	}
+}
 ]
 }`,
 					}}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -708,12 +708,18 @@ func (c *nodeComponent) createPortmapPlugin() map[string]interface{} {
 
 func (c *nodeComponent) createTuningPlugin() map[string]interface{} {
 	// tuning plugin (sysctl)
+	sysctl := map[string]string{}
 	tuningPlugin := map[string]interface{}{
 		"type":   "tuning",
-		"sysctl": []operatorv1.Sysctl{},
+		"sysctl": sysctl,
 	}
-	tuningPlugin["sysctl"] = c.cfg.Installation.CalicoNetwork.Sysctl
 
+	// convert []operatorv1.Sysctl{} to map[string]string for CNI definition
+	// details: https://www.cni.dev/plugins/current/meta/tuning/#system-controls-operation
+	for _, v := range c.cfg.Installation.CalicoNetwork.Sysctl {
+		sysctl[v.Key] = v.Value
+	}
+	tuningPlugin["sysctl"] = sysctl
 	return tuningPlugin
 }
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2748,20 +2748,12 @@ var _ = Describe("Node rendering tests", func() {
       "type": "portmap"
     },
     {
-      "sysctl": [
+      "sysctl":
 		  {
-			"key": "net.ipv4.tcp_keepalive_intvl",
-			"value": "15"
+			"net.ipv4.tcp_keepalive_intvl": "15",
+			"net.ipv4.tcp_keepalive_probes": "6",
+			"net.ipv4.tcp_keepalive_time": "40"
 		  },
-		  {
-			"key": "net.ipv4.tcp_keepalive_probes",
-			"value": "6"
-		  },
-		  {
-			"key": "net.ipv4.tcp_keepalive_time",
-		    "value": "40"
-		  }
-		],
       "type": "tuning"
 	}
   ]


### PR DESCRIPTION
## Description
This PR fixes the configuration issue introduced with https://github.com/tigera/operator/pull/2708.
The problem: if a pod starts when `sysctl` tuning is configured it will fail with:
```
 Warning  FailedCreatePodSandBox  9s                      kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "88e1a46f3075be984d7761de03df288697e9236858b961fa5844076e1b66cc43": plugin type="tuning" failed (add): failed to load netconf: json: cannot unmarshal array into Go struct field TuningConf.sysctl of type map[string]string
```
Reason: the format of the sysctl should look like `map[string]string`:
```
  "sysctl": {
          "net.core.somaxconn": "500",
          "net.ipv4.conf.IFNAME.arp_filter": "1"
  }
```
as it described here: https://www.cni.dev/plugins/current/meta/tuning/#system-controls-operation
I will attach the proof of integration testing (on a real cluster) of this PR soon.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
