### PR TITLE
[release-v1.36] Add tolerations for arm64 workloads on GKE

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1304,7 +1304,11 @@ func (c *apiServerComponent) tolerations() []corev1.Toleration {
 	if c.hostNetwork() {
 		return rmeta.TolerateAll
 	}
-	return append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+	return tolerations
 }
 
 // networkPolicy returns a NP to allow traffic to the API server. This prevents it from

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1306,7 +1306,7 @@ func (c *apiServerComponent) tolerations() []corev1.Toleration {
 	}
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	return tolerations
 }

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2068,6 +2068,23 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(tol))
 		})
 
+		It("should render toleration on GKE", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+
+			component, err := render.APIServer(cfg)
+			Expect(err).NotTo(HaveOccurred(), "Expected APIServer to create successfully %s", err)
+			Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+			resources, _ := component.Objects()
+			d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(d).NotTo(BeNil())
+			Expect(d.Spec.Template.Spec.Tolerations).To(ContainElement(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
+		})
+
 		It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
 			fipsEnabled := operatorv1.FIPSModeEnabled
 			cfg.Installation.FIPSMode = &fipsEnabled

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -60,6 +60,15 @@ var (
 
 	TolerateCriticalAddonsAndControlPlane = append(TolerateControlPlane, TolerateCriticalAddonsOnly)
 
+	// TolerateGKEArm64NoSchedule allows pods to be scheduled on GKE Arm64 nodes.
+	// See https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#multi-arch-schedule-any-arch
+	TolerateGKEArm64NoSchedule = corev1.Toleration{
+		Key:      "kubernetes.io/arch",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "arm64",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+
 	// TolerateAll returns tolerations to tolerate all taints. When used, it is not necessary
 	// to include the user's custom tolerations because we already tolerate everything.
 	TolerateAll = []corev1.Toleration{

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -60,9 +60,9 @@ var (
 
 	TolerateCriticalAddonsAndControlPlane = append(TolerateControlPlane, TolerateCriticalAddonsOnly)
 
-	// TolerateGKEArm64NoSchedule allows pods to be scheduled on GKE Arm64 nodes.
+	// TolerateGKEARM64NoSchedule allows pods to be scheduled on GKE Arm64 nodes.
 	// See https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#multi-arch-schedule-any-arch
-	TolerateGKEArm64NoSchedule = corev1.Toleration{
+	TolerateGKEARM64NoSchedule = corev1.Toleration{
 		Key:      "kubernetes.io/arch",
 		Operator: corev1.TolerationOpEqual,
 		Value:    "arm64",

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -454,7 +454,7 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podTemplate := &corev1.PodTemplateSpec{
@@ -637,7 +637,7 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podtemplate := &corev1.PodTemplate{
@@ -875,7 +875,7 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podTemplate := &corev1.PodTemplateSpec{
@@ -1084,7 +1084,7 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podTemplate := &corev1.PodTemplateSpec{

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -451,6 +451,12 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 	if c.cfg.ControllerKeyPair != nil && c.cfg.ControllerKeyPair.UseCertificateManagement() {
 		initContainers = append(initContainers, c.cfg.ControllerKeyPair.InitContainer(c.cfg.Namespace))
 	}
+
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ComplianceControllerName,
@@ -458,7 +464,7 @@ func (c *complianceComponent) complianceControllerDeployment() *appsv1.Deploymen
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: ComplianceControllerServiceAccount,
-			Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
+			Tolerations:        tolerations,
 			NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 			ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 			InitContainers:     initContainers,
@@ -629,6 +635,11 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 		initContainers = append(initContainers, c.cfg.ReporterKeyPair.InitContainer(c.cfg.Namespace))
 	}
 
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podtemplate := &corev1.PodTemplate{
 		TypeMeta: metav1.TypeMeta{Kind: "PodTemplate", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -648,7 +659,7 @@ func (c *complianceComponent) complianceReporterPodTemplate() *corev1.PodTemplat
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: ComplianceReporterServiceAccount,
-				Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
+				Tolerations:        tolerations,
 				NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 				ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 				InitContainers:     initContainers,
@@ -862,6 +873,11 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 		initContainers = append(initContainers, c.cfg.ServerKeyPair.InitContainer(c.cfg.Namespace))
 	}
 
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ComplianceServerName,
@@ -870,7 +886,7 @@ func (c *complianceComponent) complianceServerDeployment() *appsv1.Deployment {
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: ComplianceServerServiceAccount,
-			Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
+			Tolerations:        tolerations,
 			NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 			ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 			InitContainers:     initContainers,
@@ -1066,6 +1082,11 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 		initContainers = append(initContainers, c.cfg.SnapshotterKeyPair.InitContainer(c.cfg.Namespace))
 	}
 
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ComplianceSnapshotterName,
@@ -1073,7 +1094,7 @@ func (c *complianceComponent) complianceSnapshotterDeployment() *appsv1.Deployme
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: ComplianceSnapshotterServiceAccount,
-			Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
+			Tolerations:        tolerations,
 			NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 			ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 			InitContainers:     initContainers,

--- a/pkg/render/compliance_test.go
+++ b/pkg/render/compliance_test.go
@@ -708,6 +708,38 @@ var _ = Describe("compliance rendering tests", func() {
 			Expect(complianceBenchmarker.Spec.Template.Spec.Tolerations).To(ContainElements(rmeta.TolerateAll))
 		})
 
+		It("should render toleration on GKE", func() {
+			installation := &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+			}
+			dpComplianceServer, dpComplianceController, complianceSnapshotter, complianceReporter, complianceBenchmarker := renderCompliance(installation)
+			Expect(dpComplianceServer.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
+			Expect(dpComplianceController.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
+			Expect(complianceSnapshotter.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
+			Expect(complianceReporter.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
+			Expect(complianceBenchmarker.Spec.Template.Spec.Tolerations).To(ContainElements(rmeta.TolerateAll))
+		})
+
 		It("should apply controlPlaneNodeSelectors", func() {
 			dpComplianceServer, dpComplianceController, complianceSnapshotter, _, _ := renderCompliance(&operatorv1.InstallationSpec{
 				ControlPlaneNodeSelector: map[string]string{"foo": "bar"},

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -228,7 +228,7 @@ func (c *dexComponent) deployment() client.Object {
 
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	d := &appsv1.Deployment{

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -226,6 +226,11 @@ func (c *dexComponent) deployment() client.Object {
 	mounts = append(mounts, c.cfg.TLSKeyPair.VolumeMount(c.SupportedOSType()))
 	mounts = append(mounts, c.cfg.TrustedBundle.VolumeMounts(c.SupportedOSType())...)
 
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -246,7 +251,7 @@ func (c *dexComponent) deployment() client.Object {
 				Spec: corev1.PodSpec{
 					NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 					ServiceAccountName: DexObjectName,
-					Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...),
+					Tolerations:        tolerations,
 					ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 					InitContainers:     initContainers,
 					Containers: []corev1.Container{

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -17,9 +17,6 @@ package render_test
 import (
 	"fmt"
 
-	"github.com/tigera/operator/test"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -27,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,6 +47,7 @@ import (
 	"github.com/tigera/operator/pkg/render/testutils"
 	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/test"
 )
 
 var _ = Describe("dex rendering tests", func() {
@@ -304,6 +303,21 @@ var _ = Describe("dex rendering tests", func() {
 			resources, _ := component.Objects()
 			d := rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(append(rmeta.TolerateControlPlane, t)))
+		})
+
+		It("should render toleration on GKE", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+
+			component := render.Dex(cfg)
+			resources, _ := component.Objects()
+			d := rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(d).NotTo(BeNil())
+			Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
 		})
 
 		It("should render all resources for a certificate management", func() {

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -153,6 +153,10 @@ func (c *component) deploymentPodTemplate() *corev1.PodTemplateSpec {
 	for _, x := range c.config.PullSecrets {
 		ps = append(ps, corev1.LocalObjectReference{Name: x.Name})
 	}
+	tolerations := []corev1.Toleration{}
+	if c.config.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: c.egwBuildAnnotations(),
@@ -162,6 +166,7 @@ func (c *component) deploymentPodTemplate() *corev1.PodTemplateSpec {
 			InitContainers:     []corev1.Container{*c.egwInitContainer()},
 			Containers:         []corev1.Container{*c.egwContainer()},
 			ServiceAccountName: c.config.EgressGW.Name,
+			Tolerations:        tolerations,
 			Volumes:            []corev1.Volume{*c.egwVolume()},
 		},
 	}

--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -153,9 +153,9 @@ func (c *component) deploymentPodTemplate() *corev1.PodTemplateSpec {
 	for _, x := range c.config.PullSecrets {
 		ps = append(ps, corev1.LocalObjectReference{Name: x.Name})
 	}
-	tolerations := []corev1.Toleration{}
+	var tolerations []corev1.Toleration
 	if c.config.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -305,9 +305,32 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			OpenShift:    true,
 		})
 		resources, _ := component.Objects()
-		Expect(len(resources)).To(Equal(len(expectedResources)))
+		Expect(resources).To(HaveLen(len(expectedResources)))
 		for i, expectedRes := range expectedResources {
 			rtest.ExpectResourceTypeAndObjectMetadata(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
 		}
+	})
+
+	It("should render toleration on GKE", func() {
+		installation.KubernetesProvider = operatorv1.ProviderGKE
+
+		component := egressgateway.EgressGateway(&egressgateway.Config{
+			PullSecrets:  nil,
+			Installation: installation,
+			OSType:       rmeta.OSTypeLinux,
+			EgressGW:     egw,
+			VXLANVNI:     4097,
+			VXLANPort:    4790,
+			OpenShift:    true,
+		})
+		resources, _ := component.Objects()
+		deploy := rtest.GetResource(resources, "egress-test", "test-ns", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deploy).NotTo(BeNil())
+		Expect(deploy.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
 	})
 })

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -1007,7 +1007,7 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 
 	tolerations := c.cfg.Installation.ControlPlaneTolerations
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	d := &appsv1.Deployment{

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -495,7 +495,7 @@ func (c *fluentdComponent) daemonset() *appsv1.DaemonSet {
 		},
 		Spec: corev1.PodSpec{
 			NodeSelector:                  map[string]string{},
-			Tolerations:                   c.tolerations(),
+			Tolerations:                   rmeta.TolerateAll,
 			ImagePullSecrets:              secret.GetReferenceList(c.cfg.PullSecrets),
 			TerminationGracePeriodSeconds: &terminationGracePeriod,
 			InitContainers:                initContainers,
@@ -527,16 +527,6 @@ func (c *fluentdComponent) daemonset() *appsv1.DaemonSet {
 	}
 	setNodeCriticalPod(&(ds.Spec.Template))
 	return ds
-}
-
-// logCollectorTolerations creates the node's tolerations.
-func (c *fluentdComponent) tolerations() []corev1.Toleration {
-	tolerations := []corev1.Toleration{
-		{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-		{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-	}
-
-	return tolerations
 }
 
 // container creates the fluentd container.
@@ -1015,6 +1005,11 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 
 	var eksLogForwarderReplicas int32 = 1
 
+	tolerations := c.cfg.Installation.ControlPlaneTolerations
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1044,7 +1039,7 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 					Annotations: annots,
 				},
 				Spec: corev1.PodSpec{
-					Tolerations:        c.cfg.Installation.ControlPlaneTolerations,
+					Tolerations:        tolerations,
 					ServiceAccountName: EKSLogForwarderName,
 					ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 					InitContainers: []corev1.Container{{

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -18,13 +18,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/tigera/operator/pkg/tls"
-	"github.com/tigera/operator/test"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,7 +42,9 @@ import (
 	"github.com/tigera/operator/pkg/render/common/secret"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/testutils"
+	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/test"
 )
 
 var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
@@ -709,6 +709,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			}
 		}
 	})
+
 	It("should render with Syslog configuration", func() {
 		expectedResources := []struct {
 			name    string
@@ -793,6 +794,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			},
 		}))
 	})
+
 	It("should render with Syslog configuration with TLS and user's corporate CA", func() {
 		cfg.UseSyslogCertificate = true
 		var ps int32 = 180
@@ -1092,6 +1094,23 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		Expect(envs).To(Equal(expectedEnvVars))
+	})
+
+	It("should render EKS Cloudwatch Log toleration on GKE", func() {
+		cfg.EKSConfig = setupEKSCloudwatchLogConfig()
+		cfg.ESClusterConfig = relasticsearch.NewClusterConfig("clusterTestName", 1, 1, 1)
+		cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+
+		component := render.Fluentd(cfg)
+		resources, _ := component.Objects()
+		deploy := rtest.GetResource(resources, "eks-log-forwarder", "tigera-fluentd", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deploy).NotTo(BeNil())
+		Expect(deploy.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
 	})
 
 	It("should render with EKS Cloudwatch Log with resources", func() {

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -257,7 +257,7 @@ func (c *GuardianComponent) deployment() *appsv1.Deployment {
 
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	d := &appsv1.Deployment{

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -255,6 +255,11 @@ func (c *GuardianComponent) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
 func (c *GuardianComponent) deployment() *appsv1.Deployment {
 	var replicas int32 = 1
 
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -275,7 +280,7 @@ func (c *GuardianComponent) deployment() *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 					ServiceAccountName: GuardianServiceAccountName,
-					Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...),
+					Tolerations:        tolerations,
 					ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 					Containers:         c.container(),
 					Volumes:            c.volumes(),

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -28,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
@@ -170,6 +171,20 @@ var _ = Describe("Rendering tests", func() {
 			})
 			deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(deployment.Spec.Template.Spec.Tolerations).Should(ContainElements(append(rmeta.TolerateCriticalAddonsAndControlPlane, t)))
+		})
+
+		It("should render toleration on GKE", func() {
+			renderGuardian(operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+			})
+			deployment := rtest.GetResource(resources, render.GuardianDeploymentName, render.GuardianNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(deployment).NotTo(BeNil())
+			Expect(deployment.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
 		})
 	})
 

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -601,6 +601,11 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 		containers = append(containers, c.webhooksControllerContainer())
 	}
 
+	tolerations := c.cfg.Installation.ControlPlaneTolerations
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        IntrusionDetectionName,
@@ -608,7 +613,7 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 			Annotations: c.intrusionDetectionAnnotations(),
 		},
 		Spec: corev1.PodSpec{
-			Tolerations:        c.cfg.Installation.ControlPlaneTolerations,
+			Tolerations:        tolerations,
 			NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
 			ServiceAccountName: IntrusionDetectionName,
 			ImagePullSecrets:   ps,

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -603,7 +603,7 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 
 	tolerations := c.cfg.Installation.ControlPlaneTolerations
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	return &corev1.PodTemplateSpec{

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -454,6 +454,22 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 		Expect(idc.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
 	})
 
+	It("should render toleration on GKE", func() {
+		cfg.Installation = &operatorv1.InstallationSpec{
+			KubernetesProvider: operatorv1.ProviderGKE,
+		}
+		component := render.IntrusionDetection(cfg)
+		resources, _ := component.Objects()
+		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(idc).NotTo(BeNil())
+		Expect(idc.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
+	})
+
 	Context("allow-tigera rendering", func() {
 		policyNames := []types.NamespacedName{
 			{Name: "allow-tigera.intrusion-detection-controller", Namespace: "tigera-intrusion-detection"},

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -629,7 +629,7 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 	}
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	podSpec := corev1.PodSpec{
 		NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -627,9 +627,13 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 	if c.cfg.MetricsServerTLS != nil && c.cfg.MetricsServerTLS.UseCertificateManagement() {
 		initContainers = append(initContainers, c.cfg.MetricsServerTLS.InitContainer(c.cfg.Namespace))
 	}
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
 	podSpec := corev1.PodSpec{
 		NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
-		Tolerations:        append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...),
+		Tolerations:        tolerations,
 		ImagePullSecrets:   c.cfg.Installation.ImagePullSecrets,
 		ServiceAccountName: c.kubeControllerServiceAccountName,
 		InitContainers:     initContainers,

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -17,9 +17,6 @@ package kubecontrollers_test
 import (
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/authentication/serviceaccount"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -28,8 +25,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -905,6 +904,24 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 			Expect(d.Spec.Template.Spec.Tolerations).To(HaveLen(1))
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(tol))
+		})
+
+		It("should render toleration on GKE", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+
+			component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+			Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+			resources, _ := component.Objects()
+
+			depResource := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment")
+			Expect(depResource).NotTo(BeNil())
+			d := depResource.(*appsv1.Deployment)
+			Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
 		})
 	})
 

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -298,7 +298,7 @@ func (es *elasticsearchComponent) Ready() bool {
 	return true
 }
 
-func (es elasticsearchComponent) elasticsearchServiceAccount() *corev1.ServiceAccount {
+func (es *elasticsearchComponent) elasticsearchServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ElasticsearchObjectName,
@@ -308,7 +308,7 @@ func (es elasticsearchComponent) elasticsearchServiceAccount() *corev1.ServiceAc
 }
 
 // generate the PVC required for the Elasticsearch nodes
-func (es elasticsearchComponent) pvcTemplate() corev1.PersistentVolumeClaim {
+func (es *elasticsearchComponent) pvcTemplate() corev1.PersistentVolumeClaim {
 	pvcTemplate := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "elasticsearch-data", // ECK requires this name
@@ -333,7 +333,7 @@ func (es elasticsearchComponent) pvcTemplate() corev1.PersistentVolumeClaim {
 	return pvcTemplate
 }
 
-func (es elasticsearchComponent) resourceRequirements() corev1.ResourceRequirements {
+func (es *elasticsearchComponent) resourceRequirements() corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			"cpu":    resource.MustParse("1"),
@@ -351,7 +351,7 @@ func (es elasticsearchComponent) resourceRequirements() corev1.ResourceRequireme
 	return resources
 }
 
-func (es elasticsearchComponent) javaOpts() string {
+func (es *elasticsearchComponent) javaOpts() string {
 	var javaOpts string
 	resources := es.resourceRequirements()
 	if es.cfg.LogStorage.Spec.Nodes != nil && es.cfg.LogStorage.Spec.Nodes.ResourceRequirements != nil {
@@ -372,7 +372,7 @@ func (es elasticsearchComponent) javaOpts() string {
 }
 
 // Generate the pod template required for the ElasticSearch nodes (controls the ElasticSearch container)
-func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
+func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	// Setup default configuration for ES container. For more information on managing resources, see:
 	// https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html and
 	// https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-jvm-heap-size.html#k8s-jvm-heap-size
@@ -587,6 +587,11 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 		nodeSels = es.cfg.LogStorage.Spec.DataNodeSelector
 	}
 
+	tolerations := es.cfg.Installation.ControlPlaneTolerations
+	if es.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: annotations,
@@ -596,7 +601,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			Containers:                   []corev1.Container{esContainer},
 			ImagePullSecrets:             secret.GetReferenceList(es.cfg.PullSecrets),
 			NodeSelector:                 nodeSels,
-			Tolerations:                  es.cfg.Installation.ControlPlaneTolerations,
+			Tolerations:                  tolerations,
 			ServiceAccountName:           ElasticsearchObjectName,
 			Volumes:                      volumes,
 			AutomountServiceAccountToken: &autoMountToken,
@@ -607,7 +612,7 @@ func (es elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 }
 
 // render the Elasticsearch CR that the ECK operator uses to create elasticsearch cluster
-func (es elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
+func (es *elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 	elasticsearch := &esv1.Elasticsearch{
 		TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch", APIVersion: "elasticsearch.k8s.elastic.co/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -700,7 +705,7 @@ func memoryQuantityToJVMHeapSize(q *resource.Quantity) string {
 // nodeSets calculates the number of NodeSets needed for the Elasticsearch cluster. Multiple NodeSets are returned only
 // if the "nodeSets" field has been set in the LogStorage CR. The number of Nodes for the cluster will be distributed as
 // evenly as possible between the NodeSets.
-func (es elasticsearchComponent) nodeSets() []esv1.NodeSet {
+func (es *elasticsearchComponent) nodeSets() []esv1.NodeSet {
 	nodeConfig := es.cfg.LogStorage.Spec.Nodes
 	pvcTemplate := es.pvcTemplate()
 
@@ -794,7 +799,7 @@ func (es elasticsearchComponent) nodeSets() []esv1.NodeSet {
 //
 // Note that this does not return a complete NodeSet, fields like Name and Count will at least need to be set on the returned
 // NodeSet
-func (es elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentVolumeClaim) esv1.NodeSet {
+func (es *elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentVolumeClaim) esv1.NodeSet {
 	config := map[string]interface{}{
 		"node.master":                 "true",
 		"node.data":                   "true",
@@ -843,7 +848,7 @@ func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim) string {
 
 // This is a list of components that belong to Curator which has been decommissioned since it is no longer supported
 // in Elasticsearch beyond version 8. We want to be able to clean up these resources if they exist in the cluster on upgrade.
-func (es elasticsearchComponent) curatorDecommissionedResources() []client.Object {
+func (es *elasticsearchComponent) curatorDecommissionedResources() []client.Object {
 	resources := []client.Object{
 		&batchv1.CronJob{
 			ObjectMeta: metav1.ObjectMeta{
@@ -884,7 +889,7 @@ func (es elasticsearchComponent) curatorDecommissionedResources() []client.Objec
 	return resources
 }
 
-func (es elasticsearchComponent) elasticsearchClusterRole() *rbacv1.ClusterRole {
+func (es *elasticsearchComponent) elasticsearchClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -901,7 +906,7 @@ func (es elasticsearchComponent) elasticsearchClusterRole() *rbacv1.ClusterRole 
 	}
 }
 
-func (es elasticsearchComponent) elasticsearchClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+func (es *elasticsearchComponent) elasticsearchClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ElasticsearchObjectName,
@@ -921,7 +926,7 @@ func (es elasticsearchComponent) elasticsearchClusterRoleBinding() *rbacv1.Clust
 	}
 }
 
-func (es elasticsearchComponent) oidcUserRole() client.Object {
+func (es *elasticsearchComponent) oidcUserRole() client.Object {
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -945,7 +950,7 @@ func (es elasticsearchComponent) oidcUserRole() client.Object {
 	}
 }
 
-func (es elasticsearchComponent) oidcUserRoleBinding() client.Object {
+func (es *elasticsearchComponent) oidcUserRoleBinding() client.Object {
 	return &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -589,7 +589,7 @@ func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 
 	tolerations := es.cfg.Installation.ControlPlaneTolerations
 	if es.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podTemplate := corev1.PodTemplateSpec{

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -260,7 +260,7 @@ func (d *dashboards) Job() *batchv1.Job {
 
 	tolerations := d.cfg.Installation.ControlPlaneTolerations
 	if d.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podTemplate := relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -258,13 +258,18 @@ func (d *dashboards) Job() *batchv1.Job {
 		envVars = append(envVars, corev1.EnvVar{Name: "KIBANA_CLIENT_CERT", Value: "/certs/kibana/mtls/client.crt"})
 	}
 
+	tolerations := d.cfg.Installation.ControlPlaneTolerations
+	if d.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podTemplate := relasticsearch.DecorateAnnotations(&corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      map[string]string{"job-name": Name, "k8s-app": Name},
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
-			Tolerations:  d.cfg.Installation.ControlPlaneTolerations,
+			Tolerations:  tolerations,
 			NodeSelector: d.cfg.Installation.ControlPlaneNodeSelector,
 			// This value needs to be set to never. The PodFailurePolicy will still ensure that this job will run until completion.
 			RestartPolicy:    corev1.RestartPolicyNever,

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -129,6 +129,22 @@ var _ = Describe("Dashboards rendering tests", func() {
 			Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 		})
 
+		It("should render toleration on GKE", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+
+			component := Dashboards(cfg)
+
+			resources, _ := component.Objects()
+			job, ok := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
+			Expect(ok).To(BeTrue(), "Job not found")
+			Expect(job.Spec.Template.Spec.Tolerations).To(ContainElement(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
+		})
+
 		It("should apply controlPlaneTolerations correctly", func() {
 			t := corev1.Toleration{
 				Key:      "foo",

--- a/pkg/render/logstorage/eck/eck.go
+++ b/pkg/render/logstorage/eck/eck.go
@@ -299,7 +299,7 @@ func (e *eck) operatorStatefulSet() *appsv1.StatefulSet {
 	}
 	tolerations := e.cfg.Installation.ControlPlaneTolerations
 	if e.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	s := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{Kind: "StatefulSet", APIVersion: "apps/v1"},

--- a/pkg/render/logstorage/eck/eck.go
+++ b/pkg/render/logstorage/eck/eck.go
@@ -297,6 +297,10 @@ func (e *eck) operatorStatefulSet() *appsv1.StatefulSet {
 			memoryRequest = c.ResourceRequirements.Requests[corev1.ResourceMemory]
 		}
 	}
+	tolerations := e.cfg.Installation.ControlPlaneTolerations
+	if e.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
 	s := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{Kind: "StatefulSet", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -333,7 +337,7 @@ func (e *eck) operatorStatefulSet() *appsv1.StatefulSet {
 					ImagePullSecrets:   secret.GetReferenceList(e.cfg.PullSecrets),
 					HostNetwork:        false,
 					NodeSelector:       e.cfg.Installation.ControlPlaneNodeSelector,
-					Tolerations:        e.cfg.Installation.ControlPlaneTolerations,
+					Tolerations:        tolerations,
 					Containers: []corev1.Container{{
 						Image:           e.esOperatorImage,
 						ImagePullPolicy: render.ImagePullPolicy(),

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -228,7 +228,7 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 
 	tolerations := e.cfg.Installation.ControlPlaneTolerations
 	if e.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podTemplate := &corev1.PodTemplateSpec{

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -225,6 +225,12 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 
 	annotations := e.cfg.TrustedBundle.HashAnnotations()
 	annotations[e.cfg.ESGatewayKeyPair.HashAnnotationKey()] = e.cfg.ESGatewayKeyPair.HashAnnotationValue()
+
+	tolerations := e.cfg.Installation.ControlPlaneTolerations
+	if e.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        DeploymentName,
@@ -232,7 +238,7 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
-			Tolerations:        e.cfg.Installation.ControlPlaneTolerations,
+			Tolerations:        tolerations,
 			NodeSelector:       e.cfg.Installation.ControlPlaneNodeSelector,
 			ServiceAccountName: ServiceAccountName,
 			ImagePullSecrets:   secret.GetReferenceList(e.cfg.PullSecrets),

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -205,7 +205,7 @@ func (e *elasticsearchMetrics) metricsDeployment() *appsv1.Deployment {
 
 	tolerations := e.cfg.Installation.ControlPlaneTolerations
 	if e.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	d := &appsv1.Deployment{

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics_test.go
@@ -18,9 +18,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
-	"github.com/tigera/operator/pkg/dns"
-	"github.com/tigera/operator/pkg/tls"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,13 +35,15 @@ import (
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
-	"github.com/tigera/operator/pkg/render/common/meta"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/testutils"
+	"github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	"github.com/tigera/operator/test"
 )
@@ -204,8 +203,8 @@ var _ = Describe("Elasticsearch metrics", func() {
 									{Name: "ELASTIC_CA", Value: certificatemanagement.TrustedCertBundleMountPath},
 								},
 								VolumeMounts: append(
-									cfg.TrustedBundle.VolumeMounts(meta.OSTypeLinux),
-									cfg.ServerTLS.VolumeMount(meta.OSTypeLinux),
+									cfg.TrustedBundle.VolumeMounts(rmeta.OSTypeLinux),
+									cfg.ServerTLS.VolumeMount(rmeta.OSTypeLinux),
 								),
 							}},
 							ServiceAccountName: ElasticsearchMetricsName,
@@ -306,6 +305,22 @@ var _ = Describe("Elasticsearch metrics", func() {
 			Expect(initContainer).NotTo(BeNil())
 			Expect(initContainer.Resources).To(Equal(esMetricsResources))
 
+		})
+
+		It("should render toleration on GKE", func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+			component := ElasticsearchMetrics(cfg)
+			Expect(component.ResolveImages(nil)).To(BeNil())
+			resources, _ := component.Objects()
+
+			d, ok := rtest.GetResource(resources, "tigera-elasticsearch-metrics", render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(ok).To(BeTrue())
+			Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+				Key:      "kubernetes.io/arch",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "arm64",
+				Effect:   corev1.TaintEffectNoSchedule,
+			}))
 		})
 
 		It("should render SecurityContextConstrains properly when provider is OpenShift", func() {

--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -284,7 +284,7 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 
 	tolerations := k.cfg.Installation.ControlPlaneTolerations
 	if k.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	kibana := &kbv1.Kibana{

--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -282,6 +282,11 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 		count = *k.cfg.Installation.ControlPlaneReplicas
 	}
 
+	tolerations := k.cfg.Installation.ControlPlaneTolerations
+	if k.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	kibana := &kbv1.Kibana{
 		TypeMeta: metav1.TypeMeta{Kind: "Kibana", APIVersion: "kibana.k8s.elastic.co/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -324,7 +329,7 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 					ImagePullSecrets:             secret.GetReferenceList(k.cfg.PullSecrets),
 					ServiceAccountName:           ObjectName,
 					NodeSelector:                 k.cfg.Installation.ControlPlaneNodeSelector,
-					Tolerations:                  k.cfg.Installation.ControlPlaneTolerations,
+					Tolerations:                  tolerations,
 					InitContainers:               initContainers,
 					AutomountServiceAccountToken: &automountToken,
 					Containers: []corev1.Container{{

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -419,6 +419,10 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 		}
 		annotations[l.cfg.TokenKeyPair.HashAnnotationKey()] = l.cfg.TokenKeyPair.HashAnnotationValue()
 	}
+	tolerations := l.cfg.Installation.ControlPlaneTolerations
+	if l.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        DeploymentName,
@@ -426,7 +430,7 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
-			Tolerations:        l.cfg.Installation.ControlPlaneTolerations,
+			Tolerations:        tolerations,
 			NodeSelector:       l.cfg.Installation.ControlPlaneNodeSelector,
 			ServiceAccountName: ServiceAccountName,
 			ImagePullSecrets:   secret.GetReferenceList(l.cfg.PullSecrets),

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -421,7 +421,7 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 	}
 	tolerations := l.cfg.Installation.ControlPlaneTolerations
 	if l.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -359,6 +359,23 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{Name: "elastic-internal-transport-certificates", MountPath: certificatemanagement.CSRCMountPath},
 				}, false)
 			})
+
+			It("should render toleration on GKE", func() {
+				cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+
+				component := render.LogStorage(cfg)
+				createResources, _ := component.Objects()
+
+				resultES := rtest.GetResource(createResources, render.ElasticsearchName, render.ElasticsearchNamespace,
+					"elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
+				Expect(resultES).NotTo(BeNil())
+				Expect(resultES.Spec.NodeSets[0].PodTemplate.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+					Key:      "kubernetes.io/arch",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "arm64",
+					Effect:   corev1.TaintEffectNoSchedule,
+				}))
+			})
 		})
 
 		Context("Elasticsearch with a default cluster domain", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -653,7 +653,7 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 func (c *managerComponent) managerTolerations() []corev1.Toleration {
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	return tolerations
 }

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -651,7 +651,11 @@ func (c *managerComponent) managerEsProxyContainer() corev1.Container {
 
 // managerTolerations returns the tolerations for the Tigera Secure manager deployment pods.
 func (c *managerComponent) managerTolerations() []corev1.Toleration {
-	return append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+	return tolerations
 }
 
 // managerService returns the service exposing the Tigera Secure web app.

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -202,8 +202,34 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 	})
 
+	It("should render toleration on GKE", func() {
+		installation.KubernetesProvider = operatorv1.ProviderGKE
+		resources := renderObjects(renderConfig{
+			oidc:                    false,
+			managementCluster:       nil,
+			installation:            installation,
+			compliance:              compliance,
+			complianceFeatureActive: true,
+			ns:                      render.ManagerNamespace,
+		})
+		deployment := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deployment).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
+	})
+
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
-		resources := renderObjects(renderConfig{oidc: false, managementCluster: nil, installation: &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas, KubernetesProvider: operatorv1.ProviderOpenShift}, compliance: compliance, complianceFeatureActive: true})
+		resources := renderObjects(renderConfig{
+			oidc:                    false,
+			managementCluster:       nil,
+			installation:            &operatorv1.InstallationSpec{ControlPlaneReplicas: &replicas, KubernetesProvider: operatorv1.ProviderOpenShift},
+			compliance:              compliance,
+			complianceFeatureActive: true,
+		})
 
 		// tigera-manager-role clusterRole should have openshift securitycontextconstraints PolicyRule
 		managerRole := rtest.GetResource(resources, render.ManagerClusterRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -412,7 +412,7 @@ func (mc *monitorComponent) alertmanager() *monitoringv1.Alertmanager {
 
 	tolerations := mc.cfg.Installation.ControlPlaneTolerations
 	if mc.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	am := &monitoringv1.Alertmanager{
@@ -523,7 +523,7 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 
 	tolerations := mc.cfg.Installation.ControlPlaneTolerations
 	if mc.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	prometheus := &monitoringv1.Prometheus{

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -402,13 +402,17 @@ func (mc *monitorComponent) prometheusOperatorClusterRoleBinding() *rbacv1.Clust
 }
 
 func (mc *monitorComponent) alertmanager() *monitoringv1.Alertmanager {
-
 	resources := corev1.ResourceRequirements{}
 
 	if mc.cfg.Monitor.AlertManager != nil {
 		if mc.cfg.Monitor.AlertManager.AlertManagerSpec != nil {
 			resources = mc.cfg.Monitor.AlertManager.AlertManagerSpec.Resources
 		}
+	}
+
+	tolerations := mc.cfg.Installation.ControlPlaneTolerations
+	if mc.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
 	}
 
 	am := &monitoringv1.Alertmanager{
@@ -425,7 +429,7 @@ func (mc *monitorComponent) alertmanager() *monitoringv1.Alertmanager {
 			Replicas:           mc.cfg.Installation.ControlPlaneReplicas,
 			SecurityContext:    securitycontext.NewNonRootPodContext(),
 			ServiceAccountName: PrometheusServiceAccountName,
-			Tolerations:        mc.cfg.Installation.ControlPlaneTolerations,
+			Tolerations:        tolerations,
 			Version:            components.ComponentCoreOSAlertmanager.Version,
 			Resources:          resources,
 		},
@@ -517,6 +521,11 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 		env = append(env, mc.cfg.KeyValidatorConfig.RequiredEnv("")...)
 	}
 
+	tolerations := mc.cfg.Installation.ControlPlaneTolerations
+	if mc.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	prometheus := &monitoringv1.Prometheus{
 		TypeMeta: metav1.TypeMeta{Kind: monitoringv1.PrometheusesKind, APIVersion: MonitoringAPIVersion},
 		ObjectMeta: metav1.ObjectMeta{
@@ -576,7 +585,7 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 				SecurityContext:        securitycontext.NewNonRootPodContext(),
 				ServiceAccountName:     PrometheusServiceAccountName,
 				ServiceMonitorSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "network-operators"}},
-				Tolerations:            mc.cfg.Installation.ControlPlaneTolerations,
+				Tolerations:            tolerations,
 				Version:                components.ComponentCoreOSPrometheus.Version,
 				VolumeMounts:           volumeMounts,
 				Volumes:                volumes,

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -601,6 +601,31 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(rolebindingObj.Subjects[0].Namespace).To(Equal(common.OperatorNamespace()))
 	})
 
+	It("should render toleration on GKE", func() {
+		cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+		component := monitor.Monitor(cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		prometheusObj, ok := rtest.GetResource(resources, monitor.CalicoNodePrometheus, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.PrometheusesKind).(*monitoringv1.Prometheus)
+		Expect(ok).To(BeTrue())
+		alertmanagerObj, ok := rtest.GetResource(resources, monitor.CalicoNodeAlertmanager, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.AlertmanagersKind).(*monitoringv1.Alertmanager)
+		Expect(ok).To(BeTrue())
+
+		Expect(prometheusObj.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
+		Expect(alertmanagerObj.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
+	})
+
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
 		cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
 		cfg.OpenShift = true
@@ -859,6 +884,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(toCreate).To(HaveLen(len(expectedResources)))
 		Expect(toDelete).To(HaveLen(3))
 	})
+
 	It("Should render external prometheus resources with service monitor and custom token", func() {
 		cfg.Monitor.ExternalPrometheus = &operatorv1.ExternalPrometheus{
 			ServiceMonitor: &operatorv1.ServiceMonitor{
@@ -888,6 +914,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(toCreate).To(HaveLen(len(expectedResources)))
 		Expect(toDelete).To(HaveLen(3))
 	})
+
 	It("Should render external prometheus resources without service monitor", func() {
 		cfg.Monitor.ExternalPrometheus = &operatorv1.ExternalPrometheus{
 			Namespace: "external-prometheus",
@@ -907,6 +934,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(toCreate).To(HaveLen(len(expectedResources)))
 		Expect(toDelete).To(HaveLen(3))
 	})
+
 	It("Should render typha service monitor if typha metrics are enabled", func() {
 		cfg.Installation.TyphaMetricsPort = ptr.Int32ToPtr(9093)
 		component := monitor.Monitor(cfg)

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -227,6 +227,10 @@ func (pc *packetCaptureApiComponent) clusterRoleBinding() *rbacv1.ClusterRoleBin
 }
 
 func (pc *packetCaptureApiComponent) deployment() *appsv1.Deployment {
+	tolerations := append(pc.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
+	if pc.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -247,7 +251,7 @@ func (pc *packetCaptureApiComponent) deployment() *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					NodeSelector:       pc.cfg.Installation.ControlPlaneNodeSelector,
 					ServiceAccountName: PacketCaptureServiceAccountName,
-					Tolerations:        append(pc.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...),
+					Tolerations:        tolerations,
 					ImagePullSecrets:   secret.GetReferenceList(pc.cfg.PullSecrets),
 					InitContainers:     pc.initContainers(),
 					Containers:         []corev1.Container{pc.container()},

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -229,7 +229,7 @@ func (pc *packetCaptureApiComponent) clusterRoleBinding() *rbacv1.ClusterRoleBin
 func (pc *packetCaptureApiComponent) deployment() *appsv1.Deployment {
 	tolerations := append(pc.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
 	if pc.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},

--- a/pkg/render/packet_capture_api_test.go
+++ b/pkg/render/packet_capture_api_test.go
@@ -372,6 +372,20 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 		Expect(deployment.Spec.Template.Spec.Tolerations).Should(ContainElements(append(rmeta.TolerateCriticalAddonsAndControlPlane, t)))
 	})
 
+	It("should render toleration on GKE", func() {
+		resources := renderPacketCapture(operatorv1.InstallationSpec{
+			KubernetesProvider: operatorv1.ProviderGKE,
+		}, nil)
+		deployment := rtest.GetResource(resources, render.PacketCaptureDeploymentName, render.PacketCaptureNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deployment).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
+	})
+
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
 		resources := renderPacketCapture(operatorv1.InstallationSpec{
 			KubernetesProvider: operatorv1.ProviderOpenShift,

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -331,6 +331,11 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 		initContainers = append(initContainers, pr.cfg.PolicyRecommendationCertSecret.InitContainer(PolicyRecommendationNamespace))
 	}
 
+	tolerations := pr.cfg.Installation.ControlPlaneTolerations
+	if pr.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
+
 	podTemplateSpec := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        PolicyRecommendationName,
@@ -338,7 +343,7 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 			Annotations: pr.policyRecommendationAnnotations(),
 		},
 		Spec: corev1.PodSpec{
-			Tolerations:        pr.cfg.Installation.ControlPlaneTolerations,
+			Tolerations:        tolerations,
 			NodeSelector:       pr.cfg.Installation.ControlPlaneNodeSelector,
 			ServiceAccountName: PolicyRecommendationName,
 			ImagePullSecrets:   secret.GetReferenceList(pr.cfg.PullSecrets),

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -333,7 +333,7 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 
 	tolerations := pr.cfg.Installation.ControlPlaneTolerations
 	if pr.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	podTemplateSpec := &corev1.PodTemplateSpec{

--- a/pkg/render/policyrecommendation_test.go
+++ b/pkg/render/policyrecommendation_test.go
@@ -184,6 +184,22 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 			}))
 	})
 
+	It("should render toleration on GKE", func() {
+		cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+		component := render.PolicyRecommendation(cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		deploy := rtest.GetResource(resources, render.PolicyRecommendationName, render.PolicyRecommendationNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deploy).NotTo(BeNil())
+		Expect(deploy.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
+	})
+
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
 		cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
 		cfg.OpenShift = true

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -394,6 +394,9 @@ func (c *typhaComponent) typhaDeployment() *appsv1.Deployment {
 	if len(c.cfg.Installation.ControlPlaneTolerations) != 0 {
 		tolerations = c.cfg.Installation.ControlPlaneTolerations
 	}
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+	}
 
 	d := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -395,7 +395,7 @@ func (c *typhaComponent) typhaDeployment() *appsv1.Deployment {
 		tolerations = c.cfg.Installation.ControlPlaneTolerations
 	}
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEArm64NoSchedule)
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
 	d := appsv1.Deployment{

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -77,6 +77,22 @@ var _ = Describe("Typha rendering tests", func() {
 		}
 	})
 
+	It("should render toleration on GKE", func() {
+		cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
+		component := render.Typha(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		deploy := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deploy).ToNot(BeNil())
+		Expect(deploy.Spec.Template.Spec.Tolerations).To(ContainElements(corev1.Toleration{
+			Key:      "kubernetes.io/arch",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "arm64",
+			Effect:   corev1.TaintEffectNoSchedule,
+		}))
+	})
+
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
 		cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
 		component := render.Typha(&cfg)


### PR DESCRIPTION
## Description

By default, GKE schedules workloads only to x86-based nodes by by placing a taint (kubernetes.io/arch=arm64:NoSchedule) on all Arm nodes [1]. This taint prevents Calico components from being scheduled on ARM nodes. This change adds toleration to the workload specification as suggested in [2].

[1] https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#overview
[2] https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#multi-arch-schedule-any-arch

Pick https://github.com/tigera/operator/pull/3544 into release v1.36 branch.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
