### PR TITLE
Make PacketCaptureAPI optional by moving it to a separate controller

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -150,6 +150,13 @@ func AddToManager(mgr ctrl.Manager, options options.AddOptions) error {
 	}).SetupWithManager(mgr, options); err != nil {
 		return fmt.Errorf("failed to create controller %s: %v", "CSR", err)
 	}
+	if err := (&PacketCaptureReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("PacketCapture"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr, options); err != nil {
+		return fmt.Errorf("failed to create controller %s: %v", "PacketCapture", err)
+	}
 	// +kubebuilder:scaffold:builder
 	return nil
 }

--- a/controllers/packetcapture_controller.go
+++ b/controllers/packetcapture_controller.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/packetcapture"
+)
+
+// PacketCaptureReconciler reconciles a PacketCapture object.
+type PacketCaptureReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=operator.tigera.io,resources=packetcaptureapi,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=operator.tigera.io,resources=packetcaptureapi/status,verbs=get;update;patch
+
+func (pc *PacketCaptureReconciler) SetupWithManager(mgr ctrl.Manager, opts options.AddOptions) error {
+	return packetcapture.Add(mgr, opts)
+}

--- a/pkg/controller/packetcapture/packetcapture_controller.go
+++ b/pkg/controller/packetcapture/packetcapture_controller.go
@@ -201,6 +201,7 @@ func (r *ReconcilePacketCapture) Reconcile(ctx context.Context, request reconcil
 
 	// Packet capture is disabled in multi tenant management cluster
 	if r.multiTenant && managementCluster != nil {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Packet capture is disabled in the multitenant management cluster.", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/packetcapture/packetcapture_controller.go
+++ b/pkg/controller/packetcapture/packetcapture_controller.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetcapture
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/controller/utils/imageset"
+	"github.com/tigera/operator/pkg/ctrlruntime"
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/render"
+	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+const (
+	PacketCaptureControllerName = "packet-capture-controller"
+	ResourceName                = "packet-capture"
+)
+
+var log = logf.Log.WithName("controller_packet_capture")
+
+// Add creates a new PacketCapture Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, opts options.AddOptions) error {
+
+	if !opts.EnterpriseCRDExists {
+		// No need to start this controller
+		return nil
+	}
+	licenseAPIReady := &utils.ReadyFlag{}
+	tierWatchReady := &utils.ReadyFlag{}
+
+	r := newReconciler(mgr, opts, licenseAPIReady, tierWatchReady)
+
+	c, err := ctrlruntime.NewController(PacketCaptureControllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return fmt.Errorf("failed to create packetcapture-controller: %w", err)
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		log.Error(err, "Failed to establish a connection to k8s")
+		return err
+	}
+
+	go utils.WaitToAddLicenseKeyWatch(c, k8sClient, log, licenseAPIReady)
+	go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, k8sClient, log, tierWatchReady)
+
+	go utils.WaitToAddNetworkPolicyWatches(c, k8sClient, log, []types.NamespacedName{
+		{Name: render.PacketCapturePolicyName, Namespace: render.PacketCaptureNamespace},
+	})
+
+	if err = c.WatchObject(&operatorv1.PacketCaptureAPI{}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("packetcapture-controller failed to watch resource: %w", err)
+	}
+
+	if err = utils.AddSecretsWatch(c, render.PacketCaptureServerCert, common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("packetcapture-controller failed to watch the Secret resource: %v", err)
+	}
+
+	if err = imageset.AddImageSetWatch(c); err != nil {
+		return fmt.Errorf("packetcapture-controller failed to watch ImageSet: %w", err)
+	}
+
+	if err = utils.AddTigeraStatusWatch(c, ResourceName); err != nil {
+		return fmt.Errorf("packetcapture-controller failed to watch packetcapture TigeraStatus: %w", err)
+	}
+
+	log.V(5).Info("Controller created and Watches setup")
+
+	return nil
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, opts options.AddOptions, licenseAPIReady *utils.ReadyFlag, tierWatchReady *utils.ReadyFlag) reconcile.Reconciler {
+	r := &ReconcilePacketCapture{
+		client:              mgr.GetClient(),
+		scheme:              mgr.GetScheme(),
+		provider:            opts.DetectedProvider,
+		enterpriseCRDsExist: opts.EnterpriseCRDExists,
+		status:              status.New(mgr.GetClient(), ResourceName, opts.KubernetesVersion),
+		clusterDomain:       opts.ClusterDomain,
+		usePSP:              opts.UsePSP,
+		licenseAPIReady:     licenseAPIReady,
+		tierWatchReady:      tierWatchReady,
+		multiTenant:         opts.MultiTenant,
+	}
+	r.status.Run(opts.ShutdownContext)
+	return r
+}
+
+// blank assignment to verify that ReconcilePacketCapture implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcilePacketCapture{}
+
+// ReconcilePacketCapture reconciles a PackerCaptureAPI object
+type ReconcilePacketCapture struct {
+	client              client.Client
+	scheme              *runtime.Scheme
+	provider            operatorv1.Provider
+	enterpriseCRDsExist bool
+	status              status.StatusManager
+	clusterDomain       string
+	usePSP              bool
+	licenseAPIReady     *utils.ReadyFlag
+	tierWatchReady      *utils.ReadyFlag
+	multiTenant         bool
+}
+
+// Reconcile reads that state of the cluster for a PacketCapture object and makes changes based on the state read
+// and what is in the PacketCapture.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcilePacketCapture) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling PacketCapture")
+
+	packetcaptureapi, err := utils.GetPacketCaptureAPI(ctx, r.client)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.V(3).Info("PacketCaptureAPI CR not found", "err", err)
+			r.status.OnCRNotFound()
+			return reconcile.Result{}, nil
+		}
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying PacketCapture", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	r.status.OnCRFound()
+	reqLogger.V(2).Info("Loaded config", "config", packetcaptureapi)
+
+	defer r.status.SetMetaData(&packetcaptureapi.ObjectMeta)
+
+	// Changes for updating PacketCapture status conditions.
+	if request.Name == ResourceName && request.Namespace == "" {
+		ts := &operatorv1.TigeraStatus{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: ResourceName}, ts); err != nil {
+			return reconcile.Result{}, err
+		}
+		packetcaptureapi.Status.Conditions = status.UpdateStatusCondition(packetcaptureapi.Status.Conditions, ts.Status.Conditions)
+		if err := r.client.Status().Update(ctx, packetcaptureapi); err != nil {
+			log.WithValues("reason", err).Info("Failed to create packetcapture status conditions.")
+			return reconcile.Result{}, err
+		}
+	}
+
+	variant, installationSpec, err := utils.GetInstallation(context.Background(), r.client)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "Installation not found", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying installation", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	if variant != operatorv1.TigeraSecureEnterprise {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for network to be %s", operatorv1.TigeraSecureEnterprise), nil, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	managementCluster, err := utils.GetManagementCluster(ctx, r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementCluster", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	// Packet capture is disabled in multi tenant management cluster
+	if r.multiTenant && managementCluster != nil {
+		return reconcile.Result{}, err
+	}
+
+	if !utils.IsAPIServerReady(r.client, reqLogger) {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tigera API server to be ready", nil, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
+	if !r.tierWatchReady.IsReady() {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Tier watch to be established", err, reqLogger)
+		return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+	}
+
+	// Ensure the allow-tigera tier exists, before rendering any network policies within it.
+	if err := r.client.Get(ctx, client.ObjectKey{Name: networkpolicy.TigeraComponentTierName}, &v3.Tier{}); err != nil {
+		if errors.IsNotFound(err) {
+			r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for allow-tigera tier to be created, see the 'tiers' TigeraStatus for more information", err, reqLogger)
+			return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+		}
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Error querying allow-tigera tier", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	// Create a component handler to manage the rendered component.
+	handler := utils.NewComponentHandler(log, r.client, r.scheme, packetcaptureapi)
+
+	// Render the desired objects from the CRD and create or update them.
+	reqLogger.V(3).Info("rendering components")
+
+	certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.clusterDomain, common.OperatorNamespace())
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+	packetCaptureCertSecret, err := certificateManager.GetOrCreateKeyPair(
+		r.client,
+		render.PacketCaptureServerCert,
+		common.OperatorNamespace(),
+		dns.GetServiceDNSNames(render.PacketCaptureServiceName, render.PacketCaptureNamespace, r.clusterDomain))
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error retrieve or creating packet capture TLS certificate", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	// Fetch the Authentication spec. If present, we use to configure user authentication.
+	authenticationCR, err := utils.GetAuthentication(ctx, r.client)
+	if err != nil && !errors.IsNotFound(err) {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying Authentication", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	keyValidatorConfig, err := utils.GetKeyValidatorConfig(ctx, r.client, authenticationCR, r.clusterDomain)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "Failed to process the authentication CR.", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	var certificates []certificatemanagement.CertificateInterface
+	if keyValidatorConfig != nil {
+		dexSecret, err := certificateManager.GetCertificate(r.client, render.DexTLSSecretName, common.OperatorNamespace())
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve %s", render.DexTLSSecretName), err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		if dexSecret != nil {
+			certificates = append(certificates, dexSecret)
+		}
+	}
+
+	managementClusterConnection, err := utils.GetManagementClusterConnection(ctx, r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementClusterConnection", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	pullSecrets, err := utils.GetNetworkingPullSecrets(installationSpec, r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error retrieving pull secrets", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	trustedBundle := certificateManager.CreateTrustedBundle(certificates...)
+	packetCaptureApiCfg := &render.PacketCaptureApiConfiguration{
+		PullSecrets:                 pullSecrets,
+		Openshift:                   r.provider == operatorv1.ProviderOpenShift,
+		Installation:                installationSpec,
+		KeyValidatorConfig:          keyValidatorConfig,
+		ServerCertSecret:            packetCaptureCertSecret,
+		ClusterDomain:               r.clusterDomain,
+		ManagementClusterConnection: managementClusterConnection,
+		TrustedBundle:               trustedBundle,
+		UsePSP:                      r.usePSP,
+		PacketCaptureAPI:            packetcaptureapi,
+	}
+	pc := render.PacketCaptureAPI(packetCaptureApiCfg)
+	components := []render.Component{
+		pc,
+		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
+			Namespace:       render.PacketCaptureNamespace,
+			ServiceAccounts: []string{render.PacketCaptureServiceAccountName},
+			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+				rcertificatemanagement.NewKeyPairOption(packetCaptureCertSecret, true, true),
+			},
+			TrustedBundle: trustedBundle,
+		}),
+	}
+
+	if pcPolicy := render.PacketCaptureAPIPolicy(packetCaptureApiCfg); pcPolicy != nil {
+		components = append(components, pcPolicy)
+	}
+
+	if err = imageset.ApplyImageSet(ctx, r.client, variant, components...); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	for _, component := range components {
+		if err := handler.CreateOrUpdateOrDelete(context.Background(), component, r.status); err != nil {
+			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+	}
+
+	// Clear the degraded bit if we've reached this far.
+	r.status.ClearDegraded()
+
+	if !r.status.IsAvailable() {
+		// Schedule a kick to check again in the near future. Hopefully by then things will be available.
+		return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+	}
+
+	// Everything is available - update the CR status.
+	packetcaptureapi.Status.State = operatorv1.TigeraStatusReady
+	if err = r.client.Status().Update(ctx, packetcaptureapi); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+
+}

