### PR TITLE
Fix image component handling, honoring Installation spec

### DIFF
--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -85,12 +85,12 @@ func GetReference(c Component, registry, imagePath, imagePrefix string, is *oper
 	}
 
 	for _, img := range is.Spec.Images {
-		if img.Image == c.Image {
+		if img.Image == image {
 			return fmt.Sprintf("%s%s@%s", registry, image, img.Digest), nil
 		}
 	}
 
-	return "", fmt.Errorf("ImageSet did not contain image %s", c.Image)
+	return "", fmt.Errorf("ImageSet did not contain image %s", image)
 }
 
 func ReplaceImagePath(image, imagePath string) string {


### PR DESCRIPTION
components.GetReference currently ignores the image prefix and path specified in the "Installation" spec.

It makes a copy of the image component, appends the configured image path and prefix but then it uses the original component image when looping over the image set.

The fix is trivial, we just have to use the modified image string.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
