### PR TITLE
Add feature annotations to cluster-service-version

### DIFF
--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -43,6 +43,19 @@ yq write -i ${CSV} metadata.annotations.containerImage ${OPERATOR_IMAGE_DIGEST}
 TIMESTAMP=$(echo ${OPERATOR_IMAGE_INSPECT} | jq -r .[0].Created)
 yq write -i ${CSV} metadata.annotations.createdAt ${TIMESTAMP}
 
+# Add the features annotations
+FEATURES=metadata.annotations.features.operators.openshift.io
+yq write -i ${CSV} ${FEATURES}/disconnected "false"
+yq write -i ${CSV} ${FEATURES}/fips-compliant "false"
+yq write -i ${CSV} ${FEATURES}/proxy-aware "false"
+yq write -i ${CSV} ${FEATURES}/tls-profiles "false"
+yq write -i ${CSV} ${FEATURES}/token-auth-aws "false"
+yq write -i ${CSV} ${FEATURES}/token-auth-azure "false"
+yq write -i ${CSV} ${FEATURES}/token-auth-gcp "false"
+yq write -i ${CSV} ${FEATURES}/cnf "false"
+yq write -i ${CSV} ${FEATURES}/cni "true"
+yq write -i ${CSV} ${FEATURES}/csi "false"
+
 # Set the operator container image by digest in the tigera-operator deployment spec embedded in the CSV.
 yq write -i ${CSV} spec.install.spec.deployments[0].spec.template.spec.containers[0].image ${OPERATOR_IMAGE_DIGEST}
 


### PR DESCRIPTION
## Description
Openshift certification has added a set of annotations that will be required in operator bundles for certification from 1st March onwards.  This PR adds those annotations.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
