### PR TITLE
Disable CGO when build operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,7 +41,4 @@ COPY --from=source / /
 
 USER 10001:10001
 
-# The exec form of ENTRYPOINT does not invoke a command shell.
-# This means that normal shell processing does not happen, so will not
-# do variable substitution. Using this form instead of passing $OPERATOR.
 ENTRYPOINT ["/usr/bin/operator"]


### PR DESCRIPTION
## Description

This changeset disables CGO when building operator binary for all supported architectures. We shelved FIPS support so bringing back tls module from Go stdlib reenabled TLS 1.3 support.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
