### PR TITLE
Switch to ClusterRole/RoleBindings to get ManagedClusters to pass authorizat…

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -633,12 +633,6 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	if tenant.MultiTenant() {
-		// In a multi-tenant environment, we need to grant access to the canonical tigera-manager:tigera-manager service account
-		// so that es-proxy passes Voltron's authorization checks when accessing managed clusters. This is because per-tenant manager instances
-		// impersonate as this serviceaccount on these flows.
-		namespaces = append(namespaces, render.ManagerNamespace)
-	}
 
 	routeConfig, err := getVoltronRouteConfig(ctx, r.client, helper.InstallNamespace())
 	if err != nil {

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -1179,11 +1179,10 @@ var _ = Describe("Manager controller tests", func() {
 				err = test.GetResource(c, &tenantBDeployment)
 				Expect(kerror.IsNotFound(err)).Should(BeFalse())
 
-				// Ensure a cluster role binding was created that binds both tenants, as well as the
-				// canonical manager service account.
+				// Ensure a cluster role binding was created that binds both tenants,
 				err = test.GetResource(c, &clusterRoleBinding)
 				Expect(kerror.IsNotFound(err)).Should(BeFalse())
-				Expect(clusterRoleBinding.Subjects).To(HaveLen(3))
+				Expect(clusterRoleBinding.Subjects).To(HaveLen(2))
 			})
 
 			It("should apply TLSRoutes in from the manager namespace", func() {

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -1788,9 +1788,9 @@ func (c *complianceComponent) complianceServerAllowTigeraNetworkPolicy() *v3.Net
 
 func (c *complianceComponent) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.ClusterRole{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantComplianceManagedClustersAccessClusterRoleName},
+	objects = append(objects, &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: c.cfg.Namespace},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -1810,12 +1810,12 @@ func (c *complianceComponent) multiTenantManagedClustersAccess() []client.Object
 	// tigera-compliance-server from tigera-compliance namespace. In a multi-tenant setup
 	// Compliance server from the tenant's namespace impersonates service tigera-compliance-server
 	// from tigera-compliance namespace
-	objects = append(objects, &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantComplianceManagedClustersAccessClusterRoleName},
+	objects = append(objects, &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: c.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
+			Kind:     "Role",
 			Name:     MultiTenantComplianceManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -53,7 +53,7 @@ const (
 	ComplianceBenchmarkerName                                 = "compliance-benchmarker"
 	ComplianceAccessPolicyName                                = networkpolicy.TigeraComponentPolicyPrefix + "compliance-access"
 	ComplianceServerPolicyName                                = networkpolicy.TigeraComponentPolicyPrefix + ComplianceServerName
-	MultiTenantComplianceManagedClustersAccessClusterRoleName = "compliance-server-managed-cluster-access"
+	MultiTenantComplianceManagedClustersAccessRoleBindingName = "compliance-server-managed-cluster-access"
 
 	// ServiceAccount names.
 	ComplianceServerServiceAccount      = "tigera-compliance-server"
@@ -1788,23 +1788,6 @@ func (c *complianceComponent) complianceServerAllowTigeraNetworkPolicy() *v3.Net
 
 func (c *complianceComponent) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.Role{
-		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: c.cfg.Namespace},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
-				Verbs: []string{
-					// The Authentication Proxy in Voltron checks if Compliance (either using impersonation
-					// headers for tigera-compliance-server service account in tigera-compliance namespace or
-					// the actual account in a single tenant setup) can get a managed clusters before sending the
-					// request down the tunnel
-					"get",
-				},
-			},
-		},
-	})
 
 	// In a single tenant setup we want to create a cluster role that binds using service account
 	// tigera-compliance-server from tigera-compliance namespace. In a multi-tenant setup
@@ -1812,11 +1795,11 @@ func (c *complianceComponent) multiTenantManagedClustersAccess() []client.Object
 	// from tigera-compliance namespace
 	objects = append(objects, &rbacv1.RoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: c.cfg.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantComplianceManagedClustersAccessRoleBindingName, Namespace: c.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     MultiTenantComplianceManagedClustersAccessClusterRoleName,
+			Kind:     "ClusterRole",
+			Name:     MultiTenantManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{
 			// requests for compliance to managed clusters are done using service account tigera-compliance-server

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -1080,8 +1080,7 @@ var _ = Describe("compliance rendering tests", func() {
 			tenantAExpectedResources := []client.Object{
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server", Namespace: tenantANamespace}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server"}},
-				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessRoleBindingName, Namespace: tenantANamespace}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceBenchmarkerServiceAccount}},
@@ -1123,8 +1122,7 @@ var _ = Describe("compliance rendering tests", func() {
 			tenantBExpectedResources := []client.Object{
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server", Namespace: tenantBNamespace}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server"}},
-				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessRoleBindingName, Namespace: tenantBNamespace}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceBenchmarkerServiceAccount}},
@@ -1224,20 +1222,9 @@ var _ = Describe("compliance rendering tests", func() {
 			tenantACompliance, err := render.Compliance(cfg)
 			Expect(err).NotTo(HaveOccurred())
 			resources, _ := tenantACompliance.Objects()
-			cr := rtest.GetResource(resources, render.MultiTenantComplianceManagedClustersAccessClusterRoleName, tenantANamespace, rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
-			expectedRules := []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"managedclusters"},
-					Verbs: []string{
-						"get",
-					},
-				},
-			}
-			Expect(cr.Rules).To(ContainElements(expectedRules))
-			rb := rtest.GetResource(resources, render.MultiTenantComplianceManagedClustersAccessClusterRoleName, tenantANamespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
-			Expect(rb.RoleRef.Kind).To(Equal("Role"))
-			Expect(rb.RoleRef.Name).To(Equal(render.MultiTenantComplianceManagedClustersAccessClusterRoleName))
+			rb := rtest.GetResource(resources, render.MultiTenantComplianceManagedClustersAccessRoleBindingName, tenantANamespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+			Expect(rb.RoleRef.Name).To(Equal(render.MultiTenantManagedClustersAccessClusterRoleName))
 			Expect(rb.Subjects).To(ContainElements([]rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -1080,8 +1080,8 @@ var _ = Describe("compliance rendering tests", func() {
 			tenantAExpectedResources := []client.Object{
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server", Namespace: tenantANamespace}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server"}},
-				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName}},
-				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceBenchmarkerServiceAccount}},
@@ -1123,8 +1123,8 @@ var _ = Describe("compliance rendering tests", func() {
 			tenantBExpectedResources := []client.Object{
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server", Namespace: tenantBNamespace}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-compliance-server"}},
-				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName}},
-				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.MultiTenantComplianceManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceSnapshotterServiceAccount}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ComplianceBenchmarkerServiceAccount}},
@@ -1224,7 +1224,7 @@ var _ = Describe("compliance rendering tests", func() {
 			tenantACompliance, err := render.Compliance(cfg)
 			Expect(err).NotTo(HaveOccurred())
 			resources, _ := tenantACompliance.Objects()
-			cr := rtest.GetResource(resources, render.MultiTenantComplianceManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			cr := rtest.GetResource(resources, render.MultiTenantComplianceManagedClustersAccessClusterRoleName, tenantANamespace, rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
 			expectedRules := []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"projectcalico.org"},
@@ -1235,8 +1235,8 @@ var _ = Describe("compliance rendering tests", func() {
 				},
 			}
 			Expect(cr.Rules).To(ContainElements(expectedRules))
-			rb := rtest.GetResource(resources, render.MultiTenantComplianceManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+			rb := rtest.GetResource(resources, render.MultiTenantComplianceManagedClustersAccessClusterRoleName, tenantANamespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(rb.RoleRef.Kind).To(Equal("Role"))
 			Expect(rb.RoleRef.Name).To(Equal(render.MultiTenantComplianceManagedClustersAccessClusterRoleName))
 			Expect(rb.Subjects).To(ContainElements([]rbacv1.Subject{
 				{

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -55,12 +55,12 @@ const (
 	KubeControllerMetrics           = "calico-kube-controllers-metrics"
 	KubeControllerNetworkPolicyName = networkpolicy.TigeraComponentPolicyPrefix + "kube-controller-access"
 
-	EsKubeController                     = "es-calico-kube-controllers"
-	EsKubeControllerRole                 = "es-calico-kube-controllers"
-	EsKubeControllerRoleBinding          = "es-calico-kube-controllers"
-	EsKubeControllerMetrics              = "es-calico-kube-controllers-metrics"
-	EsKubeControllerNetworkPolicyName    = networkpolicy.TigeraComponentPolicyPrefix + "es-kube-controller-access"
-	MultiTenantManagedClustersAccessName = "es-calico-kube-controllers-managed-cluster-access"
+	EsKubeController                                = "es-calico-kube-controllers"
+	EsKubeControllerRole                            = "es-calico-kube-controllers"
+	EsKubeControllerRoleBinding                     = "es-calico-kube-controllers"
+	EsKubeControllerMetrics                         = "es-calico-kube-controllers-metrics"
+	EsKubeControllerNetworkPolicyName               = networkpolicy.TigeraComponentPolicyPrefix + "es-kube-controller-access"
+	MultiTenantManagedClustersAccessRoleBindingName = "es-calico-kube-controllers-managed-cluster-access"
 
 	ElasticsearchKubeControllersUserSecret             = "tigera-ee-kube-controllers-elasticsearch-access"
 	ElasticsearchKubeControllersUserName               = "tigera-ee-kube-controllers"
@@ -320,33 +320,17 @@ func (c *kubeControllersComponent) Objects() ([]client.Object, []client.Object) 
 
 func (c *kubeControllersComponent) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.Role{
-		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessName, Namespace: c.cfg.Namespace},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
-				Verbs: []string{
-					// The Authentication Proxy in Voltron checks if EsKubeControllers (using impersonation headers for
-					// calico-kube-controllers service in calico-system namespace) can get a managed clusters before
-					// sending the request down the tunnel.
-					"get",
-				},
-			},
-		},
-	})
 
 	// In a multi-tenant setup ES-Kube-Controllers from the tenant's namespace impersonates service
 	// calico-kube-controllers from calico-system namespace. (This is done via an additional ClusterRole and a
 	// ClusterRoleBinding)
 	objects = append(objects, &rbacv1.RoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessName, Namespace: c.cfg.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessRoleBindingName, Namespace: c.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     MultiTenantManagedClustersAccessName,
+			Kind:     "ClusterRole",
+			Name:     render.MultiTenantManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{
 			// requests for ES-Kube-Controllers to get managed clusters in Voltron are done using service account

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -320,9 +320,9 @@ func (c *kubeControllersComponent) Objects() ([]client.Object, []client.Object) 
 
 func (c *kubeControllersComponent) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.ClusterRole{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessName},
+	objects = append(objects, &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessName, Namespace: c.cfg.Namespace},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -340,12 +340,12 @@ func (c *kubeControllersComponent) multiTenantManagedClustersAccess() []client.O
 	// In a multi-tenant setup ES-Kube-Controllers from the tenant's namespace impersonates service
 	// calico-kube-controllers from calico-system namespace. (This is done via an additional ClusterRole and a
 	// ClusterRoleBinding)
-	objects = append(objects, &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessName},
+	objects = append(objects, &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessName, Namespace: c.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
+			Kind:     "Role",
 			Name:     MultiTenantManagedClustersAccessName,
 		},
 		Subjects: []rbacv1.Subject{

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/kubecontrollers"
@@ -1153,8 +1154,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				kind    string
 			}{
 				{name: kubecontrollers.EsKubeControllerNetworkPolicyName, ns: tenant.Namespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-				{name: kubecontrollers.MultiTenantManagedClustersAccessName, ns: tenant.Namespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-				{name: kubecontrollers.MultiTenantManagedClustersAccessName, ns: tenant.Namespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+				{name: kubecontrollers.MultiTenantManagedClustersAccessRoleBindingName, ns: tenant.Namespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 				{name: kubecontrollers.KubeControllerServiceAccount, ns: tenant.Namespace, group: "", version: "v1", kind: "ServiceAccount"},
 				{name: kubecontrollers.EsKubeControllerRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 				{name: kubecontrollers.EsKubeControllerRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -1253,21 +1253,10 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				},
 			}))
 
-			managedClusterAccessRole := rtest.GetResource(resources,
-				kubecontrollers.MultiTenantManagedClustersAccessName, tenant.Namespace, rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
-			expectedManagedClusterAccessRules := []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"managedclusters"},
-					Verbs:     []string{"get"},
-				},
-			}
-			Expect(managedClusterAccessRole.Rules).To(ContainElements(expectedManagedClusterAccessRules))
-
 			managedClusterAccessRoleBinding := rtest.GetResource(resources,
-				kubecontrollers.MultiTenantManagedClustersAccessName,
+				kubecontrollers.MultiTenantManagedClustersAccessRoleBindingName,
 				tenant.Namespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
-			Expect(managedClusterAccessRoleBinding.RoleRef.Name).To(Equal(kubecontrollers.MultiTenantManagedClustersAccessName))
+			Expect(managedClusterAccessRoleBinding.RoleRef.Name).To(Equal(render.MultiTenantManagedClustersAccessClusterRoleName))
 			Expect(managedClusterAccessRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -1153,8 +1153,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				kind    string
 			}{
 				{name: kubecontrollers.EsKubeControllerNetworkPolicyName, ns: tenant.Namespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-				{name: kubecontrollers.MultiTenantManagedClustersAccessName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-				{name: kubecontrollers.MultiTenantManagedClustersAccessName, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+				{name: kubecontrollers.MultiTenantManagedClustersAccessName, ns: tenant.Namespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
+				{name: kubecontrollers.MultiTenantManagedClustersAccessName, ns: tenant.Namespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 				{name: kubecontrollers.KubeControllerServiceAccount, ns: tenant.Namespace, group: "", version: "v1", kind: "ServiceAccount"},
 				{name: kubecontrollers.EsKubeControllerRole, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 				{name: kubecontrollers.EsKubeControllerRoleBinding, ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
@@ -1253,8 +1253,8 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				},
 			}))
 
-			managedClusterAccessClusterRole := rtest.GetResource(resources,
-				kubecontrollers.MultiTenantManagedClustersAccessName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			managedClusterAccessRole := rtest.GetResource(resources,
+				kubecontrollers.MultiTenantManagedClustersAccessName, tenant.Namespace, rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
 			expectedManagedClusterAccessRules := []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"projectcalico.org"},
@@ -1262,13 +1262,13 @@ var _ = Describe("kube-controllers rendering tests", func() {
 					Verbs:     []string{"get"},
 				},
 			}
-			Expect(managedClusterAccessClusterRole.Rules).To(ContainElements(expectedManagedClusterAccessRules))
+			Expect(managedClusterAccessRole.Rules).To(ContainElements(expectedManagedClusterAccessRules))
 
-			managedClusterAccessClusterRoleBinding := rtest.GetResource(resources,
+			managedClusterAccessRoleBinding := rtest.GetResource(resources,
 				kubecontrollers.MultiTenantManagedClustersAccessName,
-				"", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-			Expect(managedClusterAccessClusterRoleBinding.RoleRef.Name).To(Equal(kubecontrollers.MultiTenantManagedClustersAccessName))
-			Expect(managedClusterAccessClusterRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
+				tenant.Namespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(managedClusterAccessRoleBinding.RoleRef.Name).To(Equal(kubecontrollers.MultiTenantManagedClustersAccessName))
+			Expect(managedClusterAccessRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
 					Name:      kubecontrollers.KubeControllerServiceAccount,

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -258,9 +258,9 @@ func (l *linseed) linseedClusterRoleBinding(namespaces []string) client.Object {
 
 func (l *linseed) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.ClusterRole{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName},
+	objects = append(objects, &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName, Namespace: l.cfg.Namespace},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -275,15 +275,15 @@ func (l *linseed) multiTenantManagedClustersAccess() []client.Object {
 		},
 	})
 
-	// In a single tenant setup we want to create a cluster role that binds using service account
+	// In a single tenant setup we want to create a role that binds using service account
 	// tigera-linseed from tigera-elasticsearch namespace. In a multi-tenant setup Linseed from the tenant's
 	// namespace impersonates service tigera-linseed from tigera-elasticsearch namespace
-	objects = append(objects, &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName},
+	objects = append(objects, &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName, Namespace: l.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
+			Kind:     "Role",
 			Name:     MultiTenantManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -48,14 +48,14 @@ import (
 )
 
 const (
-	DeploymentName                                  = "tigera-linseed"
-	ServiceAccountName                              = "tigera-linseed"
-	PolicyName                                      = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
-	PortName                                        = "tigera-linseed"
-	TargetPort                                      = 8444
-	Port                                            = 443
-	ClusterRoleName                                 = "tigera-linseed"
-	MultiTenantManagedClustersAccessClusterRoleName = "tigera-linseed-managed-cluster-access"
+	DeploymentName                                         = "tigera-linseed"
+	ServiceAccountName                                     = "tigera-linseed"
+	PolicyName                                             = networkpolicy.TigeraComponentPolicyPrefix + "linseed-access"
+	PortName                                               = "tigera-linseed"
+	TargetPort                                             = 8444
+	Port                                                   = 443
+	ClusterRoleName                                        = "tigera-linseed"
+	MultiTenantManagedClustersAccessClusterRoleBindingName = "tigera-linseed-managed-cluster-access"
 )
 
 func Linseed(c *Config) render.Component {
@@ -258,33 +258,17 @@ func (l *linseed) linseedClusterRoleBinding(namespaces []string) client.Object {
 
 func (l *linseed) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.Role{
-		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName, Namespace: l.cfg.Namespace},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
-				Verbs: []string{
-					// The Authentication Proxy in Voltron checks if Linseed (either using impersonation headers for
-					// tigera-linseed service in tigera-elasticsearch namespace or the actual account in a single tenant
-					// setup) can get a managed clusters before sending the request down the tunnel
-					"get",
-				},
-			},
-		},
-	})
 
 	// In a single tenant setup we want to create a role that binds using service account
 	// tigera-linseed from tigera-elasticsearch namespace. In a multi-tenant setup Linseed from the tenant's
 	// namespace impersonates service tigera-linseed from tigera-elasticsearch namespace
 	objects = append(objects, &rbacv1.RoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleName, Namespace: l.cfg.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: MultiTenantManagedClustersAccessClusterRoleBindingName, Namespace: l.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     MultiTenantManagedClustersAccessClusterRoleName,
+			Kind:     "ClusterRole",
+			Name:     render.MultiTenantManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{
 			// requests for Linseed to managed clusters are done using service account tigera-linseed

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -512,7 +512,7 @@ var _ = Describe("Linseed rendering tests", func() {
 				TrustedBundle:   bundle,
 				ClusterDomain:   clusterDomain,
 				ESClusterConfig: esClusterConfig,
-				Namespace:       "tenant-test-tenant",
+				Namespace:       tenant.Namespace,
 				Tenant:          tenant,
 				ElasticHost:     "tigera-secure-es-http.tigera-elasticsearch.svc",
 				ElasticPort:     "9200",
@@ -551,20 +551,9 @@ var _ = Describe("Linseed rendering tests", func() {
 			component := Linseed(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			role := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, tenant.Namespace, rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
-			expectedRules := []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"managedclusters"},
-					Verbs: []string{
-						"get",
-					},
-				},
-			}
-			Expect(role.Rules).To(ContainElements(expectedRules))
-			rb := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, tenant.Namespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
-			Expect(rb.RoleRef.Kind).To(Equal("Role"))
-			Expect(rb.RoleRef.Name).To(Equal(MultiTenantManagedClustersAccessClusterRoleName))
+			rb := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleBindingName, tenant.Namespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+			Expect(rb.RoleRef.Name).To(Equal(render.MultiTenantManagedClustersAccessClusterRoleName))
 			Expect(rb.Subjects).To(ContainElements([]rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
@@ -617,7 +606,7 @@ var _ = Describe("Linseed rendering tests", func() {
 			resources, _ := component.Objects()
 			d := rtest.GetResource(resources, DeploymentName, cfg.Namespace, appsv1.GroupName, "v1", "Deployment").(*appsv1.Deployment)
 			Expect(d.Spec.Template.Spec.Affinity).NotTo(BeNil())
-			Expect(d.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, "tenant-test-tenant")))
+			Expect(d.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, tenant.Namespace)))
 		})
 
 		It("should override resource request with the value from TenantSpec's linseedDeployment when available", func() {

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -551,7 +551,7 @@ var _ = Describe("Linseed rendering tests", func() {
 			component := Linseed(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			cr := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			role := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, tenant.Namespace, rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
 			expectedRules := []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"projectcalico.org"},
@@ -561,9 +561,9 @@ var _ = Describe("Linseed rendering tests", func() {
 					},
 				},
 			}
-			Expect(cr.Rules).To(ContainElements(expectedRules))
-			rb := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+			Expect(role.Rules).To(ContainElements(expectedRules))
+			rb := rtest.GetResource(resources, MultiTenantManagedClustersAccessClusterRoleName, tenant.Namespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(rb.RoleRef.Kind).To(Equal("Role"))
 			Expect(rb.RoleRef.Name).To(Equal(MultiTenantManagedClustersAccessClusterRoleName))
 			Expect(rb.Subjects).To(ContainElements([]rbacv1.Subject{
 				{

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -71,10 +71,11 @@ const (
 	ManagerClusterSettingsLayerTigera = "cluster-settings.layer.tigera-infrastructure"
 	ManagerClusterSettingsViewDefault = "cluster-settings.view.default"
 
-	ElasticsearchManagerUserSecret  = "tigera-ee-manager-elasticsearch-access"
-	TlsSecretHashAnnotation         = "hash.operator.tigera.io/tls-secret"
-	KibanaTLSHashAnnotation         = "hash.operator.tigera.io/kibana-secrets"
-	ElasticsearchUserHashAnnotation = "hash.operator.tigera.io/elasticsearch-user"
+	ElasticsearchManagerUserSecret                         = "tigera-ee-manager-elasticsearch-access"
+	TlsSecretHashAnnotation                                = "hash.operator.tigera.io/tls-secret"
+	KibanaTLSHashAnnotation                                = "hash.operator.tigera.io/kibana-secrets"
+	ElasticsearchUserHashAnnotation                        = "hash.operator.tigera.io/elasticsearch-user"
+	ManagerMultiTenantManagedClustersAccessClusterRoleName = "tigera-manager-managed-cluster-access"
 )
 
 // ManagementClusterConnection configuration constants
@@ -228,6 +229,10 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 		managerClusterRoleBinding(c.cfg.BindingNamespaces),
 		managerClusterRole(false, c.cfg.Installation.KubernetesProvider, c.cfg.Tenant),
 	)
+
+	if c.cfg.Tenant.MultiTenant() {
+		objs = append(objs, c.multiTenantManagedClustersAccess()...)
+	}
 
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(c.cfg.Namespace, c.cfg.PullSecrets...)...)...)
 	objs = append(objs,
@@ -968,6 +973,52 @@ func (c *managerComponent) managerAllowTigeraNetworkPolicy() *v3.NetworkPolicy {
 			Egress:   egressRules,
 		},
 	}
+}
+
+func (c *managerComponent) multiTenantManagedClustersAccess() []client.Object {
+	var objects []client.Object
+	objects = append(objects, &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: c.cfg.Namespace},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"managedclusters"},
+				Verbs: []string{
+					// The Authentication Proxy in Voltron checks if ESProxy (either using impersonation
+					// headers for tigera-manager service in tigera-manager namespace or
+					// the actual account in a single tenant setup) can get a managed clusters before sending the
+					// request down the tunnel
+					"get",
+				},
+			},
+		},
+	})
+
+	// In a single tenant setup we want to create a role that binds using service account
+	// tigera-manager from tigera-manager namespace. In a multi-tenant setup
+	// ESProxy from the tenant's namespace impersonates service tigera-manager
+	// from tigera-manager namespace
+	objects = append(objects, &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: c.cfg.Namespace},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     ManagerMultiTenantManagedClustersAccessClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			// requests for ESProxy to managed clusters are done using service account tigera-manager
+			// from tigera-manager namespace regardless of tenancy mode (single tenant or multi-tenant)
+			{
+				Kind:      "ServiceAccount",
+				Name:      ManagerServiceName,
+				Namespace: ManagerNamespace,
+			},
+		},
+	})
+
+	return objects
 }
 
 // managerClusterWideSettingsGroup returns a UISettingsGroup with the description "cluster-wide settings"

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1002,8 +1002,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRole}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRoleBinding}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
-				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleBindingName, Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
 			}
@@ -1033,8 +1032,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRole}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRoleBinding}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
-				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleBindingName, Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
 			}
@@ -1086,32 +1084,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 					}},
 			})
 
-			clusterRole := rtest.GetResource(resources, render.ManagerClusterRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-			Expect(clusterRole.Rules).To(ContainElements([]rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"authorization.k8s.io"},
-					Resources: []string{"localsubjectaccessreviews"},
-					Verbs:     []string{"create"},
-				},
-			},
-			))
-
-			// Check that the cluster role allows the tigera-manager from namespace tigera-manager
-			// to get managed clusters in order to bypass the authentication proxy in Voltron
-			roleManagedClusters := rtest.GetResource(resources, render.ManagerMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
-			Expect(roleManagedClusters.Rules).To(ContainElements(
-				rbacv1.PolicyRule{
-					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"managedclusters"},
-					Verbs:     []string{"get"},
-				},
-			))
-			roleBindingManagedClusters := rtest.GetResource(resources, render.ManagerMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			roleBindingManagedClusters := rtest.GetResource(resources, render.ManagerMultiTenantManagedClustersAccessClusterRoleBindingName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
 			Expect(roleBindingManagedClusters.RoleRef).To(Equal(
 				rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     render.ManagerMultiTenantManagedClustersAccessClusterRoleName,
+					Kind:     "ClusterRole",
+					Name:     render.MultiTenantManagedClustersAccessClusterRoleName,
 				}))
 			Expect(roleBindingManagedClusters.Subjects).To(ConsistOf(
 				rbacv1.Subject{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -985,21 +985,27 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				compliance:              compliance,
 				complianceFeatureActive: true,
 				ns:                      tenantANamespace,
+				tenant: &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tenantA",
+						Namespace: tenantANamespace,
+					},
+					Spec: operatorv1.TenantSpec{
+						ID: "tenant-a",
+					},
+				},
 			})
 
 			expectedTenantAResources := []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-a"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.manager-access", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRole}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRoleBinding}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
-				&v3.UISettingsGroup{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettings}, TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"}},
-				&v3.UISettingsGroup{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerUserSettings}, TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"}},
-				&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsLayerTigera}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
-				&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsViewDefault}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
 			}
 			rtest.ExpectResources(tenantAResources, expectedTenantAResources)
 
