### PR TITLE
Fix! External Elastic client should use external certificate

### DIFF
--- a/pkg/controller/utils/elasticsearch.go
+++ b/pkg/controller/utils/elasticsearch.go
@@ -591,7 +591,7 @@ func getClientCredentials(ctx context.Context, client client.Client, externalEla
 	// Determine the CA to use for validating the Elasticsearch server certificate.
 	secretName := render.TigeraElasticsearchInternalCertSecret
 	if externalElastic {
-		secretName = render.TigeraElasticsearchInternalCertSecret
+		secretName = logstorage.ExternalESPublicCertName
 	}
 	roots, err := getESRoots(ctx, client, secretName)
 	if err != nil {


### PR DESCRIPTION
## Description

Multi-tenant environments need to use external certificates to create Linseed users, while internal elastic installation need internal certificates to create ILM policies.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
