### PR TITLE
Fix bad refactor on AWS SG setup

### DIFF
--- a/pkg/crds/enterprise/crd.projectcalico.org_blockaffinities.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_blockaffinities.yaml
@@ -43,6 +43,8 @@ spec:
                 type: string
               state:
                 type: string
+              type:
+                type: string
             required:
             - cidr
             - deleted

--- a/pkg/crds/enterprise/crd.projectcalico.org_ippools.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_ippools.yaml
@@ -37,6 +37,13 @@ spec:
                 items:
                   type: string
                 type: array
+              assignmentMode:
+                description: Determines the mode how IP addresses should be assigned
+                  from this pool
+                enum:
+                - Automatic
+                - Manual
+                type: string
               awsSubnetID:
                 description: 'AWSSubnetID if specified Calico will attempt to ensure
                   that IPs chosen from this IP pool are routed to the corresponding

--- a/pkg/crds/enterprise/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -45,6 +45,13 @@ spec:
                           [Default: 5m]'
                         type: string
                     type: object
+                  loadBalancer:
+                    description: LoadBalancer enables and configures the LoadBalancer
+                      controller. Enabled by default, set to nil to disable.
+                    properties:
+                      assignIPs:
+                        type: string
+                    type: object
                   namespace:
                     description: Namespace enables and configures the namespace controller.
                       Enabled by default, set to nil to disable.
@@ -161,6 +168,13 @@ spec:
                           reconcilerPeriod:
                             description: 'ReconcilerPeriod is the period to perform
                               reconciliation. [Default: 5m]'
+                            type: string
+                        type: object
+                      loadBalancer:
+                        description: LoadBalancer enables and configures the LoadBalancer
+                          controller. Enabled by default, set to nil to disable.
+                        properties:
+                          assignIPs:
                             type: string
                         type: object
                       namespace:


### PR DESCRIPTION
Fix refactor made in https://github.com/tigera/operator/pull/3633 that did not consider SG rules between SGs. This adds a string slice argument to setupSG() so that multiple SG IDs can be passed and set up as src for the rules.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
