### PR TITLE
Deploy es-kube-controllers in a multi-tenant environment

### DIFF
--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
@@ -289,7 +289,7 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 	}
 
 	// Get secrets needed for kube-controllers to talk to elastic. This is needed for zero-tenants and single-tenants
-	// that deploy eskube controllers and need to talk to es-gateway
+	// that deploy es-kube-controllers and need to talk to es-gateway
 	var kubeControllersUserSecret *core.Secret
 	if !r.multiTenant {
 		kubeControllersUserSecret, err = utils.GetSecret(ctx, r.client, kubecontrollers.ElasticsearchKubeControllersUserSecret, helper.TruthNamespace())

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
@@ -21,6 +21,8 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,8 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
@@ -41,6 +41,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/logstorage/initializer"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/tenancy"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
@@ -61,15 +62,12 @@ type ESKubeControllersController struct {
 	clusterDomain   string
 	usePSP          bool
 	elasticExternal bool
+	multiTenant     bool
 	tierWatchReady  *utils.ReadyFlag
 }
 
 func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if !opts.EnterpriseCRDExists {
-		return nil
-	}
-
-	if opts.MultiTenant {
 		return nil
 	}
 
@@ -80,6 +78,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		clusterDomain:   opts.ClusterDomain,
 		status:          status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageKubeController, opts.KubernetesVersion),
 		elasticExternal: opts.ElasticExternal,
+		multiTenant:     opts.MultiTenant,
 		tierWatchReady:  &utils.ReadyFlag{},
 	}
 	r.status.Run(opts.ShutdownContext)
@@ -90,8 +89,12 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		return err
 	}
 
-	// Determine how to handle watch events for cluster-scoped resources.
+	// Determine how to handle watch events for cluster-scoped resources. For multi-tenant clusters,
+	// we should update all tenants whenever one changes. For single-tenant clusters, we can just queue the object.
 	var eventHandler handler.EventHandler = &handler.EnqueueRequestForObject{}
