### PR TITLE
Port creating an MTLS client for ElasticSearch

### DIFF
--- a/pkg/controller/logstorage/elastic/elastic_controller.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller.go
@@ -680,7 +680,7 @@ func (r *ElasticSubController) checkOIDCUsersEsResource(ctx context.Context) err
 
 func (r *ElasticSubController) applyILMPolicies(ls *operatorv1.LogStorage, reqLogger logr.Logger, ctx context.Context) error {
 	// ES should be in ready phase when execution reaches here, apply ILM polices
-	esClient, err := r.esCliCreator(r.client, ctx, relasticsearch.ECKElasticEndpoint())
+	esClient, err := r.esCliCreator(r.client, ctx, relasticsearch.ECKElasticEndpoint(), false)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/logstorage/elastic/mock.go
+++ b/pkg/controller/logstorage/elastic/mock.go
@@ -30,7 +30,7 @@ type MockESClient struct {
 	mock.Mock
 }
 
-func MockESCLICreator(_ client.Client, ctx context.Context, _ string) (utils.ElasticClient, error) {
+func MockESCLICreator(_ client.Client, ctx context.Context, _ string, _ bool) (utils.ElasticClient, error) {
 	if esCli := ctx.Value(MockESClientKey("mockESClient")); esCli != nil {
 		return esCli.(*MockESClient), nil
 	}

--- a/pkg/controller/logstorage/users/users_controller.go
+++ b/pkg/controller/logstorage/users/users_controller.go
@@ -326,7 +326,7 @@ func (r *UserController) Reconcile(ctx context.Context, request reconcile.Reques
 }
 
 func (r *UserController) createUserLogin(ctx context.Context, elasticEndpoint string, secret *corev1.Secret, user *utils.User, reqLogger logr.Logger) error {
-	esClient, err := r.esClientFn(r.client, ctx, elasticEndpoint)
+	esClient, err := r.esClientFn(r.client, ctx, elasticEndpoint, r.elasticExternal)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Failed to connect to Elasticsearch - failed to create the Elasticsearch client", err, reqLogger)
 		return err
@@ -406,7 +406,7 @@ func (r *UsersCleanupController) cleanupStaleUsers(ctx context.Context, logger l
 		}
 
 		// This tenant is terminating - clean up its Linseed user, if it exists.
-		esClient, err := r.esClientFn(r.client, ctx, t.Spec.Elastic.URL)
+		esClient, err := r.esClientFn(r.client, ctx, t.Spec.Elastic.URL, r.elasticExternal)
 		if err != nil {
 			return fmt.Errorf("failed to connect to Elasticsearch - failed to create the Elasticsearch client")
 		}

--- a/pkg/controller/utils/elasticsearch.go
+++ b/pkg/controller/utils/elasticsearch.go
@@ -32,6 +32,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/logstorage"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -109,7 +110,7 @@ func GetElasticsearchClusterConfig(ctx context.Context, cli client.Client) (*rel
 	return relasticsearch.NewClusterConfigFromConfigMap(configMap)
 }
 
-type ElasticsearchClientCreator func(client client.Client, ctx context.Context, elasticHTTPSEndpoint string) (ElasticClient, error)
+type ElasticsearchClientCreator func(client client.Client, ctx context.Context, elasticHTTPSEndpoint string, external bool) (ElasticClient, error)
 
 type ElasticClient interface {
 	SetILMPolicies(context.Context, *operatorv1.LogStorage) error
@@ -122,25 +123,58 @@ type esClient struct {
 	client *elastic.Client
 }
 
-func NewElasticClient(client client.Client, ctx context.Context, elasticHTTPSEndpoint string) (ElasticClient, error) {
+func NewElasticClient(client client.Client, ctx context.Context, elasticHTTPSEndpoint string, external bool) (ElasticClient, error) {
 	user, password, root, err := getClientCredentials(client, ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// We must disable keep alive since we create a new client instead of persisting the client and reusing it.
-	// If we don't do this, the connections are, by default, kept around in an established state. If we don't do this,
-	// we end up leaking memory as the connections hold references to certs and other http resources.
-	//
-	// This is probably better than reusing the client (even though that's normally recommended) for a couple of
-	// reasons:
-	// - We should not actually be reconciling this logic often, this, for the most part, is initial setup logic. We might
-	//   want to look into how we can avoid creating Elasticsearch resources on every reconcile (possibly by hashing the
-	//   contents of what we created already and comparing that hash to what we want to create).
-	// - Reusing the client across the controllers / recreating the client only when credentials or root cert changes
-	//   could be little more difficult and possibly error-prone, leading to a regression where we leak resources again.
+	var clientCertificates []tls.Certificate
+	if external {
+		// mTLS is enabled. We need to provide a client certificate.
+		certSecret, err := GetSecret(ctx, client, logstorage.ExternalCertsSecret, common.OperatorNamespace())
+		if err != nil {
+			return nil, err
+		}
+		if certSecret == nil {
+			return nil, fmt.Errorf("mTLS is enabled but no client certificate was provided")
+		}
+		cert, err := tls.X509KeyPair(certSecret.Data["client.crt"], certSecret.Data["client.key"])
+		if err != nil {
+			return nil, err
+		}
+		clientCertificates = []tls.Certificate{cert}
+		root, err = getESRoots(ctx, client, logstorage.ExternalESPublicCertName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// If we're using mTLS, or internal ES, we need to provide a custom HTTP client.
+	tlsClientConfig := &tls.Config{}
+	if len(clientCertificates) > 0 {
+		tlsClientConfig.Certificates = clientCertificates
+	}
+	if root != nil {
+		tlsClientConfig.RootCAs = root
+	}
+
 	h := &http.Client{
-		Transport: &http.Transport{DisableKeepAlives: true, TLSClientConfig: &tls.Config{RootCAs: root}},
+		Transport: &http.Transport{
+			// We must disable keep alive since we create a new client instead of persisting the client and reusing it.
+			// If we don't do this, the connections are, by default, kept around in an established state. If we don't do this,
+			// we end up leaking memory as the connections hold references to certs and other http resources.
+			//
+			// This is probably better than reusing the client (even though that's normally recommended) for a couple of
+			// reasons:
+			// - We should not actually be reconciling this logic often, this, for the most part, is initial setup logic. We might
+			//   want to look into how we can avoid creating Elasticsearch resources on every reconcile (possibly by hashing the
+			//   contents of what we created already and comparing that hash to what we want to create).
+			// - Reusing the client across the controllers / recreating the client only when credentials or root cert changes
+			//   could be little more difficult and possibly error-prone, leading to a regression where we leak resources again.
+			DisableKeepAlives: true,
+			TLSClientConfig:   tlsClientConfig,
+		},
 	}
 
 	options := []elastic.ClientOptionFunc{
@@ -554,7 +588,7 @@ func getClientCredentials(client client.Client, ctx context.Context) (string, st
 	password := string(esSecret.Data[username])
 
 	// Determine the CA to use for validating the Elasticsearch server certificate.
-	roots, err := getESRoots(ctx, client)
+	roots, err := getESRoots(ctx, client, render.TigeraElasticsearchInternalCertSecret)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -563,7 +597,7 @@ func getClientCredentials(client client.Client, ctx context.Context) (string, st
 }
 
 // getESRoots returns the root certificates used to validate the Elasticsearch server certificate.
-func getESRoots(ctx context.Context, client client.Client) (*x509.CertPool, error) {
+func getESRoots(ctx context.Context, client client.Client, secretName string) (*x509.CertPool, error) {
 	instance := &operator.Installation{}
 	if err := client.Get(ctx, DefaultInstanceKey, instance); err != nil {
 		return nil, err
@@ -577,7 +611,7 @@ func getESRoots(ctx context.Context, client client.Client) (*x509.CertPool, erro
 	} else {
 		// Otherwise, load the CA from the Elasticsearch internal cert secret.
 		esPublicCert := &corev1.Secret{}
-		if err := client.Get(ctx, types.NamespacedName{Name: render.TigeraElasticsearchInternalCertSecret, Namespace: common.OperatorNamespace()}, esPublicCert); err != nil {
+		if err := client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: common.OperatorNamespace()}, esPublicCert); err != nil {
 			return nil, err
 		}
 		var exists bool


### PR DESCRIPTION
## Description

Port code from operator cloud to create an ElasticSearch client that used mTLS for ILM Policy creation for internal elasticsearch and user creation/deletion for multi-tenant setup.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
