### PR TITLE
PolicyRecommendation controller overwrites tigera-ca bundle per tenant

### DIFF
--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -455,7 +455,8 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 		return reconcile.Result{}, err
 	}
 
-	components = append(components, component)
+	// Prepend PolicyRecommendation before certificate creation
+	components = append([]render.Component{component}, components...)
 	for _, cmp := range components {
 		if err := handler.CreateOrUpdateOrDelete(context.Background(), cmp, r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, logc)

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -414,8 +414,8 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 
-			It("It should not create the trusted bundle config map as it will be created by the tenant controller", func() {
-				// Create the Tenant resources for tenant-a and tenant-b.
+			It("should not create the trusted bundle config map as it will be created by the tenant controller", func() {
+				// Create the Tenant resources for tenant-a
 				tenantA := &operatorv1.Tenant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "default",
@@ -443,7 +443,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
 				Expect(c.Create(ctx, certificateManagerTenantA.CreateTrustedBundle().ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
 
-				// Now reconcile only tenant A's namespace and do not expect an error
+				// Now reconcile tenant A's namespace and do not expect an error
 				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tenantANamespace}})
 				Expect(err).ShouldNot(HaveOccurred())
 			})

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -440,7 +440,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				// Create a CA secret for the test, and create its KeyPair.
 				certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
+				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace))).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, certificateManagerTenantA.CreateTrustedBundle().ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
 
 				// Now reconcile tenant A's namespace and do not expect an error

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -86,6 +86,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 		mockStatus.On("SetDegraded", operatorv1.ResourceUpdateError, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
 		mockStatus.On("SetDegraded", operatorv1.ResourceNotFound, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
 		mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("SetDegraded", operatorv1.ResourceCreateError, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
 		mockStatus.On("ReadyToMonitor")
 		mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
 		mockStatus.On("SetMetaData", mock.Anything).Return()
@@ -410,6 +411,40 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = test.GetResource(c, &tenantBServiceAccount)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("It should not create the trusted bundle config map as it will be created by the tenant controller", func() {
+				// Create the Tenant resources for tenant-a and tenant-b.
+				tenantA := &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: tenantANamespace,
+					},
+					Spec: operatorv1.TenantSpec{ID: "tenant-a"},
+				}
+				Expect(c.Create(ctx, tenantA)).NotTo(HaveOccurred())
+
+				Expect(c.Create(ctx, &operatorv1.PolicyRecommendation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-secure",
+						Namespace: tenantANamespace,
+					},
+				})).NotTo(HaveOccurred())
+
+				// Now reconcile only tenant A's namespace and expect an error
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tenantANamespace}})
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("CA secret"))
+
+				// Create a CA secret for the test, and create its KeyPair.
+				certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
+				Expect(c.Create(ctx, certificateManagerTenantA.CreateTrustedBundle().ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
+
+				// Now reconcile only tenant A's namespace and do not expect an error
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tenantANamespace}})
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})

--- a/pkg/controller/secrets/tenant_controller.go
+++ b/pkg/controller/secrets/tenant_controller.go
@@ -90,13 +90,10 @@ func AddTenantController(mgr manager.Manager, opts options.AddOptions) error {
 		return fmt.Errorf("tenant-controller failed to watch tenant CA Secret %s in all namespace: %w", certificatemanagement.TenantCASecretName, err)
 	}
 
-	// Make a helper for determining which namespaces to use based on tenancy mode.
-	// In multi-tenant mode, we need to watch all namespaces for secrets.
-	helper := utils.NewNamespaceHelper(opts.MultiTenant, "", "")
-	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, helper.InstallNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
+	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, "", &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-secrets-controller failed to watch ConfigMap resource: %w", err)
 	}
-	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, helper.InstallNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
+	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, "", &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-secrets-controller failed to watch ConfigMap resource: %w", err)
 	}
 

