### PR TITLE
Fix deadlock situation where two controller rely on the other to fini…

### DIFF
--- a/pkg/controller/logstorage/secrets/secret_controller.go
+++ b/pkg/controller/logstorage/secrets/secret_controller.go
@@ -521,8 +521,15 @@ func (r *SecretSubController) collectUpstreamCerts(log logr.Logger, helper utils
 		certNamespace := certs[certName]
 		cert, err := cm.GetCertificate(r.client, certName, certNamespace)
 		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, log)
-			return nil, err
+			if certificatemanager.IsCertExtKeyUsageError(err) {
+				// This secret is missing required key usages. Another controller will need to replace this secret with a
+				// new valid secret, before this controller will read and use it. The other controller may depend on this
+				// controller completing successfully. Therefore, we skip and continue.
+				log.Info(fmt.Sprintf("skipping %s/%s secret it will be added when it is updated: %s", common.OperatorNamespace(), certName, err))
+			} else {
+				r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, log)
+				return nil, err
+			}
 		} else if cert == nil {
 			msg := fmt.Sprintf("%s/%s secret not available yet, will add it if/when it becomes available", certNamespace, certName)
 			log.Info(msg)


### PR DESCRIPTION
…sh successfully.


Previously, this check existed already (<release-1.30). See https://github.com/tigera/operator/blob/release-v1.30/pkg/controller/logstorage/logstorage_controller.go#L491

When the controller was split up into multiple other controllers, this check slipped through the cracks, creating a mutual dependency between the logstorage controllers and other controllers like fluentd. If the fluentd, compliance, etc...  secret has a bad key usage, the secret controller will result in an error. Because logstorage is not ready/available, the compliance_controller won't do anything.