### PR TITLE
Automated cherry pick of #3215: Voltron and/or es-proxy should have kibana's certificate in

### DIFF
--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -23,6 +23,8 @@ import (
 
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -41,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -230,6 +233,10 @@ var _ = Describe("Manager controller tests", func() {
 			internalKp, err := certificateManager.GetOrCreateKeyPair(c, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), expectedDNSNames)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, internalKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+			kbDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
+			kbKp, err := certificateManager.GetOrCreateKeyPair(c, render.TigeraKibanaCertSecret, common.OperatorNamespace(), kbDNSNames)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, kbKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 			Expect(c.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -536,6 +543,10 @@ var _ = Describe("Manager controller tests", func() {
 			internalCertKp, err := certificateManager.GetOrCreateKeyPair(c, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), []string{render.ManagerInternalTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, internalCertKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+			kbDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
+			kbKp, err := certificateManager.GetOrCreateKeyPair(c, render.TigeraKibanaCertSecret, common.OperatorNamespace(), kbDNSNames)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, kbKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 			Expect(c.Create(ctx, relasticsearch.NewClusterConfig("cluster", 1, 1, 1).ConfigMap())).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Cherry pick of #3215 on release-v1.32.

#3215: Voltron and/or es-proxy should have kibana's certificate in