### PR TITLE
Adding felix service metric port

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -89,6 +89,8 @@ const (
 	// The default port used by calico/node to report Calico Enterprise internal metrics.
 	// This is separate from the calico/node prometheus metrics port, which is user configurable.
 	defaultNodeReporterPort = 9081
+
+	defaultFelixMetricsDefaultPort = 9091
 )
 
 const InstallationName string = "calico"
@@ -1135,17 +1137,23 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	nodeReporterMetricsPort := defaultNodeReporterPort
 	var nodePrometheusTLS certificatemanagement.KeyPairInterface
 	calicoVersion := components.CalicoRelease
+
+	felixPrometheusMetricsPort := defaultFelixMetricsDefaultPort
+
 	if instance.Spec.Variant == operator.TigeraSecureEnterprise {
 
 		// Determine the port to use for nodeReporter metrics.
 		if felixConfiguration.Spec.PrometheusReporterPort != nil {
 			nodeReporterMetricsPort = *felixConfiguration.Spec.PrometheusReporterPort
 		}
-
 		if nodeReporterMetricsPort == 0 {
 			err := errors.New("felixConfiguration prometheusReporterPort=0 not supported")
 			r.status.SetDegraded(operator.InvalidConfigurationError, "invalid metrics port", err, reqLogger)
 			return reconcile.Result{}, err
+		}
+
+		if felixConfiguration.Spec.PrometheusMetricsPort != nil {
+			felixPrometheusMetricsPort = *felixConfiguration.Spec.PrometheusMetricsPort
 		}
 
 		nodePrometheusTLS, err = certificateManager.GetOrCreateKeyPair(r.client, render.NodePrometheusTLSServerSecret, common.OperatorNamespace(), dns.GetServiceDNSNames(render.CalicoNodeMetricsService, common.CalicoNamespace, r.clusterDomain))
@@ -1365,6 +1373,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		FelixHealthPort:               *felixConfiguration.Spec.HealthPort,
 		BindMode:                      bgpConfiguration.Spec.BindMode,
 		FelixPrometheusMetricsEnabled: isFelixPrometheusMetricsEnabled(felixConfiguration),
+		FelixPrometheusMetricsPort:    felixPrometheusMetricsPort,
 	}
 	components = append(components, render.Node(&nodeCfg))
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1372,7 +1372,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		PrometheusServerTLS:           nodePrometheusTLS,
 		FelixHealthPort:               *felixConfiguration.Spec.HealthPort,
 		BindMode:                      bgpConfiguration.Spec.BindMode,
-		FelixPrometheusMetricsEnabled: isFelixPrometheusMetricsEnabled(felixConfiguration),
+		FelixPrometheusMetricsEnabled: utils.IsFelixPrometheusMetricsEnabled(felixConfiguration),
 		FelixPrometheusMetricsPort:    felixPrometheusMetricsPort,
 	}
 	components = append(components, render.Node(&nodeCfg))
@@ -1560,13 +1560,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	reqLogger.V(1).Info("Finished reconciling Installation")
 	return reconcile.Result{}, nil
