### PR TITLE
Bind all tenants service account for compliance server cluster role

### DIFF
--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -424,6 +424,15 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, nil
 	}
 
+	// Determine the namespaces to which we must bind the cluster role.
+	// For multi-tenant, the cluster role will be bind to the service account in the tenant namespace
+	// For single-tenant or zero-tenant, the cluster role will be bind to the service account in the tigera-policy-recommendation
+	// namespace
+	bindNamespaces, err := helper.TenantNamespaces(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
@@ -455,6 +464,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		ClusterDomain:               r.clusterDomain,
 		HasNoLicense:                hasNoLicense,
 		Namespace:                   helper.InstallNamespace(),
+		BindingNamespaces:           bindNamespaces,
 		Tenant:                      tenant,
 		Compliance:                  instance,
 		ExternalElastic:             r.externalElastic,

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -450,6 +450,13 @@ spec:
                   setting. \n This setting is overridden by the GOGC environment variable.
                   \n [Default: 40]"
                 type: integer
+              goMaxProcs:
+                description: "GoMaxProcs sets the maximum number of CPUs that the
+                  Go runtime will use concurrently.  A value of -1 means \"use the
+                  system default\"; typically the number of real CPUs on the system.
+                  \n this setting is overridden by the GOMAXPROCS environment variable.
+                  \n [Default: -1]"
+                type: integer
               goMemoryLimitMB:
                 description: "GoMemoryLimitMB sets a (soft) memory limit for the Go
                   runtime in MB.  The Go runtime will try to keep its memory usage

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -819,6 +819,35 @@ spec:
                   is not recommended since it doesn''t provide better performance
                   than iptables. [Default: false]'
                 type: boolean
+              goGCThreshold:
+                description: "GoGCThreshold Sets the Go runtime's garbage collection
+                  threshold.  I.e. the percentage that the heap is allowed to grow
+                  before garbage collection is triggered.  In general, doubling the
+                  value halves the CPU time spent doing GC, but it also doubles peak
+                  GC memory overhead.  A special value of -1 can be used to disable
+                  GC entirely; this should only be used in conjunction with the GoMemoryLimitMB
+                  setting. \n This setting is overridden by the GOGC environment variable.
+                  \n [Default: 40]"
+                type: integer
+              goMaxProcs:
+                description: "GoMaxProcs sets the maximum number of CPUs that the
+                  Go runtime will use concurrently.  A value of -1 means \"use the
+                  system default\"; typically the number of real CPUs on the system.
+                  \n this setting is overridden by the GOMAXPROCS environment variable.
+                  \n [Default: -1]"
+                type: integer
+              goMemoryLimitMB:
+                description: "GoMemoryLimitMB sets a (soft) memory limit for the Go
+                  runtime in MB.  The Go runtime will try to keep its memory usage
+                  under the limit by triggering GC as needed.  To avoid thrashing,
+                  it will exceed the limit if GC starts to take more than 50% of the
+                  process's CPU time.  A value of -1 disables the memory limit. \n
+                  Note that the memory limit, if used, must be considerably less than
+                  any hard resource limit set at the container or pod level.  This
+                  is because felix is not the only process that must run in the container
+                  or pod. \n This setting is overridden by the GOMEMLIMIT environment
+                  variable. \n [Default: -1]"
+                type: integer
               healthEnabled:
                 type: boolean
               healthHost:

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -108,7 +108,8 @@ type ComplianceConfiguration struct {
 	SnapshotterKeyPair certificatemanagement.KeyPairInterface
 	ControllerKeyPair  certificatemanagement.KeyPairInterface
 
-	Namespace string
+	Namespace         string
+	BindingNamespaces []string
 
 	// Whether to run the rendered components in multi-tenant, single-tenant, or zero-tenant mode
 	Tenant          *operatorv1.Tenant
@@ -843,22 +844,7 @@ func (c *complianceComponent) complianceServerManagedClusterRole() *rbacv1.Clust
 }
 
 func (c *complianceComponent) complianceServerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: ComplianceServerServiceAccount},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     ComplianceServerServiceAccount,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      ComplianceServerServiceAccount,
-				Namespace: c.cfg.Namespace,
-			},
-		},
-	}
+	return rcomponents.ClusterRoleBinding(ComplianceServerServiceAccount, ComplianceServerServiceAccount, ComplianceServerServiceAccount, c.cfg.BindingNamespaces)
 }
 
 func (c *complianceComponent) complianceServerService() *corev1.Service {


### PR DESCRIPTION
## Description

We need to bind all tenant to the cluster role compliance server in order to allow impersonation for fetching data inside the managed clusters.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
