### PR TITLE
Release tooling updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,17 +544,17 @@ release-publish: release-prereqs
 	@echo "  make VERSION=$(VERSION) release-publish-latest"
 	@echo ""
 
-release-github: hack/bin/hub release-notes
+release-github: hack/bin/gh release-notes
 	@echo "Creating github release for $(VERSION)"
-	hack/bin/hub release create --draft --file $(VERSION)-release-notes.md $(VERSION)
+	hack/bin/gh release create $(VERSION) --title $(VERSION) --draft --notes-file $(VERSION)-release-notes.md
 
-HUB_VERSION?=2.14.2
-hack/bin/hub:
+GITHUB_CLI_VERSION?=2.62.0
+hack/bin/gh:
 	mkdir -p hack/bin
-	curl -sSL -o hack/bin/hub.tgz https://github.com/mislav/hub/releases/download/v$(HUB_VERSION)/hub-linux-amd64-$(HUB_VERSION).tgz
-	tar -zxvf hack/bin/hub.tgz -C hack/bin/ hub-linux-amd64-$(HUB_VERSION)/bin/hub --strip-components=2
+	curl -sSL -o hack/bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
+	tar -zxvf hack/bin/gh.tgz -C hack/bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh/bin/hub --strip-components=2
 	chmod +x $@
-	rm hack/bin/hub.tgz
+	rm hack/bin/gh.tgz
 
 # release-prereqs checks that the environment is configured properly to create a release.
 release-prereqs:

--- a/Makefile
+++ b/Makefile
@@ -624,9 +624,7 @@ $(BINDIR)/gen-versions: $(shell find ./hack/gen-versions -type f)
 	sh -c '$(GIT_CONFIG_SSH) \
 	go build -buildvcs=false -o $(BINDIR)/gen-versions ./hack/gen-versions'
 
-# $(1) is the github project
-# $(2) is the branch or tag to fetch
-# $(3) is the directory name to use
+# $(1) is the product
 define prep_local_crds
     $(eval dir := $(1))
 	rm -rf pkg/crds/$(dir)
@@ -634,6 +632,10 @@ define prep_local_crds
 	mkdir -p pkg/crds/$(dir)
 	mkdir -p .crds/$(dir)
 endef
+
+# $(1) is the github project
+# $(2) is the branch or tag to fetch
+# $(3) is the directory name to use
 define fetch_crds
     $(eval project := $(1))
     $(eval branch := $(2))
@@ -643,7 +645,8 @@ define fetch_crds
 endef
 define copy_crds
     $(eval dir := $(1))
