### PR TITLE
Master role deprecation 

### DIFF
--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -43,7 +43,7 @@ var _ = Describe("provider discovery", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "master1",
 				Labels: map[string]string{
-					"node-role.kubernetes.io/master":    "",
+					"node-role.kubernetes.io/control-plane":    "",
 					"com.docker.ucp.orchestrator.swarm": "true",
 				},
 			},

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -43,7 +43,7 @@ var (
 	// TolerateControlPlane allows pod to be scheduled on master nodes
 	TolerateControlPlane = []corev1.Toleration{
 		{
-			Key:    "node-role.kubernetes.io/master",
+			Key:    "node-role.kubernetes.io/control-plane",
 			Effect: corev1.TaintEffectNoSchedule,
 		},
 		{


### PR DESCRIPTION
Master role was deprecated in v1.24 and became just control-plane
https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/