### PR TITLE
Set default values for vxlanVNI and BPFHostConntrackBypass for DockerEE

### DIFF
--- a/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
+++ b/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
@@ -342,6 +342,9 @@ type FelixConfigurationSpec struct {
 	// BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls whether Felix's
 	// embedded kube-proxy accepts EndpointSlices or not.
 	BPFKubeProxyEndpointSlicesEnabled *bool `json:"bpfKubeProxyEndpointSlicesEnabled,omitempty" validate:"omitempty"`
+	// BPFHostConntrackBypass Controls whether to bypass Linux conntrack in BPF mode for
+	// workloads and services. [Default: true - bypass Linux conntrack]
+	BPFHostConntrackBypass *bool `json:"bpfHostConntrackBypass,omitempty"`
 
 	// RouteSource configures where Felix gets its routing information.
 	// - WorkloadIPs: use workload endpoints to construct routes.

--- a/pkg/apis/crd.projectcalico.org/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/crd.projectcalico.org/v1/zz_generated.deepcopy.go
@@ -623,6 +623,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.BPFHostConntrackBypass != nil {
+		in, out := &in.BPFHostConntrackBypass, &out.BPFHostConntrackBypass
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RouteTableRange != nil {
 		in, out := &in.RouteTableRange, &out.RouteTableRange
 		*out = new(RouteTableRange)

--- a/pkg/controller/installation/bpf.go
+++ b/pkg/controller/installation/bpf.go
@@ -118,3 +118,8 @@ func bpfEnabledOnDaemonsetWithEnvVar(ds *appsv1.DaemonSet) (bool, error) {
 func bpfEnabledOnFelixConfig(fc *crdv1.FelixConfiguration) bool {
 	return fc.Spec.BPFEnabled != nil && *fc.Spec.BPFEnabled
 }
+
+func disableBPFHostConntrackBypass(fc *crdv1.FelixConfiguration) {
+	hostConntrackBypassDisabled := false
+	fc.Spec.BPFHostConntrackBypass = &hostConntrackBypassDisabled
+}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1686,13 +1686,17 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 		updated = true
 	}
 
-	vxlanPort := 4798
+	// MKE uses a vxlanVNI:4096 and vxlanPort:4789 for its docker swarm vxlan.
+	// This results in a conflict with calico's VXLAN and the vxlan.calico interface
+	// gets deleted. To fix this we change the vxlanVNI to 10000 as recommended by
+	// MKE docs (https://docs.mirantis.com/mke/3.7/cli-ref/mke-cli-install.html).
 	if install.Spec.KubernetesProvider == operator.ProviderDockerEE {
-		fc.Spec.VXLANPort = &vxlanPort
 		// Set bpfHostConntrackBypass to false for eBPF dataplane to work with MKE
 		if install.Spec.BPFEnabled() {
 			disableBPFHostConntrackBypass(fc)
 		}
+		vxlanVNI = 10000
+		fc.Spec.VXLANVNI = &vxlanVNI
 		updated = true
 	}
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1686,6 +1686,16 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 		updated = true
 	}
 
+	vxlanPort := 4798
+	if install.Spec.KubernetesProvider == operator.ProviderDockerEE {
+		fc.Spec.VXLANPort = &vxlanPort
+		// Set bpfHostConntrackBypass to false for eBPF dataplane to work with MKE
+		if install.Spec.BPFEnabled() {
+			disableBPFHostConntrackBypass(fc)
+		}
+		updated = true
+	}
+
 	if install.Spec.Variant == operator.TigeraSecureEnterprise {
 		// Some platforms need a different default setting for dnsTrustedServers, because their DNS service is not named "kube-dns".
 		dnsService := ""

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1681,23 +1681,25 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 		updated = true
 	}
 	vxlanVNI := 4096
-	if fc.Spec.VXLANVNI == nil {
-		fc.Spec.VXLANVNI = &vxlanVNI
-		updated = true
-	}
-
 	// MKE uses a vxlanVNI:4096 and vxlanPort:4789 for its docker swarm vxlan.
 	// This results in a conflict with calico's VXLAN and the vxlan.calico interface
 	// gets deleted. To fix this we change the vxlanVNI to 10000 as recommended by
 	// MKE docs (https://docs.mirantis.com/mke/3.7/cli-ref/mke-cli-install.html).
 	if install.Spec.KubernetesProvider == operator.ProviderDockerEE {
-		// Set bpfHostConntrackBypass to false for eBPF dataplane to work with MKE
-		if install.Spec.BPFEnabled() {
-			disableBPFHostConntrackBypass(fc)
-		}
 		vxlanVNI = 10000
+	}
+
+	if fc.Spec.VXLANVNI == nil {
 		fc.Spec.VXLANVNI = &vxlanVNI
 		updated = true
+	}
+
+	if install.Spec.KubernetesProvider == operator.ProviderDockerEE {
+		// Set bpfHostConntrackBypass to false for eBPF dataplane to work with MKE
+		if install.Spec.BPFEnabled() && fc.Spec.BPFHostConntrackBypass == nil {
+			disableBPFHostConntrackBypass(fc)
+			updated = true
+		}
 	}
 
 	if install.Spec.Variant == operator.TigeraSecureEnterprise {

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -922,8 +922,8 @@ var _ = Describe("Testing core-controller installation", func() {
 			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(fc.Spec.VXLANPort).NotTo(BeNil())
-			Expect(*fc.Spec.VXLANPort).To(Equal(4798))
+			Expect(fc.Spec.VXLANVNI).NotTo(BeNil())
+			Expect(*fc.Spec.VXLANVNI).To(Equal(10000))
 		})
 
 		It("should set bpfHostConntrackByPass to false when provider is DockerEE and BPF enabled", func() {

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -912,6 +912,36 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(*fc.Spec.BPFEnabled).To(BeFalse())
 		})
 
+		It("should set vxlanPort to 4798 when provider is DockerEE", func() {
+			cr.Spec.KubernetesProvider = operator.ProviderDockerEE
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &crdv1.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.VXLANPort).NotTo(BeNil())
+			Expect(*fc.Spec.VXLANPort).To(Equal(4798))
+		})
+
+		It("should set bpfHostConntrackByPass to false when provider is DockerEE and BPF enabled", func() {
+			cr.Spec.KubernetesProvider = operator.ProviderDockerEE
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &crdv1.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFHostConntrackBypass).NotTo(BeNil())
+			Expect(*fc.Spec.BPFHostConntrackBypass).To(BeFalse())
+		})
+
 		It("should set BPFEnabled to ture on FelixConfiguration if BPF is enabled on installation", func() {
 			createNodeDaemonSet()
 


### PR DESCRIPTION
## Description

1. DockerEE uses vxlanPort 4789 and this results in a conflict. Hence changing the default vxlanVNI for DockerEE to 10000.
2. When in BPF mode in DockerEE, ```BPFHostConntrackBypass``` needs to be disabled for cluster connectivity to work. 

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
