### PR TITLE
[RS-2143] Reducing DPI readiness initial delay 90s -> 10s.

### DIFF
--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -368,7 +368,7 @@ func (d *dpiComponent) dpiReadinessProbes() *corev1.Probe {
 			},
 		},
 		TimeoutSeconds:      10,
-		InitialDelaySeconds: 90,
+		InitialDelaySeconds: 10,
 	}
 }
 


### PR DESCRIPTION
Original Jira ticket: https://tigera.atlassian.net/browse/RS-2143