### PR TITLE
update tigera-extension-apiserver-auth-access clusterrole

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -646,6 +646,19 @@ func (c *apiServerComponent) authClusterRole() (client.Object, client.Object) {
 				"watch",
 			},
 		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"users",
+				"groups",
+				"serviceaccounts",
+			},
+			Verbs: []string{
+				"impersonate",
+			},
+		},
 	}
 
 	if c.cfg.OpenShift {


### PR DESCRIPTION
queryserver needs impersonate rbac to check if logged-in user is authorized to access resource i.e. policies, endpoints, etc.
The newly added rbac to tigera-extension-apiserver-auth-access clusterrole, allows queryserver (part of api-server pod) to request for impersonating users, groups, and serviceaccount.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
