### PR TITLE
[release-v1.34] Auto pick #3280: Fix IP pool name defaulting

### DIFF
--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -508,7 +508,7 @@ var _ = table.DescribeTable("Test OpenShift IP pool defaulting",
 		&operator.CalicoNetworkSpec{
 			IPPools: []operator.IPPool{
 				{
-					Name:          "10.0.0.0-24",
+					Name:          "default-ipv4-ippool",
 					CIDR:          "10.0.0.0/24",
 					Encapsulation: "VXLAN",
 					NATOutgoing:   "Disabled",

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -342,6 +342,9 @@ spec:
               debugSimulateCalcGraphHangAfter:
                 pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
+              debugSimulateDataplaneApplyDelay:
+                pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
+                type: string
               debugSimulateDataplaneHangAfter:
                 pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                 type: string
@@ -558,6 +561,12 @@ spec:
                 type: string
               endpointReportingEnabled:
                 type: boolean
+              endpointStatusPathPrefix:
+                description: "EndpointStatusPathPrefix is the path to the directory
+                  where endpoint status will be written. Endpoint status file reporting
+                  is disabled if field is left empty. \n Chosen directory should match
+                  the directory used by the CNI for PodStartupDelay. [Default: \"\"]"
+                type: string
               externalNetworkRoutingRulePriority:
                 description: 'ExternalNetworkRoutingRulePriority controls the priority
                   value to use for the external network routing rule. [Default: 102]'


### PR DESCRIPTION
Cherry pick of #3280 on release-v1.34.

#3280: Fix IP pool name defaulting

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Noticed that in some cases, creating a new controller was generating IP
pools that didn't have the old name. Previously, we would create pools
with `default-ipvX-ippool`. 

This PR aims to be backwards compatible and use that name format for the
following cases (the only possible scenarios prior to v1.34):

- There is only a single IP pool declared.
- This is a dual-stack cluster

Otherwise, IP pool name must either be provided by the user or it will
be defaulted based on the IP pool's CIDR.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.