### PR TITLE
Fix IP pool name defaulting

### DIFF
--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -508,7 +508,7 @@ var _ = table.DescribeTable("Test OpenShift IP pool defaulting",
 		&operator.CalicoNetworkSpec{
 			IPPools: []operator.IPPool{
 				{
-					Name:          "10.0.0.0-24",
+					Name:          "default-ipv4-ippool",
 					CIDR:          "10.0.0.0/24",
 					Encapsulation: "VXLAN",
 					NATOutgoing:   "Disabled",


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Noticed that in some cases, creating a new controller was generating IP
pools that didn't have the old name. Previously, we would create pools
with `default-ipvX-ippool`. 

This PR aims to be backwards compatible and use that name format for the
following cases (the only possible scenarios prior to v1.34):

- There is only a single IP pool declared.
- This is a dual-stack cluster

Otherwise, IP pool name must either be provided by the user or it will
be defaulted based on the IP pool's CIDR.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.