### PR TITLE
[cherry-pick] Release tooling updates (#3596)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -533,6 +533,7 @@ release-publish: release-prereqs
 	git push origin $(VERSION)
 
 	$(MAKE) release-publish-images IMAGETAG=$(VERSION)
+	$(MAKE) release-github
 
 	@echo "Finalize the GitHub release based on the pushed tag."
 	@echo ""
@@ -542,6 +543,18 @@ release-publish: release-prereqs
 	@echo ""
 	@echo "  make VERSION=$(VERSION) release-publish-latest"
 	@echo ""
+
+release-github: hack/bin/gh release-notes
+	@echo "Creating github release for $(VERSION)"
+	hack/bin/gh release create $(VERSION) --title $(VERSION) --draft --notes-file $(VERSION)-release-notes.md
+
+GITHUB_CLI_VERSION?=2.62.0
+hack/bin/gh:
+	mkdir -p hack/bin
+	curl -sSL -o hack/bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
+	tar -zxvf hack/bin/gh.tgz -C hack/bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh/bin/hub --strip-components=2
+	chmod +x $@
+	rm hack/bin/gh.tgz
 
 # release-prereqs checks that the environment is configured properly to create a release.
 release-prereqs:
@@ -624,16 +637,18 @@ $(BINDIR)/gen-versions: $(shell find ./hack/gen-versions -type f)
 	sh -c '$(GIT_CONFIG_SSH) \
 	go build -buildvcs=false -o $(BINDIR)/gen-versions ./hack/gen-versions'
 
+# $(1) is the product
+define prep_local_crds
+    $(eval product := $(1))
+	rm -rf pkg/crds/$(product)
+	rm -rf .crds/$(product)
+	mkdir -p pkg/crds/$(product)
+	mkdir -p .crds/$(product)
+endef
+
 # $(1) is the github project
 # $(2) is the branch or tag to fetch
 # $(3) is the directory name to use
-define prep_local_crds
-    $(eval dir := $(1))
-	rm -rf pkg/crds/$(dir)
-	rm -rf .crds/$(dir)
-	mkdir -p pkg/crds/$(dir)
-	mkdir -p .crds/$(dir)
-endef
 define fetch_crds
     $(eval project := $(1))
     $(eval branch := $(2))
@@ -643,7 +658,8 @@ define fetch_crds
 endef
 define copy_crds
     $(eval dir := $(1))
-	@cp .crds/$(dir)/libcalico-go/config/crd/* pkg/crds/$(dir)/ && echo "Copied $(dir) CRDs"
+		$(eval product := $(2))
+	@cp $(dir)/libcalico-go/config/crd/* pkg/crds/$(product)/ && echo "Copied $(product) CRDs"
 endef
 
 .PHONY: read-libcalico-version read-libcalico-enterprise-version
@@ -652,6 +668,8 @@ endef
 .PHONY: prepare-for-calico-crds prepare-for-enterprise-crds
 
 CALICO?=projectcalico/calico
+CALICO_CRDS_DIR?=.crds/calico
+DEFAULT_OS_CRDS_DIR?=.crds/calico
 read-libcalico-calico-version:
 	$(eval CALICO_BRANCH := $(shell $(CONTAINERIZED) $(CALICO_BUILD) \
 	bash -c '$(GIT_CONFIG_SSH) \
@@ -659,15 +677,17 @@ read-libcalico-calico-version:
 	if [ -z "$(CALICO_BRANCH)" ]; then echo "libcalico branch not defined"; exit 1; fi
 
 update-calico-crds: fetch-calico-crds
-	$(call copy_crds,"calico")
+	$(call copy_crds, $(CALICO_CRDS_DIR),"calico")
 
 prepare-for-calico-crds:
 	$(call prep_local_crds,"calico")
 
 fetch-calico-crds: prepare-for-calico-crds read-libcalico-calico-version
-	$(call fetch_crds,$(CALICO),$(CALICO_BRANCH),"calico")
+	$(if $(filter $(DEFAULT_OS_CRDS_DIR),$(CALICO_CRDS_DIR)), $(call fetch_crds,$(CALICO),$(CALICO_BRANCH),"calico"))
 
 CALICO_ENTERPRISE?=tigera/calico-private
+ENTERPRISE_CRDS_DIR?=.crds/enterprise
+DEFAULT_EE_CRDS_DIR=.crds/enterprise
 read-libcalico-enterprise-version:
 	$(eval CALICO_ENTERPRISE_BRANCH := $(shell $(CONTAINERIZED) $(CALICO_BUILD) \
 	bash -c '$(GIT_CONFIG_SSH) \
@@ -675,13 +695,13 @@ read-libcalico-enterprise-version:
 	if [ -z "$(CALICO_ENTERPRISE_BRANCH)" ]; then echo "libcalico enterprise branch not defined"; exit 1; fi
 
 update-enterprise-crds: fetch-enterprise-crds
-	$(call copy_crds,"enterprise")
+	$(call copy_crds,$(ENTERPRISE_CRDS_DIR),"enterprise")
 
 prepare-for-enterprise-crds:
 	$(call prep_local_crds,"enterprise")
 
 fetch-enterprise-crds: prepare-for-enterprise-crds  read-libcalico-enterprise-version
-	$(call fetch_crds,$(CALICO_ENTERPRISE),$(CALICO_ENTERPRISE_BRANCH),"enterprise")
+	$(if $(filter $(DEFAULT_EE_CRDS_DIR),$(ENTERPRISE_CRDS_DIR)), $(call fetch_crds,$(CALICO_ENTERPRISE),$(CALICO_ENTERPRISE_BRANCH),"enterprise"))
 
 .PHONY: prepull-image
 prepull-image:

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -9,7 +9,7 @@ fi
 if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	echo "tag ${tag} does not match the format vX.Y.Z"
 	exit 1
-fi	
+fi
 
 if [[ ! "$(git rev-parse --abbrev-ref HEAD)" =~ (release-v*.*|master) ]]; then
 	echo "not on 'master' or 'release-vX.Y'"
@@ -28,3 +28,6 @@ make release VERSION=${tag}
 
 echo "Publish release ${tag}"
 make release-publish-images VERSION=${tag}
+
+echo "Create ${tag} release on GitHub"
+make release-github VERSION=${tag}


### PR DESCRIPTION
## Description

* allow specifying an alternative dir for CRDs

* release optimization

- allow using local dir for getting CRDS
- create Github release (in drafts)

ref: DE-2646

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
