### PR TITLE
Tenant fail to clean up because of missing connection to Elasticsearch

### DIFF
--- a/pkg/controller/logstorage/users/users_controller.go
+++ b/pkg/controller/logstorage/users/users_controller.go
@@ -357,13 +357,16 @@ func (r *UsersCleanupController) Reconcile(ctx context.Context, request reconcil
 		request.Namespace, "Request.Name", request.Name, "installNS", helper.InstallNamespace(), "truthNS", helper.TruthNamespace())
 	reqLogger.Info("Reconciling LogStorage - Cleanup")
 
-	// Wait for Elasticsearch to be installed and available.
-	elasticsearch, err := utils.GetElasticsearch(ctx, r.client)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if elasticsearch == nil || elasticsearch.Status.Phase != esv1.ElasticsearchReadyPhase {
-		return reconcile.Result{}, nil
+	if !r.elasticExternal {
+		// Wait for Elasticsearch to be installed and available.
+		elasticsearch, err := utils.GetElasticsearch(ctx, r.client)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if elasticsearch == nil || elasticsearch.Status.Phase != esv1.ElasticsearchReadyPhase {
+			reqLogger.Info("Elasticsearch is not ready")
+			return reconcile.Result{}, nil
+		}
 	}
 
 	// Clean up any stale users that may have been left behind by a previous tenant


### PR DESCRIPTION
## Description

Tenants are not being deleted because of the user controller tries to first make sure Elastic is ready. In an multi-tenant environment, we never have elastic search deployed in the same cluster.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