+	if opts.MultiTenant {
+		eventHandler = utils.EnqueueAllTenants(mgr.GetClient())
+	}
 
 	// Configure watches for operator.tigera.io APIs this controller cares about.
 	if err = c.WatchObject(&operatorv1.LogStorage{}, eventHandler); err != nil {
@@ -109,13 +112,27 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if err = utils.AddTigeraStatusWatch(c, initializer.TigeraStatusLogStorageKubeController); err != nil {
 		return fmt.Errorf("logstorage-controller failed to watch logstorage Tigerastatus: %w", err)
 	}
+	if opts.MultiTenant {
+		if err = c.WatchObject(&operatorv1.Tenant{}, &handler.EnqueueRequestForObject{}); err != nil {
+			return fmt.Errorf("log-storage-kubecontrollers failed to watch Tenant resource: %w", err)
+		}
+	}
+
+	// The namespace(s) we need to monitor depend upon what tenancy mode we're running in.
+	// For single-tenant, everything is installed in the calico-system namespace.
+	// Make a helper for determining which namespaces to use based on tenancy mode.
+	esGatewayHelper := utils.NewNamespaceHelper(opts.MultiTenant, render.ElasticsearchNamespace, "")
+	helper := utils.NewNamespaceHelper(opts.MultiTenant, common.CalicoNamespace, "")
 
 	// Watch secrets this controller cares about.
 	secretsToWatch := []string{
 		render.TigeraElasticsearchGatewaySecret,
 		monitor.PrometheusClientTLSSecretName,
 	}
-	for _, ns := range []string{common.OperatorNamespace(), render.ElasticsearchNamespace} {
+
+	// Determine namespaces to watch.
+	_, _, namespacesToWatch := tenancy.GetWatchNamespaces(r.multiTenant, render.ElasticsearchNamespace)
+	for _, ns := range namespacesToWatch {
 		for _, name := range secretsToWatch {
 			if err := utils.AddSecretsWatch(c, name, ns); err != nil {
 				return fmt.Errorf("log-storage-kubecontrollers failed to watch Secret: %w", err)
@@ -124,17 +141,23 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	// Catch if something modifies the resources that this controller consumes.
-	if err := utils.AddServiceWatch(c, render.ElasticsearchServiceName, render.ElasticsearchNamespace); err != nil {
+	if err := utils.AddServiceWatch(c, render.ElasticsearchServiceName, esGatewayHelper.InstallNamespace()); err != nil {
 		return fmt.Errorf("log-storage-kubecontrollers failed to watch the Service resource: %w", err)
 	}
-	if err := utils.AddServiceWatch(c, esgateway.ServiceName, render.ElasticsearchNamespace); err != nil {
+	if err := utils.AddServiceWatch(c, esgateway.ServiceName, esGatewayHelper.InstallNamespace()); err != nil {
 		return fmt.Errorf("log-storage-kubecontrollers failed to watch the Service resource: %w", err)
 	}
-	if err := utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, common.CalicoNamespace, &handler.EnqueueRequestForObject{}); err != nil {
+	if err := utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, esGatewayHelper.InstallNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-kubecontrollers failed to watch the ConfigMap resource: %w", err)
 	}
-	if err := utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, render.ElasticsearchNamespace, &handler.EnqueueRequestForObject{}); err != nil {
-		return fmt.Errorf("log-storage-kubecontrollers failed to watch the ConfigMap resource: %w", err)
+	if err := utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, helper.InstallNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("log-storage-kubecontrollers failed to watch the Service resource: %w", err)
+	}
+	if err := utils.AddDeploymentWatch(c, esgateway.DeploymentName, helper.InstallNamespace()); err != nil {
+		return fmt.Errorf("log-storage-access-controller failed to watch the Service resource: %w", err)
+	}
+	if err := utils.AddDeploymentWatch(c, kubecontrollers.EsKubeController, helper.InstallNamespace()); err != nil {
+		return fmt.Errorf("log-storage-access-controller failed to watch the Service resource: %w", err)
 	}
 
 	// Perform periodic reconciliation. This acts as a backstop to catch reconcile issues,
@@ -152,22 +175,40 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	// Start goroutines to establish watches against projectcalico.org/v3 resources.
 	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, r.tierWatchReady)
 	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
-		{Name: esgateway.PolicyName, Namespace: render.ElasticsearchNamespace},
-		{Name: kubecontrollers.EsKubeControllerNetworkPolicyName, Namespace: common.CalicoNamespace},
+		{Name: esgateway.PolicyName, Namespace: esGatewayHelper.InstallNamespace()},
+		{Name: kubecontrollers.EsKubeControllerNetworkPolicyName, Namespace: helper.InstallNamespace()},
 	})
 
 	return nil
 }
 
 func (r *ESKubeControllersController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	helper := utils.NewNamespaceHelper(false, common.CalicoNamespace, request.Namespace)
+	helper := utils.NewNamespaceHelper(r.multiTenant, common.CalicoNamespace, request.Namespace)
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name, "installNS", helper.InstallNamespace(), "truthNS", helper.TruthNamespace())
 	reqLogger.Info("Reconciling LogStorage - ESKubeControllers")
+
+	// We skip requests without a namespace specified in multi-tenant setups.
+	if r.multiTenant && request.Namespace == "" {
+		return reconcile.Result{}, nil
+	}
+
+	// When running in multi-tenant mode, we need to install es-kubecontrollers in tenant Namespaces. However, the LogStorage
+	// resource is still cluster-scoped (since ES is a cluster-wide resource), so we need to look elsewhere to determine
+	// which tenant namespaces require an es-kubecontrollers instance. We use the tenant API to determine the set of
+	// namespaces that should have an es-kubecontrollers.
+	tenant, _, err := utils.GetTenant(ctx, r.multiTenant, r.client, request.Namespace)
+	if errors.IsNotFound(err) {
+		reqLogger.V(1).Info("No Tenant in this Namespace, skip")
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred while querying Tenant", err, reqLogger)
+		return reconcile.Result{}, err
+	}
 
 	// Get LogStorage resource.
 	logStorage := &operatorv1.LogStorage{}
 	key := utils.DefaultTSEEInstanceKey
-	err := r.client.Get(ctx, key, logStorage)
+	err = r.client.Get(ctx, key, logStorage)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			r.status.OnCRNotFound()
@@ -245,15 +286,19 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 	}
 
 	// Get secrets needed for kube-controllers to talk to elastic.
