### PR TITLE
Consolidate tigera status for all log storage controllers

### DIFF
--- a/pkg/controller/logstorage/elastic/elastic_controller.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	logstoragecommon "github.com/tigera/operator/pkg/controller/logstorage/common"
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -42,6 +43,7 @@ import (
 	"github.com/tigera/operator/pkg/render/logstorage/esmetrics"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -64,7 +66,6 @@ var log = logf.Log.WithName("controller_logstorage_elastic")
 
 const (
 	LogStorageFinalizer = "tigera.io/eck-cleanup"
-	tigeraStatusName    = "log-storage-elastic"
 )
 
 // ElasticSubController is a sub-controller of the main LogStorage controller
@@ -97,7 +98,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		scheme:         mgr.GetScheme(),
 		esCliCreator:   utils.NewElasticClient,
 		tierWatchReady: &utils.ReadyFlag{},
-		status:         status.New(mgr.GetClient(), tigeraStatusName, opts.KubernetesVersion),
+		status:         status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageElastic, opts.KubernetesVersion),
 		usePSP:         opts.UsePSP,
 		clusterDomain:  opts.ClusterDomain,
 		provider:       opts.DetectedProvider,
@@ -132,7 +133,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if err = c.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-elastic-controller failed to watch ManagementClusterConnection resource: %w", err)
 	}
