### PR TITLE
Remove bpf dual stack validation

### DIFF
--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -155,10 +155,6 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 			}
 		}
 
-		if bpfDataplane && v4pool != nil && v6pool != nil {
-			return fmt.Errorf("bpf dataplane does not support dual stack")
-		}
-
 		if v4pool != nil {
 			_, cidr, err := net.ParseCIDR(v4pool.CIDR)
 			if err != nil {

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -92,7 +92,9 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(err).To(BeNil())
 	})
 
-	It("should not allow dual stack (both IPv4 and IPv6) if BPF is enabled", func() {
+	It("should allow dual stack (both IPv4 and IPv6) if BPF is enabled", func() {
+		var enabled operator.BGPOption = operator.BGPEnabled
+		instance.Spec.CalicoNetwork.BGP = &enabled
 		bpf := operator.LinuxDataplaneBPF
 		instance.Spec.CalicoNetwork.LinuxDataplane = &bpf
 		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
@@ -116,7 +118,7 @@ var _ = Describe("Installation validation tests", func() {
 			CanReach: "8.8.8.8",
 		}
 		err := validateCustomResource(instance)
-		Expect(err).To(MatchError("bpf dataplane does not support dual stack"))
+		Expect(err).To(BeNil())
 	})
 
 	It("should allow IPv6 VXLAN", func() {

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -302,6 +302,9 @@ spec:
               debugSimulateCalcGraphHangAfter:
                 pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
+              debugSimulateDataplaneApplyDelay:
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                type: string
               debugSimulateDataplaneHangAfter:
                 pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
@@ -341,6 +344,12 @@ spec:
                 type: string
               endpointReportingEnabled:
                 type: boolean
+              endpointStatusPathPrefix:
+                description: "EndpointStatusPathPrefix is the path to the directory
+                  where endpoint status will be written. Endpoint status file reporting
+                  is disabled if field is left empty. \n Chosen directory should match
+                  the directory used by the CNI for PodStartupDelay. [Default: \"\"]"
+                type: string
               externalNodesList:
                 description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
                   which may source tunnel traffic and have the tunneled traffic be


### PR DESCRIPTION
## Description

As we are adding support for eBPF dual stack, removing the dual stack validation when in eBPF mode. 

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