-	kubeControllersUserSecret, err := utils.GetSecret(ctx, r.client, kubecontrollers.ElasticsearchKubeControllersUserSecret, helper.TruthNamespace())
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get kube controllers gateway secret", err, reqLogger)
-		return reconcile.Result{}, err
+	var kubeControllersUserSecret *core.Secret
+	if !r.multiTenant {
+		kubeControllersUserSecret, err = utils.GetSecret(ctx, r.client, kubecontrollers.ElasticsearchKubeControllersUserSecret, helper.TruthNamespace())
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get kube controllers gateway secret", err, reqLogger)
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Collect the certificates we need to provision es-kube-controllers. These will have been provisioned already by the ES secrets controller.
 	opts := []certificatemanager.Option{
 		certificatemanager.WithLogger(reqLogger),
+		certificatemanager.WithTenant(tenant),
 	}
 	cm, err := certificatemanager.Create(r.client, install, r.clusterDomain, helper.TruthNamespace(), opts...)
 	if err != nil {
@@ -270,40 +315,43 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 
-	gwNSHelper := utils.NewSingleTenantNamespaceHelper(render.ElasticsearchNamespace)
-	// Query the trusted bundle from the namespace.
-	gwTrustedBundle, err := cm.LoadTrustedBundle(ctx, r.client, gwNSHelper.InstallNamespace())
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting trusted bundle in %s", gwNSHelper.InstallNamespace()), err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
 	pullSecrets, err := utils.GetNetworkingPullSecrets(install, r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurring while retrieving the pull secrets", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
-	// ESGateway is required in order for kube-controllers to operate successfully, since es-kube-controllers talks to ES
-	// via this gateway. However, in multi-tenant mode we disable the elasticsearch controller and so this isn't needed.
-	if err := r.createESGateway(
-		ctx,
-		gwNSHelper,
-		install,
-		variant,
-		pullSecrets,
-		hdler,
-		reqLogger,
-		gwTrustedBundle,
-		r.usePSP,
-	); err != nil {
-		return reconcile.Result{}, err
+	if !r.multiTenant {
+		gwNSHelper := utils.NewSingleTenantNamespaceHelper(render.ElasticsearchNamespace)
+		// Query the trusted bundle from the namespace.
+		gwTrustedBundle, err := cm.LoadTrustedBundle(ctx, r.client, gwNSHelper.InstallNamespace())
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting trusted bundle in %s", gwNSHelper.InstallNamespace()), err, reqLogger)
+			return reconcile.Result{}, err
+		}
+
+		// ESGateway is required in order for kube-controllers to operate successfully, since es-kube-controllers talks to ES
+		// via this gateway. However, in multi-tenant mode, es-kube-controllers doesn't talk to elasticsearch,
+		// so this is only needed in single-tenant clusters.
+		if err := r.createESGateway(
+			ctx,
+			gwNSHelper,
+			install,
+			variant,
+			pullSecrets,
+			hdler,
+			reqLogger,
+			gwTrustedBundle,
+			r.usePSP,
+		); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Query the trusted bundle from the namespace.
 	trustedBundle, err := cm.LoadTrustedBundle(ctx, r.client, helper.InstallNamespace())
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting trusted bundle in %s", gwNSHelper.InstallNamespace()), err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting trusted bundle in %s", helper.InstallNamespace()), err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
@@ -324,6 +372,7 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 		TrustedBundle:                trustedBundle,
 		Namespace:                    helper.InstallNamespace(),
 		BindingNamespaces:            namespaces,
+		Tenant:                       tenant,
 	}
 	esKubeControllerComponents := kubecontrollers.NewElasticsearchKubeControllers(&kubeControllersCfg)
 

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
@@ -324,6 +324,9 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 
+	// ESGateway is required in order for kube-controllers to operate successfully, since es-kube-controllers talks to ES
+	// via this gateway. However, in multi-tenant mode, es-kube-controllers doesn't talk to elasticsearch,
+	// so this is only needed in single-tenant clusters and zero tenants clusters
 	if !r.multiTenant {
 		gwNSHelper := utils.NewSingleTenantNamespaceHelper(render.ElasticsearchNamespace)
 		// Query the trusted bundle from the namespace.
@@ -332,10 +335,6 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting trusted bundle in %s", gwNSHelper.InstallNamespace()), err, reqLogger)
 			return reconcile.Result{}, err
 		}
-
-		// ESGateway is required in order for kube-controllers to operate successfully, since es-kube-controllers talks to ES
-		// via this gateway. However, in multi-tenant mode, es-kube-controllers doesn't talk to elasticsearch,
-		// so this is only needed in single-tenant clusters.
 		if err := r.createESGateway(
 			ctx,
 			gwNSHelper,

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
@@ -288,7 +288,8 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 		}
 	}
 
-	// Get secrets needed for kube-controllers to talk to elastic.
+	// Get secrets needed for kube-controllers to talk to elastic. This is needed for zero-tenants and single-tenants
+	// that deploy eskube controllers and need to talk to es-gateway
 	var kubeControllersUserSecret *core.Secret
 	if !r.multiTenant {
 		kubeControllersUserSecret, err = utils.GetSecret(ctx, r.client, kubecontrollers.ElasticsearchKubeControllersUserSecret, helper.TruthNamespace())

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
-	controllerruntime "sigs.k8s.io/controller-runtime"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -83,6 +84,7 @@ func NewControllerWithShims(
 		status:         status,
 		clusterDomain:  opts.ClusterDomain,
 		tierWatchReady: tierWatchReady,
+		multiTenant:    multiTenant,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r, nil
@@ -282,19 +284,6 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 		Expect(kc.Image).To(Equal(fmt.Sprintf("some.registry.org/%s@%s", components.ComponentTigeraKubeControllers.Image, "sha256:kubecontrollershash")))
 	})
 
-	It("should not create es-kube-controller controller in multi-tenant mode", func() {
-		mgr, err := controllerruntime.NewManager(nil, controllerruntime.Options{})
-		Expect(err).To(Not(BeNil()))
-
-		options := options.AddOptions{
-			MultiTenant:         true,
-			EnterpriseCRDExists: true,
-		}
-
-		err = Add(mgr, options)
-		Expect(err).To(BeNil())
-	})
-
 	Context("External ES mode", func() {
 		BeforeEach(func() {
 			// Delete the Elasticsearch CR. This is created for ECK only.
@@ -347,6 +336,96 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      esgateway.DeploymentName,
 					Namespace: render.ElasticsearchNamespace,
+				},
+			}
+			Expect(test.GetResource(cli, &dep)).To(BeNil())
+		})
+	})
+
+	Context("Multi-tenant", func() {
+		var (
+			tenantNS string
+			tenant   *operatorv1.Tenant
+		)
+
+		BeforeEach(func() {
+			tenantNS = "tenant-namespace"
+			Expect(cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenantNS}})).ShouldNot(HaveOccurred())
+
+			// Create the Tenant object.
+			tenant = &operatorv1.Tenant{}
+			tenant.Name = "default"
+			tenant.Namespace = tenantNS
+			tenant.Spec.ID = "test-tenant-id"
+			tenant.Spec.Indices = []operatorv1.Index{}
+			Expect(cli.Create(ctx, tenant)).ShouldNot(HaveOccurred())
+
+			// Create a CA secret for the test, and create its KeyPair.
+			opts := []certificatemanager.Option{
+				certificatemanager.AllowCACreation(),
+				certificatemanager.WithTenant(tenant),
+			}
+			cm, err := certificatemanager.Create(cli, &install.Spec, dns.DefaultClusterDomain, tenantNS, opts...)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(cli.Create(ctx, cm.KeyPair().Secret(tenantNS))).ShouldNot(HaveOccurred())
+			bundle := cm.CreateTrustedBundle()
+			Expect(cli.Create(ctx, bundle.ConfigMap(tenantNS))).ShouldNot(HaveOccurred())
+
+			// Create the reconciler for the tests.
+			r, err = NewControllerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, dns.DefaultClusterDomain, true, readyFlag)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should wait for the tenant CA to be provisioned", func() {
+			// Delete the CA secret for this test.
+			caSecret := &corev1.Secret{}
+			caSecret.Name = certificatemanagement.TenantCASecretName
+			caSecret.Namespace = tenantNS
+			Expect(cli.Delete(ctx, caSecret)).ShouldNot(HaveOccurred())
+
+			// Run the reconciler.
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: tenantNS}})
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("CA secret"))
+		})
+
+		It("should not reconcile any resources if no Namespace was given", func() {
+			// Run the reconciler, passing in a Request with no Namespace. It should return successfully.
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check that nothing was installed on the cluster.
+			dep := appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubecontrollers.EsKubeController,
+					Namespace: tenantNS,
+				},
+			}
+			err = cli.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, &dep)
+			Expect(err).Should(HaveOccurred())
+			Expect(errors.IsNotFound(err)).Should(BeTrue())
+
+			// Check that OnCRFound was not called.
+			mockStatus.AssertNotCalled(GinkgoT(), "OnCRFound")
+		})
+
+		It("should reconcile resources for a cluster", func() {
+			// Run the reconciler.
+			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: tenantNS}})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).Should(Equal(successResult))
+
+			// SetDegraded should not have been called.
+			mockStatus.AssertNumberOfCalls(GinkgoT(), "SetDegraded", 0)
+
+			// Check that kube-controllers was created as expected. We don't need to check every resource in detail, since
+			// the render package has its own tests which cover this in more detail.
+			dep := appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubecontrollers.EsKubeController,
+					Namespace: tenantNS,
 				},
 			}
 			Expect(test.GetResource(cli, &dep)).To(BeNil())

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -105,7 +105,8 @@ type KubeControllersConfiguration struct {
 	// List of namespaces that are running a kube-controllers instance that need a cluster role binding.
 	BindingNamespaces []string
 
-	// Whether or not to run the rendered components in multi-tenant mode.
+	// Tenant object provides tenant configuration for both single and multi-tenant modes.
+	// If this is nil, then we should run in zero-tenant mode.
 	Tenant *operatorv1.Tenant
 }
 

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -484,7 +484,7 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 		{Name: "ENABLED_CONTROLLERS", Value: strings.Join(c.enabledControllers, ",")},
 		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
