### PR TITLE
revert dikastes flags rename that featured 'per-host'

### DIFF
--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -316,7 +316,7 @@ func (c *component) containers() []corev1.Container {
 				"--waf-ruleset-file", filepath.Join(ModSecurityRulesetVolumePath, "tigera.conf"),
 			)
 			if c.config.PerHostWAFEnabled {
-				commandArgs = append(commandArgs, "--per-host-waf-enabled")
+				commandArgs = append(commandArgs, "--waf-enabled")
 			}
 			volMounts = append(
 				volMounts,
@@ -335,7 +335,7 @@ func (c *component) containers() []corev1.Container {
 		}
 
 		if c.config.PerHostALPEnabled {
-			commandArgs = append(commandArgs, "--per-host-alp-enabled")
+			commandArgs = append(commandArgs, "--alp-enabled")
 		}
 
 		dikastes := corev1.Container{

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -653,7 +653,7 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 
 		dikastesArgs := dikastesContainer.Command
 		expectedDikastesArgs := []string{
-			"--per-host-waf-enabled",
+			"--waf-enabled",
 			"--waf-log-file", filepath.Join(applicationlayer.CalicologsVolumePath, "waf", "waf.log"),
 			"--waf-ruleset-file", filepath.Join(applicationlayer.ModSecurityRulesetVolumePath, "tigera.conf"),
 		}


### PR DESCRIPTION
This PR fixes the breaking changes introduced in tigera/operator#3460

- dikastes already has a SUBSCRIPTION_TYPE env var that changes its operation mode from per-host to per-pod
- Operator only deploys per-host mode dikastes (SUBSCRIPTION_TYPE is set to `per-host-policies`)
- the ALP feature switches mode based on aforementioned env var
- the WAF feature doesn't care about SUBSCRIPTION_TYPE, functions the same regardless
- Flag `--waf-enabled`  must be retained because WAF is also used in [Ingress Gateway integration](https://docs.tigera.io/calico-cloud/threat/deploying-waf-ingress-gateway)
- new `--alp-enabled` flag will behave the same for both per-host and per-pod dikastes run mode

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
