### PR TITLE
[cherry-pick][v1.33] Add back esgateway certificate to the trusted bundle (#3174)

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -146,7 +146,9 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 	for _, namespace := range namespacesToWatch {
 		for _, secretName := range []string{
-			render.ManagerTLSSecretName, render.ElasticsearchManagerUserSecret,
+			// We need to watch for es-gateway certificate because es-proxy still creates a
+			// client to talk to elastic via es-gateway
+			render.ManagerTLSSecretName, render.ElasticsearchManagerUserSecret, relasticsearch.PublicCertSecret,
 			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret, render.PacketCaptureServerCert,
 			render.ManagerInternalTLSSecretName, monitor.PrometheusServerTLSSecretName, certificatemanagement.CASecretName,
 		} {
@@ -398,6 +400,17 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 			render.ProjectCalicoAPIServerTLSSecretName(installation.Variant),
 			render.TigeraLinseedSecret,
 		}
+		// This is necessary because prior to v3.13 secrets were not signed by a single CA, so we need to include each individually
+		// in the trusted bundle
+		esgwCertificate, err := certificateManager.GetCertificate(r.client, relasticsearch.PublicCertSecret, common.OperatorNamespace())
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve / validate  %s", relasticsearch.PublicCertSecret), err, logc)
+			return reconcile.Result{}, err
+		}
+		if esgwCertificate != nil {
+			trustedSecretNames = append(trustedSecretNames, relasticsearch.PublicCertSecret)
+		}
+
 		// If external prometheus is enabled, the secret will be signed by the Calico CA and no secret will be created. We can skip
 		// adding it to the bundle, as trusting the CA will suffice.
 		monitorCR := &operatorv1.Monitor{}


### PR DESCRIPTION
* Add back esgateway certificate to the trusted bundle

* [CODE REVIEW] Update with comments

## Description

Cherry-pick #3174

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
