### PR TITLE
move tigera-prometheus secret RBAC from Clusterrole to Role

### DIFF
--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -188,12 +188,12 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 	// Create role and role bindings first.
 	// Operator needs the create/update roles for Alertmanager configuration secret for example.
 
-	roles := mc.operatorRole()
+	roles := mc.operatorRoles()
 	for _, r := range roles {
 		toCreate = append(toCreate, r)
 	}
 
-	bindings := mc.operatorRoleBinding()
+	bindings := mc.operatorRoleBindings()
 	for _, rb := range bindings {
 		toCreate = append(toCreate, rb)
 	}
@@ -956,101 +956,101 @@ func (mc *monitorComponent) serviceMonitorQueryServer() *monitoringv1.ServiceMon
 	}
 }
 
-func (mc *monitorComponent) operatorRole() []*rbacv1.Role {
-	// list and watch have to be cluster scopes for watches to work.
-	// In controller-runtime, watches are by default non-namespaced.
-	prometheusRole := &rbacv1.Role{
-		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      TigeraPrometheusRole,
-			Namespace: common.TigeraPrometheusNamespace,
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"monitoring.coreos.com"},
-				Resources: []string{
-					"alertmanagers",
-					"podmonitors",
-					"prometheuses",
-					"prometheusrules",
-					"servicemonitors",
-					"thanosrulers",
-				},
-				Verbs: []string{
-					"create",
-					"delete",
-					"get",
-					"list",
-					"update",
-					"watch",
-				},
-			},
-		},
-	}
+func (mc *monitorComponent) operatorRoles() []*rbacv1.Role {
 
-	secretRole := &rbacv1.Role{
-		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperatorSecret, Namespace: common.TigeraPrometheusNamespace},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{
-					"secrets",
-				},
-				Verbs: []string{
-					"create",
-					"delete",
-					"get",
-					"list",
-					"update",
-					"watch",
-				},
-			},
-		},
-	}
-
-	return []*rbacv1.Role{prometheusRole, secretRole}
-}
-
-func (mc *monitorComponent) operatorRoleBinding() []*rbacv1.RoleBinding {
-	prometheusBinding := &rbacv1.RoleBinding{
-		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      TigeraPrometheusRoleBinding,
-			Namespace: common.TigeraPrometheusNamespace,
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     TigeraPrometheusRole,
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      common.OperatorServiceAccount(),
-				Namespace: common.OperatorNamespace(),
-			},
-		},
-	}
-
-	secretBinding := &rbacv1.RoleBinding{
-		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperatorSecret, Namespace: common.TigeraPrometheusNamespace},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      CalicoPrometheusOperator,
+	return []*rbacv1.Role{
+		// list and watch have to be cluster scopes for watches to work.
+		// In controller-runtime, watches are by default non-namespaced.
+		{
+			TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TigeraPrometheusRole,
 				Namespace: common.TigeraPrometheusNamespace,
 			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"monitoring.coreos.com"},
+					Resources: []string{
+						"alertmanagers",
+						"podmonitors",
+						"prometheuses",
+						"prometheusrules",
+						"servicemonitors",
+						"thanosrulers",
+					},
+					Verbs: []string{
+						"create",
+						"delete",
+						"get",
+						"list",
+						"update",
+						"watch",
+					},
+				},
+			},
 		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     CalicoPrometheusOperatorSecret,
+		{
+			TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperatorSecret, Namespace: common.TigeraPrometheusNamespace},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{
+						"secrets",
+					},
+					Verbs: []string{
+						"create",
+						"delete",
+						"get",
+						"list",
+						"update",
+						"watch",
+					},
+				},
+			},
 		},
 	}
+}
 
