### PR TITLE
[RS-1818] Update ILM policy when warm index readonly setting changes

### DIFF
--- a/pkg/controller/utils/test_files/01_get_policy.json
+++ b/pkg/controller/utils/test_files/01_get_policy.json
@@ -6,12 +6,12 @@
           "actions": {
             "delete": {}
           },
-          "min_age": "5d"
+          "min_age": "10d"
         },
         "hot": {
           "actions": {
             "rollover": {
-              "max_age" : "1d",
+              "max_age" : "2d",
               "max_size" : "16911433728b"
             },
             "set_priority": {
@@ -21,6 +21,7 @@
         },
         "warm": {
           "actions": {
+            "readonly": {},
             "set_priority": {
               "priority": 50
             }

--- a/pkg/controller/utils/test_files/02_put_policy_readonly.json
+++ b/pkg/controller/utils/test_files/02_put_policy_readonly.json
@@ -1,0 +1,31 @@
+{
+  "policy" : {
+    "phases" : {
+      "delete" : {
+        "actions" : {
+          "delete" : { }
+        },
+        "min_age" : "5d"
+      },
+      "hot" : {
+        "actions" : {
+          "rollover" : {
+            "max_age" : "1d",
+            "max_size" : "16911433728b"
+          },
+          "set_priority" : {
+            "priority" : 100
+          }
+        }
+      },
+      "warm" : {
+        "actions" : {
+          "readonly": {},
+          "set_priority" : {
+            "priority" : 50
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Further testing around https://github.com/tigera/operator/pull/3325 showed that the operator does not update the ILM policy when the value of `readOnlyAfterRollover` changes. 

The code responsible for updating the ILM policy only do so if there is a change warranting an update. That check does not generically compare the old policy to the new one, but instead only looks at a handful of relevant parameters and tirggers an update only when one of these relevant parameters changes. This PR adds `readOnlyAfterRollover` to that logic and updates the tests to cover that logic.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
