### PR TITLE
Remove FIPS mode for enterprise users. It is no longer supported.

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -181,6 +181,7 @@ type InstallationSpec struct {
 	CalicoNodeWindowsDaemonSet *CalicoNodeWindowsDaemonSet `json:"calicoNodeWindowsDaemonSet,omitempty"`
 
 	// FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
+	// Only supported for Variant=Calico.
 	// Default: Disabled
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	// +optional

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -101,13 +101,6 @@ var (
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
-{{ with .Components.elasticsearch }}
-	ComponentElasticsearchFIPS = Component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
-	}
-{{- end }}
 {{ with index .Components "eck-elasticsearch-operator" }}
 	ComponentECKElasticsearchOperator = Component{
 		Version:  "{{ .Version }}",
@@ -329,13 +322,6 @@ var (
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
-{{ with index .Components "tigera-cni" }}
-	ComponentTigeraCNIFIPS = Component{
-		Version:  "{{ .Version }}-fips",
-		Image:    "{{ .Image }}",
-		Registry: "{{ .Registry }}",
-	}
-{{- end }}
 {{ with index .Components "tigera-cni-windows" }}
 	ComponentTigeraCNIWindows = Component{
 		Version:  "{{ .Version }}",
@@ -384,7 +370,6 @@ var (
 		ComponentDeepPacketInspection,
 		ComponentElasticTseeInstaller,
 		ComponentElasticsearch,
-		ComponentElasticsearchFIPS,
 		ComponentElasticsearchOperator,
 		ComponentUIAPIs,
 		ComponentFluentd,
@@ -410,7 +395,6 @@ var (
 		ComponentTigeraNodeWindows,
 		ComponentTigeraTypha,
 		ComponentTigeraCNI,
-		ComponentTigeraCNIFIPS,
 		ComponentTigeraCNIWindows,
 		ComponentElasticsearchMetrics,
 		ComponentESGateway,

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -90,12 +90,6 @@ var (
 		Registry: "",
 	}
 
-	ComponentElasticsearchFIPS = Component{
-		Version:  "master-fips",
-		Image:    "tigera/elasticsearch",
-		Registry: "",
-	}
-
 	ComponentECKElasticsearchOperator = Component{
 		Version:  "2.6.1",
 		Registry: "",
@@ -285,12 +279,6 @@ var (
 		Registry: "",
 	}
 
-	ComponentTigeraCNIFIPS = Component{
-		Version:  "master-fips",
-		Image:    "tigera/cni",
-		Registry: "",
-	}
-
 	ComponentTigeraCNIWindows = Component{
 		Version:  "master",
 		Image:    "tigera/cni-windows",
@@ -333,7 +321,6 @@ var (
 		ComponentDeepPacketInspection,
 		ComponentElasticTseeInstaller,
 		ComponentElasticsearch,
-		ComponentElasticsearchFIPS,
 		ComponentElasticsearchOperator,
 		ComponentUIAPIs,
 		ComponentFluentd,
@@ -359,7 +346,6 @@ var (
 		ComponentTigeraNodeWindows,
 		ComponentTigeraTypha,
 		ComponentTigeraCNI,
-		ComponentTigeraCNIFIPS,
 		ComponentTigeraCNIWindows,
 		ComponentElasticsearchMetrics,
 		ComponentESGateway,

--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -232,12 +232,6 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 		return reconcile.Result{}, nil
 	}
 
-	if operatorv1.IsFIPSModeEnabled(installation.FIPSMode) {
-		msg := errors.New("ApplicationLayer features cannot be used in combination with FIPSMode=Enabled")
-		r.status.SetDegraded(operatorv1.ResourceValidationError, msg.Error(), nil, reqLogger)
-		return reconcile.Result{}, nil
-	}
-
 	pullSecrets, err := utils.GetNetworkingPullSecrets(installation, r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error retrieving pull secrets", err, reqLogger)

--- a/pkg/controller/applicationlayer/applicationlayer_controller_test.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller_test.go
@@ -22,16 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
-	operatorv1 "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/apis"
-	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
-	"github.com/tigera/operator/pkg/common"
-	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/controller/status"
-	"github.com/tigera/operator/pkg/controller/utils"
-	"github.com/tigera/operator/pkg/render/applicationlayer"
-	"github.com/tigera/operator/test"
-
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -41,7 +31,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/render/applicationlayer"
+	"github.com/tigera/operator/test"
 )
 
 var _ = Describe("Application layer controller tests", func() {

--- a/pkg/controller/applicationlayer/applicationlayer_controller_test.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/tigera/operator/pkg/render/applicationlayer"
 	"github.com/tigera/operator/test"
 
-	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -41,6 +40,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 )
 
 var _ = Describe("Application layer controller tests", func() {
@@ -528,26 +529,6 @@ var _ = Describe("Application layer controller tests", func() {
 				Expect(instance.Status.Conditions[2].Message).To(Equal("Not Applicable"))
 				Expect(instance.Status.Conditions[2].ObservedGeneration).To(Equal(generation))
 			})
-		})
-		It("should not work in combination with FIPS", func() {
-			fipsEnabled := operatorv1.FIPSModeEnabled
-			installation.Spec.FIPSMode = &fipsEnabled
-			Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
-			mockStatus.On("SetDegraded", operatorv1.ResourceValidationError, "ApplicationLayer features cannot be used in combination with FIPSMode=Enabled", mock.Anything, mock.Anything).Return()
-			mockStatus.On("SetMetaData", mock.Anything).Return()
-			By("applying the ApplicationLayer CR to the fake cluster")
-			enabled := operatorv1.L7LogCollectionEnabled
-			Expect(c.Create(ctx, &operatorv1.ApplicationLayer{
-				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
-				Spec: operatorv1.ApplicationLayerSpec{
-					LogCollection: &operatorv1.LogCollectionSpec{
-						CollectLogs: &enabled,
-					},
-				},
-			})).NotTo(HaveOccurred())
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			mockStatus.AssertExpectations(GinkgoT())
 		})
 	})
 })

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -30,8 +30,8 @@ import (
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/render"
-	appsv1 "k8s.io/api/apps/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -409,6 +409,10 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 		if instance.Spec.WindowsNodes != nil {
 			return fmt.Errorf("Installation spec.WindowsNodes is not valid and should not be provided when Calico for Windows is disabled")
 		}
+	}
+
+	if operatorv1.IsFIPSModeEnabled(instance.Spec.FIPSMode) && instance.Spec.Variant == operatorv1.TigeraSecureEnterprise {
+		return fmt.Errorf("Installation spec.FIPSMode=%v combined with spec.Variant=%s is not supported", *instance.Spec.FIPSMode, instance.Spec.Variant)
 	}
 
 	return nil

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -1160,4 +1160,23 @@ var _ = Describe("Installation validation tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+	Describe("validate FIPSMode combined with Variant", func() {
+		DescribeTable("test that FIPSMode is not allowed in combination with Enterprise",
+			func(variant operator.ProductVariant, fipsMode operator.FIPSMode, expectErr bool) {
+				instance.Spec.Variant = variant
+				instance.Spec.FIPSMode = &fipsMode
+				err := validateCustomResource(instance)
+				if expectErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			},
+
+			Entry("Product: Calico FipsMode: Disabled", operator.Calico, operator.FIPSModeDisabled, false),
+			Entry("Product: Calico FipsMode: Enabled", operator.Calico, operator.FIPSModeEnabled, false),
+			Entry("Product: TigeraSecureEnterprise FipsMode: Disabled", operator.TigeraSecureEnterprise, operator.FIPSModeDisabled, false),
+			Entry("Product: TigeraSecureEnterprise FipsMode: Enabled", operator.TigeraSecureEnterprise, operator.FIPSModeEnabled, true),
+		)
+	})
 })

--- a/pkg/controller/logstorage/initializer/initializing_controller.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller.go
@@ -212,9 +212,6 @@ func (r *LogStorageInitializer) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	// Determine if Kibana is enabled for this cluster.
-	kibanaEnabled := !operatorv1.IsFIPSModeEnabled(install.FIPSMode) && !r.multiTenant
-
 	// Check if there is a management cluster connection. ManagementClusterConnection is a managed cluster only resource.
 	if err = r.client.Get(ctx, utils.DefaultTSEEInstanceKey, &operatorv1.ManagementClusterConnection{}); err == nil {
 		// LogStorage isn't valid for managed clusters.
@@ -248,7 +245,7 @@ func (r *LogStorageInitializer) Reconcile(ctx context.Context, request reconcile
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
 		return reconcile.Result{}, err
 	}
-	if kibanaEnabled {
+	if !r.multiTenant {
 		// Create the Namespace.
 		kbNamespace := render.CreateNamespace(kibana.Namespace, install.KubernetesProvider, render.PSSBaseline)
 		if err = hdler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(kbNamespace), r.status); err != nil {

--- a/pkg/controller/logstorage/initializer/initializing_controller.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller.go
@@ -245,8 +245,9 @@ func (r *LogStorageInitializer) Reconcile(ctx context.Context, request reconcile
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
 		return reconcile.Result{}, err
 	}
+
+	// Multitenant clusters do not get kibana, so namespace creation can be skipped.
 	if !r.multiTenant {
-		// Create the Namespace.
 		kbNamespace := render.CreateNamespace(kibana.Namespace, install.KubernetesProvider, render.PSSBaseline)
 		if err = hdler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(kbNamespace), r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)

--- a/pkg/controller/logstorage/secrets/secret_controller.go
+++ b/pkg/controller/logstorage/secrets/secret_controller.go
@@ -274,7 +274,7 @@ func (r *SecretSubController) Reconcile(ctx context.Context, request reconcile.R
 		// needs to include the public certificates from other Tigera components.
 
 		// Generate Elasticsearch / Kibana secrets for the tigera-elasticsearch and tigera-kibana namespaces.
-		elasticKeys, err := r.generateInternalElasticSecrets(reqLogger, !r.multiTenant, operatorSigner)
+		elasticKeys, err := r.generateInternalElasticSecrets(reqLogger, operatorSigner)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -285,6 +285,7 @@ func (r *SecretSubController) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, err
 		}
 
+		// Multitenant clusters do not get kibana, so TLS assets creation can be skipped.
 		if !r.multiTenant {
 			// Render the key pair and trusted bundle into the Kibana namespace.
 			if err = hdler.CreateOrUpdateOrDelete(ctx, elasticKeys.internalKibanaComponent(elasticKeys.trustedBundle(operatorSigner)), r.status); err != nil {
@@ -333,7 +334,7 @@ func (r *SecretSubController) Reconcile(ctx context.Context, request reconcile.R
 
 // generateInternalElasticSecrets generates key pairs for the internal ES cluster and Kibana managed by tigera-operator via ECK
 // when configured to use an internal ES.
-func (r *SecretSubController) generateInternalElasticSecrets(log logr.Logger, kibanaEnabled bool, cm certificatemanager.CertificateManager) (*elasticKeyPairCollection, error) {
+func (r *SecretSubController) generateInternalElasticSecrets(log logr.Logger, cm certificatemanager.CertificateManager) (*elasticKeyPairCollection, error) {
 	collection := elasticKeyPairCollection{log: log}
 
 	// Generate a keypair for elasticsearch.
@@ -350,7 +351,8 @@ func (r *SecretSubController) generateInternalElasticSecrets(log logr.Logger, ki
 	}
 	collection.elastic = elasticKeyPair
 
-	if kibanaEnabled {
+	// Multitenant clusters do not get kibana, so TLS assets creation can be skipped.
+	if !r.multiTenant {
 		// Generate a keypair for Kibana.
 		//
 		// This fetches the existing key pair from the tigera-operator namespace if it exists, or generates a new one in-memory otherwise.

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -401,7 +401,6 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	// This bundle contains the root CA used to sign all operator-generated certificates, as well as the explicitly named
 	// certificates, in case the user has provided their own cert in lieu of the default certificate.
 
-	var clusterConfig *relasticsearch.ClusterConfig
 	var trustedSecretNames []string
 	if !r.multiTenant {
 		// For multi-tenant systems, we don't support user-provided certs for all components. So, we don't need to include these,
@@ -451,17 +450,6 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 			}
 			trustedSecretNames = append(trustedSecretNames, render.ComplianceServerCertSecret)
 		}
-
-		clusterConfig, err = utils.GetElasticsearchClusterConfig(context.Background(), r.client)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				r.status.SetDegraded(operatorv1.ResourceNotFound, "Elasticsearch cluster configuration is not available, waiting for it to become available", err, logc)
-				return reconcile.Result{}, nil
-			}
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to get the elasticsearch cluster configuration", err, logc)
-			return reconcile.Result{}, err
-		}
-		trustedSecretNames = append(trustedSecretNames, render.TigeraKibanaCertSecret)
 	}
 
 	var authenticationCR *operatorv1.Authentication

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -6264,6 +6264,7 @@ spec:
               fipsMode:
                 description: |-
                   FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
+                  Only supported for Variant=Calico.
                   Default: Disabled
                 enum:
                 - Enabled
@@ -14444,6 +14445,7 @@ spec:
                   fipsMode:
                     description: |-
                       FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
+                      Only supported for Variant=Calico.
                       Default: Disabled
                     enum:
                     - Enabled

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1231,7 +1231,6 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		{Name: "LISTEN_ADDR", Value: fmt.Sprintf(":%d", QueryServerPort)},
 		{Name: "TLS_CERT", Value: fmt.Sprintf("/%s/tls.crt", ProjectCalicoAPIServerTLSSecretName(c.cfg.Installation.Variant))},
 		{Name: "TLS_KEY", Value: fmt.Sprintf("/%s/tls.key", ProjectCalicoAPIServerTLSSecretName(c.cfg.Installation.Variant))},
-		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 	}
 	if c.cfg.TrustedBundle != nil {
 		env = append(env, corev1.EnvVar{Name: "TRUSTED_BUNDLE_PATH", Value: c.cfg.TrustedBundle.MountPath()})

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -276,8 +276,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		Expect(d.Spec.Template.Spec.Containers[1].Env[4].Name).To(Equal("TLS_KEY"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[4].Value).To(Equal("/tigera-apiserver-certs/tls.key"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[4].ValueFrom).To(BeNil())
-		Expect(d.Spec.Template.Spec.Containers[1].Env[5].Name).To(Equal("FIPS_MODE_ENABLED"))
-		Expect(d.Spec.Template.Spec.Containers[1].Env[5].Value).To(Equal("false"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[6].Name).To(Equal("TRUSTED_BUNDLE_PATH"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[6].Value).To(Equal("/etc/pki/tls/certs/tigera-ca-bundle.crt"))
 
@@ -365,17 +363,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Verbs:         []string{"use"},
 			ResourceNames: []string{"privileged"},
 		}))
-	})
-
-	It("should render the env variable for queryserver when FIPS is enabled", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		cfg.Installation.FIPSMode = &fipsEnabled
-		component, err := render.APIServer(cfg)
-		Expect(err).NotTo(HaveOccurred())
-		resources, _ := component.Objects()
-		d := rtest.GetResource(resources, "tigera-apiserver", "tigera-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(d.Spec.Template.Spec.Containers[1].Name).To(Equal("tigera-queryserver"))
-		Expect(d.Spec.Template.Spec.Containers[1].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
 	})
 
 	It("should render an API server with custom configuration", func() {

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -260,7 +260,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		))
 		Expect(d.Spec.Template.Spec.Containers[1].Args).To(BeEmpty())
 
-		Expect(d.Spec.Template.Spec.Containers[1].Env).To(HaveLen(7))
+		Expect(d.Spec.Template.Spec.Containers[1].Env).To(HaveLen(6))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[0].Name).To(Equal("LOGLEVEL"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[0].Value).To(Equal("info"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[0].ValueFrom).To(BeNil())
@@ -276,8 +276,8 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		Expect(d.Spec.Template.Spec.Containers[1].Env[4].Name).To(Equal("TLS_KEY"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[4].Value).To(Equal("/tigera-apiserver-certs/tls.key"))
 		Expect(d.Spec.Template.Spec.Containers[1].Env[4].ValueFrom).To(BeNil())
-		Expect(d.Spec.Template.Spec.Containers[1].Env[6].Name).To(Equal("TRUSTED_BUNDLE_PATH"))
-		Expect(d.Spec.Template.Spec.Containers[1].Env[6].Value).To(Equal("/etc/pki/tls/certs/tigera-ca-bundle.crt"))
+		Expect(d.Spec.Template.Spec.Containers[1].Env[5].Name).To(Equal("TRUSTED_BUNDLE_PATH"))
+		Expect(d.Spec.Template.Spec.Containers[1].Env[5].Value).To(Equal("/etc/pki/tls/certs/tigera-ca-bundle.crt"))
 
 		// Expect the SECURITY_GROUP env variables to not be set
 		Expect(d.Spec.Template.Spec.Containers[1].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_DEFAULT_SECURITY_GROUPS")})))

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -836,7 +836,6 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 		{Name: "LOG_LEVEL", Value: "info"},
 		{Name: "TIGERA_COMPLIANCE_JOB_NAMESPACE", Value: c.cfg.Namespace},
 		{Name: "MULTI_CLUSTER_FORWARDING_CA", Value: certificatemanagement.TrustedCertBundleMountPath},
-		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
 		{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(c.cfg.ManagementClusterConnection != nil)},

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -160,17 +160,6 @@ var _ = Describe("compliance rendering tests", func() {
 		}))
 	})
 
-	It("should render the env variable for queryserver when FIPS is enabled", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		cfg.Installation.FIPSMode = &fipsEnabled
-		component, err := render.Compliance(cfg)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(component.ResolveImages(nil)).To(BeNil())
-		resources, _ := component.Objects()
-		d := rtest.GetResource(resources, "compliance-server", ns, "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
-	})
-
 	It("should render resource requests and limits for compliance components", func() {
 		cfg.Compliance = &operatorv1.Compliance{
 			Spec: operatorv1.ComplianceSpec{

--- a/pkg/render/crypto_utils.go
+++ b/pkg/render/crypto_utils.go
@@ -15,10 +15,11 @@
 package render
 
 import (
-	"github.com/tigera/operator/pkg/common"
-	calicrypto "github.com/tigera/operator/pkg/crypto"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tigera/operator/pkg/common"
+	calicrypto "github.com/tigera/operator/pkg/crypto"
 )
 
 func CreateDexClientSecret() *corev1.Secret {
@@ -30,20 +31,6 @@ func CreateDexClientSecret() *corev1.Secret {
 		},
 		Data: map[string][]byte{
 			ClientSecretSecretField: []byte(calicrypto.GeneratePassword(24)),
-		},
-	}
-}
-
-// CreateElasticsearchKeystoreSecret creates a secret to be used for initializing the keystore on Elasticsearch.
-func CreateElasticsearchKeystoreSecret() *corev1.Secret {
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ElasticsearchKeystoreSecret,
-			Namespace: common.OperatorNamespace(),
-		},
-		Data: map[string][]byte{
-			ElasticsearchKeystoreEnvName: []byte(calicrypto.GeneratePassword(24)),
 		},
 	}
 }

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -254,11 +254,7 @@ func (c *dexComponent) deployment() client.Object {
 							Name:            DexObjectName,
 							Image:           c.image,
 							ImagePullPolicy: ImagePullPolicy(),
-							Env: append(
-								[]corev1.EnvVar{
-									{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
-								},
-								c.cfg.DexConfig.RequiredEnv("")...),
+							Env:             c.cfg.DexConfig.RequiredEnv(""),
 							LivenessProbe:   c.probe(),
 							SecurityContext: securitycontext.NewNonRootContext(),
 

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -33,6 +33,7 @@ import (
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
 	"github.com/tigera/api/pkg/lib/numorstring"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	rcomponents "github.com/tigera/operator/pkg/render/common/components"
@@ -320,7 +321,6 @@ func (c *GuardianComponent) container() []corev1.Container {
 				{Name: "GUARDIAN_PACKET_CAPTURE_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
 				{Name: "GUARDIAN_PROMETHEUS_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
 				{Name: "GUARDIAN_QUERYSERVER_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
-				{Name: "GUARDIAN_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 			},
 			VolumeMounts: c.volumeMounts(),
 			LivenessProbe: &corev1.Probe{

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -670,10 +670,6 @@ func (c *intrusionDetectionComponent) intrusionDetectionControllerContainer() co
 			Value: c.cfg.TrustedCertBundle.MountPath(),
 		},
 		{
-			Name:  "FIPS_MODE_ENABLED",
-			Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode),
-		},
-		{
 			Name:  "LINSEED_URL",
 			Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant)),
 		},

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -144,7 +144,6 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		Expect(idc.Spec.Template.Spec.Containers).To(HaveLen(2))
 		idcExpectedEnvVars := []corev1.EnvVar{
 			{Name: "MULTI_CLUSTER_FORWARDING_CA", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 			{Name: "LINSEED_URL", Value: "https://tigera-linseed.tigera-elasticsearch.svc"},
 			{Name: "LINSEED_CA", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
 			{Name: "LINSEED_CLIENT_CERT", Value: "/intrusion-detection-tls/tls.crt"},
@@ -491,112 +490,6 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			Entry("for managed, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: true, OpenShift: false}),
 			Entry("for managed, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: true, OpenShift: true}),
 		)
-	})
-
-	It("should not render es-job installer when FIPS mode is enabled", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		testADStorageClassName := "test-storage-class-name"
-		cfg.Installation.FIPSMode = &fipsEnabled
-		cfg.IntrusionDetection = &operatorv1.IntrusionDetection{
-			Spec: operatorv1.IntrusionDetectionSpec{
-				AnomalyDetection: operatorv1.AnomalyDetectionSpec{
-					StorageClassName: testADStorageClassName,
-				},
-			},
-		}
-		component := render.IntrusionDetection(cfg)
-		toCreate, toRemove := component.Objects()
-
-		expected := []client.Object{
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: "tigera-intrusion-detection"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller"}},
-			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
-			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.pod"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.globalnetworkpolicy"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.globalnetworkset"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.serviceaccount"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "network.cloudapi"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "network.ssh"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "network.lateral.access"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "network.lateral.originate"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "dns.servfail"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "dns.dos"}},
-		}
-		rtest.ExpectResources(toCreate, expected)
-
-		// Check that GlobalAlertTemplates are populated
-		for i, res := range toCreate {
-			switch res.(type) {
-			case *v3.GlobalAlertTemplate:
-				rtest.ExpectGlobalAlertTemplateToBePopulated(toCreate[i])
-			}
-		}
-
-		expectedDeletes := []client.Object{
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.dga"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.dga"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.http-connection-spike"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.http-connection-spike"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.http-response-codes"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.http-response-codes"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.http-verbs"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.http-verbs"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.port-scan"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.port-scan"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.generic-dns"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.generic-dns"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.generic-flows"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.generic-flows"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.multivariable-flow"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.multivariable-flow"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.generic-l7"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.generic-l7"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.dns-latency"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.dns-latency"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.dns-tunnel"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.dns-tunnel"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.l7-bytes"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.l7-bytes"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.l7-latency"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.l7-latency"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.bytes-in"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.bytes-in"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.bytes-out"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.bytes-out"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.process-bytes"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.process-bytes"}},
-			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.process-restarts"}},
-			&v3.GlobalAlert{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detector.process-restarts"}},
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.anomaly-detection-api", Namespace: "tigera-intrusion-detection"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detection-api", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detection-api"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detection-api"}},
-			&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "tigera-anomaly-detection", Namespace: "tigera-intrusion-detection"}},
-			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detection-api", Namespace: "tigera-intrusion-detection"}},
-			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detection-api", Namespace: "tigera-intrusion-detection"}},
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.anomaly-detectors", Namespace: "tigera-intrusion-detection"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detectors", Namespace: "tigera-intrusion-detection"}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detectors", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detectors", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detectors"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detectors", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "anomaly-detectors"}},
-			&corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detectors.training", Namespace: "tigera-intrusion-detection"}},
-			&corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tigera.io.detectors.detection", Namespace: "tigera-intrusion-detection"}},
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.intrusion-detection-elastic", Namespace: "tigera-intrusion-detection"}},
-			&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-es-job-installer", Namespace: "tigera-intrusion-detection"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-es-job-installer", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-psp"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-psp"}},
-		}
-
-		rtest.ExpectResources(toRemove, expectedDeletes)
 	})
 
 	It("should render an init container for pods when certificate management is enabled", func() {

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -24,6 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -315,7 +318,6 @@ func (d *dpiComponent) dpiEnvVars() []corev1.EnvVar {
 		{Name: "LINSEED_CLIENT_CERT", Value: d.cfg.DPICertSecret.VolumeMountCertificateFilePath()},
 		{Name: "LINSEED_CLIENT_KEY", Value: d.cfg.DPICertSecret.VolumeMountKeyFilePath()},
 		{Name: "LINSEED_TOKEN", Value: render.GetLinseedTokenPath(d.cfg.ManagedCluster)},
-		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(d.cfg.Installation.FIPSMode)},
 	}
 
 	// We need at least the CN or URISAN set, we depend on the validation

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -24,9 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	"github.com/tigera/operator/pkg/tls/certificatemanagement"
-
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
 	operatorv1 "github.com/tigera/operator/api/v1"

--- a/pkg/render/intrusiondetection/dpi/dpi_test.go
+++ b/pkg/render/intrusiondetection/dpi/dpi_test.go
@@ -253,7 +253,6 @@ var _ = Describe("DPI rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
 			corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: "/deep-packet-inspection-tls/tls.crt"},
 			corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: "/deep-packet-inspection-tls/tls.key"},
-			corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "false"},
 			corev1.EnvVar{Name: "LINSEED_TOKEN", Value: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
 		))
 		Expect(len(ds.Spec.Template.Spec.Containers)).Should(Equal(1))
@@ -299,7 +298,6 @@ var _ = Describe("DPI rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
 			corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: "/deep-packet-inspection-tls/tls.crt"},
 			corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: "/deep-packet-inspection-tls/tls.key"},
