### PR TITLE
[RS-1818] Update ILM policy to keep warm tigera_secure_ee_events indices writable

### DIFF
--- a/pkg/controller/utils/elasticsearch.go
+++ b/pkg/controller/utils/elasticsearch.go
@@ -405,17 +405,17 @@ func (es *esClient) listILMPolicies(ls *operatorv1.LogStorage) map[string]policy
 
 	// Retention is not set in LogStorage for l7, benchmark and events logs
 	return map[string]policyDetail{
-		"tigera_secure_ee_flows": buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.85, int(*ls.Spec.Retention.Flows)),
-		"tigera_secure_ee_dns":   buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.05, int(*ls.Spec.Retention.DNSLogs)),
-		"tigera_secure_ee_bgp":   buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.05, int(*ls.Spec.Retention.BGPLogs)),
-		"tigera_secure_ee_l7":    buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.05, 1),
+		"tigera_secure_ee_flows": buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.85, int(*ls.Spec.Retention.Flows), true),
+		"tigera_secure_ee_dns":   buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.05, int(*ls.Spec.Retention.DNSLogs), true),
+		"tigera_secure_ee_bgp":   buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.05, int(*ls.Spec.Retention.BGPLogs), true),
+		"tigera_secure_ee_l7":    buildILMPolicy(totalEsStorage, majorPctOfTotalDisk, 0.05, 1, true),
 
-		"tigera_secure_ee_audit_ee":           buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.AuditReports)),
-		"tigera_secure_ee_audit_kube":         buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.AuditReports)),
-		"tigera_secure_ee_snapshots":          buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.Snapshots)),
-		"tigera_secure_ee_compliance_reports": buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.ComplianceReports)),
-		"tigera_secure_ee_benchmark_results":  buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, 91),
-		"tigera_secure_ee_events":             buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, 91),
+		"tigera_secure_ee_audit_ee":           buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.AuditReports), true),
+		"tigera_secure_ee_audit_kube":         buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.AuditReports), true),
+		"tigera_secure_ee_snapshots":          buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.Snapshots), true),
+		"tigera_secure_ee_compliance_reports": buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, int(*ls.Spec.Retention.ComplianceReports), true),
+		"tigera_secure_ee_benchmark_results":  buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, 91, true),
+		"tigera_secure_ee_events":             buildILMPolicy(totalEsStorage, minorPctOfTotalDisk, pctOfDisk, 91, false),
 	}
 }
 
@@ -446,11 +446,21 @@ func (es *esClient) createOrUpdatePolicies(ctx context.Context, listPolicy map[s
 	return nil
 }
 
-func buildILMPolicy(totalEsStorage int64, totalDiskPercentage float64, percentOfDiskForLogType float64, retention int) policyDetail {
+func buildILMPolicy(totalEsStorage int64, totalDiskPercentage float64, percentOfDiskForLogType float64, retention int, readOnlyAfterRollover bool) policyDetail {
 	pd := policyDetail{}
 	pd.rolloverSize = calculateRolloverSize(totalEsStorage, totalDiskPercentage, percentOfDiskForLogType)
 	pd.rolloverAge = calculateRolloverAge(retention)
 	pd.deleteAge = fmt.Sprintf("%dd", retention)
+
+	warmActions := map[string]interface{}{
+		"set_priority": map[string]interface{}{
+			"priority": 50,
+		},
+	}
+
+	if readOnlyAfterRollover {
+		warmActions["readonly"] = map[string]interface{}{}
+	}
 
 	pd.policy = map[string]interface{}{
 		"policy": map[string]interface{}{
@@ -467,12 +477,7 @@ func buildILMPolicy(totalEsStorage int64, totalDiskPercentage float64, percentOf
 					},
 				},
 				"warm": map[string]interface{}{
-					"actions": map[string]interface{}{
-						"readonly": map[string]interface{}{},
-						"set_priority": map[string]interface{}{
-							"priority": 50,
-						},
-					},
+					"actions": warmActions,
 				},
 				"delete": map[string]interface{}{
 					"min_age": pd.deleteAge,

--- a/pkg/controller/utils/elasticsearch_test.go
+++ b/pkg/controller/utils/elasticsearch_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Elasticsearch tests", func() {
 		It("apply new lifecycle policy", func() {
 			newPolicies = true
 			totalDiskSize := resource.MustParse("100Gi")
-			pd := buildILMPolicy(totalDiskSize.Value(), 0.7, .9, 10)
+			pd := buildILMPolicy(totalDiskSize.Value(), 0.7, .9, 10, true)
 
 			err := eClient.createOrUpdatePolicies(ctx, map[string]policyDetail{
 				indexName: pd,
@@ -85,7 +85,7 @@ var _ = Describe("Elasticsearch tests", func() {
 		It("update existing lifecycle policy", func() {
 			newPolicies = false
 			totalDiskSize := resource.MustParse("100Gi")
-			pd := buildILMPolicy(totalDiskSize.Value(), 0.7, .9, 5)
+			pd := buildILMPolicy(totalDiskSize.Value(), 0.7, .9, 5, false)
 			err := eClient.createOrUpdatePolicies(ctx, map[string]policyDetail{
 				indexName: pd,
 			})

--- a/pkg/controller/utils/test_files/02_put_policy.json
+++ b/pkg/controller/utils/test_files/02_put_policy.json
@@ -20,7 +20,6 @@
       },
       "warm" : {
         "actions" : {
-          "readonly" : { },
           "set_priority" : {
             "priority" : 50
           }


### PR DESCRIPTION
[RS-1818] Update ILM policy to keep warm tigera_secure_ee_events indices writable

## Description

Cherry-pick #3325 for `release-v1.34`.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.


[RS-1818]: https://tigera.atlassian.net/browse/RS-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