### PR TITLE
[cherry-pick] [v1.34] Force a Linseed restart when the credentials to connect to Elastic ch…

### DIFF
--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -123,6 +123,11 @@ type Config struct {
 	// mTLS is used between Linseed and the external Elastic cluster.
 	ElasticClientSecret *corev1.Secret
 
+	// Secret containing the user linseed connects to Elasticsearch
+	// In a zero tenant setup, es-kubecontrollers create this secret
+	// In a multi-tenant setup, users controllers create this secret
+	ElasticClientCredentialsSecret *corev1.Secret
+
 	ElasticHost string
 	ElasticPort string
 
@@ -426,6 +431,9 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 	annotations[l.cfg.KeyPair.HashAnnotationKey()] = l.cfg.KeyPair.HashAnnotationValue()
 	if l.cfg.ElasticClientSecret != nil {
 		annotations["hash.operator.tigera.io/elastic-client-secret"] = rmeta.SecretsAnnotationHash(l.cfg.ElasticClientSecret)
+	}
+	if l.cfg.ElasticClientCredentialsSecret != nil {
+		annotations[fmt.Sprintf("hash.operator.tigera.io/%s", render.ElasticsearchLinseedUserSecret)] = rmeta.SecretsAnnotationHash(l.cfg.ElasticClientCredentialsSecret)
 	}
 
 	if l.cfg.TokenKeyPair != nil {

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -92,21 +92,35 @@ var _ = Describe("Linseed rendering tests", func() {
 			replicas = 2
 			kp, tokenKP, bundle := getTLS(installation)
 
+			// Create the ES user secret. Generally this is created by either es-kube-controllers or the user controller in this operator.
+			userSecret := &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      render.ElasticsearchLinseedUserSecret,
+					Namespace: render.ElasticsearchNamespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("test-username"),
+					"password": []byte("test-username"),
+				},
+			}
+
 			cfg = &Config{
 				Installation: installation,
 				PullSecrets: []*corev1.Secret{
 					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
 				},
-				KeyPair:         kp,
-				TokenKeyPair:    tokenKP,
-				TrustedBundle:   bundle,
-				ClusterDomain:   clusterDomain,
-				UsePSP:          true,
-				ESClusterConfig: esClusterConfig,
-				Namespace:       render.ElasticsearchNamespace,
-				BindNamespaces:  []string{render.ElasticsearchNamespace},
-				ElasticHost:     "tigera-secure-es-http.tigera-elasticsearch.svc",
-				ElasticPort:     "9200",
+				KeyPair:                        kp,
+				TokenKeyPair:                   tokenKP,
+				TrustedBundle:                  bundle,
+				ClusterDomain:                  clusterDomain,
+				UsePSP:                         true,
+				ESClusterConfig:                esClusterConfig,
+				Namespace:                      render.ElasticsearchNamespace,
+				BindNamespaces:                 []string{render.ElasticsearchNamespace},
+				ElasticHost:                    "tigera-secure-es-http.tigera-elasticsearch.svc",
+				ElasticPort:                    "9200",
+				ElasticClientCredentialsSecret: userSecret,
 			}
 		})
 
@@ -150,6 +164,7 @@ var _ = Describe("Linseed rendering tests", func() {
 
 			// The deployment should have the hash annotation set, as well as a volume and volume mount for the client secret.
 			Expect(d.Spec.Template.Annotations["hash.operator.tigera.io/elastic-client-secret"]).To(Equal("ae1a6776a81bf1fc0ee4aac936a90bd61a07aea7"))
+			Expect(d.Spec.Template.Annotations[fmt.Sprintf("hash.operator.tigera.io/%s", render.ElasticsearchLinseedUserSecret)]).To(Equal("465c25d580ea36d8e7cda470a0c34afd05eae6f7"))
 			Expect(d.Spec.Template.Spec.Volumes).To(ContainElement(corev1.Volume{
 				Name: logstorage.ExternalCertsVolumeName,
 				VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
…ange (#3352)

* Annotate Linseed user

* [CODE REVIEW] Update annotation hash

## Description

Cherry-pick: #3352

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