-			corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "false"},
 			corev1.EnvVar{Name: "LINSEED_TOKEN", Value: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
 		))
 		Expect(len(ds.Spec.Template.Spec.Containers)).Should(Equal(1))
@@ -344,7 +342,6 @@ var _ = Describe("DPI rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
 			corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: "/deep-packet-inspection-tls/tls.crt"},
 			corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: "/deep-packet-inspection-tls/tls.key"},
-			corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "false"},
 			corev1.EnvVar{Name: "LINSEED_TOKEN", Value: render.LinseedTokenPath},
 		))
 		Expect(len(ds.Spec.Template.Spec.Containers)).Should(Equal(1))

--- a/pkg/render/intrusiondetection/dpi/dpi_test.go
+++ b/pkg/render/intrusiondetection/dpi/dpi_test.go
@@ -666,7 +666,6 @@ var _ = Describe("DPI rendering tests", func() {
 			Expect(ds.Spec.Template.Spec.Containers[0].Env).Should(ContainElements(
 				corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: "/deep-packet-inspection-tls/tls.crt"},
 				corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: "/deep-packet-inspection-tls/tls.key"},
-				corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "false"},
 				corev1.EnvVar{Name: "LINSEED_TOKEN", Value: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
 			))
 			Expect(len(ds.Spec.Template.Spec.Containers)).Should(Equal(1))

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -523,7 +523,6 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		{Name: "KUBE_CONTROLLERS_CONFIG_NAME", Value: c.kubeControllerConfigName},
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 		{Name: "ENABLED_CONTROLLERS", Value: strings.Join(c.enabledControllers, ",")},
-		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "DISABLE_KUBE_CONTROLLERS_CONFIG_API", Value: strconv.FormatBool(c.cfg.Tenant.MultiTenant() && c.kubeControllerConfigName == "elasticsearch")},
 	}
 

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -188,7 +188,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "ENABLED_CONTROLLERS", Value: "node"},
 			{Name: "KUBE_CONTROLLERS_CONFIG_NAME", Value: "default"},
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 			{Name: "DISABLE_KUBE_CONTROLLERS_CONFIG_API", Value: "false"},
 		}
 		Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedEnv))

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -120,7 +120,7 @@ func (d *dashboards) ResolveImages(is *operatorv1.ImageSet) error {
 }
 
 func (d *dashboards) Objects() (objsToCreate, objsToDelete []client.Object) {
-	if d.cfg.IsManaged || operatorv1.IsFIPSModeEnabled(d.cfg.Installation.FIPSMode) {
+	if d.cfg.IsManaged {
 		return nil, d.resources()
 	}
 

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -221,10 +221,6 @@ func (d *dashboards) Job() *batchv1.Job {
 			Name:  "KB_CA_CERT",
 			Value: d.cfg.TrustedBundle.MountPath(),
 		},
-		{
-			Name:  "FIPS_MODE_ENABLED",
-			Value: operatorv1.IsFIPSModeEnabledString(d.cfg.Installation.FIPSMode),
-		},
 		relasticsearch.ElasticUserEnvVar(ElasticCredentialsSecret),
 		relasticsearch.ElasticPasswordEnvVar(ElasticCredentialsSecret),
 	}

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -179,27 +179,6 @@ var _ = Describe("Dashboards rendering tests", func() {
 				Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, OpenShift: true}),
 			)
 		})
