### PR TITLE
should not ignore non-migrated nodes for typha scheduling

### DIFF
--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -235,10 +235,6 @@ func (t *typhaAutoscaler) getNodeCounts() (int, int, error) {
 		if n.Spec.Unschedulable {
 			continue
 		}
-		if n.GetObjectMeta().GetLabels()["projectcalico.org/operator-node-migration"] == "pre-operator" {
-			// This node hasn't been migrated to the operator yet. Don't include it in the number of desired Typhas.
-			continue
-		}
 
 		if _, ok := n.Labels["kubernetes.azure.com/cluster"]; ok && n.Labels["type"] == "virtual-kubelet" {
 			// in AKS, there is a feature called 'virtual-nodes' which represent azure's container service as a node in the kubernetes cluster.

--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		verifyTyphaReplicas(c, 2)
 	})
 
-	It("should ignore non-migrated nodes in its count", func() {
+	It("should not ignore non-migrated nodes in its count", func() {
 		typhaMeta := metav1.ObjectMeta{
 			Name:      "calico-typha",
 			Namespace: "calico-system",
@@ -193,9 +193,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
-		// normally we'd expect to see three replicas for five nodes, but since one node is not migrated,
-		// we should still only expect two
-		verifyTyphaReplicas(c, 2)
+		verifyTyphaReplicas(c, 3)
 	})
 
 	It("should ignore aks virtual nodes in its count", func() {


### PR DESCRIPTION
## Description
kind/bugfix

If there is any problem with the migration procedure (`kube-system` to `calico-system`), the migration does not continue automatically,  As noticed, the `typha_autoscaler` blocks the migration as it waits for nodes without the label `projectcalico.org/operator-node-migration=pre-operator`. But the migration logic puts this label to all the nodes.
That's why if the migration fails then on the next reconcile, the `typha_autoscaler` reports degraded state as it can't find enough nodes and blocks the migration. This makes no sense, as `calico-typha` does not have related node selector and it does not depend on calico-node (it uses hostNetwork).

```bash
➜ kubectl get tigerastatus calico -o yaml
apiVersion: operator.tigera.io/v1
kind: TigeraStatus
metadata:
  creationTimestamp: "2024-02-01T13:11:58Z"
  generation: 1
  name: calico
  resourceVersion: "15240"
  uid: 326eadff-c10a-4971-a617-6ec1b033e7c3
spec: {}
status:
  conditions:
  - lastTransitionTime: "2024-02-01T13:12:08Z"
    message: 'Failed to autoscale typha - not enough linux nodes to schedule typha
      pods on, require 1 and have 0: '
    observedGeneration: 8
    reason: ResourceScalingError
    status: "True"
    type: Degraded
```

Although there is a running `calico-typha` pod already in the `calico-system` namespace.

```bash
➜ kubectl get pods -n calico-system
NAME                                       READY   STATUS    RESTARTS         AGE
calico-kube-controllers-79c99bcfc8-tmgq6   1/1     Running   0                4h
calico-typha-6fb44dd6cd-w9v46              1/1     Running   0                4h
```

With the fix, the status shows a much better error if there is a `NotReady` node:
```
➜ kubectl get tigerastatus calico -o yaml
apiVersion: operator.tigera.io/v1
kind: TigeraStatus
metadata:
  creationTimestamp: "2024-02-03T19:36:03Z"
  generation: 1
  name: calico
  resourceVersion: "8289"
  uid: fc9a19c1-9cc7-4b23-9241-181a1be9e68a
spec: {}
status:
  conditions:
  - lastTransitionTime: "2024-02-03T19:46:03Z"
    message: 'error migrating resources to calico-system: the kube-system node DaemonSet
      is not ready with the updated nodeSelector: timed out waiting for the condition'
    observedGeneration: 4
    reason: ResourceMigrationError
    status: "True"
    type: Degraded
```

Once the node is fixed, the migration coninues automatically as it is expected.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
