### PR TITLE
Add egress rule to kubernetes service when configured from configmap

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -816,6 +816,14 @@ func kubeControllersAllowTigeraPolicy(cfg *KubeControllersConfiguration) *v3.Net
 		})
 	}
 
+	if r, err := cfg.K8sServiceEp.DestinationEntityRule(); r != nil && err == nil {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: *r,
+		})
+	}
+
 	return &v3.NetworkPolicy{
 		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/kubecontrollers"
 	"github.com/tigera/operator/pkg/render/testutils"
@@ -1115,6 +1116,26 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(csrInitContainer.Name).To(Equal(fmt.Sprintf("%v-key-cert-provisioner", kubecontrollers.KubeControllerPrometheusTLSSecret)))
 	})
 
+	It("should add egress policy with Enterprise variant and K8SServiceEndpoint defined", func() {
+		cfg.K8sServiceEp.Host = "k8shost"
+		cfg.K8sServiceEp.Port = "1234"
+		objects, _ := kubecontrollers.NewCalicoKubeControllersPolicy(&cfg).Objects()
+		Expect(objects).To(HaveLen(1))
+		policy, ok := objects[0].(*v3.NetworkPolicy)
+		Expect(ok).To(BeTrue())
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.Spec).ToNot(BeNil())
+		Expect(policy.Spec.Egress).ToNot(BeNil())
+		Expect(policy.Spec.Egress).To(ContainElement(v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
+				Ports:   networkpolicy.Ports(1234),
+				Domains: []string{"k8shost"},
+			},
+		}))
+	})
+
 	Context("multi-tenant rendering", func() {
 		//var installation *operatorv1.InstallationSpec
 		var tenant *operatorv1.Tenant
@@ -1316,6 +1337,5 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			Expect(d.Spec.Template.Spec.Containers[0].Name).To(Equal("es-calico-kube-controllers"))
 			Expect(d.Spec.Template.Spec.Containers[0].Resources).To(Equal(overwrites))
 		})
-
 	})
 })


### PR DESCRIPTION
Looks like kops does not come up with BPF. Some thoughts for this draft:

Some notes:
- Cluster is configured with configmap to set the kubernetes service, which is then propagated to tigera-apiserver and kube-controller
- Pod networked containers cannot resolve this domain. Host networked pods can.
- Network policy (egress) is missing from ckc to the service, this may be a bug?

Note to self: Is this a provisioning bug or a product bug? Should we do something in order to make pods resolve this service name?