### PR TITLE
Add hostendpoints get and list to tigera ui and admin users

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1485,6 +1485,12 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Resources: []string{"clusterinformations"},
 			Verbs:     []string{"get", "list"},
 		},
+		// Access to hostendpoints from the UI ServiceGraph.
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"hostendpoints"},
+			Verbs:     []string{"get", "list"},
+		},
 		// List and view the threat defense configuration
 		{
 			APIGroups: []string{"projectcalico.org"},
@@ -1662,6 +1668,12 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 		{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"clusterinformations"},
+			Verbs:     []string{"get", "list"},
+		},
+		// Access to hostendpoints from the UI ServiceGraph.
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"hostendpoints"},
 			Verbs:     []string{"get", "list"},
 		},
 		// Manage the threat defense configuration

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1308,6 +1308,11 @@ var (
 		},
 		{
 			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"hostendpoints"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{
 				"alertexceptions",
 				"globalalerts",
@@ -1443,6 +1448,11 @@ var (
 		{
 			APIGroups: []string{"projectcalico.org"},
 			Resources: []string{"clusterinformations"},
+			Verbs:     []string{"get", "list"},
+		},
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"hostendpoints"},
 			Verbs:     []string{"get", "list"},
 		},
 		{


### PR DESCRIPTION
## Description

This changeset adds `hostendpoints` get and list rbac for the built-in `tigera-ui-user` and `tigera-network-admin` users.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
