### PR TITLE
Add tigera operator scheme to the unit tests for authn.

### DIFF
--- a/pkg/controller/utils/auth_test.go
+++ b/pkg/controller/utils/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,16 +20,18 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/tigera/operator/pkg/controller/certificatemanager"
 
-	operatorv1 "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/common"
-	"github.com/tigera/operator/pkg/controller/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/controller/utils"
 )
 
 var _ = Describe("LDAP secrets tests", func() {
@@ -42,6 +44,7 @@ var _ = Describe("LDAP secrets tests", func() {
 
 	BeforeEach(func() {
 		scheme := runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 		Expect(corev1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		cli = fake.NewClientBuilder().WithScheme(scheme).Build()
 		ctx = context.Background()


### PR DESCRIPTION
Looks like PR https://github.com/tigera/operator/pull/3069 got stale after being open for a long time and after merging caused the pipelines to fail: https://tigera.semaphoreci.com/jobs/65a12b70-5548-4da3-949a-74d710ace034

