### PR TITLE
Print image options and ImageSet utility

### DIFF
--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -22,137 +22,137 @@ import "github.com/tigera/operator/version"
 var (
 	CalicoRelease string = "{{ .Title }}"
 {{ with index .Components "calico/cni" }}
-	ComponentCalicoCNI = component{
+	ComponentCalicoCNI = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/cni" }}
-	ComponentCalicoCNIFIPS = component{
+	ComponentCalicoCNIFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/cni-windows" }}
-	ComponentCalicoCNIWindows = component{
+	ComponentCalicoCNIWindows = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "key-cert-provisioner" }}
-	ComponentCalicoCSRInitContainer = component{
+	ComponentCalicoCSRInitContainer = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/kube-controllers" }}
-	ComponentCalicoKubeControllers = component{
+	ComponentCalicoKubeControllers = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/kube-controllers" }}
-	ComponentCalicoKubeControllersFIPS = component{
+	ComponentCalicoKubeControllersFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components  "calico/node" }}
-	ComponentCalicoNode = component{
+	ComponentCalicoNode = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components  "calico/node" }}
-	ComponentCalicoNodeFIPS = component{
+	ComponentCalicoNodeFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components  "calico/node-windows" }}
-	ComponentCalicoNodeWindows = component{
+	ComponentCalicoNodeWindows = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.typha }}
-	ComponentCalicoTypha = component{
+	ComponentCalicoTypha = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.typha }}
-	ComponentCalicoTyphaFIPS = component{
+	ComponentCalicoTyphaFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.flexvol }}
-	ComponentCalicoFlexVolume = component{
+	ComponentCalicoFlexVolume = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/apiserver"}}
-	ComponentCalicoAPIServer = component{
+	ComponentCalicoAPIServer = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/apiserver"}}
-	ComponentCalicoAPIServerFIPS = component{
+	ComponentCalicoAPIServerFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/csi"}}
-	ComponentCalicoCSI = component{
+	ComponentCalicoCSI = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "calico/csi"}}
-	ComponentCalicoCSIFIPS = component{
+	ComponentCalicoCSIFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "csi-node-driver-registrar"}}
-	ComponentCalicoCSIRegistrar = component{
+	ComponentCalicoCSIRegistrar = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "csi-node-driver-registrar"}}
-	ComponentCalicoCSIRegistrarFIPS = component{
+	ComponentCalicoCSIRegistrarFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
-	ComponentOperatorInit = component{
+	ComponentOperatorInit = Component{
 		Version: version.VERSION,
 		Image:   "tigera/operator",
 	}
 
-	CalicoImages = []component{
+	CalicoImages = []Component{
 		ComponentCalicoCNI,
 		ComponentCalicoCNIFIPS,
 		ComponentCalicoCNIWindows,
@@ -165,7 +165,6 @@ var (
 		ComponentCalicoTypha,
 		ComponentCalicoTyphaFIPS,
 		ComponentCalicoFlexVolume,
-		ComponentOperatorInit,
 		ComponentCalicoAPIServer,
 		ComponentCalicoAPIServerFIPS,
 		ComponentCalicoCSI,

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -20,345 +20,345 @@ package components
 var (
 	EnterpriseRelease string = "{{ .Title }}"
 {{ with index .Components "cnx-apiserver" }}
-	ComponentAPIServer = component{
+	ComponentAPIServer = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "compliance-benchmarker" }}
-	ComponentComplianceBenchmarker = component{
+	ComponentComplianceBenchmarker = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "compliance-controller" }}
-	ComponentComplianceController = component{
+	ComponentComplianceController = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "compliance-reporter" }}
-	ComponentComplianceReporter = component{
+	ComponentComplianceReporter = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "compliance-server" }}
-	ComponentComplianceServer = component{
+	ComponentComplianceServer = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "compliance-snapshotter" }}
-	ComponentComplianceSnapshotter = component{
+	ComponentComplianceSnapshotter = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "key-cert-provisioner" }}
-	ComponentTigeraCSRInitContainer = component{
+	ComponentTigeraCSRInitContainer = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "deep-packet-inspection" }}
-	ComponentDeepPacketInspection = component{
+	ComponentDeepPacketInspection = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "eck-elasticsearch" }}
-	ComponentEckElasticsearch = component{
+	ComponentEckElasticsearch = Component{
 		Version:  "{{ .Version }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "eck-kibana" }}
-	ComponentEckKibana = component{
+	ComponentEckKibana = Component{
 		Version:  "{{ .Version }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "elastic-tsee-installer" }}
-	ComponentElasticTseeInstaller = component{
+	ComponentElasticTseeInstaller = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.elasticsearch }}
-	ComponentElasticsearch = component{
+	ComponentElasticsearch = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.elasticsearch }}
-	ComponentElasticsearchFIPS = component{
+	ComponentElasticsearchFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "eck-elasticsearch-operator" }}
-	ComponentECKElasticsearchOperator = component{
+	ComponentECKElasticsearchOperator = Component{
 		Version:  "{{ .Version }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "elasticsearch-operator" }}
-	ComponentElasticsearchOperator = component{
+	ComponentElasticsearchOperator = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "es-proxy" }}
-	ComponentEsProxy = component{
+	ComponentEsProxy = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "es-gateway" }}
-	ComponentESGateway = component{
+	ComponentESGateway = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "linseed" }}
-	ComponentLinseed = component{
+	ComponentLinseed = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.fluentd }}
-	ComponentFluentd = component{
+	ComponentFluentd = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "fluentd-windows" }}
-	ComponentFluentdWindows = component{
+	ComponentFluentdWindows = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.guardian }}
-	ComponentGuardian = component{
+	ComponentGuardian = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "intrusion-detection-controller" }}
-	ComponentIntrusionDetectionController = component{
+	ComponentIntrusionDetectionController = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "security-event-webhooks-processor" }}
-	ComponentSecurityEventWebhooksProcessor = component{
+	ComponentSecurityEventWebhooksProcessor = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.kibana }}
-	ComponentKibana = component{
+	ComponentKibana = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "cnx-manager" }}
-	ComponentManager = component{
+	ComponentManager = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "dex" }}
-	ComponentDex = component{
+	ComponentDex = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.voltron }}
-	ComponentManagerProxy = component{
+	ComponentManagerProxy = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "packetcapture" }}
-	ComponentPacketCapture = component{
+	ComponentPacketCapture = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "policy-recommendation" }}
-	ComponentPolicyRecommendation = component{
+	ComponentPolicyRecommendation = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "egress-gateway" }}
-	ComponentEgressGateway = component{
+	ComponentEgressGateway = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "l7-collector" }}
-	ComponentL7Collector = component{
+	ComponentL7Collector = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "envoy" }}
-	ComponentEnvoyProxy = component{
+	ComponentEnvoyProxy = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "dikastes" }}
-	ComponentDikastes = component{
+	ComponentDikastes = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "coreos-prometheus" }}
-	ComponentCoreOSPrometheus = component{
+	ComponentCoreOSPrometheus = Component{
 		Version:  "{{ .Version }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "prometheus" }}
-	ComponentPrometheus = component{
+	ComponentPrometheus = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "tigera-prometheus-service" }}
-	ComponentTigeraPrometheusService = component{
+	ComponentTigeraPrometheusService = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "coreos-alertmanager" }}
-	ComponentCoreOSAlertmanager = component{
+	ComponentCoreOSAlertmanager = Component{
 		Version:  "{{ .Version }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "alertmanager" }}
-	ComponentPrometheusAlertmanager = component{
+	ComponentPrometheusAlertmanager = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "cnx-queryserver" }}
-	ComponentQueryServer = component{
+	ComponentQueryServer = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "cnx-kube-controllers" }}
-	ComponentTigeraKubeControllers = component{
+	ComponentTigeraKubeControllers = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "cnx-node" }}
-	ComponentTigeraNode = component{
+	ComponentTigeraNode = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "cnx-node-windows" }}
-	ComponentTigeraNodeWindows = component{
+	ComponentTigeraNodeWindows = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with .Components.typha }}
-	ComponentTigeraTypha = component{
+	ComponentTigeraTypha = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "tigera-cni" }}
-	ComponentTigeraCNI = component{
+	ComponentTigeraCNI = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "tigera-cni" }}
-	ComponentTigeraCNIFIPS = component{
+	ComponentTigeraCNIFIPS = Component{
 		Version:  "{{ .Version }}-fips",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "tigera-cni-windows" }}
