### PR TITLE
don't fail on not found for RequiresTigeraSecure as that just indicat…

### DIFF
--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -42,6 +42,10 @@ func RequiresTigeraSecure(cfg *rest.Config) (bool, error) {
 	// Use the discovery client to determine if the tigera secure specific APIs exist.
 	resources, err := clientset.Discovery().ServerResourcesForGroupVersion("operator.tigera.io/v1")
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			// If the operator API group is not found then crds just haven't been applied yet.
+			return false, nil
+		}
 		return false, err
 	}
 	for _, r := range resources.APIResources {


### PR DESCRIPTION
…es crds have not been applied

## Description

Was trying to apply tigera-operator without any CRDS (but with the arg --manage-crds) and failed in RequiresTigeraSecure.

Seems like not found should be treated differently than other errors here. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
