### PR TITLE
[cherry-pick][v1.34] Remove elastic secrets dependency for compliance and only deploy serv…

### DIFF
--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -119,9 +119,6 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	// Watch the given secrets in each both the compliance and operator namespaces
 	for _, namespace := range watchNamespaces {
 		for _, secretName := range []string{
-			render.TigeraElasticsearchGatewaySecret, render.ElasticsearchComplianceBenchmarkerUserSecret,
-			render.ElasticsearchComplianceControllerUserSecret, render.ElasticsearchComplianceReporterUserSecret,
-			render.ElasticsearchComplianceSnapshotterUserSecret, render.ElasticsearchComplianceServerUserSecret,
 			render.ComplianceServerCertSecret, render.ManagerInternalTLSSecretName, certificatemanagement.CASecretName,
 			render.TigeraLinseedSecret, render.VoltronLinseedTLS,
 			render.VoltronLinseedPublicCert,
@@ -166,6 +163,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady
 		tierWatchReady:  tierWatchReady,
 		usePSP:          opts.UsePSP,
 		multiTenant:     opts.MultiTenant,
+		externalElastic: opts.ElasticExternal,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -187,6 +185,7 @@ type ReconcileCompliance struct {
 	tierWatchReady  *utils.ReadyFlag
 	usePSP          bool
 	multiTenant     bool
+	externalElastic bool
 }
 
 func GetCompliance(ctx context.Context, cli client.Client, mt bool, ns string) (*operatorv1.Compliance, error) {
@@ -316,11 +315,6 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	secretsToWatch := []string{
-		render.ElasticsearchComplianceBenchmarkerUserSecret, render.ElasticsearchComplianceControllerUserSecret,
-		render.ElasticsearchComplianceReporterUserSecret, render.ElasticsearchComplianceSnapshotterUserSecret,
-	}
-
 	managementCluster, err := utils.GetManagementCluster(ctx, r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementCluster", err, reqLogger)
@@ -336,21 +330,6 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	if managementClusterConnection != nil && managementCluster != nil {
 		err = fmt.Errorf("having both a ManagementCluster and a ManagementClusterConnection is not supported")
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	// Compliance server is only for Standalone or Management clusters
-	if managementClusterConnection == nil {
-		secretsToWatch = append(secretsToWatch, render.ElasticsearchComplianceServerUserSecret)
-	}
-
-	esSecrets, err := utils.ElasticsearchSecrets(ctx, secretsToWatch, r.client)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, "Elasticsearch secrets are not available yet, waiting until they become available", err, reqLogger)
-			return reconcile.Result{}, nil
-		}
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get Elasticsearch credentials", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
@@ -392,7 +371,9 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	bundleMaker := certificateManager.CreateTrustedBundle(managerInternalTLSSecret, linseedCertificate)
 	trustedBundle := bundleMaker.(certificatemanagement.TrustedBundleRO)
 	if r.multiTenant {
-		trustedBundle, err = certificateManager.LoadTrustedBundle(ctx, r.client, helper.InstallNamespace())
+		// For multi-tenant systems, we load the pre-created bundle for this tenant instead of using the one we built here.
+		// Multi-tenant compliance need the bundle variant that includes system root certificates, in order to verify external auth providers.
+		trustedBundle, err = certificateManager.LoadMultiTenantTrustedBundleWithRootCertificates(ctx, r.client, helper.InstallNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting trusted bundle", err, reqLogger)
 			return reconcile.Result{}, err
@@ -461,7 +442,6 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 	hasNoLicense := !utils.IsFeatureActive(license, common.ComplianceFeature)
 	openshift := r.provider == operatorv1.ProviderOpenShift
 	complianceCfg := &render.ComplianceConfiguration{
-		ESSecrets:                   esSecrets,
 		TrustedBundle:               trustedBundle,
 		Installation:                network,
 		ServerKeyPair:               complianceServerKeyPair,
@@ -480,6 +460,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		Namespace:                   helper.InstallNamespace(),
 		Tenant:                      tenant,
 		Compliance:                  instance,
+		ExternalElastic:             r.externalElastic,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/render/testutils/expected_policies/compliance-server.json
+++ b/pkg/render/testutils/expected_policies/compliance-server.json
@@ -42,17 +42,6 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
-          "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "ports": [
-            5554
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
         "source": {
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/compliance-server_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance-server_ocp.json
@@ -42,17 +42,6 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
-          "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "ports": [
-            5554
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
         "source": {
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/compliance_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/compliance_unmanaged.json
@@ -37,17 +37,6 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "destination": {
-          "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
-          "ports": [
-            5554
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
         "source": {
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/compliance_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance_unmanaged_ocp.json
@@ -48,17 +48,6 @@
       {
         "action": "Allow",
         "protocol": "TCP",
-        "destination": {
-          "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
-          "ports": [
-            5554
-          ]
-        }
-      },
-      {
-        "action": "Allow",
-        "protocol": "TCP",
         "source": {
         },
         "destination": {


### PR DESCRIPTION
…… (#3275)

* Remove elastic secrets dependency for compliance and only deploy server in a multi-tenant environment
y
* [ADDENDUM] Add required RBAC for compliance

* [CODE REVIEW] Update how RBAC is created for multi-tenancy

## Description

Cherry-pick #3275

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
