### PR TITLE
Automated cherry pick of #3217: Voltron and/or es-proxy should have kibana's certificate

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
@@ -360,6 +361,11 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		render.ProjectCalicoAPIServerTLSSecretName(installation.Variant),
 		render.TigeraLinseedSecret,
 	}
+
+	if !operatorv1.IsFIPSModeEnabled(installation.FIPSMode) {
+		trustedSecretNames = append(trustedSecretNames, render.TigeraKibanaCertSecret)
+	}
+
 	if complianceLicenseFeatureActive && complianceCR != nil {
 		// Check that compliance is running.
 		if complianceCR.Status.State != operatorv1.TigeraStatusReady {

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -193,6 +193,10 @@ var _ = Describe("Manager controller tests", func() {
 			internalKp, err := certificateManager.GetOrCreateKeyPair(c, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), expectedDNSNames)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, internalKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+			kbDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
+			kbKp, err := certificateManager.GetOrCreateKeyPair(c, render.TigeraKibanaCertSecret, common.OperatorNamespace(), kbDNSNames)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, kbKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 			Expect(c.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -460,6 +464,10 @@ var _ = Describe("Manager controller tests", func() {
 			internalCertKp, err := certificateManager.GetOrCreateKeyPair(c, render.ManagerInternalTLSSecretName, common.OperatorNamespace(), []string{render.ManagerInternalTLSSecretName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, internalCertKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+			kbDNSNames := dns.GetServiceDNSNames(render.KibanaServiceName, render.KibanaNamespace, r.clusterDomain)
+			kbKp, err := certificateManager.GetOrCreateKeyPair(c, render.TigeraKibanaCertSecret, common.OperatorNamespace(), kbDNSNames)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, kbKp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 			Expect(c.Create(ctx, relasticsearch.NewClusterConfig("cluster", 1, 1, 1).ConfigMap())).NotTo(HaveOccurred())
 

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"


### PR DESCRIPTION
Cherry pick of #3217 on release-v1.30.

#3217: Voltron and/or es-proxy should have kibana's certificate