### PR TITLE
[cherry-pick][v1.36]Reduce the number of restart for tigera-manager (#3503)

### DIFF
--- a/pkg/controller/secrets/tenant_controller.go
+++ b/pkg/controller/secrets/tenant_controller.go
@@ -227,9 +227,8 @@ func (r *TenantController) upstreamCertificates(cm certificatemanager.Certificat
 	}
 
 	if r.elasticExternal {
-		// If configured to use external Elasticsearch, get the Elasticsearch and Kibana public certs.
+		// If configured to use external Elasticsearch, get the Elasticsearch public certs.
 		toQuery[logstorage.ExternalESPublicCertName] = common.OperatorNamespace()
-		toQuery[logstorage.ExternalKBPublicCertName] = common.OperatorNamespace()
 	}
 
 	// Query each certificate.

--- a/pkg/render/common/test/testing.go
+++ b/pkg/render/common/test/testing.go
@@ -283,6 +283,20 @@ func CreateCertSecret(name, namespace string, dnsNames ...string) *corev1.Secret
 	}
 }
 
+func CreateCertSecretWithContent(name, namespace string, keyContent []byte, crtContent []byte) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: keyContent,
+			corev1.TLSCertKey:       crtContent,
+		},
+	}
+}
+
 func ExpectBundleContents(bundle *corev1.ConfigMap, secrets ...types.NamespacedName) {
 	ExpectWithOffset(1, bundle.Data).To(HaveKey("tigera-ca-bundle.crt"), fmt.Sprintf("Bundle: %+v", bundle))
 

--- a/pkg/render/manager/manager_route_config.go
+++ b/pkg/render/manager/manager_route_config.go
@@ -290,6 +290,9 @@ func (builder *voltronRouteConfigBuilder) Build() (*VoltronRouteConfig, error) {
 		return nil, err
 	}
 
+	sort.Sort(ByVolumeMountName(builder.volumeMounts))
+	sort.Sort(ByVolumeName(builder.volumes))
+
 	return &VoltronRouteConfig{
 		routesData:   routesData,
 		volumeMounts: builder.volumeMounts,
@@ -458,6 +461,18 @@ type VoltronRouteConfig struct {
 	volumes      []corev1.Volume
 	annotations  map[string]string
 }
+
+type ByVolumeMountName []corev1.VolumeMount
+
+func (m ByVolumeMountName) Len() int           { return len(m) }
+func (m ByVolumeMountName) Less(i, j int) bool { return m[i].Name < m[j].Name }
+func (m ByVolumeMountName) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+type ByVolumeName []corev1.Volume
+
+func (m ByVolumeName) Len() int           { return len(m) }
+func (m ByVolumeName) Less(i, j int) bool { return m[i].Name < m[j].Name }
+func (m ByVolumeName) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
 // Volumes returns the volumes that Voltron needs to be configured with (references to ConfigMaps and Secrets in the
 // TLSTerminatedRoute CRs).


### PR DESCRIPTION
Tigera-manager is restarted by operator in a multi-tenant environment due to the following:
- we are picking up kibana certificates instead of elastic and we are setting the annotations to use kibana certificate. At the next reconciliation, this changes. This is happening because external kibana and external elastic have the value and thus the same hash. Certificate manager only keeps one of them, as it stores as a hash for the certificate. We do not need external kibana certificates and we can stop rendering them
- voltron routes are configured by different components (cloud rbac, image assurance) and can produce different volume mounts/volumes which causes tigera-manager to create a new replica set.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
