### PR TITLE
[release-v1.34] Auto pick #3381: Fix deadlock where terminating resources were never

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1274,6 +1274,39 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 				canRemoveCNI = false
 			}
 		}
+	} else {
+		// In some rare scenarios, we can hit a deadlock where resources have been marked with a deletion timestamp but the operator
+		// does not recognize that it must remove their finalizers. This can happen if, for example, someone manually
+		// deletes a ServiceAccount instead of deleting the Installation object. In this case, we need
+		// to allow the deletion to complete so the operator can re-create the resources. Otherwise the objects will be stuck terminating forever.
+		toCheck := render.CalicoSystemFinalizedObjects()
+		needsCleanup := []client.Object{}
+		for _, obj := range toCheck {
+			if err := r.client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
+				if !apierrors.IsNotFound(err) {
+					r.status.SetDegraded(operator.ResourceReadError, "Error querying object", err, reqLogger)
+					return reconcile.Result{}, err
+				}
+				// Not found - nothing to do.
+				continue
+			}
+			if obj.GetDeletionTimestamp() != nil {
+				// The object is marked for deletion, but the installation is not terminating. We need to remove the finalizers from this object
+				// so that it can be deleted and recreated.
+				reqLogger.Info("Object is marked for deletion but installation is not terminating",
+					"kind", obj.GetObjectKind(),
+					"name", obj.GetName(),
+					"namespace", obj.GetNamespace(),
+				)
+				obj.SetFinalizers(nil)
+				needsCleanup = append(needsCleanup, obj)
+			}
+		}
+		if len(needsCleanup) > 0 {
+			// Add a component to remove the finalizers from the objects that need it.
+			reqLogger.Info("Removing finalizers from objects that are wronly marked for deletion")
+			components = append(components, render.NewPassthrough(needsCleanup...))
+		}
 	}
 
 	// Fetch any existing default BGPConfiguration object.

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 
 	"github.com/go-logr/logr"
@@ -193,6 +194,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions) (*ReconcileInst
 		manageCRDs:           opts.ManageCRDs,
 		usePSP:               opts.UsePSP,
 		tierWatchReady:       &utils.ReadyFlag{},
+		newComponentHandler:  utils.NewComponentHandler,
 	}
 	r.status.Run(opts.ShutdownContext)
 	r.typhaAutoscaler.start(opts.ShutdownContext)
@@ -365,6 +367,9 @@ type ReconcileInstallation struct {
 	manageCRDs           bool
 	usePSP               bool
 	tierWatchReady       *utils.ReadyFlag
+
+	// newComponentHandler returns a new component handler. Useful stub for unit testing.
+	newComponentHandler func(log logr.Logger, client client.Client, scheme *runtime.Scheme, cr metav1.Object) utils.ComponentHandler
 }
 
 // getActivePools returns the full set of enabled IP pools in the cluster.
@@ -1298,7 +1303,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 					"name", obj.GetName(),
 					"namespace", obj.GetNamespace(),
 				)
-				obj.SetFinalizers(nil)
+				obj.SetFinalizers(stringsutil.RemoveStringInSlice(render.CNIFinalizer, obj.GetFinalizers()))
 				needsCleanup = append(needsCleanup, obj)
 			}
 		}
@@ -1390,7 +1395,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	}
 
 	// Create a component handler to create or update the rendered components.
