### PR TITLE
Render DPI RBAC to access Linseed for multi-tenat management clusters

### DIFF
--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -513,8 +513,6 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	}
 
 	if !r.multiTenant {
-		// DPI is only supported in single-tenant / zero-tenant clusters.
-
 		// FIXME: core controller creates TyphaNodeTLSConfig, this controller should only get it.
 		// But changing the call from GetOrCreateTyphaNodeTLSConfig() to GetTyphaNodeTLSConfig()
 		// makes tests fail, this needs to be looked at.
@@ -559,6 +557,18 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 			},
 			TrustedBundle: typhaNodeTLS.TrustedBundle,
 		}))
+	} else {
+		dpiComponent := dpi.DPI(&dpi.DPIConfig{
+			IntrusionDetection: instance,
+			Installation:       network,
+			PullSecrets:        pullSecrets,
+			OpenShift:          r.provider.IsOpenShift(),
+			ManagedCluster:     isManagedCluster,
+			ManagementCluster:  isManagementCluster,
+			ClusterDomain:      r.clusterDomain,
+			Tenant:             tenant,
+		})
+		components = append(components, dpiComponent)
 	}
 
 	for _, comp := range components {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Pick https://github.com/tigera/operator/pull/3476

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.