### PR TITLE
Grant ES Proxy rights to create LocalSubjectAccessReviews

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -358,15 +358,17 @@ spec:
                   type: string
                 type: array
               failsafeInboundHostPorts:
-                description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
-                  and CIDRs that Felix will allow incoming traffic to host endpoints
-                  on irrespective of the security policy. This is useful to avoid
-                  accidentally cutting off a host with incorrect configuration. For
-                  back-compatibility, if the protocol is not specified, it defaults
-                  to "tcp". If a CIDR is not specified, it will allow traffic from
-                  all addresses. To disable all inbound host ports, use the value
-                  none. The default value allows ssh access and DHCP. [Default: tcp:22,
-                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                description: 'FailsafeInboundHostPorts is a list of PortProto struct
+                  objects including UDP/TCP/SCTP ports and CIDRs that Felix will allow
+                  incoming traffic to host endpoints on irrespective of the security
+                  policy. This is useful to avoid accidentally cutting off a host
+                  with incorrect configuration. For backwards compatibility, if the
+                  protocol is not specified, it defaults to "tcp". If a CIDR is not
+                  specified, it will allow traffic from all addresses. To disable
+                  all inbound host ports, use the value "[]". The default value allows
+                  ssh access, DHCP, BGP, etcd and the Kubernetes API. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:5473, tcp:6443, tcp:6666,
+                  tcp:6667 ]'
                 items:
                   description: ProtoPort is combination of protocol, port, and CIDR.
                     Protocol and port must be specified.
@@ -383,17 +385,18 @@ spec:
                   type: object
                 type: array
               failsafeOutboundHostPorts:
-                description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
-                  and CIDRs that Felix will allow outgoing traffic from host endpoints
-                  to irrespective of the security policy. This is useful to avoid
-                  accidentally cutting off a host with incorrect configuration. For
-                  back-compatibility, if the protocol is not specified, it defaults
-                  to "tcp". If a CIDR is not specified, it will allow traffic from
-                  all addresses. To disable all outbound host ports, use the value
-                  none. The default value opens etcd''s standard ports to ensure that
-                  Felix does not get cut off from etcd as well as allowing DHCP and
-                  DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
-                  tcp:6667, udp:53, udp:67]'
+                description: 'FailsafeOutboundHostPorts is a list of List of PortProto
+                  struct objects including UDP/TCP/SCTP ports and CIDRs that Felix
+                  will allow outgoing traffic from host endpoints to irrespective
+                  of the security policy. This is useful to avoid accidentally cutting
+                  off a host with incorrect configuration. For backwards compatibility,
+                  if the protocol is not specified, it defaults to "tcp". If a CIDR
+                  is not specified, it will allow traffic from all addresses. To disable
+                  all outbound host ports, use the value "[]". The default value opens
+                  etcd''s standard ports to ensure that Felix does not get cut off
+                  from etcd as well as allowing DHCP, DNS, BGP and the Kubernetes
+                  API. [Default: udp:53, udp:67, tcp:179, tcp:2379, tcp:2380, tcp:5473,
+                  tcp:6443, tcp:6666, tcp:6667 ]'
                 items:
                   description: ProtoPort is combination of protocol, port, and CIDR.
                     Protocol and port must be specified.

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -129,7 +129,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 		// service account is always within the tigera-manager namespace - regardless of (multi)tenancy mode.
 		CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted),
 		managerServiceAccount(ManagerNamespace),
-		managerClusterRole(true, c.cfg.Installation.KubernetesProvider),
+		managerClusterRole(true, c.cfg.Installation.KubernetesProvider, nil),
 		managerClusterRoleBinding([]string{ManagerNamespace}),
 
 		// Install default UI settings for this managed cluster.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -226,7 +226,7 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 
 	objs = append(objs,
 		managerClusterRoleBinding(c.cfg.BindingNamespaces),
-		managerClusterRole(false, c.cfg.Installation.KubernetesProvider),
+		managerClusterRole(false, c.cfg.Installation.KubernetesProvider, c.cfg.Tenant),
 	)
 
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(c.cfg.Namespace, c.cfg.PullSecrets...)...)...)
@@ -683,7 +683,7 @@ func managerClusterRoleBinding(namespaces []string) client.Object {
 }
 
 // managerClusterRole returns a clusterrole that allows authn/authz review requests.
-func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provider) *rbacv1.ClusterRole {
+func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provider, tenant *operatorv1.Tenant) *rbacv1.ClusterRole {
 	cr := &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -822,6 +822,16 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},
 				Verbs:     []string{"list", "get", "watch", "update"},
+			},
+		)
+	}
+
+	if tenant.MultiTenant() {
+		cr.Rules = append(cr.Rules,
+			rbacv1.PolicyRule{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"localsubjectaccessreviews"},
+				Verbs:     []string{"create"},
 			},
 		)
 	}

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1055,6 +1055,36 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			}))
 		})
 
+		It("should render cluster role with additional RBAC", func() {
+			resources := renderObjects(renderConfig{
+				oidc:                    false,
+				managementCluster:       nil,
+				installation:            installation,
+				compliance:              compliance,
+				complianceFeatureActive: true,
+				ns:                      tenantANamespace,
+				bindingNamespaces:       []string{tenantANamespace},
+				tenant: &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tenantA",
+						Namespace: tenantANamespace,
+					},
+					Spec: operatorv1.TenantSpec{
+						ID: "tenant-a",
+					}},
+			})
+
+			clusterRole := rtest.GetResource(resources, render.ManagerClusterRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(clusterRole.Rules).To(ContainElements([]rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"authorization.k8s.io"},
+					Resources: []string{"localsubjectaccessreviews"},
+					Verbs:     []string{"create"},
+				},
+			},
+			))
+		})
+
 		It("should render multi-tenant environment variables", func() {
 			resources := renderObjects(renderConfig{
 				oidc:                    false,


### PR DESCRIPTION
## Description

In a multi-tenant setup, ES Proxy will authorize an user for access to lma.tigera.io resources using LocalAccessSubjectReviews instead of SubjectAccessReviews.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