-
-		It("should not render when FIPS mode is enabled", func() {
-			bundle := getBundle(installation)
-			enabled := operatorv1.FIPSModeEnabled
-			installation.FIPSMode = &enabled
-			component := Dashboards(&Config{
-				Installation: installation,
-				PullSecrets: []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				TrustedBundle: bundle,
-				Namespace:     render.ElasticsearchNamespace,
-				KibanaHost:    "tigera-secure-kb-http.tigera-kibana.tigera-kibana.svc",
-				KibanaScheme:  "htpps",
-				KibanaPort:    5601,
-			})
-
-			resources, _ := component.Objects()
-			_, ok := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
-			Expect(ok).To(BeFalse(), "Jobs not found")
-		})
 	})
 
 	Context("multi-tenant rendering", func() {

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -669,10 +669,6 @@ func expectedContainers() []corev1.Container {
 					Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt",
 				},
 				{
-					Name:  "FIPS_MODE_ENABLED",
-					Value: "false",
-				},
-				{
 					Name:  "ELASTIC_USER",
 					Value: "",
 					ValueFrom: &corev1.EnvVarSource{

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -205,7 +205,6 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 				Key: e.cfg.EsAdminUserName,
 			},
 		}},
-		{Name: "ES_GATEWAY_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(e.cfg.Installation.FIPSMode)},
 	}
 
 	var initContainers []corev1.Container

--- a/pkg/render/logstorage/esgateway/esgateway_test.go
+++ b/pkg/render/logstorage/esgateway/esgateway_test.go
@@ -236,33 +236,6 @@ var _ = Describe("ES Gateway rendering tests", func() {
 				Entry("for management/standalone, openshift-dns", testutils.AllowTigeraScenario{ManagedCluster: false, OpenShift: true}),
 			)
 		})