-	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
+	handler := r.newComponentHandler(log, r.client, r.scheme, instance)
 	for _, component := range components {
 		if err := handler.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
 			r.status.SetDegraded(operator.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
@@ -1799,7 +1804,7 @@ func (r *ReconcileInstallation) updateCRDs(ctx context.Context, variant operator
 	crdComponent := render.NewPassthrough(crds.ToRuntimeObjects(crds.GetCRDs(variant)...)...)
 	// Specify nil for the CR so no ownership is put on the CRDs. We do this so removing the
 	// Installation CR will not remove the CRDs.
-	handler := utils.NewComponentHandler(log, r.client, r.scheme, nil)
+	handler := r.newComponentHandler(log, r.client, r.scheme, nil)
 	if err := handler.CreateOrUpdateOrDelete(ctx, crdComponent, nil); err != nil {
 		r.status.SetDegraded(operator.ResourceUpdateError, "Error creating / updating CRD resource", err, log)
 		return err

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1284,7 +1284,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		// does not recognize that it must remove their finalizers. This can happen if, for example, someone manually
 		// deletes a ServiceAccount instead of deleting the Installation object. In this case, we need
 		// to allow the deletion to complete so the operator can re-create the resources. Otherwise the objects will be stuck terminating forever.
-		toCheck := render.CalicoSystemFinalizedObjects()
+		toCheck := render.CNIPluginFinalizedObjects()
 		needsCleanup := []client.Object{}
 		for _, obj := range toCheck {
 			if err := r.client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -181,6 +181,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				enterpriseCRDsExist:  true,
 				migrationChecked:     true,
 				tierWatchReady:       ready,
+				newComponentHandler:  utils.NewComponentHandler,
 			}
 
 			r.typhaAutoscaler.start(ctx)
@@ -592,6 +593,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				migrationChecked:     true,
 				clusterDomain:        dns.DefaultClusterDomain,
 				tierWatchReady:       ready,
+				newComponentHandler:  utils.NewComponentHandler,
 			}
 			r.typhaAutoscaler.start(ctx)
 
@@ -809,6 +811,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				enterpriseCRDsExist:  true,
 				migrationChecked:     true,
 				tierWatchReady:       ready,
+				newComponentHandler:  utils.NewComponentHandler,
 			}
 
 			r.typhaAutoscaler.start(ctx)
@@ -1518,6 +1521,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				migrationChecked:     true,
 				clusterDomain:        dns.DefaultClusterDomain,
 				tierWatchReady:       ready,
+				newComponentHandler:  utils.NewComponentHandler,
 			}
 			r.typhaAutoscaler.start(ctx)
 
@@ -1578,4 +1582,170 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(secret.GetOwnerReferences()).To(HaveLen(1))
 		})
 	})
