### PR TITLE
Render DPI RBAC to access Linseed

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -513,8 +513,6 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	}
 
 	if !r.multiTenant {
-		// DPI is only supported in single-tenant / zero-tenant clusters.
-
 		// FIXME: core controller creates TyphaNodeTLSConfig, this controller should only get it.
 		// But changing the call from GetOrCreateTyphaNodeTLSConfig() to GetTyphaNodeTLSConfig()
 		// makes tests fail, this needs to be looked at.
@@ -559,6 +557,18 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 			},
 			TrustedBundle: typhaNodeTLS.TrustedBundle,
 		}))
+	} else {
+		dpiComponent := dpi.DPI(&dpi.DPIConfig{
+			IntrusionDetection: instance,
+			Installation:       network,
+			PullSecrets:        pullSecrets,
+			OpenShift:          r.provider.IsOpenShift(),
+			ManagedCluster:     isManagedCluster,
+			ManagementCluster:  isManagementCluster,
+			ClusterDomain:      r.clusterDomain,
+			Tenant:             tenant,
+		})
+		components = append(components, dpiComponent)
 	}
 
 	for _, comp := range components {


### PR DESCRIPTION
## Description

DPI gets deployed only in the managed cluster and Linseed created a token that contains the canonical namespace. In a multi-tenant management cluster, DPI is never rendered. 

This PR will enable the rendering of RBAC for Linseed API in the multi-tenant management cluster.


![Screenshot from 2024-08-23 17-49-16](https://github.com/user-attachments/assets/14e4664b-bdeb-49db-bf96-0eece4c317c0)

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