-		It("should set the right env when FIPS mode is enabled", func() {
-			kp, bundle := getTLS(installation)
-			enabled := operatorv1.FIPSModeEnabled
-			installation.FIPSMode = &enabled
-			component := EsGateway(&Config{
-				Installation: installation,
-				PullSecrets: []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				ESGatewayKeyPair: kp,
-				TrustedBundle:    bundle,
-				KubeControllersUserSecrets: []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersUserSecret, Namespace: common.OperatorNamespace()}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersVerificationUserSecret, Namespace: render.ElasticsearchNamespace}},
-					{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.ElasticsearchKubeControllersSecureUserSecret, Namespace: render.ElasticsearchNamespace}},
-				},
-				ClusterDomain:   clusterDomain,
-				EsAdminUserName: "elastic",
-				Namespace:       render.ElasticsearchNamespace,
-				TruthNamespace:  common.OperatorNamespace(),
-			})
-
-			resources, _ := component.Objects()
-			d, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
-			Expect(ok).To(BeTrue())
-			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "ES_GATEWAY_FIPS_MODE_ENABLED", Value: "true"}))
-		})
 	})
 })
 

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -239,7 +239,6 @@ func (e elasticsearchMetrics) metricsDeployment() *appsv1.Deployment {
 								e.cfg.ServerTLS.VolumeMount(e.SupportedOSType()),
 							),
 							Env: []corev1.EnvVar{
-								{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(e.cfg.Installation.FIPSMode)},
 								relasticsearch.ElasticUsernameEnvVar(ElasticsearchMetricsSecret),
 								relasticsearch.ElasticPasswordEnvVar(ElasticsearchMetricsSecret),
 								relasticsearch.ElasticHostEnvVar(esHost),

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/tls"
@@ -176,7 +177,6 @@ var _ = Describe("Elasticsearch metrics", func() {
 									"--ca.crt=/etc/pki/tls/certs/tigera-ca-bundle.crt",
 								},
 								Env: []corev1.EnvVar{
-									{Name: "FIPS_MODE_ENABLED", Value: "false"},
 									{
 										Name: "ELASTIC_USERNAME",
 										ValueFrom: &corev1.EnvVarSource{

--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -70,11 +70,6 @@ var (
 
 // Kibana renders the components necessary for kibana and elasticsearch
 func Kibana(cfg *Configuration) render.Component {
-	if cfg.Enabled && operatorv1.IsFIPSModeEnabled(cfg.Installation.FIPSMode) {
-		// This branch should only be hit if there is a coding bug in the controller, as Enabled
-		// should already take into account FIPS.
-		panic("BUG: Kibana is not supported in FIPS mode")
-	}
 	return &kibana{
 		cfg: cfg,
 	}

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -287,7 +287,6 @@ func (l *linseed) multiTenantManagedClustersAccess() []client.Object {
 func (l *linseed) linseedDeployment() *appsv1.Deployment {
 	envVars := []corev1.EnvVar{
 		{Name: "LINSEED_LOG_LEVEL", Value: "INFO"},
-		{Name: "LINSEED_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(l.cfg.Installation.FIPSMode)},
 
 		// Configure Linseed server certificate.
 		{Name: "LINSEED_HTTPS_CERT", Value: l.cfg.KeyPair.VolumeMountCertificateFilePath()},

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -395,32 +395,6 @@ var _ = Describe("Linseed rendering tests", func() {
 				Entry("for management/standalone, openshift-dns with dpi", testutils.AllowTigeraScenario{ManagedCluster: false, OpenShift: true, DPIEnabled: true}),
 			)
 		})
-
-		It("should set the right env when FIPS mode is enabled", func() {
-			kp, tokenKP, bundle := getTLS(installation)
-			enabled := operatorv1.FIPSModeEnabled
-			installation.FIPSMode = &enabled
-			component := Linseed(&Config{
-				Installation: installation,
-				PullSecrets: []*corev1.Secret{
-					{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret"}},
-				},
-				KeyPair:         kp,
-				TokenKeyPair:    tokenKP,
-				TrustedBundle:   bundle,
-				ClusterDomain:   clusterDomain,
-				ESClusterConfig: esClusterConfig,
-				Namespace:       render.ElasticsearchNamespace,
-				BindNamespaces:  []string{render.ElasticsearchNamespace},
-				ElasticHost:     "tigera-secure-es-http.tigera-elasticsearch.svc",
-				ElasticPort:     "9200",
-			})
-
-			resources, _ := component.Objects()
-			d, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
-			Expect(ok).To(BeTrue(), "Deployment not found")
-			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "LINSEED_FIPS_MODE_ENABLED", Value: "true"}))
-		})
 	})
 
 	Context("multi-tenant rendering", func() {
@@ -1015,10 +989,6 @@ func expectedContainers() []corev1.Container {
 				{
 					Name:  "LINSEED_LOG_LEVEL",
 					Value: "INFO",
-				},
-				{
-					Name:  "LINSEED_FIPS_MODE_ENABLED",
-					Value: "false",
 				},
 				{
 					Name:  "LINSEED_HTTPS_CERT",

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -495,20 +495,20 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			Expect(nodeSelectors["k2"]).To(Equal("v2"))
 		})
 
+		It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+			component := render.LogStorage(cfg)
+			Expect(component.ResolveImages(nil)).To(BeNil())
+			resources, _ := component.Objects()
 
-	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
-		cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
-		component := render.LogStorage(cfg)
-		Expect(component.ResolveImages(nil)).To(BeNil())
-		resources, _ := component.Objects()
-
-		role := rtest.GetResource(resources, "tigera-elasticsearch", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
-			APIGroups:     []string{"security.openshift.io"},
-			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"use"},
-			ResourceNames: []string{"privileged"},
-		}))
+			role := rtest.GetResource(resources, "tigera-elasticsearch", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+				APIGroups:     []string{"security.openshift.io"},
+				Resources:     []string{"securitycontextconstraints"},
+				Verbs:         []string{"use"},
+				ResourceNames: []string{"privileged"},
+			}))
+		})
 	})
 
 	Context("Managed cluster", func() {

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -495,131 +495,20 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 			Expect(nodeSelectors["k2"]).To(Equal("v2"))
 		})
 