--- a/pkg/controller/packetcapture/packetcapture_controller_test.go
+++ b/pkg/controller/packetcapture/packetcapture_controller_test.go
@@ -1,7 +1,7 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// you may not use this file except in policy recommendation with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package apiserver
+package packetcapture
 
 import (
 	"context"
 	"fmt"
 	"time"
-
-	kerror "k8s.io/apimachinery/pkg/api/errors"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,8 +25,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -53,7 +50,7 @@ import (
 	"github.com/tigera/operator/test"
 )
 
-var _ = Describe("apiserver controller tests", func() {
+var _ = Describe("packet capture controller tests", func() {
 	var (
 		cli                   client.Client
 		scheme                *runtime.Scheme
@@ -61,10 +58,10 @@ var _ = Describe("apiserver controller tests", func() {
 		mockStatus            *status.MockStatus
 		installation          *operatorv1.Installation
 		certificateManagement *operatorv1.CertificateManagement
-		apiSecret             *corev1.Secret
+		packetCaptureSecret   *corev1.Secret
+		r                     ReconcilePacketCapture
 	)
 
-	notReady := &utils.ReadyFlag{}
 	ready := &utils.ReadyFlag{}
 	ready.MarkAsReady()
 
@@ -107,11 +104,12 @@ var _ = Describe("apiserver controller tests", func() {
 		Expect(cli.Create(context.Background(), certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, &operatorv1.APIServer{
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			Status:     operatorv1.APIServerStatus{State: operatorv1.TigeraStatusReady},
 		})).ToNot(HaveOccurred())
 		Expect(cli.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
 		cryptoCA, err := tls.MakeCA("byo-ca")
 		Expect(err).NotTo(HaveOccurred())
-		apiSecret, err = secret.CreateTLSSecret(cryptoCA, "tigera-apiserver-certs", common.OperatorNamespace(), "key.key", "cert.crt", time.Hour, nil, dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(operatorv1.TigeraSecureEnterprise), "tigera-system", dns.DefaultClusterDomain)...)
+		packetCaptureSecret, err = secret.CreateTLSSecret(cryptoCA, render.PacketCaptureServerCert, common.OperatorNamespace(), "key.key", "cert.crt", time.Hour, nil, dns.GetServiceDNSNames(render.PacketCaptureServiceName, render.PacketCaptureNamespace, dns.DefaultClusterDomain)...)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, &operatorv1.Authentication{
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
@@ -136,64 +134,84 @@ var _ = Describe("apiserver controller tests", func() {
 
 		// Set up a mock status
 		mockStatus = &status.MockStatus{}
-		mockStatus.On("AddDaemonsets", mock.Anything).Return()
 		mockStatus.On("AddDeployments", mock.Anything).Return()
-		mockStatus.On("AddStatefulSets", mock.Anything).Return()
-		mockStatus.On("AddCronJobs", mock.Anything)
 		mockStatus.On("IsAvailable").Return(true)
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ClearDegraded")
-		mockStatus.On("AddCertificateSigningRequests", mock.Anything)
-		mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
 		mockStatus.On("ReadyToMonitor")
 		mockStatus.On("SetMetaData", mock.Anything).Return()
+		mockStatus.On("SetDegraded", "Waiting for LicenseKeyAPI to be ready", "").Return().Maybe()
+		mockStatus.On("SetDegraded", operatorv1.ResourceValidationError, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("SetDegraded", operatorv1.ResourceReadError, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("SetDegraded", operatorv1.ResourceUpdateError, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("SetDegraded", operatorv1.ResourceNotFound, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("SetDegraded", operatorv1.ResourceNotReady, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("SetDegraded", operatorv1.ResourceCreateError, mock.AnythingOfType("string"), mock.Anything, mock.Anything).Return().Maybe()
+
+		r = ReconcilePacketCapture{
+			client:              cli,
+			scheme:              scheme,
+			provider:            operatorv1.ProviderNone,
+			enterpriseCRDsExist: true,
+			status:              mockStatus,
+			tierWatchReady:      ready,
+		}
+
+		// Apply the packetcapture CR to the fake cluster.
+		Expect(cli.Create(ctx, &operatorv1.PacketCaptureAPI{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})).NotTo(HaveOccurred())
 	})
 
 	Context("verify reconciliation", func() {
+
 		It("should use builtin images", func() {
 			installation.Spec.CertificateManagement = certificateManagement
 			Expect(cli.Create(ctx, installation)).To(BeNil())
 
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			d := appsv1.Deployment{
+			pcDeployment := appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tigera-apiserver",
-					Namespace: "tigera-system",
+					Name:      render.PacketCaptureName,
+					Namespace: render.PacketCaptureNamespace,
 				},
 			}
-			Expect(test.GetResource(cli, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(2))
-			apiserver := test.GetContainer(d.Spec.Template.Spec.Containers, "calico-apiserver")
-			Expect(apiserver).ToNot(BeNil())
-			Expect(apiserver.Image).To(Equal(
+			Expect(test.GetResource(cli, &pcDeployment)).To(BeNil())
+			Expect(pcDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			pcContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.Containers, render.PacketCaptureContainerName)
+			Expect(pcContainer).ToNot(BeNil())
+			Expect(pcContainer.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s:%s",
-					components.ComponentAPIServer.Image,
-					components.ComponentAPIServer.Version)))
-			qserver := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-queryserver")
-			Expect(qserver).ToNot(BeNil())
-			Expect(qserver.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s:%s",
-					components.ComponentQueryServer.Image,
-					components.ComponentQueryServer.Version)))
-			Expect(d.Spec.Template.Spec.InitContainers).To(HaveLen(1))
-			csrinit := test.GetContainer(d.Spec.Template.Spec.InitContainers, "calico-apiserver-certs-key-cert-provisioner")
-			Expect(csrinit).ToNot(BeNil())
-			Expect(csrinit.Image).To(Equal(
+					components.ComponentPacketCapture.Image,
+					components.ComponentPacketCapture.Version)))
+			Expect(pcContainer.VolumeMounts).To(ConsistOf([]corev1.VolumeMount{
+				{
+					Name:      packetCaptureSecret.Name,
+					ReadOnly:  true,
+					MountPath: fmt.Sprintf("/%s", packetCaptureSecret.Name),
+				},
+				{
+					Name:      "tigera-ca-bundle",
+					ReadOnly:  true,
+					MountPath: "/etc/pki/tls/certs",
+				},
+			}))
+			csrinitContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.InitContainers, "tigera-packetcapture-server-tls-key-cert-provisioner")
+			Expect(csrinitContainer).ToNot(BeNil())
+			Expect(csrinitContainer.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentTigeraCSRInitContainer.Image,
 					components.ComponentTigeraCSRInitContainer.Version)))
-
+			pcSecret := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.PacketCaptureServerCert,
+					Namespace: "tigera-operator",
+				},
+			}
+			Expect(test.GetResource(cli, &pcSecret)).To(HaveOccurred()) // Since certificate management is enabled.
+			Expect(pcSecret).NotTo(BeNil())
 		})
 		It("should use images from imageset", func() {
 			installation.Spec.CertificateManagement = certificateManagement
@@ -203,180 +221,111 @@ var _ = Describe("apiserver controller tests", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "enterprise-" + components.EnterpriseRelease},
 				Spec: operatorv1.ImageSetSpec{
 					Images: []operatorv1.Image{
-						{Image: "tigera/cnx-apiserver", Digest: "sha256:apiserverhash"},
-						{Image: "tigera/cnx-queryserver", Digest: "sha256:queryserverhash"},
 						{Image: "tigera/key-cert-provisioner", Digest: "sha256:calicocsrinithash"},
+						{Image: "tigera/packetcapture", Digest: "sha256:packetcapturehash"},
 					},
 				},
 			})).ToNot(HaveOccurred())
 
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			d := appsv1.Deployment{
+			pcDeployment := appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tigera-apiserver",
-					Namespace: "tigera-system",
+					Name:      render.PacketCaptureName,
+					Namespace: render.PacketCaptureNamespace,
 				},
 			}
-			Expect(test.GetResource(cli, &d)).To(BeNil())
-			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(2))
-			apiserver := test.GetContainer(d.Spec.Template.Spec.Containers, "calico-apiserver")
-			Expect(apiserver).ToNot(BeNil())
-			Expect(apiserver.Image).To(Equal(
+			Expect(test.GetResource(cli, &pcDeployment)).To(BeNil())
+			Expect(pcDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			pcContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.Containers, render.PacketCaptureContainerName)
+			Expect(pcContainer).ToNot(BeNil())
+			Expect(pcContainer.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s@%s",
-					components.ComponentAPIServer.Image,
-					"sha256:apiserverhash")))
-			qserver := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-queryserver")
-			Expect(qserver).ToNot(BeNil())
-			Expect(qserver.Image).To(Equal(
-				fmt.Sprintf("some.registry.org/%s@%s",
-					components.ComponentQueryServer.Image,
-					"sha256:queryserverhash")))
-			csrinit := test.GetContainer(d.Spec.Template.Spec.InitContainers, "calico-apiserver-certs-key-cert-provisioner")
-			Expect(csrinit).ToNot(BeNil())
-			Expect(csrinit.Image).To(Equal(
+					components.ComponentPacketCapture.Image,
+					"sha256:packetcapturehash")))
+			csrinitContainer := test.GetContainer(pcDeployment.Spec.Template.Spec.InitContainers, "tigera-packetcapture-server-tls-key-cert-provisioner")
+			Expect(csrinitContainer).ToNot(BeNil())
+			Expect(csrinitContainer.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s@%s",
 					components.ComponentTigeraCSRInitContainer.Image,
 					"sha256:calicocsrinithash")))
-
+			pcSecret := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.PacketCaptureServerCert,
+					Namespace: "tigera-operator",
+				},
+			}
+			Expect(test.GetResource(cli, &pcSecret)).To(HaveOccurred()) // Since certificate management is enabled.
+			Expect(pcSecret).NotTo(BeNil())
 		})
 