-}
-
-func isFelixPrometheusMetricsEnabled(felixConfiguration *crdv1.FelixConfiguration) bool {
-	if felixConfiguration.Spec.PrometheusMetricsEnabled != nil {
-		return *felixConfiguration.Spec.PrometheusMetricsEnabled
-	}
-	return false
 }
 
 func readMTUFile() (int, error) {

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1349,21 +1349,22 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	// Build a configuration for rendering calico/node.
 	nodeCfg := render.NodeConfiguration{
-		K8sServiceEp:            k8sapi.Endpoint,
-		Installation:            &instance.Spec,
-		IPPools:                 crdPoolsToOperator(currentPools.Items),
-		LogCollector:            logCollector,
-		BirdTemplates:           birdTemplates,
-		TLS:                     typhaNodeTLS,
-		ClusterDomain:           r.clusterDomain,
-		NodeReporterMetricsPort: nodeReporterMetricsPort,
-		BGPLayouts:              bgpLayout,
-		NodeAppArmorProfile:     nodeAppArmorProfile,
-		MigrateNamespaces:       needNsMigration,
-		CanRemoveCNIFinalizer:   canRemoveCNI,
-		PrometheusServerTLS:     nodePrometheusTLS,
-		FelixHealthPort:         *felixConfiguration.Spec.HealthPort,
-		BindMode:                bgpConfiguration.Spec.BindMode,
+		K8sServiceEp:                  k8sapi.Endpoint,
+		Installation:                  &instance.Spec,
+		IPPools:                       crdPoolsToOperator(currentPools.Items),
+		LogCollector:                  logCollector,
+		BirdTemplates:                 birdTemplates,
+		TLS:                           typhaNodeTLS,
+		ClusterDomain:                 r.clusterDomain,
+		NodeReporterMetricsPort:       nodeReporterMetricsPort,
+		BGPLayouts:                    bgpLayout,
+		NodeAppArmorProfile:           nodeAppArmorProfile,
+		MigrateNamespaces:             needNsMigration,
+		CanRemoveCNIFinalizer:         canRemoveCNI,
+		PrometheusServerTLS:           nodePrometheusTLS,
+		FelixHealthPort:               *felixConfiguration.Spec.HealthPort,
+		BindMode:                      bgpConfiguration.Spec.BindMode,
+		FelixPrometheusMetricsEnabled: isFelixPrometheusMetricsEnabled(felixConfiguration),
 	}
 	components = append(components, render.Node(&nodeCfg))
 
@@ -1550,6 +1551,13 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	reqLogger.V(1).Info("Finished reconciling Installation")
 	return reconcile.Result{}, nil
+}
+
+func isFelixPrometheusMetricsEnabled(felixConfiguration *crdv1.FelixConfiguration) bool {
+	if felixConfiguration.Spec.PrometheusMetricsEnabled != nil {
+		return *felixConfiguration.Spec.PrometheusMetricsEnabled
+	}
+	return false
 }
 
 func readMTUFile() (int, error) {

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
+	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,6 +143,10 @@ func add(_ manager.Manager, c ctrlruntime.Controller) error {
 	err = c.WatchObject(&operatorv1.ManagementClusterConnection{}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return fmt.Errorf("monitor-controller failed to watch ManagementClusterConnection resource: %w", err)
+	}
+
+	if err = c.WatchObject(&crdv1.FelixConfiguration{}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("monitor-controller failed to watch FelixConfiguration resource: %w", err)
 	}
 
 	for _, secret := range []string{
@@ -373,18 +379,21 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
+	felixConfiguration, err := utils.GetFelixConfiguration(ctx, r.client)
+
 	monitorCfg := &monitor.Config{
-		Monitor:                  instance.Spec,
-		Installation:             install,
-		PullSecrets:              pullSecrets,
-		AlertmanagerConfigSecret: alertmanagerConfigSecret,
-		KeyValidatorConfig:       keyValidatorConfig,
-		ServerTLSSecret:          serverTLSSecret,
-		ClientTLSSecret:          clientTLSSecret,
-		ClusterDomain:            r.clusterDomain,
-		TrustedCertBundle:        trustedBundle,
-		OpenShift:                r.provider.IsOpenShift(),
-		KubeControllerPort:       kubeControllersMetricsPort,
+		Monitor:                       instance.Spec,
+		Installation:                  install,
+		PullSecrets:                   pullSecrets,
+		AlertmanagerConfigSecret:      alertmanagerConfigSecret,
+		KeyValidatorConfig:            keyValidatorConfig,
+		ServerTLSSecret:               serverTLSSecret,
+		ClientTLSSecret:               clientTLSSecret,
+		ClusterDomain:                 r.clusterDomain,
+		TrustedCertBundle:             trustedBundle,
+		OpenShift:                     r.provider.IsOpenShift(),
+		KubeControllerPort:            kubeControllersMetricsPort,
+		FelixPrometheusMetricsEnabled: utils.IsFelixPrometheusMetricsEnabled(felixConfiguration),
 	}
 
 	// Render prometheus component

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -381,7 +381,8 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 
 	felixConfiguration, err := utils.GetFelixConfiguration(ctx, r.client)
 	if err != nil {
-		log.Error(err, "Error retrieving Felix configuration")
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error retrieving Felix configuration", err, reqLogger)
+		return reconcile.Result{}, err
 	}
 
 	monitorCfg := &monitor.Config{

--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -380,6 +380,9 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	felixConfiguration, err := utils.GetFelixConfiguration(ctx, r.client)
+	if err != nil {
+		log.Error(err, "Error retrieving Felix configuration")
+	}
 
 	monitorCfg := &monitor.Config{
 		Monitor:                       instance.Spec,

--- a/pkg/controller/utils/felix_configuration.go
+++ b/pkg/controller/utils/felix_configuration.go
@@ -56,3 +56,19 @@ func PatchFelixConfiguration(ctx context.Context, c client.Client, patchFn func(
 
 	return fc, nil
 }
+
+func GetFelixConfiguration(ctx context.Context, c client.Client) (*crdv1.FelixConfiguration, error) {
+	fc := &crdv1.FelixConfiguration{}
+	err := c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("unable to read FelixConfiguration: %w", err)
+	}
+	return fc, nil
+}
+
+func IsFelixPrometheusMetricsEnabled(felixConfiguration *crdv1.FelixConfiguration) bool {
+	if felixConfiguration.Spec.PrometheusMetricsEnabled != nil {
+		return *felixConfiguration.Spec.PrometheusMetricsEnabled
+	}
+	return false
+}

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -120,17 +120,18 @@ func MonitorPolicy(cfg *Config) render.Component {
 
 // Config contains all the config information needed to render the Monitor component.
 type Config struct {
-	Monitor                  operatorv1.MonitorSpec
-	Installation             *operatorv1.InstallationSpec
-	PullSecrets              []*corev1.Secret
-	AlertmanagerConfigSecret *corev1.Secret
-	KeyValidatorConfig       authentication.KeyValidatorConfig
-	ServerTLSSecret          certificatemanagement.KeyPairInterface
-	ClientTLSSecret          certificatemanagement.KeyPairInterface
-	ClusterDomain            string
-	TrustedCertBundle        certificatemanagement.TrustedBundle
-	OpenShift                bool
-	KubeControllerPort       int
+	Monitor                       operatorv1.MonitorSpec
+	Installation                  *operatorv1.InstallationSpec
+	PullSecrets                   []*corev1.Secret
+	AlertmanagerConfigSecret      *corev1.Secret
+	KeyValidatorConfig            authentication.KeyValidatorConfig
+	ServerTLSSecret               certificatemanagement.KeyPairInterface
+	ClientTLSSecret               certificatemanagement.KeyPairInterface
+	ClusterDomain                 string
+	TrustedCertBundle             certificatemanagement.TrustedBundle
+	OpenShift                     bool
+	KubeControllerPort            int
+	FelixPrometheusMetricsEnabled bool
 }
 
 type monitorComponent struct {
@@ -806,6 +807,35 @@ func (mc *monitorComponent) prometheusRule() *monitoringv1.PrometheusRule {
 }
 
 func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMonitor {
+	endpoints := []monitoringv1.Endpoint{
+		{
+			HonorLabels:   true,
+			Interval:      "5s",
+			Port:          "calico-metrics-port",
+			ScrapeTimeout: "5s",
+			Scheme:        "https",
+			TLSConfig:     mc.tlsConfig(render.CalicoNodeMetricsService),
+		},
+		{
+			HonorLabels:   true,
+			Interval:      "5s",
+			Port:          "calico-bgp-metrics-port",
+			ScrapeTimeout: "5s",
+			Scheme:        "https",
+			TLSConfig:     mc.tlsConfig(render.CalicoNodeMetricsService),
+		},
+	}
+
+	if mc.cfg.FelixPrometheusMetricsEnabled {
+		endpoints = append(endpoints, monitoringv1.Endpoint{
+			HonorLabels:   true,
+			Interval:      "5s",
+			Port:          "felix-metrics-port",
+			ScrapeTimeout: "5s",
+			Scheme:        "http",
+		})
+	}
+
 	return &monitoringv1.ServiceMonitor{
 		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.ServiceMonitorsKind, APIVersion: MonitoringAPIVersion},
 		ObjectMeta: metav1.ObjectMeta{
@@ -824,24 +854,7 @@ func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMoni
 				},
 			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{"calico-system"}},
-			Endpoints: []monitoringv1.Endpoint{
-				{
-					HonorLabels:   true,
-					Interval:      "5s",
-					Port:          "calico-metrics-port",
-					ScrapeTimeout: "5s",
-					Scheme:        "https",
-					TLSConfig:     mc.tlsConfig(render.CalicoNodeMetricsService),
-				},
-				{
-					HonorLabels:   true,
-					Interval:      "5s",
-					Port:          "calico-bgp-metrics-port",
-					ScrapeTimeout: "5s",
-					Scheme:        "https",
-					TLSConfig:     mc.tlsConfig(render.CalicoNodeMetricsService),
-				},
-			},
+			Endpoints:         endpoints,
 		},
 	}
 }

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -976,6 +976,32 @@ var _ = Describe("monitor rendering tests", func() {
 			},
 		}))
 	})
