### PR TITLE
Remove custom cache option when creating controller manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ endif
 BINDIR?=build/init/bin
 $(BINDIR)/kubectl:
 	mkdir -p $(BINDIR)
-	curl -L https://storage.googleapis.com/kubernetes-release/release/v1.25.6/bin/linux/$(ARCH)/kubectl -o $@
+	curl -sSf -L --retry 5 https://dl.k8s.io/release/v1.30.5/bin/linux/$(ARCH)/kubectl -o $@
 	chmod +x $@
 
 kubectl: $(BINDIR)/kubectl
@@ -298,7 +298,7 @@ run-fvs:
 
 ## Create a local kind dual stack cluster.
 KIND_KUBECONFIG?=./kubeconfig.yaml
-K8S_VERSION?=v1.21.14
+KINDEST_NODE_VERSION?=v1.30.4
 cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 	# First make sure any previous cluster is deleted
 	make cluster-destroy
@@ -307,7 +307,7 @@ cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 	$(BINDIR)/kind create cluster \
 	        --config ./deploy/kind-config.yaml \
 	        --kubeconfig $(KIND_KUBECONFIG) \
-	        --image kindest/node:$(K8S_VERSION)
+	        --image kindest/node:$(KINDEST_NODE_VERSION)
 
 	./deploy/scripts/ipv6_kind_cluster_update.sh
 	# Deploy resources needed in test env.

--- a/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
@@ -99,8 +99,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be

--- a/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
@@ -78,8 +78,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be


### PR DESCRIPTION
## Description

This change removes the Calico v3 object cache option introduced in [1]. Since v0.16.0, the controller-runtime has been updated such that cache configs can be specified per-namespace [2]. The specific change breaks our operator because runtime now contacts the API server (via dynamic rest mapper) to determine if a cache config type (e.g. network policy) is namespaced. The custom cache config is no longer needed after recent changes to how network policy is listed by Tigera apiserver.

[1] https://github.com/tigera/operator/pull/1970/files#r891164239
[2] https://github.com/kubernetes-sigs/controller-runtime/pull/2421/files#diff-964e351ee2375d359c78d69e514c4edc42577219761c4475f391ed2daf715e51R368

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
