### PR TITLE
Wait for calico-node DaemonSet rollout to avoid mass restart during manifest-to-operator migration

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1383,7 +1383,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		// Requeue so we can update our resources (without the migration changes)
 		return reconcile.Result{Requeue: true}, nil
 	} else if r.namespaceMigration.NeedCleanup() {
-		if err := r.namespaceMigration.CleanupMigration(ctx); err != nil {
+		if err := r.namespaceMigration.CleanupMigration(ctx, reqLogger); err != nil {
 			r.status.SetDegraded(operator.ResourceMigrationError, "error migrating resources to calico-system", err, reqLogger)
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -76,7 +76,7 @@ func (f *fakeNamespaceMigration) NeedCleanup() bool {
 	return false
 }
 
-func (f *fakeNamespaceMigration) CleanupMigration(ctx context.Context) error {
+func (f *fakeNamespaceMigration) CleanupMigration(ctx context.Context, log logr.Logger) error {
 	return nil
 }
 


### PR DESCRIPTION
## Description

kind/bugfix

As we have experienced when we start to use the `tigera-operator`, the migration take down ALL Calico node pods on my cluster such that they were running `0/1` ready status at the same time.  Of course if the migration continues smoothly this is fine.  However, if it does not then your pod network is taken down by the migration.

```
NAMESPACE         NAME                                                  READY   STATUS        RESTARTS      AGE   IP               NODE             NOMINATED NODE   READINESS GATES
calico-system     calico-kube-controllers-9d5b46798-wpddk               1/1     Running       0             33m   172.30.6.12      10.177.136.158   <none>           <none>
calico-system     calico-node-rc6kx                                     0/1     Terminating   0             12s   10.177.136.158   10.177.136.158   <none>           <none>
calico-system     calico-node-tlqwl                                     0/1     Running       0             9s    10.177.136.169   10.177.136.169   <none>           <none>
calico-system     calico-node-vmrdv                                     0/1     Running       0             9s    10.177.136.151   10.177.136.151   <none>           <none>
calico-system     calico-typha-7f78866dc4-5mrzm                         1/1     Running       0             7s    10.177.136.169   10.177.136.169   <none>           <none>
calico-system     calico-typha-7f78866dc4-9grbh                         1/1     Running       0             33m   10.177.136.151   10.177.136.151   <none>           <none>
```

The daemonset has the following setting:
```
  updateStrategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate
```
This is not respected and it can cause problems.

To avoid that, we need to wait the calico-node daemoset to get properly updated before doing any more change.
- Migration code uses the function `waitUntilNodeCanBeMigrated()` which is checking the `calico-system/calico-node` daemoset status, but that is not waiting the rollout to complete fully. Then the next reconcile will remove the `nodeSelector: projectcalico.org/operator-node-migration=migrated` from the `calico-system/calico-node` (as the migration is completed now), so the `calico-system/calico-node` daemonset will be updated once more. But as the `waitUntilNodeCanBeMigrated()` does not wait the last update to complete, it can be a following state e.g
```
status:
  currentNumberScheduled: 4
  desiredNumberScheduled: 4
  numberAvailable: 3
  numberMisscheduled: 0
  numberReady: 4
  numberUnavailable: 1
  observedGeneration: 2
  updatedNumberScheduled: 1
```
then the second update (removing the nodeSelector from the daemonset) could lead to mass calico-node restart as shown above. That's why let's wait the rollout fully during the migration.

- as I wrote earlier, once the migration logic is done, the next reconcile will remove the `nodeSelector: projectcalico.org/operator-node-migration=migrated` from the `calico-system/calico-node`. Then the same label will be removed from the nodes. If the label is removed earlier from the nodes than the the `nodeSelector` from the calico-node pods, it could lead to similar mass calico-node restart. So before cleaning up the migration related label from the nodes, wait for the calico-node rollout.

These changes may slow down the migration, but it makes it more stable as we have experienced.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
