### PR TITLE
Add egress rule to allow dashboards to connect to external Kibana

### DIFF
--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -89,11 +89,9 @@ type Config struct {
 	ExternalKibanaClientSecret *corev1.Secret
 
 	// Kibana service definition
-	KibanaHost      string
-	KibanaPort      string
-	KibanaScheme    string
-	KibanaDomain    string
-	KibanaPortAsInt uint16
+	KibanaHost   string
+	KibanaPort   uint16
+	KibanaScheme string
 
 	// Credentials are used to provide annotations for elastic search users
 	Credentials []*corev1.Secret
@@ -157,8 +155,8 @@ func (d *dashboards) AllowTigeraPolicy() *v3.NetworkPolicy {
 			Action:   v3.Allow,
 			Protocol: &networkpolicy.TCPProtocol,
 			Destination: v3.EntityRule{
-				Ports:   []numorstring.Port{{MinPort: d.cfg.KibanaPortAsInt, MaxPort: d.cfg.KibanaPortAsInt}},
-				Domains: []string{d.cfg.KibanaDomain},
+				Ports:   []numorstring.Port{{MinPort: d.cfg.KibanaPort, MaxPort: d.cfg.KibanaPort}},
+				Domains: []string{d.cfg.KibanaHost},
 			},
 		})
 	} else {
@@ -206,7 +204,7 @@ func (d *dashboards) Job() *batchv1.Job {
 		},
 		{
 			Name:  "KIBANA_PORT",
-			Value: d.cfg.KibanaPort,
+			Value: fmt.Sprintf("%d", d.cfg.KibanaPort),
 		},
 		{
 			Name:  "KIBANA_SCHEME",

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tigera/api/pkg/lib/numorstring"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/google/go-cmp/cmp"
@@ -429,6 +431,13 @@ var _ = Describe("Dashboards rendering tests", func() {
 			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
 				Name: "KIBANA_MTLS_ENABLED", Value: "true",
 			}))
+			netPol := rtest.GetResource(createResources, fmt.Sprintf("allow-tigera.%s", Name), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			Expect(netPol).NotTo(BeNil())
+			Expect(netPol.Spec.Egress).To(HaveLen(2))
+			Expect(netPol.Spec.Egress[1].Destination).To(Equal(v3.EntityRule{
+				Ports:   []numorstring.Port{{MinPort: 443, MaxPort: 443}},
+				Domains: []string{"external-kibana"},
+			}))
 		})
 
 		It("should render resources in the elasticsearch namespace", func() {
@@ -441,6 +450,8 @@ var _ = Describe("Dashboards rendering tests", func() {
 			Expect(sa).NotTo(BeNil())
 			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", Name), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
+			Expect(netPol.Spec.Egress).To(HaveLen(2))
+			Expect(netPol.Spec.Egress[1].Destination).To(Equal(render.KibanaEntityRule))
 		})
 
 		It("should render single-tenant environment variables", func() {

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -92,12 +92,14 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle: bundle,
-				UsePSP:        true,
-				Namespace:     render.ElasticsearchNamespace,
-				KibanaHost:    "tigera-secure-kb-http.tigera-kibana.svc",
-				KibanaScheme:  "https",
-				KibanaPort:    "5601",
+				TrustedBundle:   bundle,
+				UsePSP:          true,
+				Namespace:       render.ElasticsearchNamespace,
+				KibanaHost:      "tigera-secure-kb-http.tigera-kibana.svc",
+				KibanaScheme:    "https",
+				KibanaPort:      "5601",
+				KibanaDomain:    "tigera-secure-kb-http.tigera-kibana.svc",
+				KibanaPortAsInt: 5601,
 			}
 		})
 
@@ -192,11 +194,13 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle: bundle,
-				Namespace:     render.ElasticsearchNamespace,
-				KibanaHost:    "tigera-secure-kb-http.tigera-kibana.tigera-kibana.svc",
-				KibanaScheme:  "htpps",
-				KibanaPort:    "5601",
+				TrustedBundle:   bundle,
+				Namespace:       render.ElasticsearchNamespace,
+				KibanaHost:      "tigera-secure-kb-http.tigera-kibana.tigera-kibana.svc",
+				KibanaScheme:    "htpps",
+				KibanaPort:      "5601",
+				KibanaDomain:    "tigera-secure-kb-http.tigera-kibana.svc",
+				KibanaPortAsInt: 5601,
 			})
 
 			resources, _ := component.Objects()
@@ -237,12 +241,14 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle: bundle,
-				Namespace:     "tenant-test-tenant",
-				Tenant:        tenant,
-				KibanaHost:    "external-kibana",
-				KibanaScheme:  "https",
-				KibanaPort:    "443",
+				TrustedBundle:   bundle,
+				Namespace:       "tenant-test-tenant",
+				Tenant:          tenant,
+				KibanaHost:      "external-kibana",
+				KibanaScheme:    "https",
+				KibanaPort:      "443",
+				KibanaDomain:    "external-kibana",
+				KibanaPortAsInt: 443,
 			}
 		})
 
