### PR TITLE
[BPF] use FelixConfiguration.CgroupV2Path to set CALICO_CGROUP_PATH

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1359,6 +1359,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		Terminating:             nodeTerminating,
 		PrometheusServerTLS:     nodePrometheusTLS,
 		FelixHealthPort:         *felixConfiguration.Spec.HealthPort,
+		NodeCgroupV2Path:        felixConfiguration.Spec.CgroupV2Path,
 		BindMode:                bgpConfiguration.Spec.BindMode,
 		UsePSP:                  r.usePSP,
 	}


### PR DESCRIPTION
Read the CgroupV2Path value from FelixConfiguration and set it as env var for the mount-bpffs node's init container.

fixes https://github.com/projectcalico/calico/issues/7892

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
