### PR TITLE
Fix features annotations

### DIFF
--- a/hack/gen-bundle/update-bundle.sh
+++ b/hack/gen-bundle/update-bundle.sh
@@ -44,17 +44,17 @@ TIMESTAMP=$(echo ${OPERATOR_IMAGE_INSPECT} | jq -r .[0].Created)
 yq write -i ${CSV} metadata.annotations.createdAt ${TIMESTAMP}
 
 # Add the features annotations per https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html
-FEATURES=metadata.annotations.features.operators.openshift.io
-yq write -i ${CSV} ${FEATURES}/disconnected "false"
-yq write -i ${CSV} ${FEATURES}/fips-compliant "false"
-yq write -i ${CSV} ${FEATURES}/proxy-aware "false"
-yq write -i ${CSV} ${FEATURES}/tls-profiles "false"
-yq write -i ${CSV} ${FEATURES}/token-auth-aws "false"
-yq write -i ${CSV} ${FEATURES}/token-auth-azure "false"
-yq write -i ${CSV} ${FEATURES}/token-auth-gcp "false"
-yq write -i ${CSV} ${FEATURES}/cnf "false"
-yq write -i ${CSV} ${FEATURES}/cni "true"
-yq write -i ${CSV} ${FEATURES}/csi "false"
+FEATURES=features.operators.openshift.io
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/disconnected\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/fips-compliant\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/proxy-aware\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/tls-profiles\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/token-auth-aws\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/token-auth-azure\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/token-auth-gcp\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/cnf\"" --tag '!!str' false
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/cni\"" --tag '!!str' true
+yq write -i ${CSV} "metadata.annotations.\"${FEATURES}/csi\"" --tag '!!str' false
 
 # Set the operator container image by digest in the tigera-operator deployment spec embedded in the CSV.
 yq write -i ${CSV} spec.install.spec.deployments[0].spec.template.spec.containers[0].image ${OPERATOR_IMAGE_DIGEST}


### PR DESCRIPTION
## Description

Openshift need feature annotations to look like this:
```
metadata:
  annotations:
    features.operators.openshift.io/disconnected: "false"
    features.operators.openshift.io/fips-compliant: "false"
    features.operators.openshift.io/proxy-aware: "false"
```

Example of bundle generated with this code has been merged by Openshift:
https://github.com/redhat-openshift-ecosystem/certified-operators/blob/main/operators/tigera-operator/1.32.3/manifests/tigera-operator.clusterserviceversion.yaml#L31-L40

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