-		It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
-			cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
-			component := render.LogStorage(cfg)
-			Expect(component.ResolveImages(nil)).To(BeNil())
-			resources, _ := component.Objects()
 
-			role := rtest.GetResource(resources, "tigera-elasticsearch", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-			Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
-				APIGroups:     []string{"security.openshift.io"},
-				Resources:     []string{"securitycontextconstraints"},
-				Verbs:         []string{"use"},
-				ResourceNames: []string{"privileged"},
-			}))
-		})
+	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
+		cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+		component := render.LogStorage(cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
 
-		It("should render elastic with the correct JAVA options for FIPS", func() {
-			fipsEnabled := operatorv1.FIPSModeEnabled
-			cfg.Installation.FIPSMode = &fipsEnabled
-			cfg.LogStorage.Spec.Nodes.ResourceRequirements = &corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					"cpu":    resource.MustParse("1"),
-					"memory": resource.MustParse("150Mi"),
-				},
-				Requests: corev1.ResourceList{
-					"cpu":     resource.MustParse("1"),
-					"memory":  resource.MustParse("150Mi"),
-					"storage": resource.MustParse("10Gi"),
-				},
-			}
-
-			cfg.ApplyTrial = true
-			cfg.KeyStoreSecret = render.CreateElasticsearchKeystoreSecret()
-			cfg.KeyStoreSecret.Data[render.ElasticsearchKeystoreEnvName] = []byte("12345")
-			expectedCreateResources := []resourceTestObj{
-				{render.ElasticsearchNamespace, "", &corev1.Namespace{}, nil},
-				{render.ElasticsearchPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
-				{render.ElasticsearchInternalPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
-				{networkpolicy.TigeraComponentDefaultDenyPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
-				{"tigera-pull-secret", render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-				{"tigera-elasticsearch", render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
-				{relasticsearch.ClusterConfigConfigMapName, common.OperatorNamespace(), &corev1.ConfigMap{}, nil},
-				{render.ElasticsearchName, render.ElasticsearchNamespace, &esv1.Elasticsearch{}, nil},
-				{"tigera-elasticsearch", "", &rbacv1.ClusterRole{}, nil},
-				{"tigera-elasticsearch", "", &rbacv1.ClusterRoleBinding{}, nil},
-				{render.ElasticsearchKeystoreSecret, common.OperatorNamespace(), &corev1.Secret{}, nil},
-				{render.ElasticsearchKeystoreSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-				{render.EsManagerRole, render.ElasticsearchNamespace, &rbacv1.Role{}, nil},
-				{render.EsManagerRoleBinding, render.ElasticsearchNamespace, &rbacv1.RoleBinding{}, nil},
-			}
-
-			component := render.LogStorage(cfg)
-			Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
-			createResources, deleteResources := component.Objects()
-
-			compareResources(createResources, expectedCreateResources)
-			compareResources(deleteResources, []resourceTestObj{
-				{render.ESCuratorName, render.ElasticsearchNamespace, &batchv1.CronJob{}, nil},
-				{render.ESCuratorName, "", &rbacv1.ClusterRole{}, nil},
-				{render.ESCuratorName, "", &rbacv1.ClusterRoleBinding{}, nil},
-				{render.EsCuratorPolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
-				{render.EsCuratorServiceAccount, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
-				{render.ElasticsearchCuratorUserSecret, render.ElasticsearchNamespace, &corev1.Secret{}, nil},
-			})
-
-			es := getElasticsearch(createResources)
-			Expect(es.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-			esContainer := es.Spec.NodeSets[0].PodTemplate.Spec.Containers[0]
-			Expect(esContainer.Env).Should(ContainElement(corev1.EnvVar{
-				Name: "ES_JAVA_OPTS",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: render.ElasticsearchKeystoreSecret},
-						Key:                  "ES_JAVA_OPTS",
-					},
-				},
-			}))
-			initContainers := es.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-
-			resource := rtest.GetResource(createResources, render.ElasticsearchKeystoreSecret, common.OperatorNamespace(), "", "v1", "Secret")
-			Expect(resource).ShouldNot(BeNil())
-			keystoreSecret, ok := resource.(*corev1.Secret)
-			Expect(ok).To(BeTrue())
-			Expect(keystoreSecret.Data["ES_JAVA_OPTS"]).Should(Equal([]byte("-Xms75M -Xmx75M --module-path /usr/share/bc-fips/ -Djavax.net.ssl.trustStore=/usr/share/elasticsearch/config/cacerts.bcfks -Djavax.net.ssl.trustStoreType=BCFKS -Djavax.net.ssl.trustStorePassword=12345 -Dorg.bouncycastle.fips.approved_only=true")))
-			Expect(es.Spec.Image).To(ContainSubstring("-fips"))
-			Expect(es.Spec.NodeSets[0].PodTemplate.Spec.Containers[0].Env).To(ConsistOf(
-				corev1.EnvVar{
-					Name: render.ElasticsearchKeystoreEnvName,
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: render.ElasticsearchKeystoreSecret},
-							Key:                  render.ElasticsearchKeystoreEnvName,
-						},
-					},
-				},
-				corev1.EnvVar{
-					Name: "ES_JAVA_OPTS",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: render.ElasticsearchKeystoreSecret},
-							Key:                  "ES_JAVA_OPTS",
-						},
-					},
-				},
-			))
-			Expect(initContainers).To(HaveLen(2))
-			Expect(initContainers[1].Name).To(Equal("elastic-internal-init-keystore"))
-			Expect(initContainers[1].Image).To(ContainSubstring("-fips"))
-			Expect(initContainers[1].Command).To(Equal([]string{"/bin/sh"}))
-			Expect(initContainers[1].Args).To(Equal([]string{"-c", "/usr/bin/initialize_keystore.sh"}))
-			Expect(*initContainers[1].SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
-			Expect(*initContainers[1].SecurityContext.Privileged).To(BeFalse())
-			Expect(*initContainers[1].SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-			Expect(*initContainers[1].SecurityContext.RunAsNonRoot).To(BeFalse())
-			Expect(*initContainers[1].SecurityContext.RunAsUser).To(BeEquivalentTo(0))
-			Expect(initContainers[1].SecurityContext.Capabilities).To(Equal(
-				&corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-					Add:  []corev1.Capability{"CHOWN"},
-				},
-			))
-			Expect(initContainers[1].SecurityContext.SeccompProfile).To(Equal(
-				&corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				}))
-		})
+		role := rtest.GetResource(resources, "tigera-elasticsearch", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups:     []string{"security.openshift.io"},
+			Resources:     []string{"securitycontextconstraints"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{"privileged"},
+		}))
 	})
 
 	Context("Managed cluster", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -428,7 +428,7 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 		{Name: "CNX_CLUSTER_NAME", Value: "cluster"},
 		{Name: "CNX_POLICY_RECOMMENDATION_SUPPORT", Value: "true"},
 		{Name: "ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
-		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(KibanaEnabled(c.cfg.Tenant, c.cfg.Installation))},
+		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(!c.cfg.Tenant.MultiTenant())},
 	}
 
 	envs = append(envs, c.managerOAuth2EnvVars()...)

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -414,14 +414,6 @@ func (c *managerComponent) managerProxyProbe() *corev1.Probe {
 	}
 }
 
