### PR TITLE
EV-4792 Added Add HSTS header to dex and upgrade to 2.39

### DIFF
--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -358,6 +358,12 @@ func (c *dexComponent) configMap() *corev1.ConfigMap {
 			"tlsKey":                  c.cfg.TLSKeyPair.VolumeMountKeyFilePath(),
 			"allowedOrigins":          []string{"*"},
 			"discoveryAllowedOrigins": []string{"*"},
+			"headers": map[string]string{
+				"X-Content-Type-Options":    "nosniff",
+				"X-XSS-Protection":          "1; mode=block",
+				"X-Frame-Options":           "DENY",
+				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+			},
 		},
 		"connectors": []map[string]interface{}{c.connector},
 		"oauth2": map[string]interface{}{


### PR DESCRIPTION
calico-private changes - https://github.com/tigera/calico-private/pull/7453/files

![image](https://github.com/tigera/operator/assets/102720382/d49d0659-7a03-4521-95f8-1ccc9e719f15)

![image](https://github.com/tigera/operator/assets/102720382/9c794dc4-62f4-431b-a2c5-4703e3113550)


verification:
enable dex using` bz addons run idp:enable-oidc`
To login, use kubefwd to forward -n oidc and -n tigera-manager, go to https://tigera-manager.tigera-manager:9443. Use username=test-user@example.com and password=password (will be in the output of above bz addon)

check for dex URL response headers.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
