### PR TITLE
[Addendum] Dashboards Controller needs to know when elastic is extern…

### DIFF
--- a/pkg/controller/logstorage/dashboards/dashboards_controller.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller.go
@@ -72,12 +72,14 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	r := &DashboardsSubController{
-		client:         mgr.GetClient(),
-		scheme:         mgr.GetScheme(),
-		status:         status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageDashboards, opts.KubernetesVersion),
-		clusterDomain:  opts.ClusterDomain,
-		provider:       opts.DetectedProvider,
-		tierWatchReady: &utils.ReadyFlag{},
+		client:          mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		status:          status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageDashboards, opts.KubernetesVersion),
+		clusterDomain:   opts.ClusterDomain,
+		provider:        opts.DetectedProvider,
+		tierWatchReady:  &utils.ReadyFlag{},
+		multiTenant:     opts.MultiTenant,
+		elasticExternal: opts.ElasticExternal,
 	}
 	r.status.Run(opts.ShutdownContext)
 


### PR DESCRIPTION
…al or not

## Description

Controller does not know when running in external or internal elastic mode.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
