### PR TITLE
Update Prometheus to v2.54.1 and AlertManager to v0.27.0

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -103,14 +103,14 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v2.48.1
+    version: v2.54.1
   prometheus:
     image: tigera/prometheus
     version: master
   # coreos-prometheus holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
-    version: v0.25.0
+    version: v0.27.0
   alertmanager:
     image: tigera/alertmanager
     version: master

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -222,7 +222,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = Component{
-		Version:  "v2.48.1",
+		Version:  "v2.54.1",
 		Registry: "",
 	}
 
@@ -239,7 +239,7 @@ var (
 	}
 
 	ComponentCoreOSAlertmanager = Component{
-		Version:  "v0.25.0",
+		Version:  "v0.27.0",
 		Registry: "",
 	}
 

--- a/pkg/crds/enterprise/crd.projectcalico.org_bfdconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bfdconfigurations.yaml
@@ -1,0 +1,86 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: bfdconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BFDConfiguration
+    listKind: BFDConfigurationList
+    plural: bfdconfigurations
+    singular: bfdconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: BFDConfiguration contains the configuration for BFD sessions.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BFDConfigurationSpec contains the specification for a BFDConfiguration
+              resource.
+            properties:
+              interfaces:
+                items:
+                  description: BFDInterface contains per-interface parameters for
+                    BFD failure detection.
+                  properties:
+                    idleSendInterval:
+                      default: 1m
+                      description: IdleSendInterval is the interval between transmitted
+                        BFD packets when the BFD peer is idle. Must be a whole number
+                        of milliseconds greater than 0.
+                      type: string
+                    matchPattern:
+                      description: MatchPattern is a pattern to match one or more
+                        interfaces. Supports exact interface names, match on interface
+                        prefixes (e.g., “eth*”), or “*” to select all interfaces on
+                        the selected node(s).
+                      type: string
+                    minimumRecvInterval:
+                      default: 10ms
+                      description: MinimumRecvInterval is the minimum interval between
+                        received BFD packets. Must be a whole number of milliseconds
+                        greater than 0.
+                      type: string
+                    minimumSendInterval:
+                      default: 100ms
+                      description: MinimumSendInterval is the minimum interval between
+                        transmitted BFD packets. Must be a whole number of milliseconds
+                        greater than 0.
+                      type: string
+                    multiplier:
+                      default: 5
+                      description: Multiplier is the number of intervals that must
+                        pass without receiving a BFD packet before the peer is considered
+                        down.
+                      type: integer
+                  type: object
+                type: array
+              nodeSelector:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1066,7 +1066,7 @@ func (c *apiServerComponent) sidecarMutatingWebhookConfig() *admregv1.MutatingWe
 		},
 	}
 	rules := []admregv1.RuleWithOperations{
-		admregv1.RuleWithOperations{
+		{
 			Rule: admregv1.Rule{
 				APIGroups:   []string{""},
 				APIVersions: []string{"v1"},
@@ -1088,7 +1088,7 @@ func (c *apiServerComponent) sidecarMutatingWebhookConfig() *admregv1.MutatingWe
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: SidecarMutatingWebhookConfigName},
 		Webhooks: []admregv1.MutatingWebhook{
-			admregv1.MutatingWebhook{
+			{
 				AdmissionReviewVersions: []string{"v1"},
 				ClientConfig: admregv1.WebhookClientConfig{
 					Service:  &svcref,
@@ -1361,6 +1361,7 @@ func (c *apiServerComponent) tigeraApiServerClusterRole() *rbacv1.ClusterRole {
 				"externalnetworks",
 				"egressgatewaypolicies",
 				"securityeventwebhooks",
+				"bfdconfigurations",
 			},
 			Verbs: []string{
 				"get",
@@ -2149,19 +2150,19 @@ func (c *apiServerComponent) l7AdmissionControllerContainer() corev1.Container {
 		Image:           c.l7AdmissionControllerImage,
 		ImagePullPolicy: ImagePullPolicy(),
 		Env: []corev1.EnvVar{
-			corev1.EnvVar{
+			{
 				Name:  "L7ADMCTRL_TLSCERTPATH",
 				Value: c.cfg.TLSKeyPair.VolumeMountCertificateFilePath(),
 			},
-			corev1.EnvVar{
+			{
 				Name:  "L7ADMCTRL_TLSKEYPATH",
 				Value: c.cfg.TLSKeyPair.VolumeMountKeyFilePath(),
 			},
-			corev1.EnvVar{
+			{
 				Name:  "L7ADMCTRL_ENVOYIMAGE",
 				Value: c.l7AdmissionControllerEnvoyImage,
 			},
-			corev1.EnvVar{
+			{
 				Name:  "L7ADMCTRL_DIKASTESIMAGE",
 				Value: c.dikastesImage,
 			},

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -519,9 +519,10 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		extraRules := []rbacv1.PolicyRule{
 			{
-				// Tigera Secure needs to be able to read licenses, tiers, and config.
+				// Calico Enterprise needs to be able to read additional resources.
 				APIGroups: []string{"crd.projectcalico.org"},
 				Resources: []string{
+					"bfdconfigurations",
 					"egressgatewaypolicies",
 					"externalnetworks",
 					"licensekeys",

--- a/pkg/render/nonclusterhost/nonclusterhost.go
+++ b/pkg/render/nonclusterhost/nonclusterhost.go
@@ -135,6 +135,7 @@ func (c *nonClusterHostComponent) clusterRole() *rbacv1.ClusterRole {
 			// For monitoring Calico-specific configuration.
 			APIGroups: []string{"crd.projectcalico.org"},
 			Resources: []string{
+				"bfdconfigurations",
 				"bgpconfigurations",
 				"clusterinformations",
 				"egressgatewaypolicies",

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -332,6 +332,7 @@ func (c *typhaComponent) typhaRole() *rbacv1.ClusterRole {
 					"deeppacketinspections",
 					"externalnetworks",
 					"egressgatewaypolicies",
+					"bfdconfigurations",
 				},
 				Verbs: []string{"get", "list", "watch"},
 			},


### PR DESCRIPTION
[EV-5179][EV-5180]Changes done to upgrade Update Prometheus to v2.54.1 and AlertManager to v0.27.0 as part of prometheus upgrade.

## Description
https://tigera.atlassian.net/browse/EV-5179
https://tigera.atlassian.net/browse/EV-5180

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.


[EV-5179]: https://tigera.atlassian.net/browse/EV-5179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