--- a/pkg/controller/secrets/tenant_controller.go
+++ b/pkg/controller/secrets/tenant_controller.go
@@ -90,6 +90,17 @@ func AddTenantController(mgr manager.Manager, opts options.AddOptions) error {
 		return fmt.Errorf("tenant-controller failed to watch tenant CA Secret %s in all namespace: %w", certificatemanagement.TenantCASecretName, err)
 	}
 
+	// Make a helper for determining which namespaces to use based on tenancy mode.
+	// In multi-tenant mode, we need to watch all namespaces for secrets. In single-tenant mode,
+	// we only need to watch the elasticsearch namespace. Both need tigera-operator.
+	helper := utils.NewNamespaceHelper(opts.MultiTenant, "", "")
+	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, helper.InstallNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("log-storage-secrets-controller failed to watch ConfigMap resource: %w", err)
+	}
+	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, helper.InstallNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("log-storage-secrets-controller failed to watch ConfigMap resource: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/controller/secrets/tenant_controller.go
+++ b/pkg/controller/secrets/tenant_controller.go
@@ -91,8 +91,7 @@ func AddTenantController(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	// Make a helper for determining which namespaces to use based on tenancy mode.
-	// In multi-tenant mode, we need to watch all namespaces for secrets. In single-tenant mode,
-	// we only need to watch the elasticsearch namespace. Both need tigera-operator.
+	// In multi-tenant mode, we need to watch all namespaces for secrets.
 	helper := utils.NewNamespaceHelper(opts.MultiTenant, "", "")
 	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, helper.InstallNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-secrets-controller failed to watch ConfigMap resource: %w", err)

--- a/pkg/controller/secrets/tenant_controller.go
+++ b/pkg/controller/secrets/tenant_controller.go
@@ -91,10 +91,10 @@ func AddTenantController(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, "", &handler.EnqueueRequestForObject{}); err != nil {
-		return fmt.Errorf("log-storage-secrets-controller failed to watch ConfigMap resource: %w", err)
+		return fmt.Errorf("tenant-controller failed to watch ConfigMap resource: %w", err)
 	}
-	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapName, "", &handler.EnqueueRequestForObject{}); err != nil {
-		return fmt.Errorf("log-storage-secrets-controller failed to watch ConfigMap resource: %w", err)
+	if err = utils.AddConfigMapWatch(c, certificatemanagement.TrustedCertConfigMapNamePublic, "", &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("tenant-controller failed to watch ConfigMap resource: %w", err)
 	}
 
 	return nil

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -68,7 +68,7 @@ type PolicyRecommendationConfiguration struct {
 	ManagedCluster                 bool
 	Openshift                      bool
 	PullSecrets                    []*corev1.Secret
-	TrustedBundle                  certificatemanagement.TrustedBundle
+	TrustedBundle                  certificatemanagement.TrustedBundleRO
 	PolicyRecommendationCertSecret certificatemanagement.KeyPairInterface
 
 	// Whether the cluster supports pod security policies.


### PR DESCRIPTION
## Description

Tigera-ca-bundle is created by the tenant controller for a multi-tenant setup (https://github.com/tigera/operator/blob/master/pkg/controller/secrets/tenant_controller.go#L187-L212). This gets overwritten by PolicyRecommendation Controller. This causes Linseed to reject connection with Elastic.

```
kubectl logs -ncc-tenant-a1q3vp13 tigera-linseed-d95447fc8-8q6zc -ctigera-linseed
2024-02-22 00:38:02.708 [FATAL][1] elastic.go 59: Failed to create Elastic client error=health check timeout: Head "https://es-lss-gcpdev-01.dev.calicocloud.io:443": tls: failed to verify certificate: x509: certificate signed by unknown authority: no Elasticsearch node available
```

![Screenshot from 2024-02-21 16-37-04](https://github.com/tigera/operator/assets/41362174/d47b7c12-149d-4e2e-bfa4-c407b3c87a16)



## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