+
+	It("Should render serviceMonitor with felix endpoint if FelixPrometheusMetricsEnabled", func() {
+		cfg.FelixPrometheusMetricsEnabled = true
+		component := monitor.Monitor(cfg)
+		toCreate, _ := component.Objects()
+		servicemonitorObj, ok := rtest.GetResource(toCreate, monitor.CalicoNodeMonitor, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
+		Expect(ok).To(BeTrue())
+
+		Expect(servicemonitorObj.Spec.Endpoints).To(HaveLen(3))
+		Expect(servicemonitorObj.Spec.Endpoints[0].HonorLabels).To(BeTrue())
+		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(BeEquivalentTo("5s"))
+		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("calico-metrics-port"))
+		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(BeEquivalentTo("5s"))
+		Expect(servicemonitorObj.Spec.Endpoints[0].Scheme).To(Equal("https"))
+		Expect(servicemonitorObj.Spec.Endpoints[1].HonorLabels).To(BeTrue())
+		Expect(servicemonitorObj.Spec.Endpoints[1].Interval).To(BeEquivalentTo("5s"))
+		Expect(servicemonitorObj.Spec.Endpoints[1].Port).To(Equal("calico-bgp-metrics-port"))
+		Expect(servicemonitorObj.Spec.Endpoints[1].ScrapeTimeout).To(BeEquivalentTo("5s"))
+		Expect(servicemonitorObj.Spec.Endpoints[1].Scheme).To(Equal("https"))
+		Expect(servicemonitorObj.Spec.Endpoints[2].HonorLabels).To(BeTrue())
+		Expect(servicemonitorObj.Spec.Endpoints[2].Interval).To(BeEquivalentTo("5s"))
+		Expect(servicemonitorObj.Spec.Endpoints[2].Port).To(Equal("felix-metrics-port"))
+		Expect(servicemonitorObj.Spec.Endpoints[2].ScrapeTimeout).To(BeEquivalentTo("5s"))
+		Expect(servicemonitorObj.Spec.Endpoints[2].Scheme).To(Equal("http"))
+
+	})
 })
 
 type resource struct {

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1736,7 +1736,7 @@ func (c *nodeComponent) nodeMetricsService() *corev1.Service {
 		},
 	}
 
