### PR TITLE
Add EnvoyProxyEnvoy to gen-versions

### DIFF
--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -48,6 +48,7 @@ var defaultImages = map[string]string{
 	"tigera-cni-windows":         "tigera/cni-windows",
 	"calico/apiserver":           "calico/apiserver",
 	"tigera/linseed":             "tigera/linseed",
+	"envoyproxy-envoy":           "envoyproxy/envoy",
 }
 
 var ignoredImages = map[string]struct{}{

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -415,6 +415,7 @@ var (
 		ComponentEgressGateway,
 		ComponentL7Collector,
 		ComponentEnvoyProxy,
+                ComponentEnvoyProxyEnvoy,
 		ComponentPrometheus,
 		ComponentTigeraPrometheusService,
 		ComponentPrometheusAlertmanager,

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -240,6 +240,13 @@ var (
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
+{{ with index .Components "envoyproxy-envoy" }}
+	ComponentEnvoyProxyEnvoy = Component{
+		Version:  "{{ .Version }}",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
+	}
+{{- end }}
 {{ with index .Components "dikastes" }}
 	ComponentDikastes = Component{
 		Version:  "{{ .Version }}",


### PR DESCRIPTION
With the new EnvoyProxyEnvoy image added, we also need to add this image to gen-versions so that our generated versions files have the correct component information.