### PR TITLE
Append TIGERA_TPROXY_ENABLED to per host envoy (tigera#3518) 

### DIFF
--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -361,6 +361,7 @@ func (c *component) proxyEnv() []corev1.EnvVar {
 		// envoy needs to run as root to be able to use transparent flag (for tproxy)
 		{Name: "ENVOY_UID", Value: "0"},
 		{Name: "ENVOY_GID", Value: "0"},
+		{Name: "TIGERA_TPROXY", Value: "Enabled"},
 	}
 }
 

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -175,6 +175,7 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		expectedProxyEnvs := []corev1.EnvVar{
 			{Name: "ENVOY_UID", Value: "0"},
 			{Name: "ENVOY_GID", Value: "0"},
+			{Name: "TIGERA_TPROXY", Value: "Enabled"},
 		}
 		Expect(len(proxyEnvs)).To(Equal(len(expectedProxyEnvs)))
 
@@ -462,6 +463,7 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		expectedProxyEnvs := []corev1.EnvVar{
 			{Name: "ENVOY_UID", Value: "0"},
 			{Name: "ENVOY_GID", Value: "0"},
+			{Name: "TIGERA_TPROXY", Value: "Enabled"},
 		}
 		Expect(len(proxyEnvs)).To(Equal(len(expectedProxyEnvs)))
 
@@ -620,6 +622,7 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		expectedProxyEnvs := []corev1.EnvVar{
 			{Name: "ENVOY_UID", Value: "0"},
 			{Name: "ENVOY_GID", Value: "0"},
+			{Name: "TIGERA_TPROXY", Value: "Enabled"},
 		}
 		Expect(len(proxyEnvs)).To(Equal(len(expectedProxyEnvs)))
 


### PR DESCRIPTION
## Description

From https://github.com/tigera/operator/pull/3518

This pull request includes changes to the `applicationlayer` component to enable the `TIGERA_TPROXY` environment variable and update the corresponding tests to reflect this new configuration.

### Enhancements to `applicationlayer` component:

* [`pkg/render/applicationlayer/applicationlayer.go`](diffhunk://#diff-ffb6ddcb91ab415708c5fb7fca9459630339dc3d3e13f24f193b801de7b95723R364): Added the `TIGERA_TPROXY` environment variable to the `proxyEnv` function to enable TPROXY support.

### Updates to tests:

* [`pkg/render/applicationlayer/applicationlayer_test.go`](diffhunk://#diff-98fd0c59b27b5ae7ab75f6f31bfb9eec2cc50437372453425b05a0f1407e0604R178): Updated the expected environment variables in the `Tigera Secure Application Layer rendering tests` to include `TIGERA_TPROXY` in three different test cases. [[1]](diffhunk://#diff-98fd0c59b27b5ae7ab75f6f31bfb9eec2cc50437372453425b05a0f1407e0604R178) [[2]](diffhunk://#diff-98fd0c59b27b5ae7ab75f6f31bfb9eec2cc50437372453425b05a0f1407e0604R466) [[3]](diffhunk://#diff-98fd0c59b27b5ae7ab75f6f31bfb9eec2cc50437372453425b05a0f1407e0604R625)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.