### PR TITLE
Decrease the validity of JWTs issued by Dex to 15m

### DIFF
--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -363,9 +363,13 @@ func (c *dexComponent) configMap() *corev1.ConfigMap {
 				"secretEnv":    dexSecretEnv,
 			},
 		},
+		"expiry": map[string]string{
+			// Default duration is 24h. This is too high for most organizations. Setting it to 15m.
+			"idTokens": "15m",
+		},
 	})
 	if err != nil {
-		// Panic since this this would be a developer error, as the marshaled struct is one created by our code.
+		// Panic since this would be a developer error, as the marshaled struct is one created by our code.
 		panic(err)
 	}
 	return &corev1.ConfigMap{

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -250,6 +250,9 @@ var _ = Describe("dex rendering tests", func() {
 			}
 			Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(expectedVolumeMounts))
 			Expect(d.Spec.Template.Spec.Volumes).To(BeEquivalentTo(expectedVolumes))
+			cm, ok := rtest.GetResource(resources, "tigera-dex", "tigera-dex", "", "v1", "ConfigMap").(*corev1.ConfigMap)
+			Expect(ok).To(BeTrue())
+			Expect(cm.Data["config.yaml"]).To(ContainSubstring("idTokens: 15m"))
 		})
 
 		DescribeTable("should render the cluster name properly in the validator", func(clusterDomain string) {


### PR DESCRIPTION
EV-4612

The setting is picked up fine by Dex and our UI will bring us to the login page.

```
time="2024-02-16T00:47:47Z" level=info msg="The custom resource devicetokens.dex.coreos.com already available, skipping create"
...
time="2024-02-16T00:47:46Z" level=info msg="config id tokens valid for: 15m0s"
time="2024-02-16T00:47:46Z" level=info msg="config refresh tokens rotation enabled: true"
time="2024-02-16T00:47:46Z" level=info msg="listening (https) on 0.0.0.0:5556
```