### PR TITLE
Update Ubuntu runner version to 20.04 [master]

### DIFF
--- a/.semaphore/clean_up.yml
+++ b/.semaphore/clean_up.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 blocks:
   - name: Clear Commit Caches

--- a/.semaphore/clear_cache.yml
+++ b/.semaphore/clear_cache.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 blocks:
   - name: Clear Entire Cache

--- a/.semaphore/push_images.yml
+++ b/.semaphore/push_images.yml
@@ -3,7 +3,7 @@ name: Operator CD
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 global_job_config:
   secrets:
     - name: docker-hub

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,7 +13,7 @@ auto_cancel:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 global_job_config:
   secrets:
   - name: docker-hub
@@ -138,7 +138,7 @@ blocks:
       agent:
         machine:
           type: e1-standard-4
-          os_image: ubuntu1804
+          os_image: ubuntu2004
       jobs:
         - name: Run FVs
           execution_time_limit:


### PR DESCRIPTION
## Description

Update the CI runners from 18.04 (deprecated) to 20.04. Note that we can't update to 22.04 because it is only available on second-generation runners.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
