### PR TITLE
Automated cherry pick of #3128: Fix panic that can be caused when removing the logstorage

### DIFF
--- a/pkg/controller/logstorage/esmetrics/esmetrics_controller.go
+++ b/pkg/controller/logstorage/esmetrics/esmetrics_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -187,6 +187,10 @@ func (r *ESMetricsSubController) Reconcile(ctx context.Context, request reconcil
 			log,
 		)
 		return reconcile.Result{}, err
+	} else if serverKeyPair == nil {
+		// Possibly LogStorage was removed and caused the secret to have been deleted.
+		r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret %s/%s to be created", render.ElasticsearchNamespace, esmetrics.ElasticsearchMetricsServerTLSSecret), nil, reqLogger)
+		return reconcile.Result{}, nil
 	}
 
 	trustedBundle, err := cm.LoadTrustedBundle(ctx, r.client, render.ElasticsearchNamespace)


### PR DESCRIPTION
Cherry pick of #3128 on release-v1.33.

#3128: Fix panic that can be caused when removing the logstorage