### PR TITLE
[Pick #3424] Relax ImageSet validation (r1.35)

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1378,6 +1378,21 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
+	if imageSet == nil {
+		// There is no imageSet for the configured variant, but check to see if there are any
+		// ImageSets with a different variant so we can give the user some kind of indication
+		// to why an existing ImageSet is being ignored.
+		nvis, err := imageset.DoesNonVariantImageSetExist(ctx, r.client, instance.Spec.Variant)
+		if err != nil {
+			r.status.SetDegraded(operator.ResourceReadError, "Error checking for non-variant ImageSet", err, reqLogger)
+			return reconcile.Result{}, err
+		} else {
+			if nvis {
+				reqLogger.Info("An ImageSet exists for a different variant")
+			}
+		}
+	}
+
 	if err = imageset.ValidateImageSet(imageSet); err != nil {
 		r.status.SetDegraded(operator.ResourceValidationError, "Error validating ImageSet", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/secrets/cluster_ca_controller_test.go
+++ b/pkg/controller/secrets/cluster_ca_controller_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/components"
+	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+func NewClusterCAControllerWithShims(
+	cli client.Client,
+	scheme *runtime.Scheme,
+	clusterDomain string,
+) (*ClusterCAController, error) {
+	r := &ClusterCAController{
+		client:        cli,
+		scheme:        scheme,
+		clusterDomain: clusterDomain,
+		log:           logf.Log.WithName("controller_tenant_secrets"),
+	}
+	return r, nil
+}
+
+var _ = Describe("ClusterCA controller", func() {
+	var (
+		cli    client.Client
+		scheme *runtime.Scheme
+		ctx    context.Context
+		r      *ClusterCAController
+	)
+
+	BeforeEach(func() {
+		// Any test-specific preparation should be done in subsequen BeforeEach blocks in the Contexts below.
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(storagev1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(batchv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(admissionv1beta1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		ctx = context.Background()
+		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+
+		// Create a basic Installation.
+		install := operatorv1.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+			Status: operatorv1.InstallationStatus{
+				Computed: &operatorv1.InstallationSpec{},
+			},
+			Spec: operatorv1.InstallationSpec{
+				Variant: operatorv1.Calico,
+			},
+		}
+		Expect(cli.Create(ctx, &install)).ShouldNot(HaveOccurred())
+
+		var err error
+		r, err = NewClusterCAControllerWithShims(cli, scheme, dns.DefaultClusterDomain)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("should provision the Cluster CA", func() {
+		// Run the reconciler.
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: "tigera-operator"}})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Query for the Cluster CA which should have been created.
+		caSecret := &corev1.Secret{}
+		Expect(cli.Get(ctx, types.NamespacedName{Name: certificatemanagement.CASecretName, Namespace: common.OperatorNamespace()}, caSecret)).ShouldNot(HaveOccurred())
+		Expect(caSecret.Data).Should(HaveKey("tls.crt"))
+	})
+
+	It("should Reconcile with ImageSet", func() {
+		Expect(cli.Create(ctx, &operatorv1.ImageSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("calico-%s", components.CalicoRelease),
+			},
+			Spec: operatorv1.ImageSetSpec{
+				Images: []operatorv1.Image{
+					{
+						Image:  components.ComponentCalicoCSRInitContainer.Image,
+						Digest: "sha256:xxxxxxxxx",
+					}, {
+						Image:  components.ComponentTigeraCSRInitContainer.Image,
+						Digest: "sha256:xxxxxxxxx",
+					},
+				},
+			},
+		})).ShouldNot(HaveOccurred())
+		// Run the reconciler.
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: "tigera-operator"}})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Query for the Cluster CA which should have been created.
+		caSecret := &corev1.Secret{}
+		Expect(cli.Get(ctx, types.NamespacedName{Name: certificatemanagement.CASecretName, Namespace: common.OperatorNamespace()}, caSecret)).ShouldNot(HaveOccurred())
+		Expect(caSecret.Data).Should(HaveKey("tls.crt"))
+	})
+
+	// This test is to verify that an Overlay will be read and merged with the default
+	// Installation resource. We use the overlay to switch to enterprise mode and the
+	// fact that if we have a wrong calico ImageSet that loading the ImageSet would
+	// fail if the Installation was interpreted as Calico.
+	It("should Reconcile with Overlay", func() {
+		// Create an overlay Installation.
+		install := operatorv1.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "overlay",
+			},
+			Spec: operatorv1.InstallationSpec{
+				Variant: operatorv1.TigeraSecureEnterprise,
+			},
+		}
+		Expect(cli.Create(ctx, &install)).ShouldNot(HaveOccurred())
+		Expect(cli.Create(ctx, &operatorv1.ImageSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "calico-brokenver",
+			},
+			Spec: operatorv1.ImageSetSpec{
+				Images: []operatorv1.Image{
+					{
+						Image:  components.ComponentCalicoCSRInitContainer.Image,
+						Digest: "sha256:xxxxxxxxx",
+					}, {
+						Image:  components.ComponentTigeraCSRInitContainer.Image,
+						Digest: "sha256:xxxxxxxxx",
+					},
+				},
+			},
+		})).ShouldNot(HaveOccurred())
+		// Run the reconciler.
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: "tigera-operator"}})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Query for the Cluster CA which should have been created.
+		caSecret := &corev1.Secret{}
+		Expect(cli.Get(ctx, types.NamespacedName{Name: certificatemanagement.CASecretName, Namespace: common.OperatorNamespace()}, caSecret)).ShouldNot(HaveOccurred())
+		Expect(caSecret.Data).Should(HaveKey("tls.crt"))
+	})
+})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Only block progress when an ImageSet exists for the same variant but not one with the correct version.

These changes help ensure when a cluster using Calico is upgrade to Enterprise that an ImageSet that had been created for Calico will not block the upgrade to Enterprise.
This helps decouple the management of a Calico install that was managed by a platform where the platform added an ImageSet but the cluster had been upgraded to Enterprise, it ensures the addition of the ImageSet for Calico won't impact the already functioning Enterprise cluster that is being managed separately.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