-	@cp .crds/$(dir)/libcalico-go/config/crd/* pkg/crds/$(dir)/ && echo "Copied $(dir) CRDs"
+		$(eval prod := $(2))
+	@cp $(dir)/libcalico-go/config/crd/* pkg/crds/$(prod)/ && echo "Copied $(prod) CRDs"
 endef
 
 .PHONY: read-libcalico-version read-libcalico-enterprise-version
@@ -652,6 +655,8 @@ endef
 .PHONY: prepare-for-calico-crds prepare-for-enterprise-crds
 
 CALICO?=projectcalico/calico
+CALICO_CRDS_DIR?=.crds/calico
+DEFAULT_OS_CRDS_DIR?=.crds/calico
 read-libcalico-calico-version:
 	$(eval CALICO_BRANCH := $(shell $(CONTAINERIZED) $(CALICO_BUILD) \
 	bash -c '$(GIT_CONFIG_SSH) \
@@ -659,15 +664,17 @@ read-libcalico-calico-version:
 	if [ -z "$(CALICO_BRANCH)" ]; then echo "libcalico branch not defined"; exit 1; fi
 
 update-calico-crds: fetch-calico-crds
-	$(call copy_crds,"calico")
+	$(call copy_crds, $(CALICO_CRDS_DIR),"calico")
 
 prepare-for-calico-crds:
 	$(call prep_local_crds,"calico")
 
 fetch-calico-crds: prepare-for-calico-crds read-libcalico-calico-version
-	$(call fetch_crds,$(CALICO),$(CALICO_BRANCH),"calico")
+	$(if $(filter $(DEFAULT_OS_CRDS_DIR),$(CALICO_CRDS_DIR)), $(call fetch_crds,$(CALICO),$(CALICO_BRANCH),"calico"))
 
 CALICO_ENTERPRISE?=tigera/calico-private
+ENTERPRISE_CRDS_DIR?=.crds/enterprise
+DEFAULT_EE_CRDS_DIR=.crds/enterprise
 read-libcalico-enterprise-version:
 	$(eval CALICO_ENTERPRISE_BRANCH := $(shell $(CONTAINERIZED) $(CALICO_BUILD) \
 	bash -c '$(GIT_CONFIG_SSH) \
@@ -675,13 +682,14 @@ read-libcalico-enterprise-version:
 	if [ -z "$(CALICO_ENTERPRISE_BRANCH)" ]; then echo "libcalico enterprise branch not defined"; exit 1; fi
 
 update-enterprise-crds: fetch-enterprise-crds
-	$(call copy_crds,"enterprise")
+	$(call copy_crds,$(ENTERPRISE_CRDS_DIR),"enterprise")
 
 prepare-for-enterprise-crds:
 	$(call prep_local_crds,"enterprise")
 
 fetch-enterprise-crds: prepare-for-enterprise-crds  read-libcalico-enterprise-version
-	$(call fetch_crds,$(CALICO_ENTERPRISE),$(CALICO_ENTERPRISE_BRANCH),"enterprise")
+	$(if $(filter $(DEFAULT_EE_CRDS_DIR),$(ENTERPRISE_CRDS_DIR)), $(call fetch_crds,$(CALICO_ENTERPRISE),$(CALICO_ENTERPRISE_BRANCH),"enterprise"))
+# $(if $(filter ".crds/enterprise",$(ENTERPRISE_CRDS_DIR)),$(call fetch_crds,$(CALICO_ENTERPRISE),$(CALICO_ENTERPRISE_BRANCH),"enterprise"))
 
 .PHONY: prepull-image
 prepull-image:

--- a/hack/generate_release_notes.py
+++ b/hack/generate_release_notes.py
@@ -184,6 +184,7 @@ if __name__ == "__main__":
 
     # Write release notes out to a file.
     with open(FILENAME, "w", encoding="utf-8") as f:
+        f.write(f"{VERSION}\n")
         f.write(f"{date}\n\n")
 
         f.write("#### Included Calico versions\n\n")

--- a/hack/generate_release_notes.py
+++ b/hack/generate_release_notes.py
@@ -184,7 +184,6 @@ if __name__ == "__main__":
 
     # Write release notes out to a file.
     with open(FILENAME, "w", encoding="utf-8") as f:
-        f.write(f"{VERSION}\n")
         f.write(f"{date}\n\n")
 
         f.write("#### Included Calico versions\n\n")

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -9,7 +9,7 @@ fi
 if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	echo "tag ${tag} does not match the format vX.Y.Z"
 	exit 1
-fi	
+fi
 
 if [[ ! "$(git rev-parse --abbrev-ref HEAD)" =~ (release-v*.*|master) ]]; then
 	echo "not on 'master' or 'release-vX.Y'"
@@ -28,3 +28,6 @@ make release VERSION=${tag}
 
 echo "Publish release ${tag}"
 make release-publish-images VERSION=${tag}
+
+echo "Create ${tag} release on GitHub"
+make release-github VERSION=${tag}

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -81,6 +81,25 @@ spec:
                   for debugging purposes. \n Deprecated: Use BPFConnectTimeLoadBalancing
                   [Default: true]"
                 type: boolean
+              bpfConntrackLogLevel:
+                description: 'BPFConntrackLogLevel controls the log level of the BPF
+                  conntrack cleanup program, which runs periodically to clean up expired
+                  BPF conntrack entries. [Default: Off].'
+                enum:
+                - "Off"
+                - Debug
+                type: string
+              bpfConntrackMode:
+                description: 'BPFConntrackCleanupMode controls how BPF conntrack entries
+                  are cleaned up.  `Auto` will use a BPF program if supported, falling
+                  back to userspace if not.  `Userspace` will always use the userspace
+                  cleanup code.  `BPFProgram` will always use the BPF program (failing
+                  if not supported). [Default: Auto]'
+                enum:
+                - Auto
+                - Userspace
+                - BPFProgram
+                type: string
               bpfDSROptoutCIDRs:
                 description: BPFDSROptoutCIDRs is a list of CIDRs which are excluded
                   from DSR. That is, clients in those CIDRs will access service node
@@ -95,7 +114,8 @@ spec:
                   that Calico workload traffic flows over as well as any interfaces
                   that handle incoming traffic to nodeports and services from outside
                   the cluster.  It should not match the workload interfaces (usually
-                  named cali...).
+                  named cali...) or any other special device managed by Calico itself
+                  (e.g., tunnels).
                 type: string
               bpfDisableGROForIfaces:
                 description: BPFDisableGROForIfaces is a regular expression that controls
@@ -216,6 +236,13 @@ spec:
                   map.  This map must be large enough to hold an entry for each active
                   connection.  Warning: changing the size of the conntrack map can
                   cause disruption.'
+                type: integer
+              bpfMapSizeConntrackCleanupQueue:
+                description: BPFMapSizeConntrackCleanupQueue sets the size for the
+                  map used to hold NAT conntrack entries that are queued for cleanup.  This
+                  should be big enough to hold all the NAT entries that expire within
+                  one cleanup interval.
+                minimum: 1
                 type: integer
               bpfMapSizeIPSets:
                 description: BPFMapSizeIPSets sets the size for ipsets map.  The IP


### PR DESCRIPTION
## Description

This add the following:

- Ability to be able to use a local dir for getting CRDs. This will be helpful for the new release tooling in Calico and _eventually_ Enterprise
- Automate creating Github release (_as draft_)

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
