### PR TITLE
Fix broken policy rec req limit reconcilation

### DIFF
--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -445,6 +445,7 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 		ExternalElastic:                r.externalElastic,
 		TrustedBundle:                  trustedBundleRO,
 		PolicyRecommendationCertSecret: policyRecommendationKeyPair,
+		PolicyRecommendation:           policyRecommendation,
 	}
 
 	// Render the desired objects from the CRD and create or update them.


### PR DESCRIPTION
These changes https://github.com/tigera/operator/commit/60ff3d0585dbf5785824aa11ad046e86ae66d948
overwritten the changes to copy PolicyConfiguration in policyrecommendation_controller.go. 
Adding it again, So that operator could reconcile policy rec CR to its deployment.


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