+
+	Context("with a fake component handler", func() {
+		var componentHandler *fakeComponentHandler
+
+		BeforeEach(func() {
+			// The schema contains all objects that should be known to the fake client when the test runs.
+			scheme = runtime.NewScheme()
+			Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
+			Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(schedv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			Expect(operator.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+			Expect(storagev1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+			// Create a client that will have a crud interface of k8s objects.
+			c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+			ctx, cancel = context.WithCancel(context.Background())
+
+			// Create a fake clientset for the autoscaler.
+			var replicas int32 = 1
+			objs := []runtime.Object{
+				&corev1.Node{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node1",
+						Labels: map[string]string{"kubernetes.io/os": "linux"},
+					},
+					Spec: corev1.NodeSpec{},
+				},
+				&appsv1.Deployment{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
+					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+				},
+			}
+			cs = kfake.NewSimpleClientset(objs...)
+
+			// Create an object we can use throughout the test to do the compliance reconcile loops.
+			mockStatus = &status.MockStatus{}
+			mockStatus.On("AddDaemonsets", mock.Anything).Return()
+			mockStatus.On("AddDeployments", mock.Anything).Return()
+			mockStatus.On("AddStatefulSets", mock.Anything).Return()
+			mockStatus.On("AddCronJobs", mock.Anything)
+			mockStatus.On("IsAvailable").Return(true)
+			mockStatus.On("OnCRFound").Return()
+			mockStatus.On("ClearDegraded")
+			mockStatus.On("AddCertificateSigningRequests", mock.Anything)
+			mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
+			mockStatus.On("ReadyToMonitor")
+			mockStatus.On("SetMetaData", mock.Anything).Return()
+
+			// Create the indexer and informer used by the typhaAutoscaler
+			nlw := test.NewNodeListWatch(cs)
+			nodeIndexInformer := cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
+
+			go nodeIndexInformer.Run(ctx.Done())
+			for nodeIndexInformer.HasSynced() {
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			componentHandler = newFakeComponentHandler()
+			r = ReconcileInstallation{
+				config:               nil, // there is no fake for config
+				client:               c,
+				scheme:               scheme,
+				autoDetectedProvider: operator.ProviderNone,
+				status:               mockStatus,
+				typhaAutoscaler:      newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus),
+				namespaceMigration:   &fakeNamespaceMigration{},
+				enterpriseCRDsExist:  true,
+				migrationChecked:     true,
+				tierWatchReady:       ready,
+				newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+					return componentHandler
+				},
+			}
+
+			r.typhaAutoscaler.start(ctx)
+			certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
+			Expect(err).NotTo(HaveOccurred())
+
+			prometheusTLS, err := certificateManager.GetOrCreateKeyPair(c, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace(), []string{monitor.PrometheusClientTLSSecretName})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(c.Create(ctx, prometheusTLS.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
+
+			// We start off with a 'standard' installation, with nothing special
+			Expect(c.Create(
+				ctx,
+				&operator.Installation{
+					ObjectMeta: metav1.ObjectMeta{Name: "default"},
+					Spec: operator.InstallationSpec{
+						Variant:               operator.TigeraSecureEnterprise,
+						Registry:              "some.registry.org/",
+						CertificateManagement: &operator.CertificateManagement{CACert: prometheusTLS.GetCertificatePEM()},
+					},
+					Status: operator.InstallationStatus{
+						Variant: operator.TigeraSecureEnterprise,
+						Computed: &operator.InstallationSpec{
+							Registry: "my-reg",
+							// The test is provider agnostic.
+							KubernetesProvider: operator.ProviderNone,
+						},
+					},
+				})).NotTo(HaveOccurred())
+
+			// In most clusters, the IP pool controller is responsible for creating IP pools. The Installation controller waits for this,
+			// so we need to create those pools here.
+			pool := crdv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "default-pool-v4"},
+				Spec: crdv1.IPPoolSpec{
+					CIDR:         "192.168.0.0/16",
+					NATOutgoing:  true,
+					BlockSize:    26,
+					NodeSelector: "all()",
+					VXLANMode:    crdv1.VXLANModeAlways,
+				},
+			}
+			Expect(c.Create(ctx, &pool)).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			cancel()
+		})
+
+		// This test ensures that all resources with the CNIFinalizer applied to them are also returned by
+		// render.CalicoSystemFinalizedObjects.
+		It("should have the correct number of resources with CNIFinalizer", func() {
+			// Trigger a reconcile.
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Review the resources that were created to count the resources with a CNIFinalizer set.
+			numCreated := 0
+			for _, o := range componentHandler.objectsToCreate {
+				for _, f := range o.GetFinalizers() {
+					if f == render.CNIFinalizer {
+						numCreated++
+						break
+					}
+				}
+			}
+			Expect(numCreated).To(Equal(len(render.CalicoSystemFinalizedObjects())))
+		})
+	})
 })
+
+func newFakeComponentHandler() *fakeComponentHandler {
+	return &fakeComponentHandler{
+		objectsToCreate: make([]client.Object, 0),
+		objectsToDelete: make([]client.Object, 0),
+	}
+}
+
+type fakeComponentHandler struct {
+	objectsToCreate []client.Object
+	objectsToDelete []client.Object
+}
+
+func (f *fakeComponentHandler) CreateOrUpdateOrDelete(ctx context.Context, component render.Component, _ status.StatusManager) error {
+	c, d := component.Objects()
+	f.objectsToCreate = append(f.objectsToCreate, c...)
+	f.objectsToDelete = append(f.objectsToDelete, d...)
+	return nil
+}

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1710,7 +1710,7 @@ var _ = Describe("Testing core-controller installation", func() {
 		})
 
 		// This test ensures that all resources with the CNIFinalizer applied to them are also returned by
