### PR TITLE
[EV-4646] Remove cloud-controller references

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -91,9 +91,6 @@ components:
   tigera-cni-windows:
     image: tigera/cni-windows
     version: release-calient-v3.19
-  cloud-controllers:
-    image: tigera/cloud-controllers
-    version: release-calient-v3.19
   elasticsearch-metrics:
     image: tigera/elasticsearch-metrics
     version: release-calient-v3.19

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -336,13 +336,6 @@ var (
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
-{{ with index .Components "cloud-controllers" }}
-	ComponentCloudControllers = component{
-		Version:  "{{ .Version }}",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
-	}
-{{- end }}
 {{ with index .Components "elasticsearch-metrics" }}
 	ComponentElasticsearchMetrics = component{
 		Version:  "{{ .Version }}",
@@ -412,7 +405,6 @@ var (
 		ComponentTigeraCNI,
 		ComponentTigeraCNIFIPS,
 		ComponentTigeraCNIWindows,
-		ComponentCloudControllers,
 		ComponentElasticsearchMetrics,
 		ComponentESGateway,
 		ComponentLinseed,

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -291,12 +291,6 @@ var (
 		Registry: "",
 	}
 
-	ComponentCloudControllers = component{
-		Version:  "release-calient-v3.19",
-		Image:    "tigera/cloud-controllers",
-		Registry: "",
-	}
-
 	ComponentElasticsearchMetrics = component{
 		Version:  "release-calient-v3.19",
 		Image:    "tigera/elasticsearch-metrics",
@@ -361,7 +355,6 @@ var (
 		ComponentTigeraCNI,
 		ComponentTigeraCNIFIPS,
 		ComponentTigeraCNIWindows,
-		ComponentCloudControllers,
 		ComponentElasticsearchMetrics,
 		ComponentESGateway,
 		ComponentLinseed,


### PR DESCRIPTION
## Description

Cherry-pick of #3292 to remove cloud-controller references on `v1.34`.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