-		It("should not add OwnerReference to user-supplied apiserver TLS cert secrets", func() {
+		It("should not add OwnerReference to packetcapture TLS cert secrets", func() {
 			Expect(cli.Create(ctx, installation)).To(BeNil())
+			Expect(cli.Create(ctx, packetCaptureSecret)).ShouldNot(HaveOccurred())
 
-			secretName := render.ProjectCalicoAPIServerTLSSecretName(operatorv1.TigeraSecureEnterprise)
-
-			Expect(cli.Create(ctx, apiSecret)).ShouldNot(HaveOccurred())
-
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				clusterDomain:       dns.DefaultClusterDomain,
-				tierWatchReady:      ready,
-			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			apiSecret2 := &corev1.Secret{}
-			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: secretName}, apiSecret2)).ShouldNot(HaveOccurred())
-			Expect(apiSecret2.GetOwnerReferences()).To(HaveLen(0))
-
+			packetCaptureSecret2 := &corev1.Secret{}
+			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: render.PacketCaptureServerCert}, packetCaptureSecret2)).ShouldNot(HaveOccurred())
+			Expect(packetCaptureSecret2.GetOwnerReferences()).To(HaveLen(0))
 		})
 
-		It("should add OwnerReference apiserver cert operator managed secrets", func() {
+		It("should add OwnerReference packetcapture TLS cert operator managed secrets", func() {
 			Expect(cli.Create(ctx, installation)).To(BeNil())
 
-			secretName := "tigera-apiserver-certs"
-
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			secret := &corev1.Secret{}
-			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: secretName}, secret)).ShouldNot(HaveOccurred())
+			Expect(cli.Get(ctx, client.ObjectKey{Namespace: common.OperatorNamespace(), Name: render.PacketCaptureServerCert}, secret)).ShouldNot(HaveOccurred())
 			Expect(secret.GetOwnerReferences()).To(HaveLen(1))
-
 		})
 
 		It("should render allow-tigera policy when tier and tier watch are ready", func() {
 			Expect(cli.Create(ctx, installation)).To(BeNil())
 
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
 			policies := v3.NetworkPolicyList{}
 			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())
 			Expect(policies.Items).To(HaveLen(1))
-			Expect(policies.Items[0].Name).To(Equal("allow-tigera.cnx-apiserver-access"))
+			Expect(policies.Items[0].Name).To(Equal("allow-tigera.tigera-packetcapture"))
 		})
