### PR TITLE
update script to generate release notes from milestone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -477,8 +477,8 @@ maybe-build-release:
 	./hack/maybe-build-release.sh
 
 release-notes: var-require-all-VERSION-GITHUB_TOKEN clean
-	@python3 -m pip install PyYAML PyGithub==2.3.0 && \
-		GITHUB_TOKEN=$(GITHUB_TOKEN) VERSION=$(VERSION) ./generate-release-notes.py
+	@docker build -t tigera/release-notes -f build/Dockerfile.release-notes .
+	@docker run --rm -v $(CURDIR):/workdir -e	GITHUB_TOKEN=$(GITHUB_TOKEN) -e VERSION=$(VERSION) tigera/release-notes
 
 ## Tags and builds a release from start to finish.
 release: release-prereqs

--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,10 @@ endif
 maybe-build-release:
 	./hack/maybe-build-release.sh
 
+release-notes: var-require-all-VERSION-GITHUB_TOKEN clean
+	@python3 -m pip install PyYAML PyGithub==2.3.0 && \
+		GITHUB_TOKEN=$(GITHUB_TOKEN) VERSION=$(VERSION) ./generate-release-notes.py
+
 ## Tags and builds a release from start to finish.
 release: release-prereqs
 ifneq ($(VERSION), $(GIT_VERSION))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,12 +4,12 @@
 
 For a major or minor release, you will need to create:
 
-- A new `release-vX.Y` branch based on the target minor version.  We always do releases from a release 
+- A new `release-vX.Y` branch based on the target minor version.  We always do releases from a release
   branch, not from master.
 - An empty commit on the master branch, tagged with the "dev" version for the next minor release.
   This ensures that `git describe --tags` (which is used to generate versions for CI builds) will
   produce a version that "makes sense" for master commits after the release branch is created.
-- A new GitHub milestone for the next minor release.  This ensures that new PRs get auto-added to 
+- A new GitHub milestone for the next minor release.  This ensures that new PRs get auto-added to
   the correct milestone.
 
 To create a new release branch:
@@ -20,17 +20,17 @@ To create a new release branch:
    ```sh
    git checkout <remote>/master -b release-vX.Y
    ```
-   
+
 3. Push the new branch to the repository:
 
    ```sh
    git push <remote> release-vX.Y
    ```
-   
+
 To create an empty commit and tag on master; run the following commands.  This will push directly to master,
 bypassing the normal PR process.  This is important to make sure that the tag is directly on the master branch.
 We create an empty commit because, when the release branch is created, it shares its commit history with master.
-So, if we tagged the tip of master, we'd also be tagging the tip of the release branch, which would give 
+So, if we tagged the tip of master, we'd also be tagging the tip of the release branch, which would give
 incorrect results for `git describe --tags` on the release branch.
 
    ```sh
@@ -41,8 +41,8 @@ incorrect results for `git describe --tags` on the release branch.
    git push <remote> vX.Y.0-0.dev
    ```
 
-*Note* that the tag should have the exact format `vX.Y.0-0.dev` where `X.Y` is the next minor version.  
-The `-0.dev` suffix was chosen to produce a semver-compliant version that is less than the 
+*Note* that the tag should have the exact format `vX.Y.0-0.dev` where `X.Y` is the next minor version.
+The `-0.dev` suffix was chosen to produce a semver-compliant version that is less than the
 first release version for the new minor version.
 
 Finally, create the next minor release's first milestone at https://github.com/tigera/operator/milestones.
@@ -109,7 +109,7 @@ git push --tags
 1. Run the following command to generate release notes for the release
 
    ```
-   GITHUB_TOKEN=<access-token> VERSION=<TAG> ./generate-release-notes.py
+   make release-note
    ```
 
 1. Go to https://github.com/tigera/operator/releases and edit the release tag to include the generated release notes, and update the title.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,7 +109,7 @@ git push --tags
 1. Run the following command to generate release notes for the release
 
    ```
-   make release-note
+   make release-notes VERSION=<TAG> GITHUB_TOKEN=<access-token>
    ```
 
 1. Go to https://github.com/tigera/operator/releases and edit the release tag to include the generated release notes, and update the title.

--- a/build/Dockerfile.release-notes
+++ b/build/Dockerfile.release-notes
@@ -1,0 +1,9 @@
+FROM python:3-alpine
+
+LABEL maintainer="engineering-release@tigera.io"
+
+WORKDIR /workdir
+
+RUN python3 -m pip install PyGithub==2.3.0 PyYAML==6.0.1
+
+CMD [ "./hack/generate_release_notes.py" ]

--- a/generate-release-notes.py
+++ b/generate-release-notes.py
@@ -1,20 +1,39 @@
 #!/usr/bin/env python3
-from github import Github  # https://github.com/PyGithub/PyGithub
-import yaml
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
 import os
 import re
 import io
 import datetime
 
+# To install, run python3 -m pip install PyYAML
+import yaml
+
+# To install, run python3 -m pip install PyGithub==2.3.0
+from github import Github, Auth  # https://github.com/PyGithub/PyGithub
+
+# Validate required environment variables
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+assert GITHUB_TOKEN, "GITHUB_TOKEN must be set"
+VERSION = os.environ.get("VERSION")
+assert os.environ.get("VERSION"), "VERSION must be set"
+assert VERSION.startswith("v"), "VERSION must start with 'v'"
+
 # First create a Github instance. Create a token through Github website - provide "repo" auth.
-g = Github(os.environ.get('GITHUB_TOKEN'))
+auth = Auth.Token(os.environ.get("GITHUB_TOKEN"))
+g = Github(auth=auth)
 
 # The milestone to generate notes for.
-assert os.environ.get('VERSION')
-MILESTONE=os.environ.get('VERSION')
+MILESTONE = VERSION
 
 # The file where we'll store the release notes.
