### PR TITLE
Update AWS SG setup job for OpenShift

### DIFF
--- a/pkg/awssgsetup/aws_security_group_setup.go
+++ b/pkg/awssgsetup/aws_security_group_setup.go
@@ -16,6 +16,7 @@ package awssgsetup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +35,15 @@ import (
 var log = logf.Log.WithName("AWS_SG_Setup")
 var TRACE = 7
 var DEBUG = 5
+
+type errorSecurityGroupNotFound struct {
+	FilterKey   string
+	FilterValue string
+}
+
+func (e errorSecurityGroupNotFound) Error() string {
+	return fmt.Sprintf("No security groups found matching filter %s = %s", e.FilterKey, e.FilterValue)
+}
 
 // setupAWSSecurityGroups updates the master and worker security groups used in an
 // OpenShift AWS setup. It sets a time that should be checked before attempting
@@ -86,56 +96,35 @@ func SetupAWSSecurityGroups(ctx context.Context, client client.Client, hosted bo
 
 func setupClusterSGs(ec2Cli *ec2.EC2, vpcId string) error {
 	// Get SG ids in VPC
-	// Get one with filter tag:Name with *-master-sg
-	// Get one with filter tag:Name with *-worker-sg
-	masterSg, err := getSGGroup(ec2Cli, vpcId, "*-master-sg")
-	if err != nil {
-		return fmt.Errorf("failed to get AWS SecurityGroups: %v", err)
+	// Get controlplane SG with role filter
+	controlPlaneSg, err := getSecurityGroup(ec2Cli, vpcId, "tag:sigs.k8s.io/cluster-api-provider-aws/role", "controlplane")
+	// Fall back to using filter tag:Name with *-master-sg if not found
+	var notFound errorSecurityGroupNotFound
+	if err != nil && errors.As(err, &notFound) {
+		controlPlaneSg, err = getSecurityGroup(ec2Cli, vpcId, "tag:Name", "*-master-sg")
 	}
-	workerSg, err := getSGGroup(ec2Cli, vpcId, "*-worker-sg")
 	if err != nil {
-		return fmt.Errorf("failed to get AWS SecurityGroups: %v", err)
-	}
-
-	// # Add rules to master and worker SG that allow incoming from master and worker for BGP, IPIP, Typha comms
-	src := []ingressSrc{
-		{
-			srcSGId:  aws.StringValue(masterSg.GroupId),
-			protocol: "tcp",
-			port:     aws.Int64(179),
-		},
-		{
-			srcSGId:  aws.StringValue(masterSg.GroupId),
-			protocol: "4",
-		},
-		{
-			srcSGId:  aws.StringValue(masterSg.GroupId),
-			protocol: "tcp",
-			port:     aws.Int64(5473),
-		},
-		{
-			srcSGId:  aws.StringValue(workerSg.GroupId),
-			protocol: "tcp",
-			port:     aws.Int64(179),
-		},
-		{
-			srcSGId:  aws.StringValue(workerSg.GroupId),
-			protocol: "4",
-		},
-		{
-			srcSGId:  aws.StringValue(workerSg.GroupId),
-			protocol: "tcp",
-			port:     aws.Int64(5473),
-		},
-	}
-	err = allowIngressToSG(ec2Cli, masterSg, src)
-	if err != nil {
-		return fmt.Errorf("failed to update master AWS SecurityGroup: %v", err)
+		return fmt.Errorf("failed to get controlplane AWS SecurityGroup: %v", err)
 	}
 
-	err = allowIngressToSG(ec2Cli, workerSg, src)
+	err = setupSG(ec2Cli, controlPlaneSg)
 	if err != nil {
-		return fmt.Errorf("failed to update worker AWS SecurityGroup: %v", err)
+		return fmt.Errorf("failed to update controlplane AWS SecurityGroup: %v", err)
+	}
+
+	// Get node SG with role filter
+	nodeSg, err := getSecurityGroup(ec2Cli, vpcId, "tag:sigs.k8s.io/cluster-api-provider-aws/role", "node")
+	// Fall back to using filter tag:Name with *-worker-sg if not found
+	if err != nil && errors.As(err, &notFound) {
+		nodeSg, err = getSecurityGroup(ec2Cli, vpcId, "tag:Name", "*-worker-sg")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get node AWS SecurityGroup: %v", err)
+	}
+
+	err = setupSG(ec2Cli, nodeSg)
+	if err != nil {
+		return fmt.Errorf("failed to update node AWS SecurityGroup: %v", err)
 	}
 
 	return nil
@@ -144,27 +133,11 @@ func setupClusterSGs(ec2Cli *ec2.EC2, vpcId string) error {
 func setupHostedClusterSGs(ec2Cli *ec2.EC2, vpcId string) error {
 	// On an OpenShift HCP hosted (guest) cluster, there are no master and worker
 	// security groups, there is only one sg named '*-default-sg'
-	defaultSg, err := getSGGroup(ec2Cli, vpcId, "*-default-sg")
+	defaultSg, err := getSecurityGroup(ec2Cli, vpcId, "tag:Name", "*-default-sg")
 	if err != nil {
 		return fmt.Errorf("failed to get AWS SecurityGroups: %v", err)
 	}
-	src := []ingressSrc{
-		{
-			srcSGId:  aws.StringValue(defaultSg.GroupId),
-			protocol: "tcp",
-			port:     aws.Int64(179),
-		},
-		{
-			srcSGId:  aws.StringValue(defaultSg.GroupId),
-			protocol: "4",
-		},
-		{
-			srcSGId:  aws.StringValue(defaultSg.GroupId),
-			protocol: "tcp",
-			port:     aws.Int64(5473),
-		},
-	}
-	err = allowIngressToSG(ec2Cli, defaultSg, src)
+	err = setupSG(ec2Cli, defaultSg)
 	if err != nil {
 		return fmt.Errorf("failed to update default AWS SecurityGroup: %v", err)
 	}
@@ -214,18 +187,18 @@ func getVPCid(meta *ec2metadata.EC2Metadata) (string, error) {
 	return vpcId, nil
 }
 
-// getSGGroup returns the first SG that is in the specified VPC and matches the nameFilter.
+// getSecurityGroup returns the first SG that is in the specified VPC and matches the nameFilter.
 // nameFilter matches tag:Name.
-func getSGGroup(cli *ec2.EC2, vpcId string, nameFilter string) (*ec2.SecurityGroup, error) {
+func getSecurityGroup(cli *ec2.EC2, vpcId string, filterKey string, filterValue string) (*ec2.SecurityGroup, error) {
 	in := &ec2.DescribeSecurityGroupsInput{}
 	in.SetFilters([]*ec2.Filter{
-		&ec2.Filter{
+		{
 			Name:   aws.String("vpc-id"),
 			Values: []*string{aws.String(vpcId)},
 		},
-		&ec2.Filter{
-			Name:   aws.String("tag:Name"),
-			Values: []*string{aws.String(nameFilter)},
+		{
+			Name:   aws.String(filterKey),
+			Values: []*string{aws.String(filterValue)},
 		},
 	})
 	out, err := cli.DescribeSecurityGroups(in)
@@ -234,12 +207,12 @@ func getSGGroup(cli *ec2.EC2, vpcId string, nameFilter string) (*ec2.SecurityGro
 	}
 
 	if len(out.SecurityGroups) == 0 {
-		log.Info("No security groups found", "vpc-id", vpcId, "tag:Name", nameFilter, "SecurityGroupOutput", out)
-		return nil, fmt.Errorf("No security groups found matching name %s", nameFilter)
+		log.Info("No security groups found", "vpc-id", vpcId, filterKey, filterValue, "SecurityGroupOutput", out)
+		return nil, errorSecurityGroupNotFound{FilterKey: filterKey, FilterValue: filterValue}
 	}
 
 	if len(out.SecurityGroups) > 1 {
-		log.Info("Multiple security groups matching filter, using the first", "tag:Name", nameFilter, "SecurityGroupOutput", out)
+		log.Info("Multiple security groups matching filter, using the first", filterKey, "=", filterValue, "SecurityGroupOutput", out)
 	}
 
 	log.V(TRACE).Info("DescribeSecurityGroups", "SecurityGroupOutput", out)
@@ -277,6 +250,34 @@ func ingressSrcMatchesIpPermission(s ingressSrc, ipp *ec2.IpPermission) bool {
 		}
 	}
 	return false
+}
+
+func setupSG(ec2Cli *ec2.EC2, sg *ec2.SecurityGroup) error {
+	src := []ingressSrc{
+		{
+			// BGP
+			srcSGId:  aws.StringValue(sg.GroupId),
+			protocol: "tcp",
+			port:     aws.Int64(179),
+		},
+		{
+			// IP-in-IP
+			srcSGId:  aws.StringValue(sg.GroupId),
+			protocol: "4",
+		},
+		{
+			// Typha
+			srcSGId:  aws.StringValue(sg.GroupId),
+			protocol: "tcp",
+			port:     aws.Int64(5473),
+		},
+	}
+
+	err := allowIngressToSG(ec2Cli, sg, src)
+	if err != nil {
+		return fmt.Errorf("failed to update AWS SecurityGroup Name: %v, ID: %v, error: %v", sg.GroupName, sg.GroupId, err)
+	}
+	return nil
 }
 
 // allowIngressToSG adds rules to the toSG Security Group for each element of sources.

--- a/pkg/crds/calico/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
+++ b/pkg/crds/calico/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -1,0 +1,1057 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/network-policy-api/pull/30
+    policy.networking.k8s.io/bundle-version: v0.1.1
+    policy.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: baselineadminnetworkpolicies.policy.networking.k8s.io
+spec:
+  group: policy.networking.k8s.io
+  names:
+    kind: BaselineAdminNetworkPolicy
+    listKind: BaselineAdminNetworkPolicyList
+    plural: baselineadminnetworkpolicies
+    shortNames:
+    - banp
+    singular: baselineadminnetworkpolicy
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BaselineAdminNetworkPolicy is a cluster level resource that is part of the
+          AdminNetworkPolicy API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of BaselineAdminNetworkPolicy.
+            properties:
+              egress:
+                description: |-
+                  Egress is the list of Egress rules to be applied to the selected pods if
+                  they are not matched by any AdminNetworkPolicy or NetworkPolicy rules.
+                  A total of 100 Egress rules will be allowed in each BANP instance.
+                  The relative precedence of egress rules within a single BANP object
+                  will be determined by the order in which the rule is written.
+                  Thus, a rule that appears at the top of the egress rules
+                  would take the highest precedence.
+                  BANPs with no egress rules do not affect egress traffic.
+
+
+                  Support: Core
+                items:
+                  description: |-
+                    BaselineAdminNetworkPolicyEgressRule describes an action to take on a particular
+                    set of traffic originating from pods selected by a BaselineAdminNetworkPolicy's
+                    Subject field.
+                    <network-policy-api:experimental:validation>
+                  properties:
+                    action:
+                      description: |-
+                        Action specifies the effect this rule will have on matching traffic.
+                        Currently the following actions are supported:
+                        Allow: allows the selected traffic
+                        Deny: denies the selected traffic
+
+
+                        Support: Core
+                      enum:
+                      - Allow
+                      - Deny
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this rule, that may be no more than 100 characters
+                        in length. This field should be used by the implementation to help
+                        improve observability, readability and error-reporting for any applied
+                        BaselineAdminNetworkPolicies.
+
+
+                        Support: Core
+                      maxLength: 100
+                      type: string
+                    ports:
+                      description: |-
+                        Ports allows for matching traffic based on port and protocols.
+                        This field is a list of destination ports for the outgoing egress traffic.
+                        If Ports is not set then the rule does not filter traffic via port.
+                      items:
+                        description: |-
+                          AdminNetworkPolicyPort describes how to select network ports on pod(s).
+                          Exactly one field must be set.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
+                          portNumber:
+                            description: |-
+                              Port selects a port on a pod(s) based on number.
+
+
+                              Support: Core
+                            properties:
+                              port:
+                                description: |-
+                                  Number defines a network port value.
+
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                  match. If not specified, this field defaults to TCP.
+
+
+                                  Support: Core
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          portRange:
+                            description: |-
+                              PortRange selects a port range on a pod(s) based on provided start and end
+                              values.
+
+
+                              Support: Core
+                            properties:
+                              end:
+                                description: |-
+                                  End defines a network port that is the end of a port range, the End value
+                                  must be greater than Start.
+
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                  match. If not specified, this field defaults to TCP.
+
+
+                                  Support: Core
+                                type: string
+                              start:
+                                description: |-
+                                  Start defines a network port that is the start of a port range, the Start
+                                  value must be less than End.
+
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            required:
+                            - end
+                            - start
+                            type: object
+                        type: object
+                      maxItems: 100
+                      type: array
+                    to:
+                      description: |-
+                        To is the list of destinations whose traffic this rule applies to.
+                        If any AdminNetworkPolicyEgressPeer matches the destination of outgoing
+                        traffic then the specified action is applied.
+                        This field must be defined and contain at least one item.
+
+
+                        Support: Core
+                      items:
+                        description: |-
+                          AdminNetworkPolicyEgressPeer defines a peer to allow traffic to.
+                          Exactly one of the selector pointers must be set for a given peer. If a
+                          consumer observes none of its fields are set, they must assume an unknown
+                          option has been specified and fail closed.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          namespaces:
+                            description: |-
+                              Namespaces defines a way to select all pods within a set of Namespaces.
+                              Note that host-networked pods are not included in this type of peer.
+
+
+                              Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          networks:
+                            description: |-
+                              Networks defines a way to select peers via CIDR blocks.
+                              This is intended for representing entities that live outside the cluster,
+                              which can't be selected by pods, namespaces and nodes peers, but note
+                              that cluster-internal traffic will be checked against the rule as
+                              well. So if you Allow or Deny traffic to `"0.0.0.0/0"`, that will allow
+                              or deny all IPv4 pod-to-pod traffic as well. If you don't want that,
+                              add a rule that Passes all pod traffic before the Networks rule.
+
+
+                              Each item in Networks should be provided in the CIDR format and should be
+                              IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+
+
+                              Networks can have upto 25 CIDRs specified.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            items:
+                              description: |-
+                                CIDR is an IP address range in CIDR notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                This string must be validated by implementations using net.ParseCIDR
+                                TODO: Introduce CEL CIDR validation regex isCIDR() in Kube 1.31 when it is available.
+                              maxLength: 43
+                              type: string
+                              x-kubernetes-validations:
+                              - message: CIDR must be either an IPv4 or IPv6 address.
+                                  IPv4 address embedded in IPv6 addresses are not
+                                  supported
+                                rule: self.contains(':') != self.contains('.')
+                            maxItems: 25
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                          nodes:
+                            description: |-
+                              Nodes defines a way to select a set of nodes in
+                              the cluster. This field follows standard label selector
+                              semantics; if present but empty, it selects all Nodes.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          pods:
+                            description: |-
+                              Pods defines a way to select a set of pods in
+                              a set of namespaces. Note that host-networked pods
+                              are not included in this type of peer.
+
+
+                              Support: Core
+                            properties:
+                              namespaceSelector:
+                                description: |-
+                                  NamespaceSelector follows standard label selector semantics; if empty,
+                                  it selects all Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  PodSelector is used to explicitly select pods within a namespace; if empty,
+                                  it selects all Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - namespaceSelector
+                            - podSelector
+                            type: object
+                        type: object
+                      maxItems: 100
+                      minItems: 1
+                      type: array
+                  required:
+                  - action
+                  - to
+                  type: object
+                  x-kubernetes-validations:
+                  - message: networks/nodes peer cannot be set with namedPorts since
+                      there are no namedPorts for networks/nodes
+                    rule: '!(self.to.exists(peer, has(peer.networks) || has(peer.nodes))
+                      && has(self.ports) && self.ports.exists(port, has(port.namedPort)))'
+                maxItems: 100
+                type: array
+              ingress:
+                description: |-
+                  Ingress is the list of Ingress rules to be applied to the selected pods
+                  if they are not matched by any AdminNetworkPolicy or NetworkPolicy rules.
+                  A total of 100 Ingress rules will be allowed in each BANP instance.
+                  The relative precedence of ingress rules within a single BANP object
+                  will be determined by the order in which the rule is written.
+                  Thus, a rule that appears at the top of the ingress rules
+                  would take the highest precedence.
+                  BANPs with no ingress rules do not affect ingress traffic.
+
+
+                  Support: Core
+                items:
+                  description: |-
+                    BaselineAdminNetworkPolicyIngressRule describes an action to take on a particular
+                    set of traffic destined for pods selected by a BaselineAdminNetworkPolicy's
+                    Subject field.
+                  properties:
+                    action:
+                      description: |-
+                        Action specifies the effect this rule will have on matching traffic.
+                        Currently the following actions are supported:
+                        Allow: allows the selected traffic
+                        Deny: denies the selected traffic
+
+
+                        Support: Core
+                      enum:
+                      - Allow
+                      - Deny
+                      type: string
+                    from:
+                      description: |-
+                        From is the list of sources whose traffic this rule applies to.
+                        If any AdminNetworkPolicyIngressPeer matches the source of incoming
+                        traffic then the specified action is applied.
+                        This field must be defined and contain at least one item.
+
+
+                        Support: Core
+                      items:
+                        description: |-
+                          AdminNetworkPolicyIngressPeer defines an in-cluster peer to allow traffic from.
+                          Exactly one of the selector pointers must be set for a given peer. If a
+                          consumer observes none of its fields are set, they must assume an unknown
+                          option has been specified and fail closed.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          namespaces:
+                            description: |-
+                              Namespaces defines a way to select all pods within a set of Namespaces.
+                              Note that host-networked pods are not included in this type of peer.
+
+
+                              Support: Core
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          pods:
+                            description: |-
+                              Pods defines a way to select a set of pods in
+                              a set of namespaces. Note that host-networked pods
+                              are not included in this type of peer.
+
+
+                              Support: Core
+                            properties:
+                              namespaceSelector:
+                                description: |-
+                                  NamespaceSelector follows standard label selector semantics; if empty,
+                                  it selects all Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              podSelector:
+                                description: |-
+                                  PodSelector is used to explicitly select pods within a namespace; if empty,
+                                  it selects all Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - namespaceSelector
+                            - podSelector
+                            type: object
+                        type: object
+                      maxItems: 100
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is an identifier for this rule, that may be no more than 100 characters
+                        in length. This field should be used by the implementation to help
+                        improve observability, readability and error-reporting for any applied
+                        BaselineAdminNetworkPolicies.
+
+
+                        Support: Core
+                      maxLength: 100
+                      type: string
+                    ports:
+                      description: |-
+                        Ports allows for matching traffic based on port and protocols.
+                        This field is a list of ports which should be matched on
+                        the pods selected for this policy i.e the subject of the policy.
+                        So it matches on the destination port for the ingress traffic.
+                        If Ports is not set then the rule does not filter traffic via port.
+
+
+                        Support: Core
+                      items:
+                        description: |-
+                          AdminNetworkPolicyPort describes how to select network ports on pod(s).
+                          Exactly one field must be set.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          namedPort:
+                            description: |-
+                              NamedPort selects a port on a pod(s) based on name.
+
+
+                              Support: Extended
+
+
+                              <network-policy-api:experimental>
+                            type: string
+                          portNumber:
+                            description: |-
+                              Port selects a port on a pod(s) based on number.
+
+
+                              Support: Core
+                            properties:
+                              port:
+                                description: |-
+                                  Number defines a network port value.
+
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                  match. If not specified, this field defaults to TCP.
+
+
+                                  Support: Core
+                                type: string
+                            required:
+                            - port
+                            - protocol
+                            type: object
+                          portRange:
+                            description: |-
+                              PortRange selects a port range on a pod(s) based on provided start and end
+                              values.
+
+
+                              Support: Core
+                            properties:
+                              end:
+                                description: |-
+                                  End defines a network port that is the end of a port range, the End value
+                                  must be greater than Start.
+
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol is the network protocol (TCP, UDP, or SCTP) which traffic must
+                                  match. If not specified, this field defaults to TCP.
+
+
+                                  Support: Core
+                                type: string
+                              start:
+                                description: |-
+                                  Start defines a network port that is the start of a port range, the Start
+                                  value must be less than End.
+
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                            required:
+                            - end
+                            - start
+                            type: object
+                        type: object
+                      maxItems: 100
+                      type: array
+                  required:
+                  - action
+                  - from
+                  type: object
+                maxItems: 100
+                type: array
+              subject:
+                description: |-
+                  Subject defines the pods to which this BaselineAdminNetworkPolicy applies.
+                  Note that host-networked pods are not included in subject selection.
+
+
+                  Support: Core
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  namespaces:
+                    description: Namespaces is used to select pods via namespace selectors.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  pods:
+                    description: Pods is used to select pods via namespace AND pod
+                      selectors.
+                    properties:
+                      namespaceSelector:
+                        description: |-
+                          NamespaceSelector follows standard label selector semantics; if empty,
+                          it selects all Namespaces.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      podSelector:
+                        description: |-
+                          PodSelector is used to explicitly select pods within a namespace; if empty,
+                          it selects all Pods.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - namespaceSelector
+                    - podSelector
+                    type: object
+                type: object
+            required:
+            - subject
+            type: object
+          status:
+            description: Status is the status to be reported by the implementation.
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            required:
+            - conditions
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: Only one baseline admin network policy with metadata.name="default"
+            can be created in the cluster
+          rule: self.metadata.name == 'default'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -104,6 +104,25 @@ spec:
                   for debugging purposes. \n Deprecated: Use BPFConnectTimeLoadBalancing
                   [Default: true]"
                 type: boolean
+              bpfConntrackLogLevel:
+                description: 'BPFConntrackLogLevel controls the log level of the BPF
+                  conntrack cleanup program, which runs periodically to clean up expired
+                  BPF conntrack entries. [Default: Off].'
+                enum:
+                - "Off"
+                - Debug
+                type: string
+              bpfConntrackMode:
+                description: 'BPFConntrackCleanupMode controls how BPF conntrack entries
+                  are cleaned up.  `Auto` will use a BPF program if supported, falling
+                  back to userspace if not.  `Userspace` will always use the userspace
+                  cleanup code.  `BPFProgram` will always use the BPF program (failing
+                  if not supported). [Default: Auto]'
+                enum:
+                - Auto
+                - Userspace
+                - BPFProgram
+                type: string
               bpfDNSPolicyMode:
                 description: 'BPFDNSPolicyMode specifies how DNS policy programming
                   will be handled. Inline - BPF parses DNS response inline with DNS
@@ -251,6 +270,13 @@ spec:
                   map.  This map must be large enough to hold an entry for each active
                   connection.  Warning: changing the size of the conntrack map can
                   cause disruption.'
+                type: integer
+              bpfMapSizeConntrackCleanupQueue:
+                description: BPFMapSizeConntrackCleanupQueue sets the size for the
+                  map used to hold NAT conntrack entries that are queued for cleanup.  This
+                  should be big enough to hold all the NAT entries that expire within
+                  one cleanup interval.
+                minimum: 1
                 type: integer
               bpfMapSizeIPSets:
                 description: BPFMapSizeIPSets sets the size for ipsets map.  The IP
@@ -1688,6 +1714,10 @@ spec:
                 description: 'WireguardRoutingRulePriority controls the priority value
                   to use for the Wireguard routing rule. [Default: 99]'
                 type: integer
+              wireguardThreadingEnabled:
+                description: 'WireguardThreadingEnabled controls whether Wireguard
+                  has NAPI threading enabled. [Default: false]'
+                type: boolean
               workloadSourceSpoofing:
                 description: WorkloadSourceSpoofing controls whether pods can use
                   the allowedSourcePrefixes annotation to send traffic with a source


### PR DESCRIPTION
## Description

Update AWS security group setup job (ran only on OpenShift clusters) for OCP v4.16+ (SG names have changed, and now role tags are used), falling back to names to maintain OCP v4.15 and earlier compatibility. Tested manually by creating OCP 4.15, 4.16 and 4.17 clusters (v4.16+ still needs editing SGs in manifests during setup, due to cluster-api reconciling those, but at least these changes make the job not fail).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