-	ComponentTigeraCNIWindows = component{
+	ComponentTigeraCNIWindows = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "elasticsearch-metrics" }}
-	ComponentElasticsearchMetrics = component{
+	ComponentElasticsearchMetrics = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "flexvol" }}
-	ComponentTigeraFlexVolume = component{
+	ComponentTigeraFlexVolume = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "csi" }}
-	ComponentTigeraCSI = component{
+	ComponentTigeraCSI = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
 {{ with index .Components "csi-node-driver-registrar" }}
-	ComponentTigeraCSINodeDriverRegistrar = component{
+	ComponentTigeraCSINodeDriverRegistrar = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",
@@ -366,7 +366,7 @@ var (
 {{- end }}
 	// Only components that correspond directly to images should be included in this list,
 	// Components that are only for providing a version should be left out of this list.
-	EnterpriseImages = []component{
+	EnterpriseImages = []Component{
 		ComponentAPIServer,
 		ComponentComplianceBenchmarker,
 		ComponentComplianceController,

--- a/main.go
+++ b/main.go
@@ -139,18 +139,24 @@ func main() {
 		os.Exit(0)
 	}
 	if printImages != "" {
+		var cmpnts []components.Component
 		if strings.ToLower(printImages) == "list" {
-			cmpnts := components.CalicoImages
+			cmpnts = components.CalicoImages
 			cmpnts = append(cmpnts, components.EnterpriseImages...)
-
-			for _, x := range cmpnts {
-				ref, _ := components.GetReference(x, "", "", "", nil)
-				fmt.Println(ref)
-			}
-			os.Exit(0)
+		} else if strings.ToLower(printImages) == "listcalico" {
+			cmpnts = components.CalicoImages
+		} else if strings.ToLower(printImages) == "listenterprise" {
+			cmpnts = components.EnterpriseImages
+		} else {
+			fmt.Println("Invalid option for --print-images flag", printImages)
+			os.Exit(1)
 		}
-		fmt.Println("Invalid option for --print-images flag", printImages)
-		os.Exit(1)
+		cmpnts = append(cmpnts, components.ComponentOperatorInit)
+		for _, x := range cmpnts {
+			ref, _ := components.GetReference(x, "", "", "", nil)
+			fmt.Println(ref)
+		}
+		os.Exit(0)
 	}
 	if printCalicoCRDs != "" {
 		if err := showCRDs(operatorv1.Calico, printCalicoCRDs); err != nil {

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -22,119 +22,119 @@ import "github.com/tigera/operator/version"
 var (
 	CalicoRelease string = "master"
 
-	ComponentCalicoCNI = component{
+	ComponentCalicoCNI = Component{
 		Version:  "master",
 		Image:    "calico/cni",
 		Registry: "",
 	}
 
-	ComponentCalicoCNIFIPS = component{
+	ComponentCalicoCNIFIPS = Component{
 		Version:  "master-fips",
 		Image:    "calico/cni",
 		Registry: "",
 	}
 
-	ComponentCalicoCNIWindows = component{
+	ComponentCalicoCNIWindows = Component{
 		Version:  "master",
 		Image:    "calico/cni-windows",
 		Registry: "",
 	}
 
-	ComponentCalicoCSRInitContainer = component{
+	ComponentCalicoCSRInitContainer = Component{
 		Version:  "master",
 		Image:    "calico/key-cert-provisioner",
 		Registry: "",
 	}
 
-	ComponentCalicoKubeControllers = component{
+	ComponentCalicoKubeControllers = Component{
 		Version:  "master",
 		Image:    "calico/kube-controllers",
 		Registry: "",
 	}
 
-	ComponentCalicoKubeControllersFIPS = component{
+	ComponentCalicoKubeControllersFIPS = Component{
 		Version:  "master-fips",
 		Image:    "calico/kube-controllers",
 		Registry: "",
 	}
 
-	ComponentCalicoNode = component{
+	ComponentCalicoNode = Component{
 		Version:  "master",
 		Image:    "calico/node",
 		Registry: "",
 	}
 
-	ComponentCalicoNodeFIPS = component{
+	ComponentCalicoNodeFIPS = Component{
 		Version:  "master-fips",
 		Image:    "calico/node",
 		Registry: "",
 	}
 
-	ComponentCalicoNodeWindows = component{
+	ComponentCalicoNodeWindows = Component{
 		Version:  "master",
 		Image:    "calico/node-windows",
 		Registry: "",
 	}
 
-	ComponentCalicoTypha = component{
+	ComponentCalicoTypha = Component{
 		Version:  "master",
 		Image:    "calico/typha",
 		Registry: "",
 	}
 
-	ComponentCalicoTyphaFIPS = component{
+	ComponentCalicoTyphaFIPS = Component{
 		Version:  "master-fips",
 		Image:    "calico/typha",
 		Registry: "",
 	}
 
-	ComponentCalicoFlexVolume = component{
+	ComponentCalicoFlexVolume = Component{
 		Version:  "master",
 		Image:    "calico/pod2daemon-flexvol",
 		Registry: "",
 	}
 
-	ComponentCalicoAPIServer = component{
+	ComponentCalicoAPIServer = Component{
 		Version:  "master",
 		Image:    "calico/apiserver",
 		Registry: "",
 	}
 
-	ComponentCalicoAPIServerFIPS = component{
+	ComponentCalicoAPIServerFIPS = Component{
 		Version:  "master-fips",
 		Image:    "calico/apiserver",
 		Registry: "",
 	}
 
-	ComponentCalicoCSI = component{
+	ComponentCalicoCSI = Component{
 		Version:  "master",
 		Image:    "calico/csi",
 		Registry: "",
 	}
 
-	ComponentCalicoCSIFIPS = component{
+	ComponentCalicoCSIFIPS = Component{
 		Version:  "master-fips",
 		Image:    "calico/csi",
 		Registry: "",
 	}
 
-	ComponentCalicoCSIRegistrar = component{
+	ComponentCalicoCSIRegistrar = Component{
 		Version:  "master",
 		Image:    "calico/node-driver-registrar",
 		Registry: "",
 	}
 
-	ComponentCalicoCSIRegistrarFIPS = component{
+	ComponentCalicoCSIRegistrarFIPS = Component{
 		Version:  "master-fips",
 		Image:    "calico/node-driver-registrar",
 		Registry: "",
 	}
-	ComponentOperatorInit = component{
+	ComponentOperatorInit = Component{
 		Version: version.VERSION,
 		Image:   "tigera/operator",
 	}
 
-	CalicoImages = []component{
+	CalicoImages = []Component{
 		ComponentCalicoCNI,
 		ComponentCalicoCNIFIPS,
 		ComponentCalicoCNIWindows,
@@ -147,7 +147,6 @@ var (
 		ComponentCalicoTypha,
 		ComponentCalicoTyphaFIPS,
 		ComponentCalicoFlexVolume,
-		ComponentOperatorInit,
 		ComponentCalicoAPIServer,
 		ComponentCalicoAPIServerFIPS,
 		ComponentCalicoCSI,

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -20,303 +20,303 @@ package components
 var (
 	EnterpriseRelease string = "master"
 
-	ComponentAPIServer = component{
+	ComponentAPIServer = Component{
 		Version:  "master",
 		Image:    "tigera/cnx-apiserver",
 		Registry: "",
 	}
 
-	ComponentComplianceBenchmarker = component{
+	ComponentComplianceBenchmarker = Component{
 		Version:  "master",
 		Image:    "tigera/compliance-benchmarker",
 		Registry: "",
 	}
 
-	ComponentComplianceController = component{
+	ComponentComplianceController = Component{
 		Version:  "master",
 		Image:    "tigera/compliance-controller",
 		Registry: "",
 	}
 
-	ComponentComplianceReporter = component{
+	ComponentComplianceReporter = Component{
 		Version:  "master",
 		Image:    "tigera/compliance-reporter",
 		Registry: "",
 	}
 
-	ComponentComplianceServer = component{
+	ComponentComplianceServer = Component{
 		Version:  "master",
 		Image:    "tigera/compliance-server",
 		Registry: "",
 	}
 
-	ComponentComplianceSnapshotter = component{
+	ComponentComplianceSnapshotter = Component{
 		Version:  "master",
 		Image:    "tigera/compliance-snapshotter",
 		Registry: "",
 	}
 
-	ComponentTigeraCSRInitContainer = component{
+	ComponentTigeraCSRInitContainer = Component{
 		Version:  "master",
 		Image:    "tigera/key-cert-provisioner",
 		Registry: "",
 	}
 
-	ComponentDeepPacketInspection = component{
+	ComponentDeepPacketInspection = Component{
 		Version:  "master",
 		Image:    "tigera/deep-packet-inspection",
 		Registry: "",
 	}
 
-	ComponentEckElasticsearch = component{
+	ComponentEckElasticsearch = Component{
 		Version:  "7.17.22",
 		Registry: "",
 	}
 
-	ComponentEckKibana = component{
+	ComponentEckKibana = Component{
 		Version:  "7.17.22",
 		Registry: "",
 	}
 
-	ComponentElasticTseeInstaller = component{
+	ComponentElasticTseeInstaller = Component{
 		Version:  "master",
 		Image:    "tigera/intrusion-detection-job-installer",
 		Registry: "",
 	}
 
-	ComponentElasticsearch = component{
+	ComponentElasticsearch = Component{
 		Version:  "master",
 		Image:    "tigera/elasticsearch",
 		Registry: "",
 	}
 
-	ComponentElasticsearchFIPS = component{
+	ComponentElasticsearchFIPS = Component{
 		Version:  "master-fips",
 		Image:    "tigera/elasticsearch",
 		Registry: "",
 	}
 
-	ComponentECKElasticsearchOperator = component{
+	ComponentECKElasticsearchOperator = Component{
 		Version:  "2.6.1",
 		Registry: "",
 	}
 
-	ComponentElasticsearchOperator = component{
+	ComponentElasticsearchOperator = Component{
 		Version:  "master",
 		Image:    "tigera/eck-operator",
 		Registry: "",
 	}
 
-	ComponentEsProxy = component{
+	ComponentEsProxy = Component{
 		Version:  "master",
 		Image:    "tigera/es-proxy",
 		Registry: "",
 	}
 
-	ComponentESGateway = component{
+	ComponentESGateway = Component{
 		Version:  "master",
 		Image:    "tigera/es-gateway",
 		Registry: "",
 	}
 
-	ComponentLinseed = component{
+	ComponentLinseed = Component{
 		Version:  "master",
 		Image:    "tigera/linseed",
 		Registry: "",
 	}
 
-	ComponentFluentd = component{
+	ComponentFluentd = Component{
 		Version:  "master",
 		Image:    "tigera/fluentd",
 		Registry: "",
 	}
 
-	ComponentFluentdWindows = component{
+	ComponentFluentdWindows = Component{
 		Version:  "master",
 		Image:    "tigera/fluentd-windows",
 		Registry: "",
 	}
 
-	ComponentGuardian = component{
+	ComponentGuardian = Component{
 		Version:  "master",
 		Image:    "tigera/guardian",
 		Registry: "",
 	}
 
-	ComponentIntrusionDetectionController = component{
+	ComponentIntrusionDetectionController = Component{
 		Version:  "master",
 		Image:    "tigera/intrusion-detection-controller",
 		Registry: "",
 	}
 
-	ComponentSecurityEventWebhooksProcessor = component{
+	ComponentSecurityEventWebhooksProcessor = Component{
 		Version:  "master",
 		Image:    "tigera/webhooks-processor",
 		Registry: "",
 	}
 
-	ComponentKibana = component{
+	ComponentKibana = Component{
 		Version:  "master",
 		Image:    "tigera/kibana",
 		Registry: "",
 	}
 
-	ComponentManager = component{
+	ComponentManager = Component{
 		Version:  "master",
 		Image:    "tigera/cnx-manager",
 		Registry: "",
 	}
 
-	ComponentDex = component{
+	ComponentDex = Component{
 		Version:  "master",
 		Image:    "tigera/dex",
 		Registry: "",
 	}
 
-	ComponentManagerProxy = component{
+	ComponentManagerProxy = Component{
 		Version:  "master",
 		Image:    "tigera/voltron",
 		Registry: "",
 	}
 
-	ComponentPacketCapture = component{
+	ComponentPacketCapture = Component{
 		Version:  "master",
 		Image:    "tigera/packetcapture",
 		Registry: "",
 	}
 
-	ComponentPolicyRecommendation = component{
+	ComponentPolicyRecommendation = Component{
 		Version:  "master",
 		Image:    "tigera/policy-recommendation",
 		Registry: "",
 	}
 
-	ComponentEgressGateway = component{
+	ComponentEgressGateway = Component{
 		Version:  "master",
 		Image:    "tigera/egress-gateway",
 		Registry: "",
 	}
 
-	ComponentL7Collector = component{
+	ComponentL7Collector = Component{
 		Version:  "master",
 		Image:    "tigera/l7-collector",
 		Registry: "",
 	}
 
-	ComponentEnvoyProxy = component{
+	ComponentEnvoyProxy = Component{
 		Version:  "master",
 		Image:    "tigera/envoy",
 		Registry: "",
 	}
 
-	ComponentDikastes = component{
+	ComponentDikastes = Component{
 		Version:  "master",
 		Image:    "tigera/dikastes",
 		Registry: "",
 	}
 
-	ComponentCoreOSPrometheus = component{
+	ComponentCoreOSPrometheus = Component{
 		Version:  "v2.48.1",
 		Registry: "",
 	}
 
-	ComponentPrometheus = component{
+	ComponentPrometheus = Component{
 		Version:  "master",
 		Image:    "tigera/prometheus",
 		Registry: "",
 	}
 
-	ComponentTigeraPrometheusService = component{
+	ComponentTigeraPrometheusService = Component{
 		Version:  "master",
 		Image:    "tigera/prometheus-service",
 		Registry: "",
 	}
 
-	ComponentCoreOSAlertmanager = component{
+	ComponentCoreOSAlertmanager = Component{
 		Version:  "v0.25.0",
 		Registry: "",
 	}
 
-	ComponentPrometheusAlertmanager = component{
+	ComponentPrometheusAlertmanager = Component{
 		Version:  "master",
 		Image:    "tigera/alertmanager",
 		Registry: "",
 	}
 
-	ComponentQueryServer = component{
+	ComponentQueryServer = Component{
 		Version:  "master",
 		Image:    "tigera/cnx-queryserver",
 		Registry: "",
 	}
 
-	ComponentTigeraKubeControllers = component{
+	ComponentTigeraKubeControllers = Component{
 		Version:  "master",
 		Image:    "tigera/kube-controllers",
 		Registry: "",
 	}
 
-	ComponentTigeraNode = component{
+	ComponentTigeraNode = Component{
 		Version:  "master",
 		Image:    "tigera/cnx-node",
 		Registry: "",
 	}
 
-	ComponentTigeraNodeWindows = component{
+	ComponentTigeraNodeWindows = Component{
 		Version:  "master",
 		Image:    "tigera/cnx-node-windows",
 		Registry: "",
 	}
 
-	ComponentTigeraTypha = component{
+	ComponentTigeraTypha = Component{
 		Version:  "master",
 		Image:    "tigera/typha",
 		Registry: "",
 	}
 
-	ComponentTigeraCNI = component{
+	ComponentTigeraCNI = Component{
 		Version:  "master",
 		Image:    "tigera/cni",
 		Registry: "",
 	}
 
-	ComponentTigeraCNIFIPS = component{
+	ComponentTigeraCNIFIPS = Component{
 		Version:  "master-fips",
 		Image:    "tigera/cni",
 		Registry: "",
 	}
 
-	ComponentTigeraCNIWindows = component{
+	ComponentTigeraCNIWindows = Component{
 		Version:  "master",
 		Image:    "tigera/cni-windows",
 		Registry: "",
 	}
 
-	ComponentElasticsearchMetrics = component{
+	ComponentElasticsearchMetrics = Component{
 		Version:  "master",
 		Image:    "tigera/elasticsearch-metrics",
 		Registry: "",
 	}
 
-	ComponentTigeraFlexVolume = component{
+	ComponentTigeraFlexVolume = Component{
 		Version:  "master",
 		Image:    "tigera/pod2daemon-flexvol",
 		Registry: "",
 	}
 
-	ComponentTigeraCSI = component{
+	ComponentTigeraCSI = Component{
 		Version:  "master",
 		Image:    "tigera/csi",
 		Registry: "",
 	}
 
-	ComponentTigeraCSINodeDriverRegistrar = component{
+	ComponentTigeraCSINodeDriverRegistrar = Component{
 		Version:  "master",
 		Image:    "tigera/node-driver-registrar",
 		Registry: "",
 	}
 	// Only components that correspond directly to images should be included in this list,
 	// Components that are only for providing a version should be left out of this list.
-	EnterpriseImages = []component{
+	EnterpriseImages = []Component{
 		ComponentAPIServer,
 		ComponentComplianceBenchmarker,
 		ComponentComplianceController,

--- a/pkg/components/images_test.go
+++ b/pkg/components/images_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Describe("test GetReference", func() {
 	Context("No registry override", func() {
 		DescribeTable("should render",
-			func(c component, registry, image string) {
+			func(c Component, registry, image string) {
 				Expect(GetReference(c, "", "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, CalicoRegistry, "calico/node"),
@@ -41,7 +41,7 @@ var _ = Describe("test GetReference", func() {
 
 	Context("UseDefault for registry and imagepath", func() {
 		DescribeTable("should render",
-			func(c component, registry, image string) {
+			func(c Component, registry, image string) {
 				ud := "UseDefault"
 				Expect(GetReference(c, ud, ud, "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
 			},
@@ -56,7 +56,7 @@ var _ = Describe("test GetReference", func() {
 
 	Context("registry override", func() {
 		DescribeTable("should render",
-			func(c component, image string) {
+			func(c Component, image string) {
 				Expect(GetReference(c, "quay.io/", "", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", "quay.io/", image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, "calico/node"),
@@ -70,7 +70,7 @@ var _ = Describe("test GetReference", func() {
 
 	Context("image prefix override", func() {
 		DescribeTable("should render",
-			func(c component, image string) {
+			func(c Component, image string) {
 				Expect(GetReference(c, "quay.io/", "", "prefix-", nil)).To(Equal(fmt.Sprintf("quay.io/%s:%s", image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, "calico/prefix-node"),
@@ -84,7 +84,7 @@ var _ = Describe("test GetReference", func() {
 
 	Context("imagepath override", func() {
 		DescribeTable("should render",
-			func(c component, registry, image string) {
+			func(c Component, registry, image string) {
 				Expect(GetReference(c, "", "userpath", "", nil)).To(Equal(fmt.Sprintf("%s%s:%s", registry, image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, CalicoRegistry, "userpath/node"),
@@ -97,7 +97,7 @@ var _ = Describe("test GetReference", func() {
 	})
 	Context("registry and imagepath override", func() {
 		DescribeTable("should render",
-			func(c component, image string) {
+			func(c Component, image string) {
 				Expect(GetReference(c, "quay.io/extra/", "userpath", "", nil)).To(Equal(fmt.Sprintf("quay.io/extra/%s:%s", image, c.Version)))
 			},
 			Entry("a calico image correctly", ComponentCalicoNode, "userpath/node"),
@@ -110,7 +110,7 @@ var _ = Describe("test GetReference", func() {
 	})
 	Context("with an ImageSet", func() {
 		DescribeTable("should render",
-			func(c component, image, hash string) {
+			func(c Component, image, hash string) {
 				is := &op.ImageSet{
 					Spec: op.ImageSetSpec{
 						Images: []op.Image{

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -20,7 +20,7 @@ import (
 	operator "github.com/tigera/operator/api/v1"
 )
 
-type component struct {
+type Component struct {
 	// Image is the full image path and name for this component (e.g., tigera/cnx-node, calico/cni)
 	Image   string
 	Version string
@@ -34,7 +34,7 @@ type component struct {
 const UseDefault = "UseDefault"
 
 // GetReference returns the fully qualified image to use, including registry and version.
-func GetReference(c component, registry, imagePath, imagePrefix string, is *operator.ImageSet) (string, error) {
+func GetReference(c Component, registry, imagePath, imagePrefix string, is *operator.ImageSet) (string, error) {
 	// If a user did not supply a registry, use the default registry
 	// based on component
 	if registry == "" || registry == UseDefault {


### PR DESCRIPTION
## Description

Added additional `--print-images` values to print only Calico or Enterprise images.
Also add makefile targets for generating ImageSets from an operator image.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