-FILENAME="%s-release-notes.md" % MILESTONE
+FILENAME = f"{VERSION}-release-notes.md"
+
+
+class ReleaseNoteError(Exception):
+    pass
+
 
 # Returns a dictionary where the keys are repositories, and the values are
 # a list of issues in the repository which match the milestone and
@@ -28,14 +47,22 @@ def issues_in_milestone():
         if m.title == MILESTONE:
             # Found the milestone in this repo - look for issues (but only
             # ones that have been closed!)
+            print(f"  found milestone {m.title}")
             issues = []
-            for i in repo.get_issues(milestone=m, state="closed", labels=['release-note-required']):
-                pr = i.as_pull_request()
+            milestone_issues = repo.get_issues(
+                milestone=m, state="closed", labels=["release-note-required"]
+            )
+            for issue in milestone_issues:
+                pr = issue.as_pull_request()
                 if pr.merged:
                     # Filter out PRs which are closed but not merged.
-                    issues.append(i)
+                    issues.append(issue)
+                else:
+                    print(f"WARNING: {pr.number} is not merged, skipping")
+            if len(issues) == 0:
+                raise ReleaseNoteError(f"no issues found for milestone {m.title}")
             return issues
-    raise Exception("Unable to find issues in milestone")
+
 
 # Takes an issue and returns the appropriate release notes from that
 # issue as a list.  If it has a release-note section defined, that is used.
@@ -44,13 +71,14 @@ def extract_release_notes(issue):
     # Look for a release note section in the body.
     matches = None
     if issue.body:
-        matches = re.findall(r'```release-note(.*?)```', issue.body, re.DOTALL)
+        matches = re.findall(r"```release-note(.*?)```", str(issue.body), re.DOTALL)
 
     if matches:
         return [m.strip() for m in matches]
     else:
         # If no release notes explicitly declared, then use the PR title.
         return [issue.title.strip()]
+
 
 def kind(issue):
     for l in issue.labels:
@@ -60,28 +88,37 @@ def kind(issue):
             return "bug"
     return "other"
 
+
 def enterprise_feature(issue):
     for l in issue.labels:
         if l.name == "enterprise":
             return True
     return False
 
-def print_issues_to_file(f, issues):
-    for i in issues:
-        for note in extract_release_notes(i):
-            if enterprise_feature(i):
-                f.write(" - [Calico Enterprise] %s [#%d](%s) (@%s)\n" % (note, i.number, i.html_url, i.user.login))
+
+def print_issues_to_file(file, issues):
+    for issue in issues:
+        for note in extract_release_notes(issue):
+            if enterprise_feature(issue):
+                file.write(
+                    f" - [Calico Enterprise] {note} [#{issue.number}]({issue.html_url}) (@{issue.user.login})\n"  # pylint: disable=line-too-long
+                )
             else:
-                f.write(" - %s [#%d](%s) (@%s)\n" % (note, i.number, i.html_url, i.user.login))
-    f.write(u"\n")
+                file.write(
+                    f" - {note} [#{issue.number}]({issue.html_url}) (@{issue.user.login})\n"
+                )
+    file.write("\n")
+
 
 def calico_version():
-    v = yaml.safe_load(open('config/calico_versions.yml', 'r'))
-    return v['title']
+    v = yaml.safe_load(open("config/calico_versions.yml", "r", encoding="utf-8"))
+    return v["title"]
+
 
 def enterprise_version():
-    v = yaml.safe_load(open('config/enterprise_versions.yml', 'r'))
-    return v['title']
+    v = yaml.safe_load(open("config/enterprise_versions.yml", "r", encoding="utf-8"))
+    return v["title"]
+
 
 if __name__ == "__main__":
     # Get the list of issues.
@@ -103,25 +140,27 @@ if __name__ == "__main__":
             other.append(i)
 
     # Write release notes out to a file.
-    with io.open(FILENAME, "w", encoding='utf-8') as f:
-        f.write(u"%s\n\n" % date)
+    with io.open(FILENAME, "w", encoding="utf-8") as f:
+        f.write(f"{date}\n\n")
 
-        f.write(u"#### Included Calico versions\n\n")
-        f.write(u"Calico version: %s\n" % calico_version())
-        f.write(u"Calico Enterprise version: %s\n\n" % enterprise_version())
+        f.write("#### Included Calico versions\n\n")
+        f.write(f"Calico version: {calico_version()}\n")
+        f.write(f"Calico Enterprise version: {enterprise_version()}\n\n")
 
         if len(enhancements) > 0:
-            f.write(u"#### Enhancements\n\n")
+            f.write("#### Enhancements\n\n")
             print_issues_to_file(f, enhancements)
         if len(bugs) > 0:
-            f.write(u"#### Bug fixes\n\n")
+            f.write("#### Bug fixes\n\n")
             print_issues_to_file(f, bugs)
         if len(other) > 0:
-            f.write(u"#### Other changes\n\n")
+            f.write("#### Other changes\n\n")
             print_issues_to_file(f, other)
 
     print("")
     print("Release notes written to " + FILENAME)
     print("Please review for accuracy, and format appropriately before releasing.")
     print("")
-    print("Visit https://github.com/tigera/operator/releases/edit/%s# to publish" % MILESTONE)
+    print(
+        f"Visit https://github.com/tigera/operator/releases/new?tag={MILESTONE}# to publish"
+    )


### PR DESCRIPTION
## Description

This updates the scripts for generating release notes based on milestone.

Had to do a bit of refactor to:
- use black formatter
- dockerize script
- adhere to pylint: include types to help with docstrings, rename file

**NOTE**: There is work planned in future sprints for switching to Go but this prevent having issues between now and when that change goes in

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
