### PR TITLE
Ci 1558 3.18

### DIFF
--- a/pkg/controller/logstorage/secrets/secret_controller.go
+++ b/pkg/controller/logstorage/secrets/secret_controller.go
@@ -469,7 +469,7 @@ func (r *SecretSubController) collectUpstreamCerts(log logr.Logger, helper utils
 		monitor.PrometheusClientTLSSecretName: common.OperatorNamespace(),
 
 		// Get certificate for es-proxy, which Linseed and es-gateway need to trust.
-		render.ManagerTLSSecretName: helper.TruthNamespace(),
+		render.ManagerInternalTLSSecretName: helper.TruthNamespace(),
 
 		// Get certificate for fluentd, which Linseed needs to trust in a standalone or management cluster.
 		render.FluentdPrometheusTLSSecretName: common.OperatorNamespace(),

--- a/pkg/controller/logstorage/secrets/secret_controller.go
+++ b/pkg/controller/logstorage/secrets/secret_controller.go
@@ -503,8 +503,15 @@ func (r *SecretSubController) collectUpstreamCerts(log logr.Logger, helper utils
 	for certName, certNamespace := range certs {
 		cert, err := cm.GetCertificate(r.client, certName, certNamespace)
 		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, log)
-			return nil, err
+			if certificatemanager.IsCertExtKeyUsageError(err) {
+				// This secret is missing required key usages. Another controller will need to replace this secret with a
+				// new valid secret, before this controller will read and use it. The other controller may depend on this
+				// controller completing successfully. Therefore, we skip and continue.
+				log.Info(fmt.Sprintf("skipping %s/%s secret it will be added when it is updated: %s", common.OperatorNamespace(), certName, err))
+			} else {
+				r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get certificate", err, log)
+				return nil, err
+			}
 		} else if cert == nil {
 			msg := fmt.Sprintf("%s/%s secret not available yet, will add it if/when it becomes available", certNamespace, certName)
 			log.Info(msg)

--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -15,6 +15,7 @@
 package monitor
 
 import (
+	"bytes"
 	"context"
 
 	. "github.com/onsi/ginkgo"
@@ -29,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -42,16 +44,21 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls"
 )
 
 var _ = Describe("Monitor controller tests", func() {
-	var cli client.Client
-	var ctx context.Context
-	var mockStatus *status.MockStatus
-	var r ReconcileMonitor
-	var scheme *runtime.Scheme
-	var installation *operatorv1.Installation
+	var (
+		cli                client.Client
+		ctx                context.Context
+		mockStatus         *status.MockStatus
+		r                  ReconcileMonitor
+		scheme             *runtime.Scheme
+		installation       *operatorv1.Installation
+		certificateManager certificatemanager.CertificateManager
+	)
 
 	BeforeEach(func() {
 		// The schema contains all objects that should be known to the fake client when the test runs.
@@ -115,9 +122,10 @@ var _ = Describe("Monitor controller tests", func() {
 
 		// Create a certificate manager and provision the CA to unblock the controller. Generally this would be done by
 		// the cluster CA controller and is a prerequisite for the monitor controller to function.
-		cm, err := certificatemanager.Create(cli, &installation.Spec, "cluster.local", common.OperatorNamespace(), certificatemanager.AllowCACreation())
+		var err error
+		certificateManager, err = certificatemanager.Create(cli, &installation.Spec, "cluster.local", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cli.Create(ctx, cm.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+		Expect(cli.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 		// Mark that watches were successful.
 		r.prometheusReady.MarkAsReady()
@@ -153,6 +161,28 @@ var _ = Describe("Monitor controller tests", func() {
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeMonitor, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.ElasticsearchMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
+		})
+
+		It("should create Prometheus related resources even when a cert with missing key usages is configured for other components", func() {
+			By("Creating a fluentd certificate secret without all necessary usages")
+			cryptoCA, err := tls.MakeCA(rmeta.TigeraOperatorCAIssuerPrefix)
+			Expect(err).NotTo(HaveOccurred())
+			tlsCfg, err := cryptoCA.MakeServerCertForDuration(sets.NewString("test"), rmeta.DefaultCertificateDuration, tls.SetServerAuth)
+			Expect(err).NotTo(HaveOccurred())
+			keyContent, crtContent := &bytes.Buffer{}, &bytes.Buffer{}
+			Expect(tlsCfg.WriteCertConfig(crtContent, keyContent)).NotTo(HaveOccurred())
+			privateKeyPEM, certificatePEM := keyContent.Bytes(), crtContent.Bytes()
+			fluentdCert, err := certificateManager.GetOrCreateKeyPair(cli, render.FluentdPrometheusTLSSecretName, common.OperatorNamespace(), []string{""})
+			Expect(err).NotTo(HaveOccurred())
+			fluentdSecret := fluentdCert.Secret(common.OperatorNamespace())
+			fluentdSecret.Data[corev1.TLSCertKey] = certificatePEM
+			fluentdSecret.Data[corev1.TLSPrivateKeyKey] = privateKeyPEM
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r.client.Create(ctx, fluentdSecret)).NotTo(HaveOccurred())
+
+			By("reconciling the controller after a bad secret was created, we expect no problems, because bad secrets should be skipped")
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should render allow-tigera policy when tier and policy watch are ready", func() {


### PR DESCRIPTION
Previously, this check existed already (<release-1.30). See https://github.com/tigera/operator/blob/release-v1.30/pkg/controller/logstorage/logstorage_controller.go#L491

When the controller was split up into multiple other controllers, this check slipped through the cracks, creating a mutual dependency between the logstorage controllers and other controllers like fluentd. If the fluentd, compliance, etc... secret has a bad key usage, the secret controller will result in an error. Because logstorage is not ready/available, the compliance_controller won't do anything.

Secrets controller is now adding internal-manager-tls to its bundle, rather than manager-tls. The internal secret is the one that is used for component-to-component authentication, while manager-tls is used for browser-to-manager TLS.