### PR TITLE
Move Encapsulation validation into IP pool controller

### DIFF
--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -175,9 +175,6 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 						if instance.Spec.CalicoNetwork.BGP == nil || *instance.Spec.CalicoNetwork.BGP == operatorv1.BGPDisabled {
 							return fmt.Errorf("Unencapsulated IP pools require that BGP is enabled")
 						}
-					default:
-						return fmt.Errorf("%s is invalid for ipPool.encapsulation, should be one of %s",
-							pool.Encapsulation, strings.Join(operatorv1.EncapsulationTypesString, ","))
 					}
 				case operatorv1.IPAMPluginHostLocal:
 					// The host-local IPAM plugin doesn't support VXLAN.
@@ -192,6 +189,9 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 			} else {
 				// If not using Calico CNI, then the encapsulation must be None and BGP must be disabled.
 				switch pool.Encapsulation {
+				case "":
+					// If empty, the IP pool controller hasn't defaulted the value yet. We'll let the IP pool controller
+					// handle this before passing judgment.
 				case operatorv1.EncapsulationNone:
 				default:
 					return fmt.Errorf("%s is invalid for ipPool.encapsulation when using non-Calico CNI, should be None",

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -612,6 +612,8 @@ var _ = Describe("fillDefaults()", func() {
 		}
 
 		// Fill defaults to make sure we pass other validation. Then remove the Encapsulation.
+		// Fill in prerequisite defaults.
+		fillPrerequisiteDefaults(instance)
 		Expect(fillDefaults(ctx, cli, instance, currentPools)).ToNot(HaveOccurred())
 		instance.Spec.CalicoNetwork.IPPools[0].Encapsulation = ""
 

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -600,6 +600,26 @@ var _ = Describe("fillDefaults()", func() {
 		ctx = context.Background()
 	})
 
+	It("should reject an IP pool with no Encapsulation", func() {
+		instance := &operator.Installation{
+			Spec: operator.InstallationSpec{
+				CalicoNetwork: &operator.CalicoNetworkSpec{
+					IPPools: []operator.IPPool{
+						{CIDR: "192.168.0.0/16"},
+					},
+				},
+			},
+		}
+
+		// Fill defaults to make sure we pass other validation. Then remove the Encapsulation.
+		Expect(fillDefaults(ctx, cli, instance, currentPools)).ToNot(HaveOccurred())
+		instance.Spec.CalicoNetwork.IPPools[0].Encapsulation = ""
+
+		err := ValidatePools(instance)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("is invalid for ipPool.encapsulation, should be one of"))
+	})
+
 	// This table verifies that kubernetes provider configuration is accounted for in defaulting. Specifically, it
 	// makes sure that defaulting takes OpenShift config.Network and the kubeadm configmap into account.
 	table.DescribeTable("incorporation of kubernetesProvider config",

--- a/pkg/controller/ippool/validation.go
+++ b/pkg/controller/ippool/validation.go
@@ -65,6 +65,16 @@ func ValidatePools(instance *operator.Installation) error {
 			}
 		}
 
+		// Verify the Encapsulation mode is valid.
+		switch pool.Encapsulation {
+		case operator.EncapsulationIPIP, operator.EncapsulationIPIPCrossSubnet:
+		case operator.EncapsulationVXLAN, operator.EncapsulationVXLANCrossSubnet:
+		case operator.EncapsulationNone:
+		default:
+			return fmt.Errorf("%s is invalid for ipPool.encapsulation, should be one of %s",
+				pool.Encapsulation, strings.Join(operator.EncapsulationTypesString, ","))
+		}
+
 		// Verify per-address-family settings.
 		isIPv4 := !strings.Contains(pool.CIDR, ":")
 		if isIPv4 {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We were deadlocking because the IP pool controller requires the core controller to validate 
and default before taking action, but the validation in this PR was failing because the IP pool controller 
hadn't run yet.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.