### PR TITLE
Reduce the number of restart for tigera-manager

### DIFF
--- a/pkg/controller/secrets/tenant_controller.go
+++ b/pkg/controller/secrets/tenant_controller.go
@@ -227,9 +227,8 @@ func (r *TenantController) upstreamCertificates(cm certificatemanager.Certificat
 	}
 
 	if r.elasticExternal {
-		// If configured to use external Elasticsearch, get the Elasticsearch and Kibana public certs.
+		// If configured to use external Elasticsearch, get the Elasticsearch public certs.
 		toQuery[logstorage.ExternalESPublicCertName] = common.OperatorNamespace()
-		toQuery[logstorage.ExternalKBPublicCertName] = common.OperatorNamespace()
 	}
 
 	// Query each certificate.

--- a/pkg/render/common/test/testing.go
+++ b/pkg/render/common/test/testing.go
@@ -283,6 +283,20 @@ func CreateCertSecret(name, namespace string, dnsNames ...string) *corev1.Secret
 	}
 }
 
+func CreateCertSecretWithContent(name, namespace string, keyContent []byte, crtContent []byte) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: keyContent,
+			corev1.TLSCertKey:       crtContent,
+		},
+	}
+}
+
 func ExpectBundleContents(bundle *corev1.ConfigMap, secrets ...types.NamespacedName) {
 	ExpectWithOffset(1, bundle.Data).To(HaveKey("tigera-ca-bundle.crt"), fmt.Sprintf("Bundle: %+v", bundle))
 

--- a/pkg/render/manager/manager_route_config.go
+++ b/pkg/render/manager/manager_route_config.go
@@ -290,6 +290,9 @@ func (builder *voltronRouteConfigBuilder) Build() (*VoltronRouteConfig, error) {
 		return nil, err
 	}
 
+	sort.Sort(ByVolumeMountName(builder.volumeMounts))
+	sort.Sort(ByVolumeName(builder.volumes))
+
 	return &VoltronRouteConfig{
 		routesData:   routesData,
 		volumeMounts: builder.volumeMounts,
@@ -458,6 +461,18 @@ type VoltronRouteConfig struct {
 	volumes      []corev1.Volume
 	annotations  map[string]string
 }
+
+type ByVolumeMountName []corev1.VolumeMount
+
+func (m ByVolumeMountName) Len() int           { return len(m) }
+func (m ByVolumeMountName) Less(i, j int) bool { return m[i].Name < m[j].Name }
+func (m ByVolumeMountName) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+type ByVolumeName []corev1.Volume
+
+func (m ByVolumeName) Len() int           { return len(m) }
+func (m ByVolumeName) Less(i, j int) bool { return m[i].Name < m[j].Name }
+func (m ByVolumeName) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
 // Volumes returns the volumes that Voltron needs to be configured with (references to ConfigMaps and Secrets in the
 // TLSTerminatedRoute CRs).


### PR DESCRIPTION
## Description

Tigera-manager is restarted by operator in a multi-tenant environment due to the following:
- we are picking up kibana certificates instead of elastic and we are setting the annotations to use kibana certificate. At the next reconciliation, this changes. This is happening because external kibana and external elastic have the value and thus the same hash. Certificate manager only keeps one of them, as it stores as a hash for the certificate. We do not need external kibana certificates and we can stop rendering them. (How we store certs for the trusted bundle: https://github.com/tigera/operator/blob/2f071c36038db04ff46aa0de9b0422efe74daff9/pkg/tls/certificatemanagement/certificatebundle.go#L104)

```
diff tigera-linseed-566bbc65cf-cc-tenant-u45b0nkt tigera-linseed-5db6cd6fcd-cc-tenant-u45b0nkt 
7,10c7,9
<     deployment.kubernetes.io/revision: "3"
<     deployment.kubernetes.io/revision-history: "1"
<   creationTimestamp: "2024-09-16T18:39:49Z"
<   generation: 1
---
>     deployment.kubernetes.io/revision: "2"
>   creationTimestamp: "2024-09-16T21:37:18Z"
>   generation: 2
14,15c13,14
<     pod-template-hash: 566bbc65cf
<   name: tigera-linseed-566bbc65cf
---
>     pod-template-hash: 5db6cd6fcd
>   name: tigera-linseed-5db6cd6fcd
24,25c23,24
<   resourceVersion: "696063"
<   uid: ec4c7d2f-60b0-41ed-a6b7-1f79767c3093
---
>   resourceVersion: "696071"
>   uid: feb1aa56-42f0-447d-9ea9-4dc4e9e5d655
27c26
<   replicas: 1
---
>   replicas: 0
31c30
<       pod-template-hash: 566bbc65cf
---
>       pod-template-hash: 5db6cd6fcd
41c40
<         tigera-operator.hash.operator.tigera.io/tigera-secure-es-http-certs-public: ba4e8391ac56eed2f5bf4458d05f25f92d65c672
---
>         tigera-operator.hash.operator.tigera.io/tigera-secure-kb-http-certs-public: ba4e8391ac56eed2f5bf4458d05f25f92d65c672
46c45
<         pod-template-hash: 566bbc65cf
---
>         pod-template-hash: 5db6cd6fcd
249,253c248,249
<   availableReplicas: 1
<   fullyLabeledReplicas: 1
<   observedGeneration: 1
<   readyReplicas: 1
<   replicas: 1
---
>   observedGeneration: 2
>   replicas: 0
```

```
diff tigera-secure-es-http-certs-public tigera-secure-kb-http-certs-public 
8,9c8,9
<   creationTimestamp: "2024-09-16T16:26:51Z"
<   name: tigera-secure-es-http-certs-public
---
>   creationTimestamp: "2024-09-16T16:26:49Z"
>   name: tigera-secure-kb-http-certs-public
15,18c15,18
<     name: tigera-secure-es-http-certs-public
<     uid: 567c1091-3617-403f-8281-45cdcbf3ee31
<   resourceVersion: "350817"
<   uid: 71a7273f-4e90-4274-91f9-ca18032a015b
---
>     name: tigera-secure-kb-http-certs-public
>     uid: 5ae7df17-f223-40c3-9323-6a9fed331a73
>   resourceVersion: "350753"
>   uid: 3025e0fe-fe33-4483-ade0-305fc3b8b892
```



- voltron routes are configured by different components (cloud rbac, image assurance) and can produce different volume mounts/volumes which causes tigera-manager to create a new replica set.

```
diff tigera-manager-d68b7cbd4-cc-tenant-cvlocpq8 tigera-manager-5c44d49556-cc-tenant-cvlocpq8 --color
7,10c7,10
<     deployment.kubernetes.io/revision: "29"
<     deployment.kubernetes.io/revision-history: 3,5,7,9,11,13,15,17,19,21,23,25,27
<   creationTimestamp: "2024-09-16T16:50:20Z"
<   generation: 27
---
>     deployment.kubernetes.io/revision: "28"
>     deployment.kubernetes.io/revision-history: 2,6,8,10,12,14,16,18,20,22,24,26
>   creationTimestamp: "2024-09-16T16:37:11Z"
>   generation: 26
14,15c14,15
<     pod-template-hash: d68b7cbd4
<   name: tigera-manager-d68b7cbd4
---
>     pod-template-hash: 5c44d49556
>   name: tigera-manager-5c44d49556
24,25c24,25
<   resourceVersion: "749585"
<   uid: 857c37aa-dddd-41cd-9996-4f13914aca15
---
>   resourceVersion: "749515"
>   uid: 881189f0-5d90-48d2-897c-259856f6ae94
27c27
<   replicas: 1
---
>   replicas: 0
31c31
<       pod-template-hash: d68b7cbd4
---
>       pod-template-hash: 5c44d49556
59c59
<         pod-template-hash: d68b7cbd4
---
>         pod-template-hash: 5c44d49556
305,307d304
<         - mountPath: /config_maps/tigera-image-assurance-api-public-cert
<           name: cm-tigera-image-assurance-api-public-cert
<           readOnly: true
310a308,310
>         - mountPath: /config_maps/tigera-image-assurance-api-public-cert
>           name: cm-tigera-image-assurance-api-public-cert
>           readOnly: true
359,362d358
<           name: tigera-image-assurance-api-public-cert
<         name: cm-tigera-image-assurance-api-public-cert
<       - configMap:
<           defaultMode: 420
366a363,366
>           name: tigera-image-assurance-api-public-cert
>         name: cm-tigera-image-assurance-api-public-cert
>       - configMap:
>           defaultMode: 420
377,381c377,378
<   availableReplicas: 1
<   fullyLabeledReplicas: 1
<   observedGeneration: 27
<   readyReplicas: 1
<   replicas: 1
---
>   observedGeneration: 26
>   replicas: 0
```



## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
