### PR TITLE
Fix autodetection of current RKE2

### DIFF
--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -222,18 +222,30 @@ func isEKS(ctx context.Context, c kubernetes.Interface) (bool, error) {
 
 // isRKE2 returns true if running on an RKE2 cluster, and false otherwise.
 // While the presence of Rancher can be determined based on API Groups, it's important to
-// differentiate between versions, which requires another approach. In this case,
-// the presence of an "rke2" configmap in kube-system namespace is used.
+// differentiate between versions, which requires another approach. In this case we use
+// the presence of an "rke2" configmap or an "rke2-coredns-rke2-coredns" service in the
+// kube-system namespace
 func isRKE2(ctx context.Context, c kubernetes.Interface) (bool, error) {
-	cm, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "rke2", metav1.GetOptions{})
-	if err != nil {
-		if kerrors.IsNotFound(err) {
-			return false, nil
-		}
+	foundRKE2Resource := false
+	_, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "rke2", metav1.GetOptions{})
+	if err == nil {
+		foundRKE2Resource = true
+	} else if !kerrors.IsNotFound(err) {
 		return false, err
 	}
 
-	return (cm != nil), nil
+	// In current RKE2 the above ConfigMap no longer exists, but we leave that code in place in
+	// case there are variants where it is useful.  Check also for the RKE2 DNS service - which
+	// is especially relevant because one of the main uses of the RKE2 autodetection is to set
+	// DNS config.
+	_, err = c.CoreV1().Services("kube-system").Get(ctx, "rke2-coredns-rke2-coredns", metav1.GetOptions{})
+	if err == nil {
+		foundRKE2Resource = true
+	} else if !kerrors.IsNotFound(err) {
+		return false, err
+	}
+
+	return foundRKE2Resource, nil
 }
 
 // SupportsPodSecurityPolicies returns true if the cluster contains the policy/v1beta1 PodSecurityPolicy API,

--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -121,4 +121,16 @@ var _ = Describe("provider discovery", func() {
 		Expect(e).To(BeNil())
 		Expect(p).To(Equal(operatorv1.ProviderRKE2))
 	})
+
+	It("should detect RKE2 based on presence of kube-system/rke2-coredns-rke2-coredns Service", func() {
+		c := fake.NewSimpleClientset(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rke2-coredns-rke2-coredns",
+				Namespace: "kube-system",
+			},
+		})
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderRKE2))
+	})
 })

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -141,6 +141,13 @@ spec:
                   Loose]'
                 pattern: ^(?i)(Disabled|Strict|Loose)?$
                 type: string
+              bpfExcludeCIDRsFromNAT:
+                description: BPFExcludeCIDRsFromNAT is a list of CIDRs that are to
+                  be excluded from NAT resolution so that host can handle them. A
+                  typical usecase is node local DNS cache.
+                items:
+                  type: string
+                type: array
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
                   mark that is set on connections from an external client to a local


### PR DESCRIPTION
Previously based on the kube-system/rke2 ConfigMap, but in current RKE2 the above ConfigMap no longer exists.  We leave that code in place in case there are variants where it is useful, but check also for the RKE2 DNS service - which is especially relevant because one of the main uses of the RKE2 autodetection is to set DNS config.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
