### PR TITLE
Force a Linseed restart when the credentials to connect to Elastic change

### DIFF
--- a/pkg/controller/logstorage/linseed/linseed_controller.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller.go
@@ -136,6 +136,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		render.LinseedTokenSecret,
 		monitor.PrometheusClientTLSSecretName,
 		render.ElasticsearchLinseedUserSecret,
+		render.ElasticsearchLinseedUserSecret,
 	}
 
 	// Determine namespaces to watch.
@@ -346,6 +347,19 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 		}
 	}
 
+	// Query the username and password this Linseed instance should use to authenticate with Elasticsearch.
+	// For multi-tenant systems, credentials are created by the elasticsearch users controller.
+	// For single-tenant system, these are created by es-kube-controllers.
+	key = types.NamespacedName{Name: render.ElasticsearchLinseedUserSecret, Namespace: helper.InstallNamespace()}
+	credentials := corev1.Secret{}
+	if err = r.client.Get(ctx, key, &credentials); err != nil && !errors.IsNotFound(err) {
+		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting Secret %s", key), err, reqLogger)
+		return reconcile.Result{}, err
+	} else if errors.IsNotFound(err) {
+		r.status.SetDegraded(operatorv1.ResourceNotFound, fmt.Sprintf("Waiting for Linseed credential Secret %s", key), err, reqLogger)
+		return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+	}
+
 	// Collect the certificates we need to provision Linseed. These will have been provisioned already by the ES secrets controller.
 	opts := []certificatemanager.Option{
 		certificatemanager.WithLogger(reqLogger),
@@ -418,24 +432,25 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	cfg := &linseed.Config{
-		Installation:        install,
-		PullSecrets:         pullSecrets,
-		Namespace:           helper.InstallNamespace(),
-		BindNamespaces:      bindNamespaces,
-		TrustedBundle:       trustedBundle,
-		ClusterDomain:       r.clusterDomain,
-		KeyPair:             linseedKeyPair,
-		TokenKeyPair:        tokenKeyPair,
-		UsePSP:              r.usePSP,
-		ESClusterConfig:     esClusterConfig,
-		HasDPIResource:      hasDPIResource,
-		ManagementCluster:   managementCluster != nil,
-		Tenant:              tenant,
-		ExternalElastic:     r.elasticExternal,
-		ElasticHost:         elasticHost,
-		ElasticPort:         elasticPort,
-		ElasticClientSecret: esClientSecret,
-		LogStorage:          logStorage,
+		Installation:                   install,
+		PullSecrets:                    pullSecrets,
+		Namespace:                      helper.InstallNamespace(),
+		BindNamespaces:                 bindNamespaces,
+		TrustedBundle:                  trustedBundle,
+		ClusterDomain:                  r.clusterDomain,
+		KeyPair:                        linseedKeyPair,
+		TokenKeyPair:                   tokenKeyPair,
+		UsePSP:                         r.usePSP,
+		ESClusterConfig:                esClusterConfig,
+		HasDPIResource:                 hasDPIResource,
+		ManagementCluster:              managementCluster != nil,
+		Tenant:                         tenant,
+		ExternalElastic:                r.elasticExternal,
+		ElasticHost:                    elasticHost,
+		ElasticPort:                    elasticPort,
+		ElasticClientSecret:            esClientSecret,
+		ElasticClientCredentialsSecret: &credentials,
+		LogStorage:                     logStorage,
 	}
 	linseedComponent := linseed.Linseed(cfg)
 

--- a/pkg/controller/logstorage/linseed/linseed_controller.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller.go
@@ -136,7 +136,6 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		render.LinseedTokenSecret,
 		monitor.PrometheusClientTLSSecretName,
 		render.ElasticsearchLinseedUserSecret,
-		render.ElasticsearchLinseedUserSecret,
 	}
 
 	// Determine namespaces to watch.

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -433,7 +433,7 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 		annotations["hash.operator.tigera.io/elastic-client-secret"] = rmeta.SecretsAnnotationHash(l.cfg.ElasticClientSecret)
 	}
 	if l.cfg.ElasticClientCredentialsSecret != nil {
-		annotations["hash.operator.tigera.io/elastic-client-credential-secret"] = rmeta.SecretsAnnotationHash(l.cfg.ElasticClientCredentialsSecret)
+		annotations[fmt.Sprintf("hash.operator.tigera.io/%s", render.ElasticsearchLinseedUserSecret)] = rmeta.SecretsAnnotationHash(l.cfg.ElasticClientCredentialsSecret)
 	}
 
 	if l.cfg.TokenKeyPair != nil {

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -123,6 +123,11 @@ type Config struct {
 	// mTLS is used between Linseed and the external Elastic cluster.
 	ElasticClientSecret *corev1.Secret
 
+	// Secret containing the user linseed connects to Elasticsearch
+	// In a zero tenant setup, es-kubecontrollers create this secret
+	// In a multi-tenant setup, users controllers create this secret
+	ElasticClientCredentialsSecret *corev1.Secret
+
 	ElasticHost string
 	ElasticPort string
 
@@ -426,6 +431,9 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 	annotations[l.cfg.KeyPair.HashAnnotationKey()] = l.cfg.KeyPair.HashAnnotationValue()
 	if l.cfg.ElasticClientSecret != nil {
 		annotations["hash.operator.tigera.io/elastic-client-secret"] = rmeta.SecretsAnnotationHash(l.cfg.ElasticClientSecret)
+	}
+	if l.cfg.ElasticClientCredentialsSecret != nil {
+		annotations["hash.operator.tigera.io/elastic-client-credential-secret"] = rmeta.SecretsAnnotationHash(l.cfg.ElasticClientCredentialsSecret)
 	}
 
 	if l.cfg.TokenKeyPair != nil {

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Linseed rendering tests", func() {
 
 			// The deployment should have the hash annotation set, as well as a volume and volume mount for the client secret.
 			Expect(d.Spec.Template.Annotations["hash.operator.tigera.io/elastic-client-secret"]).To(Equal("ae1a6776a81bf1fc0ee4aac936a90bd61a07aea7"))
-			Expect(d.Spec.Template.Annotations["hash.operator.tigera.io/elastic-client-credential-secret"]).To(Equal("465c25d580ea36d8e7cda470a0c34afd05eae6f7:wq"))
+			Expect(d.Spec.Template.Annotations[fmt.Sprintf("hash.operator.tigera.io/%s", render.ElasticsearchLinseedUserSecret)]).To(Equal("465c25d580ea36d8e7cda470a0c34afd05eae6f7"))
 			Expect(d.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
 				Name: logstorage.ExternalCertsVolumeName,
 				VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
## Description

We encountered a situation where linseed user was recreated, but Linseed was still referencing the old password causing the following errors to show up on all APIs:

```
[status 500] server error: elastic: Error 401 (Unauthorized): unable to authenticate user [tigera-ee-linseed-yeidobci-secure] for REST request [/tigera_secure_ee_benchmark_results.yeidobci.cluster.%2A/_search] 
```

After restart, Linseed errors were resolved. At further inspection, the container that got restarted was referencing the new password, while the one that did not get restarted was still using the old password.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
