### PR TITLE
remove default creation of tigera-dex namespace

### DIFF
--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -236,17 +236,6 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, nil
 	}
 
-	// Make sure the tigera-dex namespace exists, before rendering any objects there.
-	if err := r.client.Get(ctx, client.ObjectKey{Name: render.DexObjectName}, &corev1.Namespace{}); err != nil {
-		if errors.IsNotFound(err) {
-			r.status.SetDegraded(oprv1.ResourceNotFound, "Waiting for namespace tigera-dex to be created", err, reqLogger)
-			return reconcile.Result{}, nil
-		} else {
-			r.status.SetDegraded(oprv1.ResourceReadError, "Error querying tigera-dex namespace", err, reqLogger)
-			return reconcile.Result{}, err
-		}
-	}
-
 	// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
 	if !r.tierWatchReady.IsReady() {
 		r.status.SetDegraded(oprv1.ResourceNotReady, "Waiting for Tier watch to be established", nil, reqLogger)

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -117,7 +117,9 @@ func (*dexComponent) SupportedOSType() rmeta.OSType {
 }
 
 func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
+
 	objs := []client.Object{
+		CreateNamespace(DexObjectName, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 		c.allowTigeraNetworkPolicy(),
 		networkpolicy.AllowTigeraDefaultDeny(DexNamespace),
 		c.serviceAccount(),

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -212,6 +212,7 @@ var _ = Describe("dex rendering tests", func() {
 				version string
 				kind    string
 			}{
+				{render.DexObjectName, "", "", "v1", "Namespace"},
 				{render.DexPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 				{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 				{render.DexObjectName, render.DexNamespace, "", "v1", "ServiceAccount"},
@@ -320,6 +321,7 @@ var _ = Describe("dex rendering tests", func() {
 				version string
 				kind    string
 			}{
+				{render.DexObjectName, "", "", "v1", "Namespace"},
 				{render.DexPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 				{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.DexNamespace, "projectcalico.org", "v3", "NetworkPolicy"},
 				{render.DexObjectName, render.DexNamespace, "", "v1", "ServiceAccount"},

--- a/pkg/render/namespaces.go
+++ b/pkg/render/namespaces.go
@@ -62,10 +62,6 @@ func (c *namespaceComponent) Objects() ([]client.Object, []client.Object) {
 		ns = []client.Object{}
 	}
 
-	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
-		// We need to always have ns tigera-dex even when the Authentication CR is not present, so policies can be added to this namespace.
-		ns = append(ns, CreateNamespace(DexObjectName, c.cfg.Installation.KubernetesProvider, PSSRestricted))
-	}
 	if len(c.cfg.PullSecrets) > 0 {
 		ns = append(ns, secret.ToRuntimeObjects(secret.CopyToNamespace(common.CalicoNamespace, c.cfg.PullSecrets...)...)...)
 	}

--- a/pkg/render/namespaces_test.go
+++ b/pkg/render/namespaces_test.go
@@ -66,28 +66,4 @@ var _ = Describe("Namespace rendering tests", func() {
 		Expect(meta.GetLabels()).NotTo(ContainElement("openshift.io/run-level"))
 		Expect(meta.GetLabels()["control-plane"]).To(Equal("true"))
 	})
-
-	It("should render a namespace for tigera-dex on EE", func() {
-		cfg.Installation.Variant = operatorv1.TigeraSecureEnterprise
-		component := render.Namespaces(cfg)
-		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(2))
-		rtest.ExpectResourceTypeAndObjectMetadata(resources[1], "tigera-dex", "", "", "v1", "Namespace")
-		meta := resources[1].(metav1.ObjectMetaAccessor).GetObjectMeta()
-		Expect(meta.GetLabels()["name"]).To(Equal("tigera-dex"))
-		Expect(meta.GetLabels()).NotTo(ContainElement("openshift.io/run-level"))
-		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
-	})
-
-	It("should render a namespace for tigera-dex for openshift on EE", func() {
-		cfg.Installation.Variant = operatorv1.TigeraSecureEnterprise
-		cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
-		component := render.Namespaces(cfg)
-		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(2))
-		rtest.ExpectResourceTypeAndObjectMetadata(resources[1], "tigera-dex", "", "", "v1", "Namespace")
-		meta := resources[1].(metav1.ObjectMetaAccessor).GetObjectMeta()
-		Expect(meta.GetLabels()["openshift.io/run-level"]).To(Equal("0"))
-		Expect(meta.GetAnnotations()["openshift.io/node-selector"]).To(Equal(""))
-	})
 })

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -232,13 +232,12 @@ var _ = Describe("Rendering tests", func() {
 		// - X Same as default config
 		// - 1 Service to expose calico/node metrics.
 		// - 1 Service to expose Windows calico/node metrics.
-		// - 1 ns (tigera-dex)
 		var nodeMetricsPort int32 = 9081
 		instance.Variant = operatorv1.TigeraSecureEnterprise
 		instance.NodeMetricsPort = &nodeMetricsPort
 		c, err := allCalicoComponents(k8sServiceEp, instance, nil, nil, nil, typhaNodeTLS, nil, nil, false, "", dns.DefaultClusterDomain, 9094, 0, nil, nil)
 		Expect(err).To(BeNil(), "Expected Calico to create successfully %s", err)
-		Expect(componentCount(c)).To(Equal((6 + 3 + 4 + 1 + 7 + 6 + 1 + 2) + 1 + 1 + 1))
+		Expect(componentCount(c)).To(Equal((6 + 3 + 4 + 1 + 7 + 6 + 1 + 2) + 1 + 1))
 	})
 
 	It("should render all resources when variant is Tigera Secure and Management Cluster", func() {
@@ -261,7 +260,6 @@ var _ = Describe("Rendering tests", func() {
 		}{
 			// Namespaces first.
 			{common.CalicoNamespace, "", "", "v1", "Namespace"},
-			{render.DexObjectName, "", "", "v1", "Namespace"},
 
 			// Typha objects.
 			{render.TyphaServiceAccountName, common.CalicoNamespace, "", "v1", "ServiceAccount"},


### PR DESCRIPTION
Currently, the tigera-dex namespace is created by default without any resources  in standalone, managed, and management clusters. 

Removed the default creation of the tigera-dex namespace. Now, it will only be created when the Authentication CR is created and will be removed when the Authentication CR is deleted.  Also, Dex is not needed in managed clusters.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