-		{Name: "DISABLE_RUN_CONFIG_CONTROLLER", Value: strconv.FormatBool(c.cfg.Tenant.MultiTenant() && c.kubeControllerConfigName == "elasticsearch")},
+		{Name: "DISABLE_KUBE_CONTROLLERS_CONFIG_API", Value: strconv.FormatBool(c.cfg.Tenant.MultiTenant() && c.kubeControllerConfigName == "elasticsearch")},
 	}
 
 	env = append(env, c.cfg.K8sServiceEp.EnvVars(false, c.cfg.Installation.KubernetesProvider)...)

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tigera/operator/pkg/common"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/url"
 
@@ -100,6 +103,9 @@ type KubeControllersConfiguration struct {
 
 	// List of namespaces that are running a kube-controllers instance that need a cluster role binding.
 	BindingNamespaces []string
+
+	// Whether or not to run the rendered components in multi-tenant mode.
+	Tenant *operatorv1.Tenant
 }
 
 func NewCalicoKubeControllers(cfg *KubeControllersConfiguration) *kubeControllersComponent {
@@ -147,6 +153,27 @@ func NewCalicoKubeControllersPolicy(cfg *KubeControllersConfiguration) render.Co
 func NewElasticsearchKubeControllers(cfg *KubeControllersConfiguration) *kubeControllersComponent {
 	var kubeControllerAllowTigeraPolicy *v3.NetworkPolicy
 	kubeControllerRolePolicyRules := kubeControllersRoleCommonRules(cfg, EsKubeController)
+	if cfg.Tenant.MultiTenant() {
+		kubeControllerRolePolicyRules = append(kubeControllerRolePolicyRules, []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"serviceaccounts"},
+				Verbs:         []string{"impersonate"},
+				ResourceNames: []string{KubeControllerServiceAccount},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"groups"},
+				Verbs:     []string{"impersonate"},
+				ResourceNames: []string{
+					serviceaccount.AllServiceAccountsGroup,
+					"system:authenticated",
+					fmt.Sprintf("%s%s", serviceaccount.ServiceAccountGroupPrefix, common.CalicoNamespace),
+				},
+			},
+		}...)
+	}
+
 	if cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		kubeControllerRolePolicyRules = append(kubeControllerRolePolicyRules, kubeControllersRoleEnterpriseCommonRules(cfg)...)
 		kubeControllerRolePolicyRules = append(kubeControllerRolePolicyRules,
@@ -171,10 +198,22 @@ func NewElasticsearchKubeControllers(cfg *KubeControllersConfiguration) *kubeCon
 		kubeControllerAllowTigeraPolicy = esKubeControllersAllowTigeraPolicy(cfg)
 	}
 