-func KibanaEnabled(tenant *operatorv1.Tenant, installation *operatorv1.InstallationSpec) bool {
-	enableKibana := !operatorv1.IsFIPSModeEnabled(installation.FIPSMode)
-	if tenant.MultiTenant() {
-		enableKibana = false
-	}
-	return enableKibana
-}
-
 // managerEnvVars returns the envvars for the manager container.
 func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 	envs := []corev1.EnvVar{
@@ -526,7 +518,6 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
 		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: defaultForwardServer},
 		{Name: "VOLTRON_ENABLE_COMPLIANCE", Value: strconv.FormatBool(c.cfg.ComplianceLicenseActive)},
-		{Name: "VOLTRON_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 	}
 
 	if c.cfg.VoltronRouteConfig != nil {
@@ -603,10 +594,9 @@ func (c *managerComponent) managerUIAPIsContainer() corev1.Container {
 	env := []corev1.EnvVar{
 		{Name: "ELASTIC_LICENSE_TYPE", Value: string(c.cfg.ESLicenseType)},
 		{Name: "ELASTIC_KIBANA_ENDPOINT", Value: rkibana.HTTPSEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain)},
-		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
-		{Name: "ELASTIC_KIBANA_DISABLED", Value: strconv.FormatBool(!KibanaEnabled(c.cfg.Tenant, c.cfg.Installation))},
+		{Name: "ELASTIC_KIBANA_DISABLED", Value: strconv.FormatBool(c.cfg.Tenant.MultiTenant())},
 		{Name: "VOLTRON_URL", Value: fmt.Sprintf("https://tigera-manager.%s.svc:9443", c.cfg.Namespace)},
 	}
 

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -135,7 +135,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		uiAPIsExpectedEnvVars := []corev1.EnvVar{
 			{Name: "ELASTIC_LICENSE_TYPE", Value: "enterprise_trial"},
 			{Name: "ELASTIC_KIBANA_ENDPOINT", Value: "https://tigera-secure-es-gateway-http.tigera-elasticsearch.svc:5601"},
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 			{Name: "LINSEED_CLIENT_CERT", Value: "/internal-manager-tls/tls.crt"},
 			{Name: "LINSEED_CLIENT_KEY", Value: "/internal-manager-tls/tls.key"},
 			{Name: "ELASTIC_KIBANA_DISABLED", Value: "false"},
@@ -799,27 +798,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
 		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-manager", render.ManagerNamespace)))
-	})
-
-	It("should set the right env when FIPS is enabled", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		installation.FIPSMode = &fipsEnabled
-		resources := renderObjects(renderConfig{
-			oidc:                    false,
-			managementCluster:       nil,
-			installation:            installation,
-			compliance:              compliance,
-			complianceFeatureActive: true,
-			ns:                      render.ManagerNamespace,
-		})
-		deployment, ok := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(ok).To(BeTrue())
-		Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("tigera-ui-apis"))
-		Expect(deployment.Spec.Template.Spec.Containers[1].Name).To(Equal("tigera-voltron"))
-		Expect(deployment.Spec.Template.Spec.Containers[2].Name).To(Equal("tigera-manager"))
-		Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
-		Expect(deployment.Spec.Template.Spec.Containers[1].Env).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_FIPS_MODE_ENABLED", Value: "true"}))
-		Expect(deployment.Spec.Template.Spec.Containers[2].Env).To(ContainElement(corev1.EnvVar{Name: "ENABLE_KIBANA", Value: "false"}))
 	})
 
 	It("should override container's resource request with the value from Manager CR", func() {

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -496,10 +496,6 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 			Name:  "TLS_CA_BUNDLE_HASH_ANNOTATION",
 			Value: rmeta.AnnotationHash(mc.cfg.TrustedCertBundle.HashAnnotations()),
 		},
-		{
-			Name:  "FIPS_MODE_ENABLED",
-			Value: operatorv1.IsFIPSModeEnabledString(mc.cfg.Installation.FIPSMode),
-		},
 	}
 
 	volumes := []corev1.Volume{

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -707,11 +707,6 @@ var _ = Describe("monitor rendering tests", func() {
 				ValueFrom: nil,
 			},
 			{
-				Name:      "FIPS_MODE_ENABLED",
-				Value:     "false",
-				ValueFrom: nil,
-			},
-			{
 				Name:      "DEX_ENABLED",
 				Value:     "true",
 				ValueFrom: nil,

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -154,11 +154,7 @@ func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	}
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
-		if operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode) {
-			c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNIFIPS, reg, path, prefix, is))
-		} else {
-			c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNI, reg, path, prefix, is))
-		}
+		c.cniImage = appendIfErr(components.GetReference(components.ComponentTigeraCNI, reg, path, prefix, is))
 		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNode, reg, path, prefix, is))
 		c.flexvolImage = appendIfErr(components.GetReference(components.ComponentTigeraFlexVolume, reg, path, prefix, is))
 	} else {
@@ -1442,7 +1438,6 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		{Name: "FELIX_TYPHACAFILE", Value: c.cfg.TLS.TrustedBundle.MountPath()},
 		{Name: "FELIX_TYPHACERTFILE", Value: c.cfg.TLS.NodeSecret.VolumeMountCertificateFilePath()},
 		{Name: "FELIX_TYPHAKEYFILE", Value: c.cfg.TLS.NodeSecret.VolumeMountKeyFilePath()},
-		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "NO_DEFAULT_POOLS", Value: "true"},
 	}
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -327,7 +327,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{Name: "NO_DEFAULT_POOLS", Value: "true"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -570,7 +569,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{Name: "NO_DEFAULT_POOLS", Value: "true"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -823,7 +821,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 					{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
 					{Name: "MULTI_INTERFACE_MODE", Value: operatorv1.MultiInterfaceModeNone.Value()},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{Name: "NO_DEFAULT_POOLS", Value: "true"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -1109,7 +1106,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{Name: "NO_DEFAULT_POOLS", Value: "true"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -1275,7 +1271,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_ROUTESOURCE", Value: "WorkloadIPs"},
 					{Name: "FELIX_BPFEXTTOSERVICECONNMARK", Value: "0x80"},
 					{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 
@@ -1522,7 +1517,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{Name: "NO_DEFAULT_POOLS", Value: "true"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -1685,7 +1679,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_ROUTESOURCE", Value: "WorkloadIPs"},
 					{Name: "FELIX_BPFEXTTOSERVICECONNMARK", Value: "0x80"},
 					{Name: "FELIX_WIREGUARDHOSTENCRYPTIONENABLED", Value: "true"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 
@@ -1856,7 +1849,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{Name: "NO_DEFAULT_POOLS", Value: "true"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -1960,7 +1952,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_DNSLOGSFILEENABLED", Value: "true"},
 					{Name: "FELIX_DNSLOGSFILEPERNODELIMIT", Value: "1000"},
 					{Name: "MULTI_INTERFACE_MODE", Value: operatorv1.MultiInterfaceModeNone.Value()},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{Name: "NO_DEFAULT_POOLS", Value: "true"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
@@ -2055,7 +2046,6 @@ var _ = Describe("Node rendering tests", func() {
 
 					// The RKE2 envvar overrides.
 					{Name: "MULTI_INTERFACE_MODE", Value: operatorv1.MultiInterfaceModeNone.Value()},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
@@ -3071,7 +3061,6 @@ var _ = Describe("Node rendering tests", func() {
 					{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 					{Name: "FELIX_HEALTHENABLED", Value: "true"},
 					{Name: "FELIX_HEALTHPORT", Value: "9099"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 					{
 						Name: "NODENAME",
 						ValueFrom: &corev1.EnvVarSource{
@@ -3286,33 +3275,6 @@ var _ = Describe("Node rendering tests", func() {
 				rtest.ExpectEnv(deploy.Spec.Template.Spec.Containers[0].Env, "CALICO_EARLY_NETWORKING", render.BGPLayoutPath)
 			})
 
-			It("should render the correct env and/or images when FIPS mode is enabled (EE)", func() {
-				fipsEnabled := operatorv1.FIPSModeEnabled
-				cfg.Installation.FIPSMode = &fipsEnabled
-				cfg.Installation.Variant = operatorv1.TigeraSecureEnterprise
-				cfg.Installation.NodeMetricsPort = ptr.Int32ToPtr(123)
-
-				certificateManager, err := certificatemanager.Create(cli, nil, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
-				Expect(err).NotTo(HaveOccurred())
-
-				cfg.PrometheusServerTLS = certificateManager.KeyPair()
-				component := render.Node(&cfg)
-				Expect(component.ResolveImages(nil)).To(BeNil())
-
-				resources, _ := component.Objects()
-				nodeDSObj := rtest.GetResource(resources, common.NodeDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet")
-				Expect(nodeDSObj).ToNot(BeNil())
-
-				nodeDS, ok := nodeDSObj.(*appsv1.DaemonSet)
-				Expect(ok).To(BeTrue())
-
-				Expect(nodeDS.Spec.Template.Spec.Containers[0].Name).To(Equal("calico-node"))
-				Expect(nodeDS.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
-
-				Expect(nodeDS.Spec.Template.Spec.InitContainers[1].Name).To(Equal("install-cni"))
-				Expect(nodeDS.Spec.Template.Spec.InitContainers[1].Image).To(ContainSubstring("-fips"))
-			})
-
 			It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
 				fipsEnabled := operatorv1.FIPSModeEnabled
 				cfg.Installation.FIPSMode = &fipsEnabled
@@ -3334,7 +3296,6 @@ var _ = Describe("Node rendering tests", func() {
 				Expect(ok).To(BeTrue())
 
 				Expect(nodeDS.Spec.Template.Spec.Containers[0].Name).To(Equal("calico-node"))
-				Expect(nodeDS.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "FIPS_MODE_ENABLED", Value: "true"}))
 				Expect(nodeDS.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
 
 				Expect(nodeDS.Spec.Template.Spec.InitContainers[1].Name).To(Equal("install-cni"))

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/ptr"
@@ -282,7 +283,6 @@ func (pc *packetCaptureApiComponent) container() corev1.Container {
 		{Name: "PACKETCAPTURE_API_LOG_LEVEL", Value: "Info"},
 		{Name: "PACKETCAPTURE_API_HTTPS_KEY", Value: pc.cfg.ServerCertSecret.VolumeMountKeyFilePath()},
 		{Name: "PACKETCAPTURE_API_HTTPS_CERT", Value: pc.cfg.ServerCertSecret.VolumeMountCertificateFilePath()},
-		{Name: "PACKETCAPTURE_API_FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(pc.cfg.Installation.FIPSMode)},
 	}
 
 	if pc.cfg.KeyValidatorConfig != nil {

--- a/pkg/render/packet_capture_api_test.go
+++ b/pkg/render/packet_capture_api_test.go
@@ -129,11 +129,6 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 				Name:  "PACKETCAPTURE_API_HTTPS_CERT",
 				Value: "/tigera-packetcapture-server-tls/tls.crt",
 			},
-			{
-				Name:      "PACKETCAPTURE_API_FIPS_MODE_ENABLED",
-				Value:     "false",
-				ValueFrom: nil,
-			},
 		}
 
 		if enableOIDC {

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -536,7 +536,6 @@ func (c *typhaComponent) typhaEnvVars() []corev1.EnvVar {
 		{Name: "TYPHA_CAFILE", Value: c.cfg.TLS.TrustedBundle.MountPath()},
 		{Name: "TYPHA_SERVERCERTFILE", Value: c.cfg.TLS.TyphaSecret.VolumeMountCertificateFilePath()},
 		{Name: "TYPHA_SERVERKEYFILE", Value: c.cfg.TLS.TyphaSecret.VolumeMountKeyFilePath()},
-		{Name: "TYPHA_FIPSMODEENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: shutdownTimeoutEnvVar, Value: fmt.Sprint(defaultTyphaTerminationGracePeriod)}, // May get overridden later.
 	}
 	// We need at least the CN or URISAN set, we depend on the validation

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -149,8 +149,6 @@ var _ = Describe("Typha rendering tests", func() {
 	})
 
 	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		cfg.Installation.FIPSMode = &fipsEnabled
 		cfg.Installation.Variant = operatorv1.Calico
 		component := render.Typha(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -150,6 +150,8 @@ var _ = Describe("Typha rendering tests", func() {
 
 	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
 		cfg.Installation.Variant = operatorv1.Calico
+		fipsEnabled := operatorv1.FIPSModeEnabled
+		cfg.Installation.FIPSMode = &fipsEnabled
 		component := render.Typha(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -562,7 +562,6 @@ func (c *windowsComponent) windowsEnvVars() []corev1.EnvVar {
 		{Name: "FELIX_TYPHACAFILE", Value: c.cfg.TLS.TrustedBundle.MountPath()},
 		{Name: "FELIX_TYPHACERTFILE", Value: c.cfg.TLS.NodeSecret.VolumeMountCertificateFilePath()},
 		{Name: "FELIX_TYPHAKEYFILE", Value: c.cfg.TLS.NodeSecret.VolumeMountKeyFilePath()},
-		{Name: "FIPS_MODE_ENABLED", Value: operatorv1.IsFIPSModeEnabledString(c.cfg.Installation.FIPSMode)},
 		{Name: "VXLAN_VNI", Value: fmt.Sprintf("%d", c.cfg.VXLANVNI)},
 		{Name: "VXLAN_ADAPTER", Value: vxlanAdapter},
 	}

--- a/pkg/render/windows_test.go
+++ b/pkg/render/windows_test.go
@@ -411,7 +411,6 @@ var _ = Describe("Windows rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 
 					{Name: "VXLAN_VNI", Value: "4096"},
 					{Name: "VXLAN_ADAPTER", Value: ""},
@@ -874,7 +873,6 @@ var _ = Describe("Windows rendering tests", func() {
 					{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 					{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 					{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-					{Name: "FIPS_MODE_ENABLED", Value: "false"},
 
 					{Name: "VXLAN_VNI", Value: "4096"},
 					{Name: "VXLAN_ADAPTER", Value: ""},
@@ -1197,7 +1195,6 @@ var _ = Describe("Windows rendering tests", func() {
 			{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 			{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 			{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 
 			{Name: "VXLAN_VNI", Value: "4096"},
 			{Name: "VXLAN_ADAPTER", Value: ""},
@@ -1395,7 +1392,6 @@ var _ = Describe("Windows rendering tests", func() {
 			{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
 			{Name: "FELIX_ROUTESOURCE", Value: "WorkloadIPs"},
 			{Name: "FELIX_BPFEXTTOSERVICECONNMARK", Value: "0x80"},
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 
 			{Name: "VXLAN_VNI", Value: "4096"},
 			{Name: "VXLAN_ADAPTER", Value: ""},
@@ -1632,8 +1628,6 @@ var _ = Describe("Windows rendering tests", func() {
 			{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 			{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
 
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
-
 			// Calico Windows specific envvars
 			{Name: "VXLAN_VNI", Value: "4096"},
 			{Name: "VXLAN_ADAPTER", Value: ""},
@@ -1770,8 +1764,6 @@ var _ = Describe("Windows rendering tests", func() {
 			{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 			{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 			{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 
 			{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:openshift-dns/dns-default"},
 
@@ -1922,8 +1914,6 @@ var _ = Describe("Windows rendering tests", func() {
 			{Name: "FELIX_TYPHACAFILE", Value: certificatemanagement.TrustedCertBundleMountPath},
 			{Name: "FELIX_TYPHACERTFILE", Value: "/node-certs/tls.crt"},
 			{Name: "FELIX_TYPHAKEYFILE", Value: "/node-certs/tls.key"},
-
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 
 			{Name: "FELIX_DNSTRUSTEDSERVERS", Value: "k8s-service:kube-system/rke2-coredns-rke2-coredns"},
 
@@ -2398,7 +2388,6 @@ var _ = Describe("Windows rendering tests", func() {
 			{Name: "USE_POD_CIDR", Value: "true"},
 			{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			{Name: "FELIX_HEALTHENABLED", Value: "true"},
-			{Name: "FIPS_MODE_ENABLED", Value: "false"},
 			{
 				Name: "NODENAME",
 				ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Support was removed in v3.18 (release-v1.30+), but the code was never removed.

If you enable FIPS on EE, you will now see the following:

```
$ k get tigerastatus  calico -o yaml
apiVersion: operator.tigera.io/v1
kind: TigeraStatus
metadata:
  creationTimestamp: "2024-08-19T18:02:49Z"
  generation: 1
  name: calico
  resourceVersion: "10643"
  uid: f52ae118-9282-47ca-b362-64865ce7a8fe
spec: {}
status:
  conditions:
  - lastTransitionTime: "2024-08-19T18:22:10Z"
    message: 'Invalid Installation provided: Installation spec.FIPSMode=Enabled combined
      with spec.Variant=TigeraSecureEnterprise is not supported'
    observedGeneration: 4
    reason: InvalidConfigurationError
    status: "True"
    type: Degraded
  - lastTransitionTime: "2024-08-19T18:22:10Z"
    observedGeneration: 4
    reason: Unknown
    status: "False"
    type: Available
  - lastTransitionTime: "2024-08-19T18:03:59Z"
    observedGeneration: 4
    reason: Unknown
    status: "False"
    type: Progressing
```