### PR TITLE
CSI DaemonSet no longer uses the "default" ServiceAccount

### DIFF
--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -277,11 +277,12 @@ func (c *csiComponent) csiTemplate() corev1.PodTemplateSpec {
 		Labels: templateLabels,
 	}
 	templateSpec := corev1.PodSpec{
-		Tolerations:      c.csiTolerations(),
-		Affinity:         c.csiAffinities(),
-		Containers:       c.csiContainers(),
-		ImagePullSecrets: c.cfg.Installation.ImagePullSecrets,
-		Volumes:          c.csiVolumes(),
+		Tolerations:        c.csiTolerations(),
+		Affinity:           c.csiAffinities(),
+		Containers:         c.csiContainers(),
+		ImagePullSecrets:   c.cfg.Installation.ImagePullSecrets,
+		Volumes:            c.csiVolumes(),
+		ServiceAccountName: CSIDaemonSetName,
 	}
 
 	return corev1.PodTemplateSpec{
@@ -405,10 +406,14 @@ func (c *csiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 }
 
 func (c *csiComponent) Objects() (objsToCreate, objsToDelete []client.Object) {
-	objs := []client.Object{c.csiDriver(), c.csiDaemonset()}
+	objs := []client.Object{
+		c.csiDriver(),
+		c.csiDaemonset(),
+		c.serviceAccount(),
+	}
 
 	if c.cfg.OpenShift {
-		objs = append(objs, c.serviceAccount(), c.role(), c.roleBinding())
+		objs = append(objs, c.role(), c.roleBinding())
 	}
 
 	if c.cfg.Terminating || c.cfg.Installation.KubeletVolumePluginPath == "None" {

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -56,6 +56,7 @@ var _ = Describe("CSI rendering tests", func() {
 		}{
 			{name: "csi.tigera.io", ns: "", group: "storage", version: "v1", kind: "CSIDriver"},
 			{name: "csi-node-driver", ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
+			{name: "csi-node-driver", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 		}
 
 		comp := render.CSI(&cfg)
@@ -115,6 +116,7 @@ var _ = Describe("CSI rendering tests", func() {
 		}{
 			{name: "csi.tigera.io", ns: "", group: "storage", version: "v1", kind: "CSIDriver"},
 			{name: "csi-node-driver", ns: "calico-system", group: "apps", version: "v1", kind: "DaemonSet"},
+			{name: "csi-node-driver", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
 		}
 		comp := render.CSI(&cfg)
 		Expect(comp.ResolveImages(nil)).To(BeNil())

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -101,6 +101,7 @@ var _ = Describe("CSI rendering tests", func() {
 			&corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			}))
+		Expect(ds.Spec.Template.Spec.ServiceAccountName).To(Equal(render.CSIDaemonSetName))
 	})
 
 	It("should render properly when KubeletVolumePluginPath is set to 'None'", func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Some users have an internal requirement to not use the default serviceaccount in a
namespace. Even though we aren't binding any permissions to this, it's
simple enough to just use a unique SA for CSI.

Fixes https://github.com/projectcalico/calico/issues/8077

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.