+	})
 
-		It("should omit allow-tigera policy and not degrade when tier is not ready", func() {
-			Expect(cli.Create(ctx, installation)).To(BeNil())
-			Expect(cli.Delete(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
+	Context("allow-tigera reconciliation", func() {
+		var readyFlag *utils.ReadyFlag
 
-			r := ReconcileAPIServer{
+		BeforeEach(func() {
+			mockStatus = &status.MockStatus{}
+			mockStatus.On("OnCRFound").Return()
+			mockStatus.On("SetMetaData", mock.Anything).Return()
+
+			readyFlag = &utils.ReadyFlag{}
+			readyFlag.MarkAsReady()
+			r = ReconcilePacketCapture{
 				client:              cli,
 				scheme:              scheme,
 				provider:            operatorv1.ProviderNone,
 				enterpriseCRDsExist: true,
 				status:              mockStatus,
-				tierWatchReady:      ready,
+				tierWatchReady:      readyFlag,
 			}
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			policies := v3.NetworkPolicyList{}
-			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(0))
+			Expect(cli.Create(ctx, installation)).To(BeNil())
 		})
 
-		It("should omit allow-tigera policy and not degrade when tier watch is not ready", func() {
-			Expect(cli.Create(ctx, installation)).To(BeNil())
-
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      notReady,
-			}
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			policies := v3.NetworkPolicyList{}
-			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(0))
+		It("should wait if allow-tigera tier is unavailable", func() {
+			test.DeleteAllowTigeraTierAndExpectWait(ctx, cli, &r, mockStatus)
 		})
 
-		It("should omit allow-tigera policy and not degrade when installation is calico", func() {
-			Expect(netv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-			installation.Spec.Variant = operatorv1.Calico
-			installation.Status.Variant = operatorv1.Calico
-			Expect(cli.Create(ctx, installation)).To(BeNil())
-			Expect(cli.Delete(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
-
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: false,
-				status:              mockStatus,
-			}
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-
-			Expect(err).ShouldNot(HaveOccurred())
-			policies := v3.NetworkPolicyList{}
-			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())
-			Expect(policies.Items).To(HaveLen(0))
+		It("should wait if tier watch is not ready", func() {
+			r.tierWatchReady = &utils.ReadyFlag{}
+			test.ExpectWaitForTierWatch(ctx, &r, mockStatus)
 		})
 	})
 
@@ -387,7 +336,7 @@ var _ = Describe("apiserver controller tests", func() {
 		})
 		It("should reconcile with creating new status condition with one item", func() {
 			ts := &operatorv1.TigeraStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: "apiserver"},
+				ObjectMeta: metav1.ObjectMeta{Name: "packet-capture"},
 				Spec:       operatorv1.TigeraStatusSpec{},
 				Status: operatorv1.TigeraStatusStatus{
 					Conditions: []operatorv1.TigeraStatusCondition{
@@ -402,20 +351,13 @@ var _ = Describe("apiserver controller tests", func() {
 				},
 			}
 			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
+
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
-				Name:      "apiserver",
+				Name:      "packet-capture",
 				Namespace: "",
 			}})
 			Expect(err).ShouldNot(HaveOccurred())
-			instance, _, err := utils.GetAPIServer(ctx, r.client)
+			instance, err := utils.GetPacketCaptureAPI(ctx, r.client)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(instance.Status.Conditions).To(HaveLen(1))
 
@@ -427,31 +369,24 @@ var _ = Describe("apiserver controller tests", func() {
 		})
 		It("should reconcile with empty tigerastatus conditions ", func() {
 			ts := &operatorv1.TigeraStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: "apiserver"},
+				ObjectMeta: metav1.ObjectMeta{Name: "packet-capture"},
 				Spec:       operatorv1.TigeraStatusSpec{},
 				Status:     operatorv1.TigeraStatusStatus{},
 			}
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
+
 			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
-				Name:      "apiserver",
+				Name:      "packet-capture",
 				Namespace: "",
 			}})
 			Expect(err).ShouldNot(HaveOccurred())
-			instance, _, err := utils.GetAPIServer(ctx, r.client)
+			instance, err := utils.GetPacketCaptureAPI(ctx, r.client)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(instance.Status.Conditions).To(HaveLen(0))
 		})
 		It("should reconcile with creating new status condition  with multiple conditions as true", func() {
 			ts := &operatorv1.TigeraStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: "apiserver"},
+				ObjectMeta: metav1.ObjectMeta{Name: "packet-capture"},
 				Spec:       operatorv1.TigeraStatusSpec{},
 				Status: operatorv1.TigeraStatusStatus{
 					Conditions: []operatorv1.TigeraStatusCondition{
@@ -480,20 +415,13 @@ var _ = Describe("apiserver controller tests", func() {
 				},
 			}
 			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
+
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
-				Name:      "apiserver",
+				Name:      "packet-capture",
 				Namespace: "",
 			}})
 			Expect(err).ShouldNot(HaveOccurred())
-			instance, _, err := utils.GetAPIServer(ctx, r.client)
+			instance, err := utils.GetPacketCaptureAPI(ctx, r.client)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(instance.Status.Conditions).To(HaveLen(3))
 
@@ -517,7 +445,7 @@ var _ = Describe("apiserver controller tests", func() {
 		})
 		It("should reconcile with creating new status condition and toggle Available to true & others to false", func() {
 			ts := &operatorv1.TigeraStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: "apiserver"},
+				ObjectMeta: metav1.ObjectMeta{Name: "packet-capture"},
 				Spec:       operatorv1.TigeraStatusSpec{},
 				Status: operatorv1.TigeraStatusStatus{
 					Conditions: []operatorv1.TigeraStatusCondition{
@@ -546,14 +474,7 @@ var _ = Describe("apiserver controller tests", func() {
 				},
 			}
 			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
+
 			installation.Status.Conditions = []metav1.Condition{
 				{
 					Type:               "Ready",
@@ -578,11 +499,11 @@ var _ = Describe("apiserver controller tests", func() {
 				},
 			}
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
-				Name:      "apiserver",
+				Name:      "packet-capture",
 				Namespace: "",
 			}})
 			Expect(err).ShouldNot(HaveOccurred())
-			instance, _, err := utils.GetAPIServer(ctx, r.client)
+			instance, err := utils.GetPacketCaptureAPI(ctx, r.client)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(instance.Status.Conditions).To(HaveLen(3))
 
@@ -619,115 +540,11 @@ var _ = Describe("apiserver controller tests", func() {
 					},
 				}
 				Expect(cli.Create(ctx, managementCluster)).NotTo(HaveOccurred())
-
-				// Create the APIServer CR needed to jumpstart the reconciliation
-				// for the api server
-				err := cli.Create(ctx, &operatorv1.APIServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tigera-secure",
-						Namespace: common.OperatorNamespace(),
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("Should create management-cluster certificate with old cert keys", func() {
-				// Create the tunnel secret in operator namespace
-				// In a production cluster, this would be created by Manager controller in tigera-operator namespace
-				err := cli.Create(ctx, &corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.VoltronTunnelSecretName,
-						Namespace: common.OperatorNamespace(),
-					},
-					Data: map[string][]byte{
-						"cert": []byte("certvalue"),
-						"key":  []byte("keyvalue"),
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
+			It("Should reconcile and not create packet capture resources for a management cluster in multi tenant mode", func() {
 
-				r := ReconcileAPIServer{
-					client:              cli,
-					scheme:              scheme,
-					provider:            operatorv1.ProviderNone,
-					enterpriseCRDsExist: true,
-					status:              mockStatus,
-					tierWatchReady:      ready,
-					multiTenant:         false,
-				}
-
-				// Reconcile the API server
-				_, err = r.Reconcile(ctx, reconcile.Request{})
-				Expect(err).ShouldNot(HaveOccurred())
-
-				clusterConnectionInAppNs := corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.VoltronTunnelSecretName,
-						Namespace: "tigera-system",
-					},
-				}
-
-				// Ensure that the tunnel secret was copied in tigera-system namespace
-				err = test.GetResource(cli, &clusterConnectionInAppNs)
-				Expect(kerror.IsNotFound(err)).Should(BeFalse())
-				Expect(clusterConnectionInAppNs.Data).Should(HaveKeyWithValue("tls.crt", []byte("certvalue")))
-				Expect(clusterConnectionInAppNs.Data).Should(HaveKeyWithValue("tls.key", []byte("keyvalue")))
-			})
-
-			It("Should reconcile multi-cluster setup for a management cluster for a single tenant", func() {
-				// Create the tunnel secret in operator namespace
-				// In a production cluster, this would be created by Manager controller in tigera-operator namespace
-				err := cli.Create(ctx, &corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.VoltronTunnelSecretName,
-						Namespace: common.OperatorNamespace(),
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-
-				r := ReconcileAPIServer{
-					client:              cli,
-					scheme:              scheme,
-					provider:            operatorv1.ProviderNone,
-					enterpriseCRDsExist: true,
-					status:              mockStatus,
-					tierWatchReady:      ready,
-					multiTenant:         false,
-				}
-
-				// Reconcile the API server
-				_, err = r.Reconcile(ctx, reconcile.Request{})
-				Expect(err).ShouldNot(HaveOccurred())
-
-				deployment := appsv1.Deployment{
-					TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tigera-apiserver",
-						Namespace: "tigera-system",
-					},
-				}
-				clusterConnectionInAppNs := corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.VoltronTunnelSecretName,
-						Namespace: "tigera-system",
-					},
-				}
-
-				// Ensure a deployment was created for the API server
-				err = test.GetResource(cli, &deployment)
-				Expect(kerror.IsNotFound(err)).Should(BeFalse())
-
-				// Ensure that the tunnel secret was copied in tigera-system namespace
-				err = test.GetResource(cli, &clusterConnectionInAppNs)
-				Expect(kerror.IsNotFound(err)).Should(BeFalse())
-			})
-
-			It("Should reconcile multi-cluster setup for a management cluster for a multiple tenant", func() {
-				r := ReconcileAPIServer{
+				r := ReconcilePacketCapture{
 					client:              cli,
 					scheme:              scheme,
 					provider:            operatorv1.ProviderNone,
@@ -744,27 +561,44 @@ var _ = Describe("apiserver controller tests", func() {
 				deployment := appsv1.Deployment{
 					TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tigera-apiserver",
-						Namespace: "tigera-system",
-					},
-				}
-				clusterConnectionInAppNs := corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.VoltronTunnelSecretName,
-						Namespace: "tigera-system",
+						Name:      "tigera-packetcapture",
+						Namespace: "tigera-packetcapture",
 					},
 				}
 
-				// Ensure a deployment was created for the API server
+				// Ensure a deployment is not created for the packetcapture API
 				err = test.GetResource(cli, &deployment)
-				Expect(kerror.IsNotFound(err)).Should(BeFalse())
+				Expect(errors.IsNotFound(err)).Should(BeTrue())
 
-				// Do not expect any secrets to be copied over
-				err = test.GetResource(cli, &clusterConnectionInAppNs)
-				Expect(kerror.IsNotFound(err)).Should(BeTrue())
 			})
+			It("Should reconcile and create packet capture resources for a management cluster in single tenant mode", func() {
+				r := ReconcilePacketCapture{
+					client:              cli,
+					scheme:              scheme,
+					provider:            operatorv1.ProviderNone,
+					enterpriseCRDsExist: true,
+					status:              mockStatus,
+					tierWatchReady:      ready,
+					multiTenant:         false,
+				}
 
+				// Reconcile the API server
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				deployment := appsv1.Deployment{
+					TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-packetcapture",
+						Namespace: "tigera-packetcapture",
+					},
+				}
+
+				// Ensure a deployment was created for the packetcapture API
+				err = test.GetResource(cli, &deployment)
+				Expect(errors.IsNotFound(err)).Should(BeFalse())
+
+			})
 		})
 	})
 })

