### PR TITLE
Revert bad FLOW_LOG_FILE fluentd env var Windows fix

### DIFF
--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -99,9 +99,6 @@ const (
 
 	PacketCaptureAPIRole        = "packetcapture-api-role"
 	PacketCaptureAPIRoleBinding = "packetcapture-api-role-binding"
-
-	flowLogFile        = "/var/log/calico/flowlogs/flows.log"
-	flowLogFileWindows = "c:/TigeraCalico/flowlogs/flows.log"
 )
 
 var FluentdSourceEntityRule = v3.EntityRule{
@@ -660,12 +657,6 @@ func (c *fluentdComponent) metricsService() *corev1.Service {
 }
 
 func (c *fluentdComponent) envvars() []corev1.EnvVar {
-	// The flow log filepath is considerably different on Windows
-	flowLogFileVal := flowLogFile
-	if c.cfg.OSType == rmeta.OSTypeWindows {
-		flowLogFileVal = flowLogFileWindows
-	}
-
 	envs := []corev1.EnvVar{
 		{Name: "LINSEED_ENABLED", Value: "true"},
 		// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
@@ -675,7 +666,7 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		{Name: "TLS_KEY_PATH", Value: c.keyPath()},
 		{Name: "TLS_CRT_PATH", Value: c.certPath()},
 		{Name: "FLUENT_UID", Value: "0"},
-		{Name: "FLOW_LOG_FILE", Value: flowLogFileVal},
+		{Name: "FLOW_LOG_FILE", Value: c.path("/var/log/calico/flowlogs/flows.log")},
 		{Name: "DNS_LOG_FILE", Value: c.path("/var/log/calico/dnslogs/dns.log")},
 		{Name: "FLUENTD_ES_SECURE", Value: "true"},
 		{Name: "NODENAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -418,7 +418,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{Name: "TLS_KEY_PATH", Value: "c:/tigera-fluentd-prometheus-tls/tls.key"},
 			{Name: "TLS_CRT_PATH", Value: "c:/tigera-fluentd-prometheus-tls/tls.crt"},
 			{Name: "FLUENT_UID", Value: "0"},
-			{Name: "FLOW_LOG_FILE", Value: "c:/TigeraCalico/flowlogs/flows.log"},
+			{Name: "FLOW_LOG_FILE", Value: "c:/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "c:/var/log/calico/dnslogs/dns.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			{
@@ -438,7 +438,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 		expectedEnvs = []corev1.EnvVar{
 			{Name: "FLUENT_UID", Value: "0"},
-			{Name: "FLOW_LOG_FILE", Value: "c:/TigeraCalico/flowlogs/flows.log"},
+			{Name: "FLOW_LOG_FILE", Value: "c:/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "c:/var/log/calico/dnslogs/dns.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			{


### PR DESCRIPTION
## Description

Revert bad FLOW_LOG_FILE fluentd env var Windows fix (https://github.com/tigera/operator/pull/3090), as the fluentd windows pod mounts `c:/TigeraCalico/` under  `c:/var/log/calico` (https://github.com/tigera/operator/blob/fb438b87cd485970133733b3e018f11ae551807d/pkg/render/fluentd.go#L907-L912 and https://github.com/tigera/operator/blob/fb438b87cd485970133733b3e018f11ae551807d/pkg/render/fluentd.go#L263)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
