### PR TITLE
[RS-1725] Allow intrusion-detection-controller to read alert exceptions (#3252)

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -323,6 +323,11 @@ func (c *intrusionDetectionComponent) intrusionDetectionClusterRole() *rbacv1.Cl
 			Resources: []string{"securityeventwebhooks"},
 			Verbs:     []string{"get", "watch", "update"},
 		},
+		{
+			APIGroups: []string{"crd.projectcalico.org"},
+			Resources: []string{"alertexceptions"},
+			Verbs:     []string{"get", "list"},
+		},
 	}
 
 	if !c.cfg.ManagedCluster {

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -214,6 +214,11 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 				Resources: []string{"securityeventwebhooks"},
 				Verbs:     []string{"get", "watch", "update"},
 			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"crd.projectcalico.org"},
+				Resources: []string{"alertexceptions"},
+				Verbs:     []string{"get", "list"},
+			},
 		))
 
 		role := rtest.GetResource(resources, render.IntrusionDetectionName, render.IntrusionDetectionNamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)


### PR DESCRIPTION
Cherry-pick of #3252.

## Description

Allow intrusion-detection-controller to read alert exceptions (#3252)

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
