### PR TITLE
Shorten kibana session

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1265,8 +1265,9 @@ func (es elasticsearchComponent) kibanaCR() *kbv1.Kibana {
 
 	config := map[string]interface{}{
 		"elasticsearch.ssl.certificateAuthorities": []string{"/usr/share/kibana/config/elasticsearch-certs/tls.crt"},
-		"server":                          server,
-		"xpack.security.session.lifespan": "24h",
+		"server":                             server,
+		"xpack.security.session.lifespan":    "8h",
+		"xpack.security.session.idleTimeout": "30m",
 		"tigera": map[string]interface{}{
 			"enabled":        true,
 			"licenseEdition": "enterpriseEdition",

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				}
 			})
 
-			It("should render an elasticsearchComponent", func() {
+			It("should render an elasticsearchComponent and a kibanaComponent", func() {
 				expectedCreateResources := []client.Object{
 					// ECK Resources
 					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.ECKOperatorNamespace}},
@@ -462,6 +462,11 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						ResourceNames: []string{"elastic-operator"},
 					},
 				}))
+
+				resultKB := rtest.GetResource(createResources, render.KibanaName, render.KibanaNamespace,
+					"kibana.k8s.elastic.co", "v1", "Kibana").(*kbv1.Kibana)
+				Expect(resultKB.Spec.Config.Data["xpack.security.session.lifespan"]).To(Equal("8h"))
+				Expect(resultKB.Spec.Config.Data["xpack.security.session.idleTimeout"]).To(Equal("30m"))
 			})
 
 			It("should render an elasticsearchComponent and delete the Elasticsearch and Kibana ExternalService as well as Curator components", func() {


### PR DESCRIPTION
See: https://www.elastic.co/guide/en/kibana/7.17/xpack-security-session-management.html

The UX is as follows: after you don't do anything for a while and you have only a minute left, kibana will display a box in the bottom right informing you that the session expires. You can click a button there to prolong it. If you don't you will be logged out. 
