### PR TITLE
Fix for PriorityClassName override handling

### DIFF
--- a/pkg/render/common/components/components.go
+++ b/pkg/render/common/components/components.go
@@ -158,7 +158,10 @@ func GetPriorityClassName(overrides any) string {
 	if !value.IsValid() {
 		return ""
 	}
-	return value.String()
+	if value.Kind() == reflect.String {
+		return value.String()
+	}
+	return ""
 }
 
 func getField(overrides any, fieldNames ...string) (value reflect.Value) {


### PR DESCRIPTION
This is a follow-up to #3613.  During the work in #3626 to add some additional UT for that, I discovered the problem that is fixed here.  `getField` can return:
1. an invalid value - when the field being looked for doesn't exist
2. a nil pointer or slice value - when a field along the looked for path exists but is nil
3. a string value - when everything exists and ends up at a string field.

In case (2), `value.String()` will - misleadingly for our purposes - return a non-empty string representation of the fact that the value is a nil pointer. But what we really want in that case is just "".  So make sure we only use `value.String()` when `value.Kind()` is `String`, and otherwise return "".

Note, the UT for this will be in #3626, when that is merged.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
