### PR TITLE
[release-v1.33][cherry-pick] Fix security-context for apiserver - audit logs are supported only in Enterprise version

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1073,9 +1073,6 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 		ImagePullPolicy: ImagePullPolicy(),
 		Args:            c.startUpArgs(),
 		Env:             env,
-		// OpenShift apiserver needs privileged access to write audit logs to host path volume.
-		// Audit logs are owned by root on hosts so we need to be root user and group.
-		SecurityContext: securitycontext.NewRootContext(c.cfg.Openshift),
 		VolumeMounts:    volumeMounts,
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -1100,6 +1097,13 @@ func (c *apiServerComponent) apiServerContainer() corev1.Container {
 			InitialDelaySeconds: 5,
 			TimeoutSeconds:      10,
 		},
+	}
+	// In case of OpenShift, apiserver needs privileged access to write audit logs to host path volume.
+	// Audit logs are owned by root on hosts so we need to be root user and group. Audit logs are supported only in Enterprise version.
+	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
+		apiServer.SecurityContext = securitycontext.NewRootContext(c.cfg.Openshift)
+	} else {
+		apiServer.SecurityContext = securitycontext.NewNonRootContext()
 	}
 
 	return apiServer

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1655,11 +1655,11 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds).To(BeEquivalentTo(90))
 		Expect(d.Spec.Template.Spec.Containers[0].LivenessProbe.TimeoutSeconds).To(BeEquivalentTo(10))
 
-		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
-		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeTrue())
-		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeFalse())
-		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(0))
+		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
+		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup).To(BeEquivalentTo(10001))
+		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
+		Expect(*d.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(BeEquivalentTo(10001))
 		Expect(d.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities).To(Equal(
 			&corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},


### PR DESCRIPTION
## Description

Cherry-pick https://github.com/tigera/operator/pull/2906

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
