### PR TITLE
[cherry pick] update release note generation (#3591)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ CGO_ENABLED=0
 endif
 
 ###############################################################################
-
+REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
 GO_BUILD_VER?=v0.91
@@ -552,7 +552,7 @@ GITHUB_CLI_VERSION?=2.62.0
 hack/bin/gh:
 	mkdir -p hack/bin
 	curl -sSL -o hack/bin/gh.tgz https://github.com/cli/cli/releases/download/v$(GITHUB_CLI_VERSION)/gh_$(GITHUB_CLI_VERSION)_linux_amd64.tar.gz
-	tar -zxvf hack/bin/gh.tgz -C hack/bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh/bin/hub --strip-components=2
+	tar -zxvf hack/bin/gh.tgz -C hack/bin/ gh_$(GITHUB_CLI_VERSION)_linux_amd64/bin/gh --strip-components=2
 	chmod +x $@
 	rm hack/bin/gh.tgz
 
@@ -565,7 +565,19 @@ ifdef LOCAL_BUILD
 	$(error LOCAL_BUILD must not be set for a release)
 endif
 
-release-prep: var-require-all-GIT_PR_BRANCH_BASE-GIT_REPO_SLUG-VERSION-CALICO_VERSION-COMMON_VERSION-CALICO_ENTERPRISE_VERSION
+check-milestone: hack/bin/gh var-require-all-VERSION-GITHUB_TOKEN
+	@gh extension install valeriobelli/gh-milestone
+	@echo "Checking milestone $(VERSION) exists"
+	$(eval MILESTONE_NUMBER := $(shell gh milestone list --query $(VERSION) --repo $(REPO) --state all --json title --jq '.[0].title' | grep $(VERSION)))
+	$(if $(MILESTONE_NUMBER),,$(error Milestone $(VERSION) does not exist))
+	@echo "Checking $(VERSION) milestone has no open PRs"
+	$(eval OPEN_PRS := $(shell gh search prs --milestone $(VERSION) --repo $(REPO) --state open --json number --jq '.[].number'))
+	$(if $(OPEN_PRS),$(error Milestone $(VERSION) has open PRs))
+	@echo "Checking milestone $(VERSION) is closed"
+	$(eval CLOSED_MILESTONE := $(shell gh milestone list --query $(VERSION) --repo $(REPO) --state closed --json title --jq '.[0].title' | grep $(VERSION)))
+	$(if $(CLOSED_MILESTONE),,$(error Milestone $(VERSION) is not closed))
+
+release-prep: check-milestone var-require-all-GIT_PR_BRANCH_BASE-GIT_REPO_SLUG-VERSION-CALICO_VERSION-COMMON_VERSION-CALICO_ENTERPRISE_VERSION
 	$(YQ_V4) ".title = \"$(CALICO_ENTERPRISE_VERSION)\" | .components |= with_entries(select(.key | test(\"^(eck-|coreos-).*\") | not)) |= with(.[]; .version = \"$(CALICO_ENTERPRISE_VERSION)\")" -i config/enterprise_versions.yml
 	$(YQ_V4) ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
 	sed -i "s/\"gcr.io.*\"/\"quay.io\/\"/g" pkg/components/images.go

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,14 +14,19 @@ For a major or minor release, you will need to create:
 
 To create a new release branch:
 
-1. If needed, fetch the latest changes from the repository with `git fetch <remote>`
-2. Create a new branch based on the target minor version:
+1. If needed, fetch the latest changes from the repository remote `<remote>`:
+
+    ```sh
+    git fetch <remote>
+    ```
+
+1. Create a new branch based on the target minor version:
 
    ```sh
    git checkout <remote>/master -b release-vX.Y
    ```
 
-3. Push the new branch to the repository:
+1. Push the new branch to the repository:
 
    ```sh
    git push <remote> release-vX.Y
@@ -51,7 +56,12 @@ This ensures that new PRs against master will be automatically given the correct
 
 ## Preparing for the release
 
-Review the milestone for this release and ensure it is accurate. https://github.com/tigera/operator/milestones
+- Create any new milestones that should exist
+  - Create the next patch version
+  - If a new minor was released (`.0`), also ensure the next minor has been created (this should have already been created as part of [Preparing a new release branch](#preparing-a-new-release-branch))
+- Review the milestone for this release and ensure it is accurate. https://github.com/tigera/operator/milestones
+  - Move any open PRs to a new milestone (*likely* the newly created one)
+  - Close the milestone for the release
 
 ## Updating versions
 
@@ -93,66 +103,25 @@ Go to the PR created and:
 
 1. Merge your PR to the release branch
 
-1. Create a git tag for the new commit on the release branch and push it:
+1. Create a git tag `<tag>` for the new commit on the release branch and push it:
 
-```
-git tag v1.30.3
-git push --tags
-```
+    ```sh
+    git tag <tag> # e.g git tag v1.30.2
+    git push <remote> <tag> # e.g git push origin v1.30.2
+    ```
 
 1. Log in to semaphore and find the new build for the release branch commit, and
    click 'Rerun'. When Semaphore starts the rebuild, it will notice the new tag and
    build and publish an operator release.
 
-## Release notes and milestones
+1. Go to [releases](https://github.com/tigera/operator/releases) and edit the draft release for the release tag
 
-1. Run the following command to generate release notes for the release
+1. Publish the release.
 
-   ```
-   make release-notes VERSION=<TAG> GITHUB_TOKEN=<access-token>
-   ```
-
-1. Go to https://github.com/tigera/operator/releases and edit the release tag to include the generated release notes, and update the title.
-
-1. Close the milestone for this release. https://github.com/tigera/operator/milestones
-
-1. Go to https://github.com/tigera/operator/milestones and create any new milestones that should exist
-   - Create the next patch version
-   - If a new minor was released (`.0`), also ensure the next minor has been created (this should have already been created as part of [Preparing a new release branch](#preparing-a-new-release-branch))
+    > NOTE: Only mark this release as latest if it is the highest released version
 
 ## Updates for new Calico CRDs
 
 (TODO: We need to be able to detect new CRDs and do this automatically)
 
 If the release includes new Calico CRDs, add the new CRDs to `hack/gen-bundle/get-manifests.sh` and `config/manifests/bases/operator.clusterserviceversion.yaml`.
-
-## Publishing a release on the RH Catalog
-
-(Note: We are not currently publishing to RH Catalog, but we will resume soon. These notes are left here for current and future reference.)
-
-We currently only publish operator releases targeting Calico. If the release targets Calico, continue onto the following steps to generate the
-operator bundle for it, and publish the release on the RH Catalog.
-
-Before beginning, ensure that the docs at docs.projectcalico.org for the Calico version this operator release targets is live.
-
-1. After the semaphore job in the releasing steps is complete, and images have been tagged and pushed, checkout the tag you released and create a new branch.
-
-1. Login to our operator project on connect.redhat.com and publish the operator image on the RH Catalog. This step needs to happen before we generate and submit the operator bundle.
-
-1. Create the operator bundle using `make bundle` with the required variables `VERSION`, `PREV_VERSION`, `CHANNELS`, and `DEFAULT_CHANNEL`:
-
-   **Note**: the version strings in `VERSION` and `PREV_VERSION` are semver strings without the v.
-
-   - **VERSION**: this release version. E.g. `1.13.1`
-   - **PREV_VERSION**: the latest published bundle version in this release stream. Navigate to the [certified operators production catalog](https://github.com/redhat-openshift-ecosystem/certified-operators/tree/main/operators/tigera-operator) and look for the most recent version from this release branch. E.g., if this release is `v1.24.11` but the most recently published v1.24.x bundle is `1.24.9` then you would use `VERSION=1.24.11` and `PREV_VERSION=1.24.9`. If this release is the first in this release branch, then there is no prior version so set `PREV_VERSION=0.0.0`.
-   - **CHANNELS** and **DEFAULT_CHANNEL**: should be set to the release branch of this operator release. E.g., if the operator release tag is `v1.23.5`, then CHANNELS and DEFAULT_CHANNEL should be `release-v1.23`.
-
-   For example:
-
-   ```
-   make bundle VERSION=1.13.1 PREV_VERSION=1.13.0 CHANNELS=release-v1.13 DEFAULT_CHANNEL=release-v1.13
-   ```
-
-   This step will create the bundle `bundle/1.13.1`.
-
-1. Publish the generated operator bundle following the [Operator Certification CI Pipeline instructions](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/ci-pipeline.md). Bundles are no longer committed in this repository as they are committed in [redhat-openshift-ecosystem/certified-operators](https://github.com/redhat-openshift-ecosystem/certified-operators).

--- a/hack/generate_release_notes.py
+++ b/hack/generate_release_notes.py
@@ -47,27 +47,36 @@ def issues_in_milestone() -> list:
     """
     repo = g.get_repo("tigera/operator")
 
-    # Find the milestone. This finds all open milestones.
-    milestones = repo.get_milestones()
-    for m in milestones:
-        if m.title == VERSION:
-            # Found the milestone in this repo - look for issues (but only
-            # ones that have been closed!)
-            print(f"  found milestone {m.title}")
-            milestone_issues = repo.get_issues(
-                milestone=m, state="closed", labels=["release-note-required"]
-            )
-            issues = []
-            for issue in milestone_issues:
-                pr = issue.as_pull_request()
-                if pr.merged:
-                    # Filter out PRs which are closed but not merged.
-                    issues.append(issue)
-                elif pr.state == "open":
-                    print(f"WARNING: {pr.number} is still open, remove from milestione... skipping")
-            if len(issues) == 0:
-                raise ReleaseNoteError(f"no issues found for milestone {m.title}")
-            return issues
+    # Find the milestone to get the id.
+    milestones = repo.get_milestones(state="all")
+    # Filter for the milestone we're interested in.
+    milestone = [m for m in milestones if m.title == VERSION]
+    m = milestone[0] if milestone else None
+    if not m:
+        raise ReleaseNoteError(f"milestone {VERSION} not found")
+    # Ensure the milestone is closed before generating release notes.
+    if m.state != "closed":
+        raise ReleaseNoteError(
+            f"milestone {m.title} is not closed, please close it before generating release notes"
+        )
+    print(f"  found milestone {m.title}")
+    milestone_issues = repo.get_issues(
+        milestone=m, state="closed", labels=["release-note-required"]
+    )
+    # If there are no issues in the milestone, raise an error.
+    if len(milestone_issues) == 0:
+        raise ReleaseNoteError(f"no issues found for milestone {m.title}")
+    open_issues = [
+        issue for issue in milestone_issues if issue.as_pull_request().state == "open"
+    ]
+    # If there are open issues in the milestone, raise an error.
+    if len(open_issues) > 0:
+        raise ReleaseNoteError(
+            f"{len(open_issues)} PRs are still open, remove from milestone"
+        )
+
+    # Return only the merged PRs
+    return [issue for issue in milestone_issues if issue.as_pull_request().merged]
 
 
 def extract_release_notes(issue: Issue) -> list:


### PR DESCRIPTION
## Description

* update release note generation
  - ensure milestone is closed before generating release notes
  - ensure there are no open PRs in the milestone
* update releasing docs
* add handling milestone to release-prep

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
