### PR TITLE
Report dashboard status

### DIFF
--- a/pkg/controller/logstorage/dashboards/dashboards_controller.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller.go
@@ -253,6 +253,8 @@ func (d DashboardsSubController) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, err
 	}
 
+	d.status.OnCRFound()
+
 	// Determine where to access Kibana.
 	kibanaHost := "tigera-secure-kb-http.tigera-kibana.svc"
 	kibanaPort := "5601"


### PR DESCRIPTION
## Description

Report dashboard status as tigerastatus

```
kubectl get tigerastatus
NAME                          AVAILABLE   PROGRESSING   DEGRADED   SINCE
apiserver                     True        False         False      168m
calico                        True        False         False      168m
compliance                    True        False         False      167m
intrusion-detection           True        False         False      166m
log-collector                 True        False         False      167m
log-storage                   True        False         False      168m
log-storage-access            True        False         False      165m
log-storage-dashboards        True        False         False      166m
log-storage-elastic           True        False         False      166m
log-storage-esmetrics         True        False         False      22h
log-storage-kubecontrollers   True        False         False      166m
log-storage-secrets           True        False         False      22h
manager                       True        False         False      166m
monitor                       True        False         False      22h
policy-recommendation         True        False         False      22h
tiers                         True        False         False      22h

```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
