### PR TITLE
Add es kube controllers as containers

### DIFF
--- a/api/v1/calico_kubecontrollers_types.go
+++ b/api/v1/calico_kubecontrollers_types.go
@@ -24,8 +24,8 @@ import (
 // CalicoKubeControllersDeploymentContainer is a calico-kube-controllers Deployment container.
 type CalicoKubeControllersDeploymentContainer struct {
 	// Name is an enum which identifies the calico-kube-controllers Deployment container by name.
-	// Supported values are: calico-kube-controllers
-	// +kubebuilder:validation:Enum=calico-kube-controllers
+	// Supported values are: calico-kube-controllers, es-calico-kube-controllers
+	// +kubebuilder:validation:Enum=calico-kube-controllers;es-calico-kube-controllers
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -1220,6 +1220,10 @@ spec:
                 type: string
               nfNetlinkBufSize:
                 type: string
+              nftablesMode:
+                description: 'NFTablesMode configures nftables support in Felix. [Default:
+                  Disabled]'
+                type: string
               openstackRegion:
                 description: 'OpenstackRegion is the name of the region that a particular
                   Felix belongs to. In a multi-region Calico/OpenStack deployment,

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -918,9 +918,10 @@ spec:
                                     name:
                                       description: |-
                                         Name is an enum which identifies the calico-kube-controllers Deployment container by name.
-                                        Supported values are: calico-kube-controllers
+                                        Supported values are: calico-kube-controllers, es-calico-kube-controllers
                                       enum:
                                       - calico-kube-controllers
+                                      - es-calico-kube-controllers
                                       type: string
                                     resources:
                                       description: |-
@@ -8294,9 +8295,10 @@ spec:
                                         name:
                                           description: |-
                                             Name is an enum which identifies the calico-kube-controllers Deployment container by name.
-                                            Supported values are: calico-kube-controllers
+                                            Supported values are: calico-kube-controllers, es-calico-kube-controllers
                                           enum:
                                           - calico-kube-controllers
+                                          - es-calico-kube-controllers
                                           type: string
                                         resources:
                                           description: |-

--- a/pkg/crds/operator/operator.tigera.io_tenants.yaml
+++ b/pkg/crds/operator/operator.tigera.io_tenants.yaml
@@ -1025,9 +1025,10 @@ spec:
                                     name:
                                       description: |-
                                         Name is an enum which identifies the calico-kube-controllers Deployment container by name.
-                                        Supported values are: calico-kube-controllers
+                                        Supported values are: calico-kube-controllers, es-calico-kube-controllers
                                       enum:
                                       - calico-kube-controllers
+                                      - es-calico-kube-controllers
                                       type: string
                                     resources:
                                       description: |-


### PR DESCRIPTION
## Description

Add es-calico-kube-controllers as a valid container in order to set resources per tenant.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
