### PR TITLE
Fix autodetection of current RKE2 [pick#3168 r1.32]

### DIFF
--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -121,4 +121,16 @@ var _ = Describe("provider discovery", func() {
 		Expect(e).To(BeNil())
 		Expect(p).To(Equal(operatorv1.ProviderRKE2))
 	})
+
+	It("should detect RKE2 based on presence of kube-system/rke2-coredns-rke2-coredns Service", func() {
+		c := fake.NewSimpleClientset(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rke2-coredns-rke2-coredns",
+				Namespace: "kube-system",
+			},
+		})
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderRKE2))
+	})
 })


### PR DESCRIPTION
Previously based on the kube-system/rke2 ConfigMap, but in current RKE2 the above ConfigMap no longer exists.  We leave that code in place in case there are variants where it is useful, but check also for the RKE2 DNS service - which is especially relevant because one of the main uses of the RKE2 autodetection is to set DNS config.

(cherry-pick of #3168)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
