### PR TITLE
[EV-4854] Adding X-Frames-Options DENY header for Kibana

### DIFF
--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -215,6 +215,9 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 		"basePath":        fmt.Sprintf("/%s", BasePath),
 		"rewriteBasePath": true,
 		"defaultRoute":    fmt.Sprintf(DefaultRoute, TimeFilter, url.PathEscape(FlowsDashboardName)),
+		"customResponseHeaders": map[string]interface{}{
+			"X-Frame-Options": "DENY",
+		},
 	}
 
 	if k.cfg.BaseURL != "" {

--- a/pkg/render/logstorage/kibana/kibana_test.go
+++ b/pkg/render/logstorage/kibana/kibana_test.go
@@ -169,6 +169,17 @@ var _ = Describe("Kibana rendering tests", func() {
 			Expect(x["publicBaseUrl"]).To(Equal("https://test.domain.com/tigera-kibana"))
 		})
 
+		It("should configure X-Frame-Options as DENY in customResponseHeaders", func() {
+			component := kibana.Kibana(cfg)
+
+			createResources, _ := component.Objects()
+			kb := rtest.GetResource(createResources, kibana.CRName, kibana.Namespace, "kibana.k8s.elastic.co", "v1", "Kibana")
+			kibana := kb.(*kbv1.Kibana)
+			server := kibana.Spec.Config.Data["server"].(map[string]interface{})
+			customResponseHeaders := server["customResponseHeaders"].(map[string]interface{})
+			Expect(customResponseHeaders["X-Frame-Options"]).To(Equal("DENY"))
+		})
+
 		It("should delete Kibana ExternalService", func() {
 			cfg.KbService = &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: kibana.ServiceName, Namespace: kibana.Namespace},


### PR DESCRIPTION
## Description
Changes done to add X-Frames-Options DENY header for Kibana requests.
https://tigera.atlassian.net/browse/EV-4854

## TESTING
![Screenshot from 2024-09-23 13-15-03](https://github.com/user-attachments/assets/7a819b72-a00e-46ab-a408-e0114cbf0be2)


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
