### PR TITLE
[cherry-pick][v1.35]Bind all tenants service account for compliance server cluster role

### DIFF
--- a/pkg/controller/compliance/compliance_controller.go
+++ b/pkg/controller/compliance/compliance_controller.go
@@ -424,6 +424,15 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, nil
 	}
 
+	// Determine the namespaces to which we must bind the cluster role.
+	// For multi-tenant, the cluster role will be bind to the service account in the tenant namespace
+	// For single-tenant or zero-tenant, the cluster role will be bind to the service account in the tigera-policy-recommendation
+	// namespace
+	bindNamespaces, err := helper.TenantNamespaces(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
@@ -455,6 +464,7 @@ func (r *ReconcileCompliance) Reconcile(ctx context.Context, request reconcile.R
 		ClusterDomain:               r.clusterDomain,
 		HasNoLicense:                hasNoLicense,
 		Namespace:                   helper.InstallNamespace(),
+		BindingNamespaces:           bindNamespaces,
 		Tenant:                      tenant,
 		Compliance:                  instance,
 		ExternalElastic:             r.externalElastic,

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -108,7 +108,8 @@ type ComplianceConfiguration struct {
 	SnapshotterKeyPair certificatemanagement.KeyPairInterface
 	ControllerKeyPair  certificatemanagement.KeyPairInterface
 
-	Namespace string
+	Namespace         string
+	BindingNamespaces []string
 
 	// Whether to run the rendered components in multi-tenant, single-tenant, or zero-tenant mode
 	Tenant          *operatorv1.Tenant
@@ -843,22 +844,7 @@ func (c *complianceComponent) complianceServerManagedClusterRole() *rbacv1.Clust
 }
 
 func (c *complianceComponent) complianceServerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: ComplianceServerServiceAccount},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     ComplianceServerServiceAccount,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      ComplianceServerServiceAccount,
-				Namespace: c.cfg.Namespace,
-			},
-		},
-	}
+	return rcomponents.ClusterRoleBinding(ComplianceServerServiceAccount, ComplianceServerServiceAccount, ComplianceServerServiceAccount, c.cfg.BindingNamespaces)
 }
 
 func (c *complianceComponent) complianceServerService() *corev1.Service {


### PR DESCRIPTION
## Description

Cherry-pick https://github.com/tigera/operator/pull/3411

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
