### PR TITLE
Set tenant ID for intrusion detection

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -466,6 +466,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		Namespace:                    helper.InstallNamespace(),
 		BindNamespaces:               namespaces,
 		Tenant:                       tenant,
+		ExternalElastic:              r.elasticExternal,
 	}
 	intrusionDetectionComponent := render.IntrusionDetection(intrusionDetectionCfg)
 

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -619,11 +619,14 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			// Configure a tenant.
 			tenantA = &operatorv1.Tenant{
 				ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: tenantANamespace},
-				Spec:       operatorv1.TenantSpec{},
+				Spec: operatorv1.TenantSpec{
+					ID: "tenant-a",
+				},
 			}
 			cfg.Namespace = tenantANamespace
 			cfg.BindNamespaces = []string{tenantANamespace, tenantBNamespace}
 			cfg.Tenant = tenantA
+			cfg.ExternalElastic = true
 		})
 
 		It("should render multi-tenant resources", func() {
@@ -686,6 +689,21 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 				},
 			}
 			Expect(netpol.Spec.Egress).To(ConsistOf(expectedEgressRules))
+		})
+
+		It("should render multi-tenant environment variables", func() {
+			component := render.IntrusionDetection(cfg)
+			toCreate, _ := component.Objects()
+
+			deployment, err := rtest.GetResourceOfType[*appsv1.Deployment](toCreate, render.IntrusionDetectionName, tenantANamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			envs := deployment.Spec.Template.Spec.Containers[0].Env
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "TENANT_NAMESPACE", Value: tenantANamespace}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "TENANT_ID", Value: "tenant-a"}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "LINSEED_URL", Value: fmt.Sprintf("https://tigera-linseed.%s.svc", tenantANamespace)}))
+			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", tenantANamespace)}))
+
 		})
 	})
 })


### PR DESCRIPTION
## Description

Set tenant ID in intrusion detection when installing in a multi-tenant management cluster.

Zero-tenant : tenant ID is not needed.
Single tenant with internal elastic (0.5 half tenant) :  tenant ID is not needed, as we need to assume we make queries as MCM does
Single tenant with external elastic: Needs tenant ID, but talk to Linseed from tigera-elasticsearch namespace and Manager from tigera-manager namespace
Multi-tenant: Needs tenant ID, tenant namespace and per tenant services for Linseed and Manager.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