-		// render.CalicoSystemFinalizedObjects.
+		// render.CNIPluginFinalizedObjects.
 		It("should have the correct number of resources with CNIFinalizer", func() {
 			// Trigger a reconcile.
 			_, err := r.Reconcile(ctx, reconcile.Request{})
@@ -1726,7 +1726,7 @@ var _ = Describe("Testing core-controller installation", func() {
 					}
 				}
 			}
-			Expect(numCreated).To(Equal(len(render.CalicoSystemFinalizedObjects())))
+			Expect(numCreated).To(Equal(len(render.CNIPluginFinalizedObjects())))
 		})
 	})
 })

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -254,6 +254,19 @@ func (c *nodeComponent) Ready() bool {
 	return true
 }
 
+// CalicoSystemFinalizedObjects returns a list of objects that use the CNIFinalizer that should be
+// removed only after the CNI plugin is removed.
+func CalicoSystemFinalizedObjects() []client.Object {
+	return []client.Object{
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: CalicoNodeObjectName, Namespace: common.CalicoNamespace}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: CalicoCNIPluginObjectName, Namespace: common.CalicoNamespace}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: CalicoNodeObjectName}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: CalicoCNIPluginObjectName}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: CalicoNodeObjectName}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: CalicoCNIPluginObjectName}},
+	}
+}
+
 // nodeServiceAccount creates the node's service account.
 func (c *nodeComponent) nodeServiceAccount() *corev1.ServiceAccount {
 	finalizer := []string{}

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -254,9 +254,9 @@ func (c *nodeComponent) Ready() bool {
 	return true
 }
 
-// CalicoSystemFinalizedObjects returns a list of objects that use the CNIFinalizer that should be
+// CNIPluginFinalizedObjects returns a list of objects that use the CNIFinalizer that should be
 // removed only after the CNI plugin is removed.
-func CalicoSystemFinalizedObjects() []client.Object {
+func CNIPluginFinalizedObjects() []client.Object {
 	return []client.Object{
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: CalicoNodeObjectName, Namespace: common.CalicoNamespace}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: CalicoCNIPluginObjectName, Namespace: common.CalicoNamespace}},

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -45,9 +45,11 @@ import (
 	"github.com/tigera/operator/controllers"
 	"github.com/tigera/operator/pkg/apis"
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/crds"
+	"github.com/tigera/operator/pkg/render"
 )
 
 const (
@@ -131,6 +133,32 @@ var _ = Describe("Mainline component function tests", func() {
 		}, 30*time.Second).Should(BeNil())
 
 		mgr = nil
+	})
+
+	It("should recreate resources with DeletionTimestamp set", func() {
+		// Reconcile as usual, allowing resources to be created.
+		operatorDone = createInstallation(c, mgr, shutdownContext, nil)
+		verifyCalicoHasDeployed(c)
+
+		// Delete a resource with a finalizer. This should set the DeletionTimestamp, but leave the
+		// resource in place. However, the operator should notice this an recreate the resource, thus
+		// clearing the DeletionTimestamp.
+		By("Deleting a resource with a finalizer")
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoNodeObjectName, Namespace: common.CalicoNamespace}}
+		err := c.Delete(context.Background(), sa)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the resource is recreated")
+		Eventually(func() error {
+			err := GetResource(c, sa)
+			if err != nil {
+				return err
+			}
+			if sa.DeletionTimestamp != nil {
+				return fmt.Errorf("ServiceAccount DeletionTimestamp is still set")
+			}
+			return nil
+		}, 10*time.Second).Should(BeNil())
 	})
 
 	Describe("Installing CRD", func() {


### PR DESCRIPTION
Cherry pick of #3381 on release-v1.34.

#3381: Fix deadlock where terminating resources were never

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Originally spotted in this comment: https://github.com/projectcalico/calico/issues/8368#issuecomment-2033258096

The operator only removes the CNI protector finalizers on these resources when the Installation is `Terminating`. However, in practice there are other scenarios that might result in these resources being deleted. In those cases, we should allow the deletion to complete and immmediately recreate them. Otherwise, they will be stuck terminating forever and be left in a broken state.

Fixes https://github.com/projectcalico/calico/issues/8368

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.