-	enabledControllers := []string{"authorization", "elasticsearchconfiguration"}
+	var enabledControllers []string
 
-	if cfg.ManagementCluster != nil {
-		enabledControllers = append(enabledControllers, "managedcluster")
+	if !cfg.Tenant.MultiTenant() {
+		enabledControllers = append(enabledControllers, "authorization", "elasticsearchconfiguration")
+		if cfg.ManagementCluster != nil {
+			enabledControllers = append(enabledControllers, "managedcluster")
+		}
+	} else {
+		if cfg.ManagementCluster != nil {
+			enabledControllers = append(enabledControllers, "managedclusterlicensing")
+		}
+	}
+
+	kubeControllerConfigName := "elasticsearch"
+	if cfg.Tenant.MultiTenant() {
+		kubeControllerConfigName = fmt.Sprintf("tenant-%s", cfg.Tenant.Spec.ID)
 	}
 
 	return &kubeControllersComponent{
@@ -183,7 +222,7 @@ func NewElasticsearchKubeControllers(cfg *KubeControllersConfiguration) *kubeCon
 		kubeControllerRoleName:           EsKubeControllerRole,
 		kubeControllerRoleBindingName:    EsKubeControllerRoleBinding,
 		kubeControllerName:               EsKubeController,
-		kubeControllerConfigName:         "elasticsearch",
+		kubeControllerConfigName:         kubeControllerConfigName,
 		kubeControllerMetricsName:        EsKubeControllerMetrics,
 		kubeControllersRules:             kubeControllerRolePolicyRules,
 		kubeControllerAllowTigeraPolicy:  kubeControllerAllowTigeraPolicy,
@@ -456,6 +495,14 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 	env = append(env, c.cfg.K8sServiceEp.EnvVars(false, c.cfg.Installation.KubernetesProvider)...)
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
+		if c.cfg.Tenant != nil {
+			env = append(env, corev1.EnvVar{Name: "TENANT_ID", Value: c.cfg.Tenant.Spec.ID})
+			if c.cfg.Tenant.MultiTenant() {
+				env = append(env, corev1.EnvVar{Name: "TENANT_NAMESPACE", Value: c.cfg.Tenant.Namespace})
+				env = append(env, corev1.EnvVar{Name: "MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: render.ManagerService(c.cfg.Tenant)})
+			}
+		}
+
 		if c.kubeControllerName == EsKubeController {
 			// What started as a workaround is now the default behaviour. This feature uses our backend in order to
 			// log into Kibana for users from external identity providers, rather than configuring an authn realm
@@ -530,7 +577,7 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		VolumeMounts:    c.kubeControllersVolumeMounts(),
 	}
 
-	if c.kubeControllerName == EsKubeController {
+	if c.kubeControllerName == EsKubeController && !c.cfg.Tenant.MultiTenant() {
 		_, esHost, esPort, _ := url.ParseEndpoint(relasticsearch.GatewayEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, render.ElasticsearchNamespace))
 		container.Env = append(container.Env, []corev1.EnvVar{
 			relasticsearch.ElasticHostEnvVar(esHost),
@@ -578,7 +625,10 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 			},
 		},
 	}
-	render.SetClusterCriticalPod(&(d.Spec.Template))
+
+	if !c.cfg.Tenant.MultiTenant() {
+		render.SetClusterCriticalPod(&(d.Spec.Template))
+	}
 
 	if overrides := c.cfg.Installation.CalicoKubeControllersDeployment; overrides != nil {
 		rcomp.ApplyDeploymentOverrides(&d, overrides)
@@ -760,11 +810,19 @@ func esKubeControllersAllowTigeraPolicy(cfg *KubeControllersConfiguration) *v3.N
 				Ports: networkpolicy.Ports(443, 6443, 12388),
 			},
 		},
-		{
-			Action:      v3.Allow,
-			Protocol:    &networkpolicy.TCPProtocol,
-			Destination: networkpolicy.DefaultHelper().ESGatewayEntityRule(),
-		},
+	}...)
+
+	if !cfg.Tenant.MultiTenant() {
+		egressRules = append(egressRules, []v3.Rule{
+			{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: networkpolicy.DefaultHelper().ESGatewayEntityRule(),
+			},
+		}...)
+	}
+
+	egressRules = append(egressRules, []v3.Rule{
 		{
 			Action:      v3.Allow,
 			Protocol:    &networkpolicy.TCPProtocol,

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -206,9 +206,7 @@ func NewElasticsearchKubeControllers(cfg *KubeControllersConfiguration) *kubeCon
 			enabledControllers = append(enabledControllers, "managedcluster")
 		}
 	} else {
-		if cfg.ManagementCluster != nil {
-			enabledControllers = append(enabledControllers, "managedclusterlicensing")
-		}
+		enabledControllers = append(enabledControllers, "managedclusterlicensing")
 	}
 
 	kubeControllerConfigName := "elasticsearch"
@@ -627,7 +625,7 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 	}
 
 	if !c.cfg.Tenant.MultiTenant() {
-		render.SetClusterCriticalPod(&(d.Spec.Template))
+		render.SetClusterCriticalPod(&d.Spec.Template)
 	}
 
 	if overrides := c.cfg.Installation.CalicoKubeControllersDeployment; overrides != nil {

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -188,6 +188,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			{Name: "ENABLED_CONTROLLERS", Value: "node"},
 			{Name: "KUBE_CONTROLLERS_CONFIG_NAME", Value: "default"},
 			{Name: "FIPS_MODE_ENABLED", Value: "false"},
+			{Name: "DISABLE_KUBE_CONTROLLERS_CONFIG_API", Value: "false"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedEnv))
 
@@ -1208,7 +1209,11 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				},
 				corev1.EnvVar{
 					Name:  "KUBE_CONTROLLERS_CONFIG_NAME",
-					Value: fmt.Sprintf("tenant-%s", tenant.Spec.ID),
+					Value: "elasticsearch",
+				},
+				corev1.EnvVar{
+					Name:  "DISABLE_KUBE_CONTROLLERS_CONFIG_API",
+					Value: "true",
 				},
 			),
 			)


### PR DESCRIPTION
## Description

Deploy es kube controllers in a tenant namespace to enable license copy in the managed clusters. We will use a new configuration `managedclusterlicensing`, that only deploy the licensing controller. We also need to impersonate kube-controllers service account from calico-system namespace, since this is the one that has rights inside the managed cluster.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