-	if err = utils.AddTigeraStatusWatch(c, tigeraStatusName); err != nil {
+	if err = utils.AddTigeraStatusWatch(c, initializer.TigeraStatusLogStorageElastic); err != nil {
 		return fmt.Errorf("logstorage-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
 	if err = c.Watch(&source.Kind{Type: &operatorv1.Authentication{}}, &handler.EnqueueRequestForObject{}); err != nil {

--- a/pkg/controller/logstorage/elastic/external_elastic_controller.go
+++ b/pkg/controller/logstorage/elastic/external_elastic_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package elastic
 import (
 	"context"
 	"fmt"
+
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
@@ -61,7 +63,7 @@ func AddExternalES(mgr manager.Manager, opts options.AddOptions) error {
 	r := &ExternalESController{
 		client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),
-		status:        status.New(mgr.GetClient(), tigeraStatusName, opts.KubernetesVersion),
+		status:        status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageElastic, opts.KubernetesVersion),
 		usePSP:        opts.UsePSP,
 		clusterDomain: opts.ClusterDomain,
 		provider:      opts.DetectedProvider,
@@ -90,7 +92,7 @@ func AddExternalES(mgr manager.Manager, opts options.AddOptions) error {
 	if err = c.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-external-es-controller failed to watch ManagementClusterConnection resource: %w", err)
 	}
-	if err = utils.AddTigeraStatusWatch(c, tigeraStatusName); err != nil {
+	if err = utils.AddTigeraStatusWatch(c, initializer.TigeraStatusLogStorageElastic); err != nil {
 		return fmt.Errorf("log-storage-external-es-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
 

--- a/pkg/controller/logstorage/esmetrics/esmetrics_controller.go
+++ b/pkg/controller/logstorage/esmetrics/esmetrics_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -50,10 +52,6 @@ import (
 
 var log = logf.Log.WithName("controller_logstorage_esmetrics")
 
-const (
-	tigeraStatusName = "log-storage-esmetrics"
-)
-
 type ESMetricsSubController struct {
 	client         client.Client
 	scheme         *runtime.Scheme
@@ -79,7 +77,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	r := &ESMetricsSubController{
 		client:         mgr.GetClient(),
 		scheme:         mgr.GetScheme(),
-		status:         status.New(mgr.GetClient(), tigeraStatusName, opts.KubernetesVersion),
+		status:         status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageESMetrics, opts.KubernetesVersion),
 		clusterDomain:  opts.ClusterDomain,
 		provider:       opts.DetectedProvider,
 		tierWatchReady: &utils.ReadyFlag{},

--- a/pkg/controller/logstorage/esmetrics/esmetrics_controller.go
+++ b/pkg/controller/logstorage/esmetrics/esmetrics_controller.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
-
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +28,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	logstoragecommon "github.com/tigera/operator/pkg/controller/logstorage/common"
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"

--- a/pkg/controller/logstorage/initializer/conditions_controller.go
+++ b/pkg/controller/logstorage/initializer/conditions_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,10 +17,11 @@ package initializer
 import (
 	"context"
 	"fmt"
+	"time"
 
-	operatorv1 "github.com/tigera/operator/api/v1"
-
+	"github.com/tigera/operator/pkg/controller/logstorage/esmetrics"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/options"
-	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 )
 
@@ -90,18 +91,127 @@ func (r *LogStorageConditions) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	// Update conditions on the LogStorage object based on the status of the various components.
-	// TODO: Incorporate status from other sub controllers as well.
-	ts := &operatorv1.TigeraStatus{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: TigeraStatusName}, ts); err != nil {
+	// Fetch the current status condition for log storage
+	currentConditions := getCurrentConditions(ls.Status.Conditions)
+
+	// Aggregate TigeraStatus conditions from all logstorage subcontrollers into a map,
+	// using the condition type (e.g., Available, Progressing, and Degraded) as the key.
+	desiredConditions, err := r.getDesiredConditions(ctx)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	ls.Status.Conditions = status.UpdateStatusCondition(ls.Status.Conditions, ts.Status.Conditions)
+	// Compare and update the current StatusCondition if there are any new changes
+	ls.Status.Conditions = updateConditions(currentConditions, desiredConditions)
+
 	if err := r.client.Status().Update(ctx, ls); err != nil {
 		log.WithValues("reason", err).Info("Failed to update LogStorage status conditions")
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func getCurrentConditions(lsConditions []metav1.Condition) map[string]metav1.Condition {
+	statusConditions := make(map[string]metav1.Condition)
+	for _, condition := range lsConditions {
+		statusConditions[condition.Type] = condition
+	}
+	return statusConditions
+}
+
+func (r *LogStorageConditions) getDesiredConditions(ctx context.Context) (map[string]metav1.Condition, error) {
+
+	expectedInstances := []string{TigeraStatusName, TigeraStatusLogStorageAccess, TigeraStatusLogStorageElastic, TigeraStatusLogStorageSecrets}
+	if r.multiTenant {
+		expectedInstances = append(expectedInstances, TigeraStatusLogStorageUsers)
+	} else {
+		expectedInstances = append(expectedInstances, esmetrics.TigeraStatusLogStorageESMetrics, TigeraStatusLogStorageKubeController)
+	}
+
+	// Keep track of which instances are in which state.
+	states := map[string][]string{
+		string(operatorv1.ComponentDegraded):    {},
+		string(operatorv1.ComponentAvailable):   {},
+		string(operatorv1.ComponentProgressing): {},
+	}
+
+	// We also keep track of the oldest observed generation here so we can add it to the conditions later.
+	var observedGeneration int64
+
+	// Build up the lists of which components are in which state.
+	for _, instance := range expectedInstances {
+		ts := &operatorv1.TigeraStatus{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: instance}, ts); err != nil && errors.IsNotFound(err) {
+			// Expected status not found, treat it as an error.
+			states[string(operatorv1.ComponentDegraded)] = append(states[string(operatorv1.ComponentDegraded)], instance)
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+
+		// Found it - add to states map, which we use to track which TigeraStatuses are in which state(s).
+		for _, condition := range ts.Status.Conditions {
+			if condition.Status == operatorv1.ConditionTrue {
+				states[string(condition.Type)] = append(states[string(condition.Type)], instance)
+			}
+			if observedGeneration == 0 || condition.ObservedGeneration < observedGeneration {
+				observedGeneration = condition.ObservedGeneration
+			}
+		}
+	}
+
+	// Convert the states map to a set of conditions.
+	conditions := map[string]metav1.Condition{}
+	for statusType, instances := range states {
+
+		condition := metav1.Condition{
+			Type:               statusType,
+			ObservedGeneration: observedGeneration,
+			Reason:             string(operatorv1.Unknown),
+		}
+		if statusType != string(operatorv1.ComponentAvailable) && len(instances) != 0 {
+			// This condition is true.
+			condition.Status = metav1.ConditionTrue
+			condition.Reason = string(operatorv1.ResourceNotReady)
+			condition.Message = fmt.Sprintf("The following sub-controllers are in this condition: %+v", instances)
+		} else if statusType != string(operatorv1.ComponentAvailable) {
+			// This condition is false.
+			condition.Status = metav1.ConditionFalse
+		} else {
+			// This is the available condition, which is only true if all statuses are available.
+			condition.Type = string(operatorv1.ComponentReady)
+			// Available will be mapped to Ready while storing in ls Conditions. Update the key type to Ready for Available
+			statusType = condition.Type
+			if len(instances) == len(expectedInstances) {
+				condition.Status = metav1.ConditionTrue
+				condition.Reason = string(operatorv1.AllObjectsAvailable)
+				condition.Message = "All sub-controllers are available"
+			} else {
+				condition.Status = metav1.ConditionFalse
+			}
+		}
+		// Store the condition.
+		conditions[statusType] = condition
+	}
+	return conditions, nil
+}
+
+func updateConditions(currentConditions, desiredConditions map[string]metav1.Condition) []metav1.Condition {
+
+	statusConditions := []metav1.Condition{}
+
+	//Update the current log storage condition only when the aggregate desired status have new changes
+	for _, desired := range desiredConditions {
+
+		current, ok := currentConditions[desired.Type]
+		if !ok || current.Status != desired.Status || current.Message != desired.Message {
+			desired.LastTransitionTime = metav1.NewTime(time.Now())
+		} else {
+			desired.LastTransitionTime = current.LastTransitionTime
+		}
+
+		statusConditions = append(statusConditions, desired)
+	}
+	return statusConditions
 }

--- a/pkg/controller/logstorage/initializer/conditions_controller.go
+++ b/pkg/controller/logstorage/initializer/conditions_controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/tigera/operator/pkg/controller/logstorage/esmetrics"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -126,7 +125,7 @@ func (r *LogStorageConditions) getDesiredConditions(ctx context.Context) (map[st
 	if r.multiTenant {
 		expectedInstances = append(expectedInstances, TigeraStatusLogStorageUsers)
 	} else {
-		expectedInstances = append(expectedInstances, esmetrics.TigeraStatusLogStorageESMetrics, TigeraStatusLogStorageKubeController)
+		expectedInstances = append(expectedInstances, TigeraStatusLogStorageESMetrics, TigeraStatusLogStorageKubeController)
 	}
 
 	// Keep track of which instances are in which state.

--- a/pkg/controller/logstorage/initializer/conditions_controller_test.go
+++ b/pkg/controller/logstorage/initializer/conditions_controller_test.go
@@ -138,6 +138,17 @@ var _ = Describe("LogStorage Conditions controller", func() {
 		Expect(readyCondition.Message).To(Equal("All sub-controllers are available"))
 		Expect(readyCondition.ObservedGeneration).To(Equal(generation))
 
+		degCondition, ok := actualConditions["Degraded"]
+		Expect(ok).To(BeTrue())
+		Expect(string(degCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		Expect(degCondition.Reason).To(Equal(string(operatorv1.Unknown)))
+		Expect(degCondition.Message).To(Equal(""))
+		progCondition, ok := actualConditions["Progressing"]
+		Expect(ok).To(BeTrue())
+		Expect(string(progCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		Expect(progCondition.Reason).To(Equal(string(operatorv1.Unknown)))
+		Expect(progCondition.Message).To(Equal(""))
+
 	})
 
 	It("should reconcile with empty tigerastatus conditions", func() {
@@ -187,12 +198,18 @@ var _ = Describe("LogStorage Conditions controller", func() {
 		readyCondition, ok := actualConditions["Ready"]
 		Expect(ok).To(BeTrue())
 		Expect(string(readyCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		Expect(readyCondition.Reason).To(Equal(string(operatorv1.Unknown)))
+		Expect(readyCondition.Message).To(Equal(""))
 		degCondition, ok := actualConditions["Degraded"]
 		Expect(ok).To(BeTrue())
 		Expect(string(degCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		Expect(degCondition.Reason).To(Equal(string(operatorv1.Unknown)))
+		Expect(degCondition.Message).To(Equal(""))
 		progCondition, ok := actualConditions["Progressing"]
 		Expect(ok).To(BeTrue())
 		Expect(string(progCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		Expect(progCondition.Reason).To(Equal(string(operatorv1.Unknown)))
+		Expect(progCondition.Message).To(Equal(""))
 	})
 
 	It("should reconcile multiple conditions as true", func() {

--- a/pkg/controller/logstorage/initializer/conditions_controller_test.go
+++ b/pkg/controller/logstorage/initializer/conditions_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@ package initializer
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -82,24 +82,21 @@ var _ = Describe("LogStorage Conditions controller", func() {
 	})
 
 	generation := int64(2)
+	subControllers := []string{TigeraStatusName, TigeraStatusLogStorageAccess,
+		TigeraStatusLogStorageElastic, TigeraStatusLogStorageSecrets}
 
 	It("should reconcile with one item in tigerastatus conditions", func() {
-		ts := &operatorv1.TigeraStatus{
-			ObjectMeta: metav1.ObjectMeta{Name: "log-storage"},
-			Spec:       operatorv1.TigeraStatusSpec{},
-			Status: operatorv1.TigeraStatusStatus{
-				Conditions: []operatorv1.TigeraStatusCondition{
-					{
-						Type:               operatorv1.ComponentAvailable,
-						Status:             operatorv1.ConditionTrue,
-						Reason:             string(operatorv1.AllObjectsAvailable),
-						Message:            "All Objects are available",
-						ObservedGeneration: generation,
-					},
-				},
-			},
+
+		lsControllers := append(subControllers, TigeraStatusLogStorageESMetrics, TigeraStatusLogStorageKubeController)
+		for _, ls := range lsControllers {
+			createTigeraStatus(cli, ctx, ls, generation, []operatorv1.TigeraStatusCondition{{
+				Type:               operatorv1.ComponentAvailable,
+				Status:             operatorv1.ConditionTrue,
+				Reason:             string(operatorv1.AllObjectsAvailable),
+				Message:            "All Objects are available",
+				ObservedGeneration: generation,
+			}})
 		}
-		Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 
 		CreateLogStorage(cli, &operatorv1.LogStorage{
 			ObjectMeta: metav1.ObjectMeta{
@@ -130,85 +127,30 @@ var _ = Describe("LogStorage Conditions controller", func() {
 		By("asserting the finalizers have been set on the LogStorage CR")
 		instance := &operatorv1.LogStorage{}
 		Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, instance)).ShouldNot(HaveOccurred())
-		Expect(instance.Status.Conditions).To(HaveLen(1))
+		Expect(instance.Status.Conditions).To(HaveLen(3))
 
-		Expect(instance.Status.Conditions[0].Type).To(Equal("Ready"))
-		Expect(string(instance.Status.Conditions[0].Status)).To(Equal(string(operatorv1.ConditionTrue)))
-		Expect(instance.Status.Conditions[0].Reason).To(Equal(string(operatorv1.AllObjectsAvailable)))
-		Expect(instance.Status.Conditions[0].Message).To(Equal("All Objects are available"))
-		Expect(instance.Status.Conditions[0].ObservedGeneration).To(Equal(generation))
+		By("asserting Ready to be true")
+		actualConditions := getCurrentConditions(instance.Status.Conditions)
+		readyCondition, ok := actualConditions["Ready"]
+		Expect(ok).To(BeTrue())
+		Expect(string(readyCondition.Status)).To(Equal(string(operatorv1.ConditionTrue)))
+		Expect(readyCondition.Reason).To(Equal(string(operatorv1.AllObjectsAvailable)))
+		Expect(readyCondition.Message).To(Equal("All sub-controllers are available"))
+		Expect(readyCondition.ObservedGeneration).To(Equal(generation))
+
 	})
 
 	It("should reconcile with empty tigerastatus conditions", func() {
-		ts := &operatorv1.TigeraStatus{
-			ObjectMeta: metav1.ObjectMeta{Name: "log-storage"},
-			Spec:       operatorv1.TigeraStatusSpec{},
-			Status:     operatorv1.TigeraStatusStatus{},
+
+		lsControllers := append(subControllers, TigeraStatusLogStorageESMetrics, TigeraStatusLogStorageKubeController)
+		for _, ls := range lsControllers {
+			ts := &operatorv1.TigeraStatus{
+				ObjectMeta: metav1.ObjectMeta{Name: ls},
+				Spec:       operatorv1.TigeraStatusSpec{},
+				Status:     operatorv1.TigeraStatusStatus{},
+			}
+			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 		}
-		Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
-
-		CreateLogStorage(cli, &operatorv1.LogStorage{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:       "tigera-secure",
-				Generation: 3,
-			},
-			Spec: operatorv1.LogStorageSpec{
-				Nodes: &operatorv1.Nodes{
-					Count: int64(1),
-				},
-			},
-			Status: operatorv1.LogStorageStatus{
-				State: operatorv1.TigeraStatusReady,
-			},
-		})
-
-		r, err := NewTestConditionController(cli, scheme, dns.DefaultClusterDomain)
-		Expect(err).ShouldNot(HaveOccurred())
-		result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
-			Name:      "log-storage",
-			Namespace: "",
-		}})
-		Expect(err).ShouldNot(HaveOccurred())
-		// Expect to be waiting for Elasticsearch and Kibana to be functional
-		Expect(result).Should(Equal(reconcile.Result{}))
-
-		By("asserting the finalizers have been set on the LogStorage CR")
-		instance := &operatorv1.LogStorage{}
-		Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, instance)).ShouldNot(HaveOccurred())
-		Expect(instance.Status.Conditions).To(HaveLen(0))
-	})
-
-	It("should reconcile with creating new status condition with multiple conditions as true", func() {
-		ts := &operatorv1.TigeraStatus{
-			ObjectMeta: metav1.ObjectMeta{Name: "log-storage"},
-			Spec:       operatorv1.TigeraStatusSpec{},
-			Status: operatorv1.TigeraStatusStatus{
-				Conditions: []operatorv1.TigeraStatusCondition{
-					{
-						Type:               operatorv1.ComponentAvailable,
-						Status:             operatorv1.ConditionTrue,
-						Reason:             string(operatorv1.AllObjectsAvailable),
-						Message:            "All Objects are available",
-						ObservedGeneration: generation,
-					},
-					{
-						Type:               operatorv1.ComponentProgressing,
-						Status:             operatorv1.ConditionTrue,
-						Reason:             string(operatorv1.ResourceNotReady),
-						Message:            "Progressing Installation.operatorv1.tigera.io",
-						ObservedGeneration: generation,
-					},
-					{
-						Type:               operatorv1.ComponentDegraded,
-						Status:             operatorv1.ConditionTrue,
-						Reason:             string(operatorv1.ResourceUpdateError),
-						Message:            "Error resolving ImageSet for components",
-						ObservedGeneration: generation,
-					},
-				},
-			},
-		}
-		Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 
 		CreateLogStorage(cli, &operatorv1.LogStorage{
 			ObjectMeta: metav1.ObjectMeta{
@@ -240,56 +182,50 @@ var _ = Describe("LogStorage Conditions controller", func() {
 		Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, instance)).ShouldNot(HaveOccurred())
 		Expect(instance.Status.Conditions).To(HaveLen(3))
 
-		Expect(instance.Status.Conditions[0].Type).To(Equal("Ready"))
-		Expect(string(instance.Status.Conditions[0].Status)).To(Equal(string(operatorv1.ConditionTrue)))
-		Expect(instance.Status.Conditions[0].Reason).To(Equal(string(operatorv1.AllObjectsAvailable)))
-		Expect(instance.Status.Conditions[0].Message).To(Equal("All Objects are available"))
-		Expect(instance.Status.Conditions[0].ObservedGeneration).To(Equal(generation))
-
-		Expect(instance.Status.Conditions[1].Type).To(Equal("Progressing"))
-		Expect(string(instance.Status.Conditions[1].Status)).To(Equal(string(operatorv1.ConditionTrue)))
-		Expect(instance.Status.Conditions[1].Reason).To(Equal(string(operatorv1.ResourceNotReady)))
-		Expect(instance.Status.Conditions[1].Message).To(Equal("Progressing Installation.operatorv1.tigera.io"))
-		Expect(instance.Status.Conditions[1].ObservedGeneration).To(Equal(generation))
-
-		Expect(instance.Status.Conditions[2].Type).To(Equal("Degraded"))
-		Expect(string(instance.Status.Conditions[2].Status)).To(Equal(string(operatorv1.ConditionTrue)))
-		Expect(instance.Status.Conditions[2].Reason).To(Equal(string(operatorv1.ResourceUpdateError)))
-		Expect(instance.Status.Conditions[2].Message).To(Equal("Error resolving ImageSet for components"))
-		Expect(instance.Status.Conditions[2].ObservedGeneration).To(Equal(generation))
+		By("asserting all the status set to be False")
+		actualConditions := getCurrentConditions(instance.Status.Conditions)
+		readyCondition, ok := actualConditions["Ready"]
+		Expect(ok).To(BeTrue())
+		Expect(string(readyCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		degCondition, ok := actualConditions["Degraded"]
+		Expect(ok).To(BeTrue())
+		Expect(string(degCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		progCondition, ok := actualConditions["Progressing"]
+		Expect(ok).To(BeTrue())
+		Expect(string(progCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
 	})
 
-	It("should reconcile with creating new status condition and toggle Available to true & others to false", func() {
-		ts := &operatorv1.TigeraStatus{
-			ObjectMeta: metav1.ObjectMeta{Name: "log-storage"},
-			Spec:       operatorv1.TigeraStatusSpec{},
-			Status: operatorv1.TigeraStatusStatus{
-				Conditions: []operatorv1.TigeraStatusCondition{
-					{
-						Type:               operatorv1.ComponentAvailable,
-						Status:             operatorv1.ConditionTrue,
-						Reason:             string(operatorv1.AllObjectsAvailable),
-						Message:            "All Objects are available",
-						ObservedGeneration: generation,
-					},
-					{
-						Type:               operatorv1.ComponentProgressing,
-						Status:             operatorv1.ConditionFalse,
-						Reason:             string(operatorv1.NotApplicable),
-						Message:            "Not Applicable",
-						ObservedGeneration: generation,
-					},
-					{
-						Type:               operatorv1.ComponentDegraded,
-						Status:             operatorv1.ConditionFalse,
-						Reason:             string(operatorv1.NotApplicable),
-						Message:            "Not Applicable",
-						ObservedGeneration: generation,
-					},
-				},
-			},
+	It("should reconcile multiple conditions as true", func() {
+
+		lsControllers := append(subControllers, TigeraStatusLogStorageKubeController)
+		for _, ls := range lsControllers {
+			createTigeraStatus(cli, ctx, ls, generation, []operatorv1.TigeraStatusCondition{})
 		}
-		Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
+
+		// Create esmetrics with multiple conditions true
+		createTigeraStatus(cli, ctx, TigeraStatusLogStorageESMetrics, generation, []operatorv1.TigeraStatusCondition{
+			{
+				Type:               operatorv1.ComponentAvailable,
+				Status:             operatorv1.ConditionTrue,
+				Reason:             string(operatorv1.AllObjectsAvailable),
+				Message:            "All Objects are available",
+				ObservedGeneration: generation,
+			},
+			{
+				Type:               operatorv1.ComponentProgressing,
+				Status:             operatorv1.ConditionTrue,
+				Reason:             string(operatorv1.ResourceNotReady),
+				Message:            "Progressing Installation.operatorv1.tigera.io",
+				ObservedGeneration: generation,
+			},
+			{
+				Type:               operatorv1.ComponentDegraded,
+				Status:             operatorv1.ConditionTrue,
+				Reason:             string(operatorv1.ResourceUpdateError),
+				Message:            "Error resolving ImageSet for components",
+				ObservedGeneration: generation,
+			},
+		})
 
 		CreateLogStorage(cli, &operatorv1.LogStorage{
 			ObjectMeta: metav1.ObjectMeta{
@@ -313,7 +249,6 @@ var _ = Describe("LogStorage Conditions controller", func() {
 			Namespace: "",
 		}})
 		Expect(err).ShouldNot(HaveOccurred())
-
 		// Expect to be waiting for Elasticsearch and Kibana to be functional
 		Expect(result).Should(Equal(reconcile.Result{}))
 
@@ -322,23 +257,182 @@ var _ = Describe("LogStorage Conditions controller", func() {
 		Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, instance)).ShouldNot(HaveOccurred())
 		Expect(instance.Status.Conditions).To(HaveLen(3))
 
-		Expect(instance.Status.Conditions[0].Type).To(Equal("Ready"))
-		Expect(string(instance.Status.Conditions[0].Status)).To(Equal(string(operatorv1.ConditionTrue)))
-		Expect(instance.Status.Conditions[0].Reason).To(Equal(string(operatorv1.AllObjectsAvailable)))
-		Expect(instance.Status.Conditions[0].Message).To(Equal("All Objects are available"))
-		Expect(instance.Status.Conditions[0].ObservedGeneration).To(Equal(generation))
+		actualConditions := getCurrentConditions(instance.Status.Conditions)
 
-		Expect(instance.Status.Conditions[1].Type).To(Equal("Progressing"))
-		Expect(string(instance.Status.Conditions[1].Status)).To(Equal(string(operatorv1.ConditionFalse)))
-		Expect(instance.Status.Conditions[1].Reason).To(Equal(string(operatorv1.NotApplicable)))
-		Expect(instance.Status.Conditions[1].Message).To(Equal("Not Applicable"))
-		Expect(instance.Status.Conditions[1].ObservedGeneration).To(Equal(generation))
+		By("asserting degraded is marked as true with esmetrics subcontroller")
+		degraded, ok := actualConditions["Degraded"]
+		Expect(ok).To(BeTrue())
 
-		Expect(instance.Status.Conditions[2].Type).To(Equal("Degraded"))
-		Expect(string(instance.Status.Conditions[2].Status)).To(Equal(string(operatorv1.ConditionFalse)))
-		Expect(instance.Status.Conditions[2].Reason).To(Equal(string(operatorv1.NotApplicable)))
-		Expect(instance.Status.Conditions[2].Message).To(Equal("Not Applicable"))
-		Expect(instance.Status.Conditions[2].ObservedGeneration).To(Equal(generation))
+		msg := "The following sub-controllers are in this condition: [log-storage-esmetrics]"
+		Expect(string(degraded.Status)).To(Equal(string(operatorv1.ConditionTrue)))
+		Expect(degraded.Reason).To(Equal(string(operatorv1.ResourceNotReady)))
+		Expect(degraded.Message).To(Equal(msg))
+		Expect(degraded.ObservedGeneration).To(Equal(int64(2)))
+
+		By("asserting progressing is marked as True with esmetrics subcontroller")
+		progressing, ok := actualConditions["Progressing"]
+		Expect(ok).To(BeTrue())
+		Expect(string(progressing.Status)).To(Equal(string(operatorv1.ConditionTrue)))
+		Expect(progressing.Reason).To(Equal(string(operatorv1.ResourceNotReady)))
+		Expect(progressing.Message).To(Equal(msg))
+		Expect(progressing.ObservedGeneration).To(Equal(int64(2)))
+
+		By("asserting available is marked as True")
+		readyCondition, ok := actualConditions["Ready"]
+		Expect(ok).To(BeTrue())
+		Expect(string(readyCondition.Status)).To(Equal(string(operatorv1.ConditionTrue)))
+		Expect(readyCondition.Reason).To(Equal(string(operatorv1.AllObjectsAvailable)))
+		Expect(readyCondition.ObservedGeneration).To(Equal(int64(2)))
+
+	})
+
+	It("should reconcile with all log-storage-* tigerastatus conditions as Available and later move to degraded", func() {
+
+		subControllers = append(subControllers, TigeraStatusLogStorageUsers)
+		for _, ls := range subControllers {
+			createTigeraStatus(cli, ctx, ls, generation, []operatorv1.TigeraStatusCondition{})
+		}
+		CreateLogStorage(cli, &operatorv1.LogStorage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "tigera-secure",
+				Generation: 3,
+			},
+			Spec: operatorv1.LogStorageSpec{
+				Nodes: &operatorv1.Nodes{
+					Count: int64(1),
+				},
+			},
+			Status: operatorv1.LogStorageStatus{
+				State: operatorv1.TigeraStatusReady,
+			},
+		})
+
+		r, err := NewTestConditionController(cli, scheme, dns.DefaultClusterDomain)
+		r.multiTenant = true
+		Expect(err).ShouldNot(HaveOccurred())
+
+		result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      "log-storage",
+			Namespace: "",
+		}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).Should(Equal(reconcile.Result{}))
+
+		instance := &operatorv1.LogStorage{}
+		Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, instance)).ShouldNot(HaveOccurred())
+		Expect(instance.Status.Conditions).To(HaveLen(3))
+
+		actualConditions := getCurrentConditions(instance.Status.Conditions)
+
+		By("asserting Ready status to be true")
+		readyCondition, ok := actualConditions["Ready"]
+		Expect(ok).To(BeTrue())
+		Expect(string(readyCondition.Status)).To(Equal(string(operatorv1.ConditionTrue)))
+		Expect(readyCondition.Reason).To(Equal(string(operatorv1.AllObjectsAvailable)))
+		Expect(readyCondition.Message).To(Equal("All sub-controllers are available"))
+		Expect(readyCondition.ObservedGeneration).To(Equal(generation))
+		recentTransitionTime := instance.Status.Conditions[1].LastTransitionTime
+
+		// Expect tigerstatus transition time remain unchanged when there is no changes to the  condition
+		time.Sleep(5 * time.Second)
+		result, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      "log-storage",
+			Namespace: "",
+		}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).Should(Equal(reconcile.Result{}))
+		instance = &operatorv1.LogStorage{}
+
+		By("Assert last transition time is not affected when tigerastatus condition is untouched")
+		Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, instance)).ShouldNot(HaveOccurred())
+		Expect(instance.Status.Conditions).To(HaveLen(3))
+
+		actualConditions = getCurrentConditions(instance.Status.Conditions)
+
+		By("asserting Ready status remains untouched after reconcilation")
+		readyCondition, ok = actualConditions["Ready"]
+		Expect(ok).To(BeTrue())
+		Expect(string(readyCondition.Status)).To(Equal(string(operatorv1.ConditionTrue)))
+		Expect(readyCondition.Reason).To(Equal(string(operatorv1.AllObjectsAvailable)))
+		Expect(readyCondition.Message).To(Equal("All sub-controllers are available"))
+		Expect(readyCondition.ObservedGeneration).To(Equal(generation))
+		Expect(readyCondition.LastTransitionTime.Time.Equal(recentTransitionTime.Time)).To(BeTrue())
+		recentTransitionTime = instance.Status.Conditions[1].LastTransitionTime
+
+		// Expect tigerastatus set to be degraded with a different transistion time.
+		// update LogStorageUsers  Tigerastatus to degraded
+		tsUser := operatorv1.TigeraStatus{}
+		_ = cli.Get(ctx, client.ObjectKey{
+			Name: TigeraStatusLogStorageUsers,
+		}, &tsUser)
+
+		tsUser.Status.Conditions = []operatorv1.TigeraStatusCondition{
+			{
+				Type:               operatorv1.ComponentAvailable,
+				Status:             operatorv1.ConditionFalse,
+				Reason:             string(operatorv1.ResourceNotReady),
+				Message:            "",
+				ObservedGeneration: int64(1),
+			},
+			{
+				Type:               operatorv1.ComponentProgressing,
+				Status:             operatorv1.ConditionFalse,
+				Reason:             string(operatorv1.ResourceNotReady),
+				Message:            "",
+				ObservedGeneration: int64(1),
+			},
+			{
+				Type:               operatorv1.ComponentDegraded,
+				Status:             operatorv1.ConditionTrue,
+				Reason:             string(operatorv1.ResourceNotReady),
+				Message:            "no active connection found: no Elasticsearch node available",
+				ObservedGeneration: int64(1),
+			},
+		}
+
+		Expect(cli.Update(ctx, &tsUser)).NotTo(HaveOccurred())
+
+		// Sleep before reconciling again to ensure the Last Transition Time updates correctly when switching statuses.
+		time.Sleep(5 * time.Second)
+		result, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      "log-storage",
+			Namespace: "",
+		}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).Should(Equal(reconcile.Result{}))
+		instance = &operatorv1.LogStorage{}
+
+		Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-secure"}, instance)).ShouldNot(HaveOccurred())
+		Expect(instance.Status.Conditions).To(HaveLen(3))
+
+		actualConditions = getCurrentConditions(instance.Status.Conditions)
+
+		By("asserting degraded is marked as true and observed generation is updated to the oldest")
+		degraded, ok := actualConditions["Degraded"]
+		Expect(ok).To(BeTrue())
+
+		degradedMsg := "The following sub-controllers are in this condition: [log-storage-users]"
+		Expect(string(degraded.Status)).To(Equal(string(operatorv1.ConditionTrue)))
+		Expect(degraded.Reason).To(Equal(string(operatorv1.ResourceNotReady)))
+		Expect(degraded.Message).To(Equal(degradedMsg))
+		Expect(degraded.ObservedGeneration).To(Equal(int64(1)))
+
+		By("asserting available is marked as false")
+		readyCondition, ok = actualConditions["Ready"]
+		Expect(ok).To(BeTrue())
+		Expect(string(readyCondition.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		Expect(instance.Status.Conditions[1].ObservedGeneration).To(Equal(int64(1)))
+
+		By("assert transition time should be after the previously recorded transition time")
+		Expect(readyCondition.LastTransitionTime.Time.After(recentTransitionTime.Time)).To(BeTrue())
+
+		By("asserting progressing should remain unchanged")
+		progressing, ok := actualConditions["Progressing"]
+		Expect(ok).To(BeTrue())
+		Expect(string(progressing.Status)).To(Equal(string(operatorv1.ConditionFalse)))
+		Expect(progressing.Reason).To(Equal(string(operatorv1.Unknown)))
+		Expect(progressing.Message).To(Equal(""))
+		Expect(progressing.ObservedGeneration).To(Equal(int64(1)))
 	})
 })
 
@@ -350,4 +444,44 @@ func CreateLogStorage(client client.Client, ls *operatorv1.LogStorage) {
 
 	// Create the LogStorage object.
 	ExpectWithOffset(1, client.Create(context.Background(), ls)).ShouldNot(HaveOccurred())
+}
+
+func createTigeraStatus(cli client.Client, ctx context.Context, name string, generation int64, conditions []operatorv1.TigeraStatusCondition) {
+
+	// set All objects Available by default
+	if len(conditions) == 0 {
+		conditions = []operatorv1.TigeraStatusCondition{
+			{
+				Type:               operatorv1.ComponentAvailable,
+				Status:             operatorv1.ConditionTrue,
+				Reason:             string(operatorv1.AllObjectsAvailable),
+				Message:            "All Objects are available",
+				ObservedGeneration: generation,
+			},
+			{
+				Type:               operatorv1.ComponentProgressing,
+				Status:             operatorv1.ConditionFalse,
+				Reason:             string(operatorv1.AllObjectsAvailable),
+				Message:            "All Objects are available",
+				ObservedGeneration: generation,
+			},
+			{
+				Type:               operatorv1.ComponentDegraded,
+				Status:             operatorv1.ConditionFalse,
+				Reason:             string(operatorv1.AllObjectsAvailable),
+				Message:            "All Objects are available",
+				ObservedGeneration: generation,
+			},
+		}
+	}
+
+	ts := &operatorv1.TigeraStatus{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       operatorv1.TigeraStatusSpec{},
+		Status: operatorv1.TigeraStatusStatus{
+			Conditions: conditions,
+		},
+	}
+
+	Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 }

--- a/pkg/controller/logstorage/initializer/initializing_controller.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,9 +42,15 @@ import (
 var log = logf.Log.WithName("controller_logstorage")
 
 const (
-	DefaultElasticsearchStorageClass = "tigera-elasticsearch"
-	TigeraStatusName                 = "log-storage"
-	defaultEckOperatorMemorySetting  = "512Mi"
+	DefaultElasticsearchStorageClass     = "tigera-elasticsearch"
+	TigeraStatusName                     = "log-storage"
+	defaultEckOperatorMemorySetting      = "512Mi"
+	TigeraStatusLogStorageKubeController = "log-storage-kubecontrollers"
+	TigeraStatusLogStorageAccess         = "log-storage-access"
+	TigeraStatusLogStorageElastic        = "log-storage-elastic"
+	TigeraStatusLogStorageSecrets        = "log-storage-secrets"
+	TigeraStatusLogStorageUsers          = "log-storage-users"
+	TigeraStatusLogStorageESMetrics      = "log-storage-esmetrics"
 )
 
 // Add creates a new LogStorage Controller and adds it to the Manager. The Manager will set fields on the Controller

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -78,7 +80,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
 		clusterDomain:   opts.ClusterDomain,
-		status:          status.New(mgr.GetClient(), "log-storage-kubecontrollers", opts.KubernetesVersion),
+		status:          status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageKubeController, opts.KubernetesVersion),
 		elasticExternal: opts.ElasticExternal,
 		tierWatchReady:  &utils.ReadyFlag{},
 	}
@@ -106,7 +108,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if err = c.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, eventHandler); err != nil {
 		return fmt.Errorf("log-storage-kubecontrollers failed to watch ManagementClusterConnection resource: %w", err)
 	}
-	if err = utils.AddTigeraStatusWatch(c, "log-storage-kubecontrollers"); err != nil {
+	if err = utils.AddTigeraStatusWatch(c, initializer.TigeraStatusLogStorageKubeController); err != nil {
 		return fmt.Errorf("logstorage-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
 

--- a/pkg/controller/logstorage/linseed/linseed_controller.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	logstoragecommon "github.com/tigera/operator/pkg/controller/logstorage/common"
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -113,7 +114,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if err = c.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, eventHandler); err != nil {
 		return fmt.Errorf("log-storage-access-controller failed to watch ManagementClusterConnection resource: %w", err)
 	}
-	if err = utils.AddTigeraStatusWatch(c, "log-storage-access"); err != nil {
+	if err = utils.AddTigeraStatusWatch(c, initializer.TigeraStatusLogStorageAccess); err != nil {
 		return fmt.Errorf("logstorage-access-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
 	if opts.MultiTenant {

--- a/pkg/controller/logstorage/secrets/secret_controller.go
+++ b/pkg/controller/logstorage/secrets/secret_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package secrets
 import (
 	"context"
 	"fmt"
+
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 
@@ -72,7 +74,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		scheme:          mgr.GetScheme(),
 		clusterDomain:   opts.ClusterDomain,
 		multiTenant:     opts.MultiTenant,
-		status:          status.New(mgr.GetClient(), "log-storage-secrets", opts.KubernetesVersion),
+		status:          status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageSecrets, opts.KubernetesVersion),
 		elasticExternal: opts.ElasticExternal,
 	}
 	r.status.Run(opts.ShutdownContext)
@@ -103,7 +105,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if err = c.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, eventHandler); err != nil {
 		return fmt.Errorf("log-storage-secrets-controller failed to watch ManagementClusterConnection resource: %w", err)
 	}
-	if err = utils.AddTigeraStatusWatch(c, "log-storage-secrets"); err != nil {
+	if err = utils.AddTigeraStatusWatch(c, initializer.TigeraStatusLogStorageSecrets); err != nil {
 		return fmt.Errorf("logstorage-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
 	if opts.MultiTenant {

--- a/pkg/controller/logstorage/users/users_controller.go
+++ b/pkg/controller/logstorage/users/users_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package users
 import (
 	"context"
 	"fmt"
+
+	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
@@ -80,7 +82,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
 		multiTenant:     opts.MultiTenant,
-		status:          status.New(mgr.GetClient(), "log-storage-users", opts.KubernetesVersion),
+		status:          status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageUsers, opts.KubernetesVersion),
 		esClientFn:      utils.NewElasticClient,
 		elasticExternal: opts.ElasticExternal,
 	}
@@ -109,7 +111,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if err = c.Watch(&source.Kind{Type: &operatorv1.ManagementClusterConnection{}}, eventHandler); err != nil {
 		return fmt.Errorf("log-storage-user-controller failed to watch ManagementClusterConnection resource: %w", err)
 	}
-	if err = utils.AddTigeraStatusWatch(c, "log-storage-users"); err != nil {
+	if err = utils.AddTigeraStatusWatch(c, initializer.TigeraStatusLogStorageUsers); err != nil {
 		return fmt.Errorf("logstorage-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
 	if opts.MultiTenant {


### PR DESCRIPTION
## Description

```
  status:
    conditions:
    - lastTransitionTime: "2024-01-25T22:17:31Z"
      message: ""
      reason: Unknown
      status: "False"
      type: Degraded
    - lastTransitionTime: "2024-01-25T22:17:31Z"
      message: All sub-controllers are available
      reason: AllObjectsAvailable
      status: "True"
      type: Ready
    - lastTransitionTime: "2024-01-25T22:17:31Z"
      message: ""
      reason: Unknown
      status: "False"
      type: Progressing

```

```
  status:
    conditions:
    - lastTransitionTime: "2024-01-25T22:55:42Z"
      message: ""
      reason: Unknown
      status: "False"
      type: Progressing
    - lastTransitionTime: "2024-01-25T23:02:49Z"
      message: 'The following sub-controllers are in this condition: [log-storage-access
        log-storage-elastic log-storage-esmetrics log-storage-kubecontrollers]'
      reason: ResourceNotReady
      status: "True"
      type: Degraded
    - lastTransitionTime: "2024-01-25T22:55:03Z"
      message: ""
      reason: ResourceNotReady
      status: "False"
      type: Ready

```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
