### PR TITLE
Use restricted namespace for opensource apiserver

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -267,9 +267,13 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		namespacedEnterpriseObjects = append(namespacedEnterpriseObjects, c.cfg.TrustedBundle.ConfigMap(QueryserverNamespace))
 	}
 
+	podSecurityNamespaceLabel := PodSecurityStandard(PSSRestricted)
+	if c.hostNetwork() {
+		podSecurityNamespaceLabel = PSSPrivileged
+	}
 	// Global OSS-only objects.
 	globalCalicoObjects := []client.Object{
-		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.cfg.Installation.KubernetesProvider, PSSRestricted),
+		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.cfg.Installation.KubernetesProvider, podSecurityNamespaceLabel),
 	}
 
 	// Compile the final arrays based on the variant.

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -269,7 +269,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 
 	// Global OSS-only objects.
 	globalCalicoObjects := []client.Object{
-		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.cfg.Installation.KubernetesProvider, PSSPrivileged),
+		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.cfg.Installation.KubernetesProvider, PSSRestricted),
 	}
 
 	// Compile the final arrays based on the variant.


### PR DESCRIPTION
## Description

- the opensource calico-apiserver is now running as a non-root container, however the calico-apiserver namespace has privileged labels which is not necessary
- the calico-apiserver pods are happy with the restricted namespace label

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
