### PR TITLE
[RS-2143] [cherry-pick v1.36] Reducing DPI readiness initial delay 90s -> 10s.

### DIFF
--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -369,7 +369,7 @@ func (d *dpiComponent) dpiReadinessProbes() *corev1.Probe {
 			},
 		},
 		TimeoutSeconds:      10,
-		InitialDelaySeconds: 90,
+		InitialDelaySeconds: 10,
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/3545 into `release-v1.36`.
