### PR TITLE
fix releasing from v1.36.2

### DIFF
--- a/.semaphore/push_images.yml
+++ b/.semaphore/push_images.yml
@@ -7,6 +7,7 @@ agent:
 global_job_config:
   secrets:
     - name: docker-hub
+    - name: oss-release-secrets
     # Mount the github SSH secret for pulling private repositories.
     - name: private-repo
   prologue:

--- a/hack/generate_release_notes.py
+++ b/hack/generate_release_notes.py
@@ -64,7 +64,7 @@ def issues_in_milestone() -> list:
         milestone=m, state="closed", labels=["release-note-required"]
     )
     # If there are no issues in the milestone, raise an error.
-    if len(milestone_issues) == 0:
+    if milestone_issues.totalCount == 0:
         raise ReleaseNoteError(f"no issues found for milestone {m.title}")
     open_issues = [
         issue for issue in milestone_issues if issue.as_pull_request().state == "open"


### PR DESCRIPTION
## Description

Fixes from attempting to release v1.36.2

- fix checking milestone issues
- add missing secret for github

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