-	return []*rbacv1.RoleBinding{prometheusBinding, secretBinding}
+func (mc *monitorComponent) operatorRoleBindings() []*rbacv1.RoleBinding {
+
+	return []*rbacv1.RoleBinding{
+		{
+			TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TigeraPrometheusRoleBinding,
+				Namespace: common.TigeraPrometheusNamespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     TigeraPrometheusRole,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      common.OperatorServiceAccount(),
+					Namespace: common.OperatorNamespace(),
+				},
+			},
+		},
+		{
+			TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperatorSecret, Namespace: common.TigeraPrometheusNamespace},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      CalicoPrometheusOperator,
+					Namespace: common.TigeraPrometheusNamespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     CalicoPrometheusOperatorSecret,
+			},
+		},
+	}
 }
 
 // Creates a network policy to allow traffic to Alertmanager (TCP port 9093).

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -55,7 +55,8 @@ const (
 	CalicoNodeMonitor      = "calico-node-monitor"
 	CalicoNodePrometheus   = "calico-node-prometheus"
 
-	CalicoPrometheusOperator = "calico-prometheus-operator"
+	CalicoPrometheusOperator       = "calico-prometheus-operator"
+	CalicoPrometheusOperatorSecret = "calico-prometheus-operator-secret"
 
 	TigeraPrometheusObjectName  = "tigera-prometheus"
 	TigeraPrometheusDPRate      = "tigera-prometheus-dp-rate"
@@ -186,10 +187,16 @@ func (mc *monitorComponent) Objects() ([]client.Object, []client.Object) {
 
 	// Create role and role bindings first.
 	// Operator needs the create/update roles for Alertmanager configuration secret for example.
-	toCreate = append(toCreate,
-		mc.operatorRole(),
-		mc.operatorRoleBinding(),
-	)
+
+	roles := mc.operatorRole()
+	for _, r := range roles {
+		toCreate = append(toCreate, r)
+	}
+
+	bindings := mc.operatorRoleBinding()
+	for _, rb := range bindings {
+		toCreate = append(toCreate, rb)
+	}
 
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.cfg.PullSecrets...)...)...)
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(common.TigeraPrometheusNamespace, mc.cfg.AlertmanagerConfigSecret)...)...)
@@ -297,7 +304,6 @@ func (mc *monitorComponent) prometheusOperatorClusterRole() *rbacv1.ClusterRole 
 			APIGroups: []string{""},
 			Resources: []string{
 				"configmaps",
-				"secrets",
 			},
 			Verbs: []string{"*"},
 		},
@@ -950,10 +956,10 @@ func (mc *monitorComponent) serviceMonitorQueryServer() *monitoringv1.ServiceMon
 	}
 }
 
-func (mc *monitorComponent) operatorRole() *rbacv1.Role {
+func (mc *monitorComponent) operatorRole() []*rbacv1.Role {
 	// list and watch have to be cluster scopes for watches to work.
 	// In controller-runtime, watches are by default non-namespaced.
-	return &rbacv1.Role{
+	prometheusRole := &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TigeraPrometheusRole,
@@ -981,10 +987,33 @@ func (mc *monitorComponent) operatorRole() *rbacv1.Role {
 			},
 		},
 	}
+
+	secretRole := &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperatorSecret, Namespace: common.TigeraPrometheusNamespace},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{
+					"secrets",
+				},
+				Verbs: []string{
+					"create",
+					"delete",
+					"get",
+					"list",
+					"update",
+					"watch",
+				},
+			},
+		},
+	}
+
+	return []*rbacv1.Role{prometheusRole, secretRole}
 }
 
-func (mc *monitorComponent) operatorRoleBinding() *rbacv1.RoleBinding {
-	return &rbacv1.RoleBinding{
+func (mc *monitorComponent) operatorRoleBinding() []*rbacv1.RoleBinding {
+	prometheusBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TigeraPrometheusRoleBinding,
@@ -1003,6 +1032,25 @@ func (mc *monitorComponent) operatorRoleBinding() *rbacv1.RoleBinding {
 			},
 		},
 	}
+
+	secretBinding := &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: CalicoPrometheusOperatorSecret, Namespace: common.TigeraPrometheusNamespace},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      CalicoPrometheusOperator,
+				Namespace: common.TigeraPrometheusNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     CalicoPrometheusOperatorSecret,
+		},
+	}
+
+	return []*rbacv1.RoleBinding{prometheusBinding, secretBinding}
 }
 
 // Creates a network policy to allow traffic to Alertmanager (TCP port 9093).

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -237,7 +237,6 @@ var _ = Describe("monitor rendering tests", func() {
 			APIGroups: []string{""},
 			Resources: []string{
 				"configmaps",
-				"secrets",
 			},
 			Verbs: []string{"*"},
 		}))
@@ -991,7 +990,9 @@ func expectedBaseResources() []resource {
 	return []resource{
 		{"tigera-prometheus", "", "", "v1", "Namespace"},
 		{"tigera-prometheus-role", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
+		{"calico-prometheus-operator-secret", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "Role"},
 		{"tigera-prometheus-role-binding", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
+		{"calico-prometheus-operator-secret", common.TigeraPrometheusNamespace, "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 		{"tigera-pull-secret", common.TigeraPrometheusNamespace, "", "", ""},
 		{"alertmanager-calico-node-alertmanager", common.TigeraPrometheusNamespace, "", "v1", "Secret"},
 		{"calico-prometheus-operator", "tigera-prometheus", "", "v1", "ServiceAccount"},


### PR DESCRIPTION
Moving the secret RBAC for tigera-prometheus from a ClusterRole to a Role within the tigera-prometheus namespace, restricting the scope to allow the creation of secrets only in the tigera-prometheus namespace.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
