### PR TITLE
fix expected files for waf

### DIFF
--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -260,7 +260,7 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 			return reconcile.Result{}, err
 		}
 		if err = validateModSecurityRuleSet(modSecurityRuleSet); err != nil {
-			r.status.SetDegraded(operatorv1.ResourceValidationError, "Error validating Web Application Firewall ModSecurity rule set", err, reqLogger)
+			r.status.SetDegraded(operatorv1.ResourceValidationError, "Error validating Web Application Firewall rule set", err, reqLogger)
 			return reconcile.Result{}, err
 		}
 	}
@@ -431,13 +431,12 @@ func getDefaultCoreRuleset(ctx context.Context) (*corev1.ConfigMap, error) {
 
 func validateModSecurityRuleSet(cm *corev1.ConfigMap) error {
 	requiredFiles := []string{
-		"modsecdefault.conf",
-		"crs-setup.conf",
+		"tigera.conf",
 	}
 
 	for _, f := range requiredFiles {
 		if _, ok := cm.Data[f]; !ok {
-			return fmt.Errorf("file must be found in Web Application Firewall rule set: %s", f)
+			return fmt.Errorf("file must be present with ruleset files: %s", f)
 		}
 	}
 


### PR DESCRIPTION
## Description

Fix the expected files that are supposed to be present in the WAF ruleset config map. `crs-setup.conf` was part of the old modsecurity files removed in this PR: https://github.com/tigera/operator/pull/3158

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
