### PR TITLE
Dynamically add network policy for apiserver egress with configured K8SServicEndpoint

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -499,6 +499,14 @@ func allowTigeraAPIServerPolicy(cfg *APIServerConfiguration) *v3.NetworkPolicy {
 		},
 	}...)
 
+	if r, err := cfg.K8SServiceEndpoint.DestinationEntityRule(); r != nil && err == nil {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: *r,
+		})
+	}
+
 	// The ports Calico Enterprise API Server and Calico Enterprise Query Server are configured to listen on.
 	ingressPorts := networkpolicy.Ports(443, APIServerPort, QueryServerPort, 10443)
 	if cfg.IsSidecarInjectionEnabled() {

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/crypto"
 
+	calicov3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -38,6 +39,7 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/podaffinity"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/testutils"
@@ -660,6 +662,50 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 
 		deployment := deploymentResource.(*appsv1.Deployment)
 		rtest.ExpectK8sServiceEpEnvVars(deployment.Spec.Template.Spec, "k8shost", "1234")
+	})
+
+	It("should add egress policy with Enterprise variant and K8SServiceEndpoint defined", func() {
+		cfg.K8SServiceEndpoint.Host = "k8shost"
+		cfg.K8SServiceEndpoint.Port = "1234"
+		cfg.ForceHostNetwork = true
+
+		component := render.APIServerPolicy(cfg)
+		resources, _ := component.Objects()
+		policyName := types.NamespacedName{Name: "allow-tigera.cnx-apiserver-access", Namespace: "tigera-system"}
+		policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.Spec).ToNot(BeNil())
+		Expect(policy.Spec.Egress).ToNot(BeNil())
+		Expect(policy.Spec.Egress).To(ContainElement(calicov3.Rule{
+			Action:   calicov3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: calicov3.EntityRule{
+				Ports:   networkpolicy.Ports(1234),
+				Domains: []string{"k8shost"},
+			},
+		}))
+	})
+
+	It("should add egress policy with Enterprise variant and K8SServiceEndpoint as IP defined", func() {
+		cfg.K8SServiceEndpoint.Host = "169.169.169.169"
+		cfg.K8SServiceEndpoint.Port = "4321"
+		cfg.ForceHostNetwork = false
+
+		component := render.APIServerPolicy(cfg)
+		resources, _ := component.Objects()
+		policyName := types.NamespacedName{Name: "allow-tigera.cnx-apiserver-access", Namespace: "tigera-system"}
+		policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.Spec).ToNot(BeNil())
+		Expect(policy.Spec.Egress).ToNot(BeNil())
+		Expect(policy.Spec.Egress).To(ContainElement(calicov3.Rule{
+			Action:   calicov3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: calicov3.EntityRule{
+				Ports: networkpolicy.Ports(4321),
+				Nets:  []string{"169.169.169.169/32"},
+			},
+		}))
 	})
 
 	It("should not set KUBERENETES_SERVICE_... variables if not host networked on Docker EE with proxy.local", func() {


### PR DESCRIPTION
For Enterprise, where the operator creates and manages policy to allow components to function in the presence of default deny policy, it was found that there was not appropriate allow policy when the K8s apiserver is defined with a K8SServiceEndpoint. This PR add an Egress rule to allow the needed traffic.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