--- a/pkg/controller/packetcapture/packetcapture_suite_test.go
+++ b/pkg/controller/packetcapture/packetcapture_suite_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetcapture
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+	uzap "go.uber.org/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestStatus(t *testing.T) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(uzap.NewAtomicLevelAt(uzap.DebugLevel))))
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/ut/packetcapture_controller_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "pkg/controller/packetcapture Controller Suite", []Reporter{junitReporter})
+}


### PR DESCRIPTION
Migrate Packet capture into it own controller.
Design doc: https://docs.google.com/document/d/1bEU1mfjqyR4VBOHiezHBl_mbqhgP2JKFX5d2GgFMe8M/edit#heading=h.4gb7cyubsdxh

calico-private PR:
https://github.com/tigera/calico-private/pull/7544
```
apiVersion: operator.tigera.io/v1
kind: PacketCaptureAPI
metadata:
  creationTimestamp: "2024-05-03T20:59:06Z"
  generation: 1
  name: tigera-secure
  resourceVersion: "290128"
  uid: 1e100aba-28aa-4826-95c1-d238e97d4aa5
status:
  conditions:
  - lastTransitionTime: "2024-05-03T21:00:08Z"
    message: All Objects Available
    observedGeneration: 1
    reason: AllObjectsAvailable
    status: "False"
    type: Progressing
  - lastTransitionTime: "2024-05-03T21:00:08Z"
    message: All Objects Available
    observedGeneration: 1
    reason: AllObjectsAvailable
    status: "False"
    type: Degraded
  - lastTransitionTime: "2024-05-03T21:00:08Z"
    message: All objects available
    observedGeneration: 1
    reason: AllObjectsAvailable
    status: "True"
    type: Ready
  state: Ready

```

```
vara@vara:~/bzprofiles/Clusters/tc_mgmt$ k get tigerastatus packet-capture
NAME             AVAILABLE   PROGRESSING   DEGRADED   SINCE
packet-capture   True        False         False      35m

```

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