-	if c.cfg.FelixPrometheusMetricsEnabled == true {
+	if c.cfg.FelixPrometheusMetricsEnabled {
 		felixMetricsPort := c.getFelixMetricsPort()
 
 		ports = append(ports, corev1.ServicePort{

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1737,7 +1737,7 @@ func (c *nodeComponent) nodeMetricsService() *corev1.Service {
 	}
 
 	if c.cfg.FelixPrometheusMetricsEnabled {
-		felixMetricsPort := c.getFelixMetricsPort()
+		felixMetricsPort := int32(c.cfg.FelixPrometheusMetricsPort)
 
 		ports = append(ports, corev1.ServicePort{
 			Name:       "felix-metrics-port",
@@ -1764,14 +1764,6 @@ func (c *nodeComponent) nodeMetricsService() *corev1.Service {
 			Ports:     ports,
 		},
 	}
-}
-
-func (c *nodeComponent) getFelixMetricsPort() int32 {
-	if c.cfg.Installation.NodeMetricsPort != nil {
-		return *c.cfg.Installation.NodeMetricsPort
-	}
-
-	return int32(c.cfg.FelixPrometheusMetricsPort)
 }
 
 // hostPathInitContainer creates an init container that changes the permissions on hostPath volumes

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -74,6 +74,8 @@ var (
 	nodeBGPReporterPort int32 = 9900
 
 	NodeTLSSecretName = "node-certs"
+
+	felixMetricsDefaultPort int32 = 9091
 )
 
 // TyphaNodeTLS holds configuration for Node and Typha to establish TLS.
@@ -124,6 +126,8 @@ type NodeConfiguration struct {
 	// The bindMode read from the default BGPConfiguration. Used to trigger rolling updates
 	// should this value change.
 	BindMode string
+
+	FelixPrometheusMetricsEnabled bool
 }
 
 // Node creates the node daemonset and other resources for the daemonset to operate normally.
@@ -1717,6 +1721,30 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Pr
 // This service is used internally by Calico Enterprise and is separate from general
 // Prometheus metrics which are user-configurable.
 func (c *nodeComponent) nodeMetricsService() *corev1.Service {
+	ports := []corev1.ServicePort{
+		{
+			Name:       "calico-metrics-port",
+			Port:       int32(c.cfg.NodeReporterMetricsPort),
+			TargetPort: intstr.FromInt(c.cfg.NodeReporterMetricsPort),
+			Protocol:   corev1.ProtocolTCP,
+		},
+		{
+			Name:       "calico-bgp-metrics-port",
+			Port:       nodeBGPReporterPort,
+			TargetPort: intstr.FromInt(int(nodeBGPReporterPort)),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	}
+
+	if c.cfg.FelixPrometheusMetricsEnabled == true {
+		ports = append(ports, corev1.ServicePort{
+			Name:       "felix-metrics-port",
+			Port:       felixMetricsDefaultPort,
+			TargetPort: intstr.FromInt(int(felixMetricsDefaultPort)),
+			Protocol:   corev1.ProtocolTCP,
+		})
+	}
+
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1731,20 +1759,7 @@ func (c *nodeComponent) nodeMetricsService() *corev1.Service {
 			// a huge set of iptables rules for this service since there's an instance
 			// on every node.
 			ClusterIP: "None",
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "calico-metrics-port",
-					Port:       int32(c.cfg.NodeReporterMetricsPort),
-					TargetPort: intstr.FromInt(c.cfg.NodeReporterMetricsPort),
-					Protocol:   corev1.ProtocolTCP,
-				},
-				{
-					Name:       "calico-bgp-metrics-port",
-					Port:       nodeBGPReporterPort,
-					TargetPort: intstr.FromInt(int(nodeBGPReporterPort)),
-					Protocol:   corev1.ProtocolTCP,
-				},
-			},
+			Ports:     ports,
 		},
 	}
 }

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -850,7 +850,7 @@ var _ = Describe("Node rendering tests", func() {
 				verifyProbesAndLifecycle(ds, false, true)
 			})
 
-			It("should render felix service metric with FelixPrometheusMetricPort when FelixPrometheusMetricsEnabled is true and nodeMetricsPort is nil", func() {
+			It("should render felix service metric with FelixPrometheusMetricPort when FelixPrometheusMetricsEnabled is true", func() {
 
 				defaultInstance.Variant = operatorv1.TigeraSecureEnterprise
 				cfg.NodeReporterMetricsPort = 9081
@@ -877,44 +877,6 @@ var _ = Describe("Node rendering tests", func() {
 						Name:       "felix-metrics-port",
 						Port:       9098,
 						TargetPort: intstr.FromInt(int(9098)),
-						Protocol:   corev1.ProtocolTCP,
-					},
-				}
-
-				//Expect 3 Ports when FelixPrometheusMetricsEnabled is true
-				ms := rtest.GetResource(resources, "calico-node-metrics", "calico-system", "", "v1", "Service").(*corev1.Service)
-				Expect(ms.Spec.Ports).To(Equal(expectedServicePorts))
-			})
-
-			It("should render felix service metric with nodeMetricsPort when FelixPrometheusMetricsEnabled is true and nodeMetricsPort is not nil", func() {
-
-				defaultInstance.Variant = operatorv1.TigeraSecureEnterprise
-				cfg.NodeReporterMetricsPort = 9081
-				cfg.FelixPrometheusMetricsEnabled = true
-				var nodeMetricsPort int32 = 9099
-				cfg.Installation.NodeMetricsPort = &nodeMetricsPort
-
-				component := render.Node(&cfg)
-				Expect(component.ResolveImages(nil)).To(BeNil())
-				resources, _ := component.Objects()
-
-				expectedServicePorts := []corev1.ServicePort{
-					{
-						Name:       "calico-metrics-port",
-						Port:       int32(cfg.NodeReporterMetricsPort),
-						TargetPort: intstr.FromInt(cfg.NodeReporterMetricsPort),
-						Protocol:   corev1.ProtocolTCP,
-					},
-					{
-						Name:       "calico-bgp-metrics-port",
-						Port:       9900,
-						TargetPort: intstr.FromInt(int(9900)),
-						Protocol:   corev1.ProtocolTCP,
-					},
-					{
-						Name:       "felix-metrics-port",
-						Port:       nodeMetricsPort,
-						TargetPort: intstr.FromInt(int(nodeMetricsPort)),
 						Protocol:   corev1.ProtocolTCP,
 					},
 				}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -133,12 +133,13 @@ var _ = Describe("Node rendering tests", func() {
 
 				// Create a default configuration.
 				cfg = render.NodeConfiguration{
-					K8sServiceEp:    k8sServiceEp,
-					Installation:    defaultInstance,
-					TLS:             typhaNodeTLS,
-					ClusterDomain:   defaultClusterDomain,
-					FelixHealthPort: 9099,
-					IPPools:         defaultInstance.CalicoNetwork.IPPools,
+					K8sServiceEp:                  k8sServiceEp,
+					Installation:                  defaultInstance,
+					TLS:                           typhaNodeTLS,
+					ClusterDomain:                 defaultClusterDomain,
+					FelixHealthPort:               9099,
+					IPPools:                       defaultInstance.CalicoNetwork.IPPools,
+					FelixPrometheusMetricsEnabled: false,
 				}
 			})
 
@@ -841,7 +842,47 @@ var _ = Describe("Node rendering tests", func() {
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
 				Expect(len(ds.Spec.Template.Spec.Containers[0].Env)).To(Equal(len(expectedNodeEnv)))
 
+				//Expect 2 Ports when FelixPrometheusMetricsEnabled is false
+				ms := rtest.GetResource(resources, "calico-node-metrics", "calico-system", "", "v1", "Service").(*corev1.Service)
+				Expect(len(ms.Spec.Ports)).To(Equal(2))
+
 				verifyProbesAndLifecycle(ds, false, true)
+			})
+
+			It("should render felix service metric port when FelixPrometheusMetricsEnabled is true ", func() {
+
+				defaultInstance.Variant = operatorv1.TigeraSecureEnterprise
+				cfg.NodeReporterMetricsPort = 9081
+				cfg.FelixPrometheusMetricsEnabled = true
+
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+
+				expectedServicePorts := []corev1.ServicePort{
+					{
+						Name:       "calico-metrics-port",
+						Port:       int32(cfg.NodeReporterMetricsPort),
+						TargetPort: intstr.FromInt(cfg.NodeReporterMetricsPort),
+						Protocol:   corev1.ProtocolTCP,
+					},
+					{
+						Name:       "calico-bgp-metrics-port",
+						Port:       9900,
+						TargetPort: intstr.FromInt(int(9900)),
+						Protocol:   corev1.ProtocolTCP,
+					},
+					{
+						Name:       "felix-metrics-port",
+						Port:       9091,
+						TargetPort: intstr.FromInt(int(9091)),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				}
+
+				//Expect 3 Ports when FelixPrometheusMetricsEnabled is true
+				ms := rtest.GetResource(resources, "calico-node-metrics", "calico-system", "", "v1", "Service").(*corev1.Service)
+				Expect(ms.Spec.Ports).To(Equal(expectedServicePorts))
 			})
 
 			It("should render all resources with the appropriate permissions when running as non-privileged", func() {


### PR DESCRIPTION
## Description
Changes done to add felix service metric
port in calico-node service. This helps in
removing the manual step required by the client
to enable felix metric for BYO prometheus.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
https://tigera.atlassian.net/browse/EV-5305


*** Additional changes required to update felix-metrics-service-monitor.yaml to this :
```
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  labels:
    team: network-operators
  name: felix-metrics
spec:
  endpoints:
    - honorLabels: true
      interval: 5s
      port: felix-metrics-port
      scheme: http
      scrapeTimeout: 5s
  namespaceSelector:
    matchNames:
      - calico-system
  selector:
    matchLabels:
      k8s-app: calico-node
```

## Testing
![Screenshot from 2024-10-09 14-41-06](https://github.com/user-attachments/assets/64b56d23-26b9-445d-a979-9fc0699e3e07)
![Screenshot from 2024-10-09 15-23-01](https://github.com/user-attachments/assets/51e7b6f9-cb2c-429e-901c-a6d24205fb33)


## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
