### PR TITLE
the calico-apiserver namespace frequently get stuck for a long time in terminating status when upgrading to enterprise

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -243,7 +243,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	}
 
 	// Query for the installation object.
-	variant, installationSpec, err := utils.GetInstallation(context.Background(), r.client)
+	_, installationSpec, err := utils.GetInstallation(context.Background(), r.client)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			r.status.SetDegraded(operatorv1.ResourceNotFound, "Installation not found", err, reqLogger)
@@ -252,11 +252,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying installation", err, reqLogger)
 		return reconcile.Result{}, err
 	}
-	if variant == "" {
-		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Installation to be ready", nil, reqLogger)
-		return reconcile.Result{}, nil
-	}
-	ns := rmeta.APIServerNamespace(variant)
+	ns := rmeta.APIServerNamespace(installationSpec.Variant)
 
 	certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
@@ -286,7 +282,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	var managementCluster *operatorv1.ManagementCluster
 	var managementClusterConnection *operatorv1.ManagementClusterConnection
 	includeV3NetworkPolicy := false
-	if variant == operatorv1.TigeraSecureEnterprise {
+	if installationSpec.Variant == operatorv1.TigeraSecureEnterprise {
 		managementCluster, err = utils.GetManagementCluster(ctx, r.client)
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading ManagementCluster", err, reqLogger)
@@ -408,7 +404,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		components = append(components, render.APIServerPolicy(&apiServerCfg))
 	}
 
-	if err = imageset.ApplyImageSet(ctx, r.client, variant, components...); err != nil {
+	if err = imageset.ApplyImageSet(ctx, r.client, installationSpec.Variant, components...); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -252,6 +252,10 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying installation", err, reqLogger)
 		return reconcile.Result{}, err
 	}
+	if installationSpec.Variant == "" {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Installation to be ready", nil, reqLogger)
+		return reconcile.Result{}, nil
+	}
 	ns := rmeta.APIServerNamespace(installationSpec.Variant)
 
 	certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.clusterDomain, common.OperatorNamespace())

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -253,7 +253,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		return reconcile.Result{}, err
 	}
 	if installationSpec.Variant == "" {
-		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Installation to be ready", nil, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Installation Variant to be set", nil, reqLogger)
 		return reconcile.Result{}, nil
 	}
 	ns := rmeta.APIServerNamespace(installationSpec.Variant)

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -391,8 +391,8 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	components := []render.Component{
 		component,
 		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       rmeta.APIServerNamespace(variant),
-			ServiceAccounts: []string{render.APIServerServiceAccountName(variant)},
+			Namespace:       rmeta.APIServerNamespace(installationSpec.Variant),
+			ServiceAccounts: []string{render.APIServerServiceAccountName(installationSpec.Variant)},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(tlsSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(tunnelCAKeyPair, false, true),

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -392,6 +392,7 @@ var _ = Describe("apiserver controller tests", func() {
 				provider:            operatorv1.ProviderNone,
 				enterpriseCRDsExist: false,
 				status:              mockStatus,
+				tierWatchReady:      ready,
 			}
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -378,6 +378,28 @@ var _ = Describe("apiserver controller tests", func() {
 			Expect(cli.List(ctx, &policies)).ToNot(HaveOccurred())
 			Expect(policies.Items).To(HaveLen(0))
 		})
+
+		It("should create the cert secrets in the correct namespace when migrating from calico to enterprise", func() {
+			Expect(netv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+			installation.Spec.Variant = operatorv1.TigeraSecureEnterprise
+			installation.Status.Variant = operatorv1.Calico
+			Expect(cli.Create(ctx, installation)).To(BeNil())
+			Expect(cli.Delete(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
+
+			r := ReconcileAPIServer{
+				client:              cli,
+				scheme:              scheme,
+				provider:            operatorv1.ProviderNone,
+				enterpriseCRDsExist: false,
+				status:              mockStatus,
+			}
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			certSecret := corev1.Secret{}
+			Expect(cli.Get(ctx, client.ObjectKey{Name: "tigera-apiserver-certs", Namespace: "tigera-system"}, &certSecret)).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("Reconcile for Condition status", func() {


### PR DESCRIPTION
…
## Description

The apiserver TigeraStatus error message `Error creating / updating resource: secrets "tigera-apiserver-certs" is forbidden: unable to create new content in namespace calico-apiserver because it is being terminated`  identifies the problem as the certs secret is called "calico-apiserver-certs" when it is in the "calico-apiserver" namespace, and "tigera-apiserver-certs" when in the "tigera-apiserver" namespace


```
apiVersion: operator.tigera.io/v1
kind: TigeraStatus
metadata:
    creationTimestamp: "2024-07-18T11:15:59Z"
    generation: 1
    name: apiserver
    resourceVersion: "2010"
    uid: fcdb9846-3772-4684-afe3-db458486608b
spec: {}
status:
    conditions:
        - lastTransitionTime: "2024-07-18T11:18:06Z"
          message: 'Error creating / updating resource: secrets "tigera-apiserver-certs" is forbidden: unable to create new content in namespace calico-apiserver because it is being terminated'
          observedGeneration: 1
          reason: ResourceUpdateError
          status: "True"
          type: Degraded
        - lastTransitionTime: "2024-07-18T11:17:56Z"
          observedGeneration: 1
          reason: Unknown
          status: "False"
          type: Available
        - lastTransitionTime: "2024-07-18T11:17:56Z"
          message: Deployment "tigera-system/tigera-apiserver" is not available (awaiting 2 replicas)
          observedGeneration: 1
          reason: ResourceNotReady
          status: "True"
          type: Progressing
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
