### PR TITLE
v1.34 pick: Limit TLSRoute lists to the tenant namespace in multi-tenant clusters (#3367)

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -761,12 +761,12 @@ func fillDefaults(mc *operatorv1.ManagementCluster) {
 
 func getVoltronRouteConfig(ctx context.Context, cli client.Client, managerNamespace string) (*rmanager.VoltronRouteConfig, error) {
 	terminatedRouteList := &operatorv1.TLSTerminatedRouteList{}
-	if err := cli.List(ctx, terminatedRouteList); err != nil {
+	if err := cli.List(ctx, terminatedRouteList, client.InNamespace(managerNamespace)); err != nil {
 		return nil, err
 	}
 
 	passThroughRouteList := &operatorv1.TLSPassThroughRouteList{}
-	if err := cli.List(ctx, passThroughRouteList); err != nil {
+	if err := cli.List(ctx, passThroughRouteList, client.InNamespace(managerNamespace)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -55,6 +55,7 @@ import (
 	rsecret "github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/monitor"
 	tigeratls "github.com/tigera/operator/pkg/tls"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	"github.com/tigera/operator/test"
 )
 
@@ -1044,9 +1045,6 @@ var _ = Describe("Manager controller tests", func() {
 			tenantBNamespace := "tenant-b"
 			BeforeEach(func() {
 				r.multiTenant = true
-			})
-
-			It("Should reconcile only if a namespace is provided.", func() {
 				// Create the Tenant resources for tenant-a and tenant-b.
 				tenantA := &operatorv1.Tenant{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1108,7 +1106,11 @@ var _ = Describe("Manager controller tests", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = r.Reconcile(ctx, reconcile.Request{})
+			})
+
+			It("Should reconcile only if a namespace is provided.", func() {
+
+				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
 
 				tenantADeployment := appsv1.Deployment{
@@ -1195,6 +1197,64 @@ var _ = Describe("Manager controller tests", func() {
 				Expect(kerror.IsNotFound(err)).Should(BeFalse())
 				Expect(clusterRoleBinding.Subjects).To(HaveLen(3))
 			})
+
+			It("should apply TLSRoutes in from the manager namespace", func() {
+
+				Expect(c.Create(ctx, &operatorv1.TLSTerminatedRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: tenantANamespace,
+						Name:      "tenant-a-route",
+					},
+					Spec: operatorv1.TLSTerminatedRouteSpec{
+						CABundle: &corev1.ConfigMapKeySelector{
+							Key: "tigera-ca-bundle.crt",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: certificatemanagement.TrustedCertConfigMapNamePublic,
+							},
+						},
+						Destination: "https://internal.foo.svc",
+						PathMatch: &operatorv1.PathMatch{
+							Path: "/foo/",
+						},
+						Target: "UI",
+					},
+				})).NotTo(HaveOccurred())
+
+				_, err := r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: tenantANamespace,
+					},
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				_, err = r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: tenantBNamespace,
+					},
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				tenantARoutes := corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "voltron-routes",
+						Namespace: tenantANamespace,
+					},
+				}
+				tenantBRoutes := corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "voltron-routes",
+						Namespace: tenantBNamespace,
+					},
+				}
+
+				Expect(test.GetResource(c, &tenantARoutes)).ToNot(HaveOccurred())
+				Expect(tenantARoutes.Data).ToNot(BeEmpty())
+
+				Expect(kerror.IsNotFound(test.GetResource(c, &tenantBRoutes))).Should(BeTrue())
+			})
+
 		})
 
 		Context("FIPS reconciliation", func() {


### PR DESCRIPTION


* Limit TLSRoute lists to the tenant namespace in multi-tenant clusters

* don't export voltronRoutesConfigMapName and undo import change

(cherry picked from commit 6e6048da5dcbf0f89f3efdcb4eb5c2f214422027)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
