### PR TITLE
refactor: set kube network based on cni type instead of provider

### DIFF
--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -591,7 +591,7 @@ func (c *windowsComponent) windowsEnvVars() []corev1.EnvVar {
 	if c.cfg.Installation.CNI != nil && c.cfg.Installation.CNI.Type == operatorv1.PluginAzureVNET {
 		kubeNetwork = "azure.*"
 	}
-	
+
 	windowsEnv = append(windowsEnv, corev1.EnvVar{Name: "KUBE_NETWORK", Value: kubeNetwork})
 
 	// Determine MTU to use. If specified explicitly, use that. Otherwise, set defaults based on an overall

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -576,6 +576,7 @@ func (c *windowsComponent) windowsEnvVars() []corev1.EnvVar {
 		windowsEnv = append(windowsEnv, corev1.EnvVar{Name: "FELIX_TYPHAURISAN", Value: c.cfg.TLS.TyphaURISAN})
 	}
 
+	kubeNetwork := "Calico.*"
 	if c.cfg.Installation.CNI != nil && c.cfg.Installation.CNI.Type == operatorv1.PluginCalico {
 		// If using Calico CNI, we need to manage CNI credential rotation on the host.
 		windowsEnv = append(windowsEnv, corev1.EnvVar{Name: "CALICO_MANAGE_CNI", Value: "true"})
@@ -585,16 +586,12 @@ func (c *windowsComponent) windowsEnvVars() []corev1.EnvVar {
 
 	if c.cfg.Installation.CNI != nil && c.cfg.Installation.CNI.Type == operatorv1.PluginAmazonVPC {
 		windowsEnv = append(windowsEnv, corev1.EnvVar{Name: "FELIX_BPFEXTTOSERVICECONNMARK", Value: "0x80"})
-	}
-
-	// Set the KUBE_NETWORK env var based on the Provider
-	kubeNetwork := "Calico.*"
-	switch c.cfg.Installation.KubernetesProvider {
-	case operatorv1.ProviderAKS:
-		kubeNetwork = "azure.*"
-	case operatorv1.ProviderEKS:
 		kubeNetwork = "vpc.*"
 	}
+	if c.cfg.Installation.CNI != nil && c.cfg.Installation.CNI.Type == operatorv1.PluginAzureVNET {
+		kubeNetwork = "azure.*"
+	}
+	
 	windowsEnv = append(windowsEnv, corev1.EnvVar{Name: "KUBE_NETWORK", Value: kubeNetwork})
 
 	// Determine MTU to use. If specified explicitly, use that. Otherwise, set defaults based on an overall

--- a/pkg/render/windows_test.go
+++ b/pkg/render/windows_test.go
@@ -1050,6 +1050,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		// defaultInstance.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		defaultInstance.KubernetesProvider = operatorv1.ProviderEKS
+		defaultInstance.CNI = &operatorv1.CNISpec{Type: AwsCIName}
 		defaultInstance.CalicoNetwork.BGP = &bgpDisabled
 		defaultInstance.CalicoNetwork.IPPools[0].Encapsulation = operatorv1.EncapsulationVXLAN
 		component := render.Windows(&cfg)

--- a/pkg/render/windows_test.go
+++ b/pkg/render/windows_test.go
@@ -1050,7 +1050,9 @@ var _ = Describe("Windows rendering tests", func() {
 
 		// defaultInstance.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 		defaultInstance.KubernetesProvider = operatorv1.ProviderEKS
-		defaultInstance.CNI = &operatorv1.CNISpec{Type: AwsCIName}
+		defaultInstance.CNI = &operatorv1.CNISpec{Type: operatorv1.PluginCalico, IPAM: &operatorv1.IPAMSpec{
+			Type: operatorv1.IPAMPluginAmazonVPC,
+		}}
 		defaultInstance.CalicoNetwork.BGP = &bgpDisabled
 		defaultInstance.CalicoNetwork.IPPools[0].Encapsulation = operatorv1.EncapsulationVXLAN
 		component := render.Windows(&cfg)
@@ -1197,7 +1199,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 			{Name: "VXLAN_VNI", Value: "4096"},
 			{Name: "VXLAN_ADAPTER", Value: ""},
-			{Name: "KUBE_NETWORK", Value: "vpc.*"},
+			{Name: "KUBE_NETWORK", Value: "Calico.*"},
 			{Name: "KUBERNETES_SERVICE_HOST", Value: "1.2.3.4"},
 			{Name: "KUBERNETES_SERVICE_PORT", Value: "6443"},
 		}


### PR DESCRIPTION
## Description

Changes the behavior how the kubeNetwork environment variable is defined by looking at the actual used CNI type instead of the k8s platform.

Fixes https://github.com/tigera/operator/issues/3165

## For PR author

- [X] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
