### PR TITLE
Send the list of all ips to egress gateway to support dual stack

### DIFF
--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -257,10 +257,10 @@ func (c *component) egwVolumeMounts() []corev1.VolumeMount {
 }
 
 func (c *component) egwEnvVars() []corev1.EnvVar {
-	egressPodIp := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}
+	egressPodIps := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIPs"}}
 	envVar := []corev1.EnvVar{
 		{Name: "HEALTH_PORT", Value: fmt.Sprintf("%d", DefaultHealthPort)},
-		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIp},
+		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIps},
 		{Name: "EGRESS_VXLAN_VNI", Value: fmt.Sprintf("%d", c.config.VXLANVNI)},
 		{Name: "LOG_SEVERITY", Value: c.config.EgressGW.GetLogSeverity()},
 	}
@@ -293,11 +293,11 @@ func (c *component) egwEnvVars() []corev1.EnvVar {
 }
 
 func (c *component) egwInitEnvVars() []corev1.EnvVar {
-	egressPodIp := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}
+	egressPodIps := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIPs"}}
 	envVar := []corev1.EnvVar{
 		{Name: "EGRESS_VXLAN_VNI", Value: fmt.Sprintf("%d", c.config.VXLANVNI)},
 		{Name: "EGRESS_VXLAN_PORT", Value: fmt.Sprintf("%d", c.config.VXLANPort)},
-		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIp},
+		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIps},
 	}
 	if c.config.IptablesBackend != "" {
 		envVar = append(envVar, corev1.EnvVar{Name: "IPTABLES_BACKEND", Value: c.config.IptablesBackend})

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -257,9 +257,11 @@ func (c *component) egwVolumeMounts() []corev1.VolumeMount {
 }
 
 func (c *component) egwEnvVars() []corev1.EnvVar {
+	egressPodIp := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}
 	egressPodIps := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIPs"}}
 	envVar := []corev1.EnvVar{
 		{Name: "HEALTH_PORT", Value: fmt.Sprintf("%d", DefaultHealthPort)},
+		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIp},
 		{Name: "EGRESS_POD_IPS", ValueFrom: egressPodIps},
 		{Name: "EGRESS_VXLAN_VNI", Value: fmt.Sprintf("%d", c.config.VXLANVNI)},
 		{Name: "LOG_SEVERITY", Value: c.config.EgressGW.GetLogSeverity()},
@@ -293,10 +295,12 @@ func (c *component) egwEnvVars() []corev1.EnvVar {
 }
 
 func (c *component) egwInitEnvVars() []corev1.EnvVar {
+	egressPodIp := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}
 	egressPodIps := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIPs"}}
 	envVar := []corev1.EnvVar{
 		{Name: "EGRESS_VXLAN_VNI", Value: fmt.Sprintf("%d", c.config.VXLANVNI)},
 		{Name: "EGRESS_VXLAN_PORT", Value: fmt.Sprintf("%d", c.config.VXLANPort)},
+		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIp},
 		{Name: "EGRESS_POD_IPS", ValueFrom: egressPodIps},
 	}
 	if c.config.IptablesBackend != "" {

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -260,7 +260,7 @@ func (c *component) egwEnvVars() []corev1.EnvVar {
 	egressPodIps := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIPs"}}
 	envVar := []corev1.EnvVar{
 		{Name: "HEALTH_PORT", Value: fmt.Sprintf("%d", DefaultHealthPort)},
-		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIps},
+		{Name: "EGRESS_POD_IPS", ValueFrom: egressPodIps},
 		{Name: "EGRESS_VXLAN_VNI", Value: fmt.Sprintf("%d", c.config.VXLANVNI)},
 		{Name: "LOG_SEVERITY", Value: c.config.EgressGW.GetLogSeverity()},
 	}
@@ -297,7 +297,7 @@ func (c *component) egwInitEnvVars() []corev1.EnvVar {
 	envVar := []corev1.EnvVar{
 		{Name: "EGRESS_VXLAN_VNI", Value: fmt.Sprintf("%d", c.config.VXLANVNI)},
 		{Name: "EGRESS_VXLAN_PORT", Value: fmt.Sprintf("%d", c.config.VXLANPort)},
-		{Name: "EGRESS_POD_IP", ValueFrom: egressPodIps},
+		{Name: "EGRESS_POD_IPS", ValueFrom: egressPodIps},
 	}
 	if c.config.IptablesBackend != "" {
 		envVar = append(envVar, corev1.EnvVar{Name: "IPTABLES_BACKEND", Value: c.config.IptablesBackend})

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -167,10 +167,14 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		Expect(dep.Spec.Template.Spec.ServiceAccountName).To(Equal("egress-test"))
 		initContainer := dep.Spec.Template.Spec.InitContainers[0]
 		egwContainer := dep.Spec.Template.Spec.Containers[0]
+		egressPodIp := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}}
+		egressPodIps := &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIPs"}}
 		expectedInitEnvVars := []corev1.EnvVar{
 			{Name: "EGRESS_VXLAN_VNI", Value: "4097"},
 			{Name: "EGRESS_VXLAN_PORT", Value: "4790"},
 			{Name: "IPTABLES_BACKEND", Value: "nft"},
+			{Name: "EGRESS_POD_IP", ValueFrom: egressPodIp},
+			{Name: "EGRESS_POD_IPS", ValueFrom: egressPodIps},
 		}
 		for _, elem := range expectedInitEnvVars {
 			Expect(initContainer.Env).To(ContainElement(elem))
@@ -198,6 +202,8 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			{Name: "ICMP_PROBE_TIMEOUT", Value: "40s"},
 			{Name: "HTTP_PROBE_INTERVAL", Value: "20s"},
 			{Name: "HTTP_PROBE_TIMEOUT", Value: "40s"},
+			{Name: "EGRESS_POD_IP", ValueFrom: egressPodIp},
+			{Name: "EGRESS_POD_IPS", ValueFrom: egressPodIps},
 		}
 		for _, elem := range expectedEnvVars {
 			Expect(egwContainer.Env).To(ContainElement(elem))


### PR DESCRIPTION
## Description
Send the list of all addresses to egress gateways, to allow them run in dual stack clusters.
This PR is related to https://github.com/tigera/calico-private/pull/7415

The change is to introduce new env variable for egress gateways, called `EGRESS_POD_IPS` to list all pod's addresses, so egress gateways can use correct address.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
