### PR TITLE
[cherry-pick] [1.34] Make monitor controller aware that there are multi tenant options (#3…

### DIFF
--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -110,6 +110,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions, prometheusReady
 		tierWatchReady:  tierWatchReady,
 		clusterDomain:   opts.ClusterDomain,
 		usePSP:          opts.UsePSP,
+		multiTenant:     opts.MultiTenant,
 	}
 
 	r.status.AddStatefulSets([]types.NamespacedName{
@@ -188,6 +189,7 @@ type ReconcileMonitor struct {
 	tierWatchReady  *utils.ReadyFlag
 	clusterDomain   string
 	usePSP          bool
+	multiTenant     bool
 }
 
 func (r *ReconcileMonitor) getMonitor(ctx context.Context) (*operatorv1.Monitor, error) {


### PR DESCRIPTION
…269)

## Description

Cherry-pick #3269 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