@@ -1010,21 +1016,27 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				compliance:              compliance,
 				complianceFeatureActive: true,
 				ns:                      tenantBNamespace,
+				tenant: &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tenantB",
+						Namespace: tenantBNamespace,
+					},
+					Spec: operatorv1.TenantSpec{
+						ID: "tenant-b",
+					},
+				},
 			})
 
 			expectedTenantBResources := []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.manager-access", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRole}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRoleBinding}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerMultiTenantManagedClustersAccessClusterRoleName, Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
-				&v3.UISettingsGroup{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettings}, TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"}},
-				&v3.UISettingsGroup{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerUserSettings}, TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"}},
-				&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsLayerTigera}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
-				&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsViewDefault}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
 			}
 			rtest.ExpectResources(tenantBResources, expectedTenantBResources)
 		})
@@ -1055,7 +1067,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			}))
 		})
 
-		It("should render cluster role with additional RBAC", func() {
+		It("should render cluster role/roles with additional RBAC", func() {
 			resources := renderObjects(renderConfig{
 				oidc:                    false,
 				managementCluster:       nil,
@@ -1083,6 +1095,31 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				},
 			},
 			))
+
+			// Check that the cluster role allows the tigera-manager from namespace tigera-manager
+			// to get managed clusters in order to bypass the authentication proxy in Voltron
+			roleManagedClusters := rtest.GetResource(resources, render.ManagerMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
+			Expect(roleManagedClusters.Rules).To(ContainElements(
+				rbacv1.PolicyRule{
+					APIGroups: []string{"projectcalico.org"},
+					Resources: []string{"managedclusters"},
+					Verbs:     []string{"get"},
+				},
+			))
+			roleBindingManagedClusters := rtest.GetResource(resources, render.ManagerMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(roleBindingManagedClusters.RoleRef).To(Equal(
+				rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     render.ManagerMultiTenantManagedClustersAccessClusterRoleName,
+				}))
+			Expect(roleBindingManagedClusters.Subjects).To(ConsistOf(
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      render.ManagerServiceName,
+					Namespace: render.ManagerNamespace,
+				}))
+
 		})
 
 		It("should render multi-tenant environment variables", func() {

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -235,9 +235,9 @@ func (pr *policyRecommendationComponent) clusterRoleBinding() client.Object {
 
 func (pr *policyRecommendationComponent) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.ClusterRole{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName},
+	objects = append(objects, &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, Namespace: pr.cfg.Namespace},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -257,12 +257,12 @@ func (pr *policyRecommendationComponent) multiTenantManagedClustersAccess() []cl
 	// tigera-policy-recommendation from tigera-policy-recommendation namespace. In a multi-tenant setup
 	// PolicyRecommendation Controller from the tenant's namespace impersonates service tigera-policy-recommendation
 	// from tigera-policy-recommendation namespace
-	objects = append(objects, &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName},
+	objects = append(objects, &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, Namespace: pr.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
+			Kind:     "Role",
 			Name:     PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -51,7 +51,7 @@ const (
 	PolicyRecommendationPolicyName = networkpolicy.TigeraComponentPolicyPrefix + PolicyRecommendationName
 
 	PolicyRecommendationTLSSecretName                                   = "policy-recommendation-tls"
-	PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName = "tigera-policy-recommendation-managed-cluster-access"
+	PolicyRecommendationMultiTenantManagedClustersAccessRoleBindingName = "tigera-policy-recommendation-managed-cluster-access"
 )
 
 // Register secret/certs that need Server and Client Key usage
@@ -235,23 +235,6 @@ func (pr *policyRecommendationComponent) clusterRoleBinding() client.Object {
 
 func (pr *policyRecommendationComponent) multiTenantManagedClustersAccess() []client.Object {
 	var objects []client.Object
-	objects = append(objects, &rbacv1.Role{
-		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, Namespace: pr.cfg.Namespace},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
-				Verbs: []string{
-					// The Authentication Proxy in Voltron checks if PolicyRecommendation (either using impersonation
-					// headers for tigera-policy-recommendation service in tigera-policy-recommendation namespace or
-					// the actual account in a single tenant setup) can get a managed clusters before sending the
-					// request down the tunnel
-					"get",
-				},
-			},
-		},
-	})
 
 	// In a single tenant setup we want to create a cluster role that binds using service account
 	// tigera-policy-recommendation from tigera-policy-recommendation namespace. In a multi-tenant setup
@@ -259,11 +242,11 @@ func (pr *policyRecommendationComponent) multiTenantManagedClustersAccess() []cl
 	// from tigera-policy-recommendation namespace
 	objects = append(objects, &rbacv1.RoleBinding{
 		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, Namespace: pr.cfg.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: PolicyRecommendationMultiTenantManagedClustersAccessRoleBindingName, Namespace: pr.cfg.Namespace},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName,
+			Kind:     "ClusterRole",
+			Name:     MultiTenantManagedClustersAccessClusterRoleName,
 		},
 		Subjects: []rbacv1.Subject{
 			// requests for policy recommendation to managed clusters are done using service account tigera-policy-recommendation

--- a/pkg/render/policyrecommendation_test.go
+++ b/pkg/render/policyrecommendation_test.go
@@ -402,7 +402,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 				{name: "allow-tigera.default-deny", ns: tenantANamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantANamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
 				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantANamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 				{name: "allow-tigera.tigera-policy-recommendation", ns: tenantANamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 				{name: "tigera-policy-recommendation", ns: tenantANamespace, group: "apps", version: "v1", kind: "Deployment"},
@@ -447,7 +446,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 				{name: "allow-tigera.default-deny", ns: tenantBNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantBNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
 				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantBNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 				{name: "allow-tigera.tigera-policy-recommendation", ns: tenantBNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 				{name: "tigera-policy-recommendation", ns: tenantBNamespace, group: "apps", version: "v1", kind: "Deployment"},
@@ -583,22 +581,12 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 					Namespace: cfg.Tenant.Namespace,
 				}))
 
-			// Check that the cluster role allows the tigera-policy-recommendation from namesapce tigera-policy-recommendation
-			// to get managed clusters in order to bypass the authentication proxy in Voltron
-			roleManagedClusters := rtest.GetResource(createdResources, render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
-			Expect(roleManagedClusters.Rules).To(ContainElements(
-				rbacv1.PolicyRule{
-					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"managedclusters"},
-					Verbs:     []string{"get"},
-				},
-			))
-			roleBindingManagedClusters := rtest.GetResource(createdResources, render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			roleBindingManagedClusters := rtest.GetResource(createdResources, render.PolicyRecommendationMultiTenantManagedClustersAccessRoleBindingName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
 			Expect(roleBindingManagedClusters.RoleRef).To(Equal(
 				rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName,
+					Kind:     "ClusterRole",
+					Name:     render.MultiTenantManagedClustersAccessClusterRoleName,
 				}))
 			Expect(roleBindingManagedClusters.Subjects).To(ConsistOf(
 				rbacv1.Subject{

--- a/pkg/render/policyrecommendation_test.go
+++ b/pkg/render/policyrecommendation_test.go
@@ -402,8 +402,8 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 				{name: "allow-tigera.default-deny", ns: tenantANamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-				{name: "tigera-policy-recommendation-managed-cluster-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-				{name: "tigera-policy-recommendation-managed-cluster-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantANamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantANamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 				{name: "allow-tigera.tigera-policy-recommendation", ns: tenantANamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 				{name: "tigera-policy-recommendation", ns: tenantANamespace, group: "apps", version: "v1", kind: "Deployment"},
 			}
@@ -447,8 +447,8 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
 				{name: "tigera-policy-recommendation", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 				{name: "allow-tigera.default-deny", ns: tenantBNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
-				{name: "tigera-policy-recommendation-managed-cluster-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-				{name: "tigera-policy-recommendation-managed-cluster-access", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
+				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantBNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "Role"},
+				{name: "tigera-policy-recommendation-managed-cluster-access", ns: tenantBNamespace, group: "rbac.authorization.k8s.io", version: "v1", kind: "RoleBinding"},
 				{name: "allow-tigera.tigera-policy-recommendation", ns: tenantBNamespace, group: "projectcalico.org", version: "v3", kind: "NetworkPolicy"},
 				{name: "tigera-policy-recommendation", ns: tenantBNamespace, group: "apps", version: "v1", kind: "Deployment"},
 			}
@@ -585,22 +585,22 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 
 			// Check that the cluster role allows the tigera-policy-recommendation from namesapce tigera-policy-recommendation
 			// to get managed clusters in order to bypass the authentication proxy in Voltron
-			clusterRoleManagedClusters := rtest.GetResource(createdResources, render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-			Expect(clusterRoleManagedClusters.Rules).To(ContainElements(
+			roleManagedClusters := rtest.GetResource(createdResources, render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "Role").(*rbacv1.Role)
+			Expect(roleManagedClusters.Rules).To(ContainElements(
 				rbacv1.PolicyRule{
 					APIGroups: []string{"projectcalico.org"},
 					Resources: []string{"managedclusters"},
 					Verbs:     []string{"get"},
 				},
 			))
-			clusterRoleManagedClustersBinding := rtest.GetResource(createdResources, render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-			Expect(clusterRoleManagedClustersBinding.RoleRef).To(Equal(
+			roleBindingManagedClusters := rtest.GetResource(createdResources, render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName, tenantANamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(roleBindingManagedClusters.RoleRef).To(Equal(
 				rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "ClusterRole",
+					Kind:     "Role",
 					Name:     render.PolicyRecommendationMultiTenantManagedClustersAccessClusterRoleName,
 				}))
-			Expect(clusterRoleManagedClustersBinding.Subjects).To(ConsistOf(
+			Expect(roleBindingManagedClusters.Subjects).To(ConsistOf(
 				rbacv1.Subject{
 					Kind:      "ServiceAccount",
 					Name:      render.PolicyRecommendationName,


### PR DESCRIPTION
…ion in Voltron

## Description

Switch ClusterRoles/ClusterRoleBindings to ClusterRole/RoleBindings to access managed clusters in a multi-tenant setup. This is needed by components that monitor and access data from the managed clusters. 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
