### PR TITLE
Update ImageSet docstring

### DIFF
--- a/api/v1/imageset_types.go
+++ b/api/v1/imageset_types.go
@@ -30,8 +30,11 @@ type ImageSetSpec struct {
 type Image struct {
 	// Image is an image that the operator deploys and instead of using the built in tag
 	// the operator will use the Digest for the image identifier.
-	// The value should be the image name without registry or tag or digest.
+	// The value should be the *original* image name without registry or tag or digest.
 	// For the image `docker.io/calico/node:v3.17.1` it should be represented as `calico/node`
+	// The "Installation" spec allows defining custom image registries, paths or prefixes.
+	// Even for custom images such as example.com/custompath/customprefix-calico-node:v3.17.1,
+	// this value should still be `calico/node`.
 	Image string `json:"image"`
 
 	// Digest is the image identifier that will be used for the Image.

--- a/pkg/crds/operator/operator.tigera.io_imagesets.yaml
+++ b/pkg/crds/operator/operator.tigera.io_imagesets.yaml
@@ -59,8 +59,11 @@ spec:
                       description: |-
                         Image is an image that the operator deploys and instead of using the built in tag
                         the operator will use the Digest for the image identifier.
-                        The value should be the image name without registry or tag or digest.
+                        The value should be the *original* image name without registry or tag or digest.
                         For the image `docker.io/calico/node:v3.17.1` it should be represented as `calico/node`
+                        The "Installation" spec allows defining custom image registries, paths or prefixes.
+                        Even for custom images such as example.com/custompath/customprefix-calico-node:v3.17.1,
+                        this value should still be `calico/node`.
                       type: string
                   required:
                   - digest


### PR DESCRIPTION
The ImageSet documentation can be a little confusing when having custom image prefixes.

We'll clarify the expected value of the "image" field, underlining the fact that the original image names should be used, without the custom prefixes that may be applied through the Installation spec.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