@@ -379,12 +385,14 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle: bundle,
-				Namespace:     render.ElasticsearchNamespace,
-				Tenant:        tenant,
-				KibanaHost:    "external-kibana",
-				KibanaScheme:  "https",
-				KibanaPort:    "443",
+				TrustedBundle:   bundle,
+				Namespace:       render.ElasticsearchNamespace,
+				Tenant:          tenant,
+				KibanaHost:      "external-kibana",
+				KibanaScheme:    "https",
+				KibanaPort:      "443",
+				KibanaDomain:    "external-kibana",
+				KibanaPortAsInt: 443,
 			}
 		})
 
@@ -494,12 +502,14 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle: bundle,
-				Namespace:     render.ElasticsearchNamespace,
-				Tenant:        tenant,
-				KibanaHost:    "tigera-secure-kb-http.tigera-kibana.svc",
-				KibanaScheme:  "https",
-				KibanaPort:    "5601",
+				TrustedBundle:   bundle,
+				Namespace:       render.ElasticsearchNamespace,
+				Tenant:          tenant,
+				KibanaHost:      "tigera-secure-kb-http.tigera-kibana.svc",
+				KibanaScheme:    "https",
+				KibanaPort:      "5601",
+				KibanaDomain:    "external-kibana",
+				KibanaPortAsInt: 443,
 			}
 		})
 

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -92,14 +92,12 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle:   bundle,
-				UsePSP:          true,
-				Namespace:       render.ElasticsearchNamespace,
-				KibanaHost:      "tigera-secure-kb-http.tigera-kibana.svc",
-				KibanaScheme:    "https",
-				KibanaPort:      "5601",
-				KibanaDomain:    "tigera-secure-kb-http.tigera-kibana.svc",
-				KibanaPortAsInt: 5601,
+				TrustedBundle: bundle,
+				UsePSP:        true,
+				Namespace:     render.ElasticsearchNamespace,
+				KibanaHost:    "tigera-secure-kb-http.tigera-kibana.svc",
+				KibanaScheme:  "https",
+				KibanaPort:    5601,
 			}
 		})
 
@@ -194,13 +192,11 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle:   bundle,
-				Namespace:       render.ElasticsearchNamespace,
-				KibanaHost:      "tigera-secure-kb-http.tigera-kibana.tigera-kibana.svc",
-				KibanaScheme:    "htpps",
-				KibanaPort:      "5601",
-				KibanaDomain:    "tigera-secure-kb-http.tigera-kibana.svc",
-				KibanaPortAsInt: 5601,
+				TrustedBundle: bundle,
+				Namespace:     render.ElasticsearchNamespace,
+				KibanaHost:    "tigera-secure-kb-http.tigera-kibana.tigera-kibana.svc",
+				KibanaScheme:  "htpps",
+				KibanaPort:    5601,
 			})
 
 			resources, _ := component.Objects()
@@ -241,14 +237,12 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle:   bundle,
-				Namespace:       "tenant-test-tenant",
-				Tenant:          tenant,
-				KibanaHost:      "external-kibana",
-				KibanaScheme:    "https",
-				KibanaPort:      "443",
-				KibanaDomain:    "external-kibana",
-				KibanaPortAsInt: 443,
+				TrustedBundle: bundle,
+				Namespace:     "tenant-test-tenant",
+				Tenant:        tenant,
+				KibanaHost:    "external-kibana",
+				KibanaScheme:  "https",
+				KibanaPort:    443,
 			}
 		})
 
@@ -385,14 +379,12 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle:   bundle,
-				Namespace:       render.ElasticsearchNamespace,
-				Tenant:          tenant,
-				KibanaHost:      "external-kibana",
-				KibanaScheme:    "https",
-				KibanaPort:      "443",
-				KibanaDomain:    "external-kibana",
-				KibanaPortAsInt: 443,
+				TrustedBundle: bundle,
+				Namespace:     render.ElasticsearchNamespace,
+				Tenant:        tenant,
+				KibanaHost:    "external-kibana",
+				KibanaScheme:  "https",
+				KibanaPort:    443,
 			}
 		})
 
@@ -502,14 +494,12 @@ var _ = Describe("Dashboards rendering tests", func() {
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				TrustedBundle:   bundle,
-				Namespace:       render.ElasticsearchNamespace,
-				Tenant:          tenant,
-				KibanaHost:      "tigera-secure-kb-http.tigera-kibana.svc",
-				KibanaScheme:    "https",
-				KibanaPort:      "5601",
-				KibanaDomain:    "external-kibana",
-				KibanaPortAsInt: 443,
+				TrustedBundle: bundle,
+				Namespace:     render.ElasticsearchNamespace,
+				Tenant:        tenant,
+				KibanaHost:    "tigera-secure-kb-http.tigera-kibana.svc",
+				KibanaScheme:  "https",
+				KibanaPort:    5601,
 			}
 		})
 


### PR DESCRIPTION
## Description

Single tenant with external Kibana need to access the external Kibana URL to setup up the dashboards in the tenant namespace. We need to create an egress rule to match that.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
