### PR TITLE
Update Prometheus to v2.54.1 and AlertManager to v0.27.0

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -103,14 +103,14 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v2.48.1
+    version: v2.54.1
   prometheus:
     image: tigera/prometheus
     version: master
   # coreos-prometheus holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
-    version: v0.25.0
+    version: v0.27.0
   alertmanager:
     image: tigera/alertmanager
     version: master

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -222,7 +222,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = Component{
-		Version:  "v2.48.1",
+		Version:  "v2.54.1",
 		Registry: "",
 	}
 
@@ -239,7 +239,7 @@ var (
 	}
 
 	ComponentCoreOSAlertmanager = Component{
-		Version:  "v0.25.0",
+		Version:  "v0.27.0",
 		Registry: "",
 	}
 


### PR DESCRIPTION
Changes done to upgrade Update Prometheus to v2.54.1 and AlertManager to v0.27.0 as part of prometheus upgrade.

## Description
https://tigera.atlassian.net/browse/EV-5179
https://tigera.atlassian.net/browse/EV-5180
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
