### PR TITLE
Annotate Linseed clients with a hash of the token

### DIFF
--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -122,6 +122,10 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 			render.ComplianceServerCertSecret, render.ManagerInternalTLSSecretName, certificatemanagement.CASecretName,
 			render.TigeraLinseedSecret, render.VoltronLinseedTLS,
 			render.VoltronLinseedPublicCert,
+			fmt.Sprintf(render.LinseedTokenSecret, render.ComplianceBenchmarkerServiceAccount),
+			fmt.Sprintf(render.LinseedTokenSecret, render.ComplianceControllerServiceAccount),
+			fmt.Sprintf(render.LinseedTokenSecret, render.ComplianceReporterServiceAccount),
+			fmt.Sprintf(render.LinseedTokenSecret, render.ComplianceSnapshotterServiceAccount),
 		} {
 			if err = utils.AddSecretsWatch(complianceController, secretName, namespace); err != nil {
 				return fmt.Errorf("compliance-controller failed to watch the secret '%s' in '%s' namespace: %w", secretName, namespace, err)

--- a/pkg/controller/logstorage/linseed/linseed_controller.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller.go
@@ -133,7 +133,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	secretsToWatch := []string{
 		render.TigeraElasticsearchGatewaySecret,
 		render.TigeraLinseedSecret,
-		render.LinseedTokenSecret,
+		render.TigeraLinseedTokenSecret,
 		monitor.PrometheusClientTLSSecretName,
 		render.ElasticsearchLinseedUserSecret,
 	}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -919,3 +919,7 @@ func RemoveInstallationFinalizer(i *operatorv1.Installation, finalizer string) {
 		i.SetFinalizers(stringsutil.RemoveStringInSlice(finalizer, i.GetFinalizers()))
 	}
 }
+
+func LinseedTokenSecretName(serviceAccountName string) string {
+	return fmt.Sprintf(render.LinseedTokenSecret, serviceAccountName)
+}


### PR DESCRIPTION
## Description

Adding an annotations for Linseed token will force a restart and the volume for the token will be reloaded. This is needed when the connection is down, the token expires and in order for the new value to be picked up, we need to to force a restart. This PR only adds annotations for fluentD tokens, as the rest of the application use Linseed client that reloads when it changes.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
