### PR TITLE
Bump guardian to 3.20.0-2.3

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -84,7 +84,7 @@ components:
     version: v3.20.0-2.0
   guardian:
     image: tigera/guardian
-    version: v3.20.0-2.0
+    version: v3.20.0-2.3
   tigera-cni:
     image: tigera/cni
     version: v3.20.0-2.0

--- a/hack/maybe-build-release.sh
+++ b/hack/maybe-build-release.sh
@@ -6,7 +6,7 @@ if ! tag=$(git describe --exact-match --tags HEAD); then
 	exit 0
 fi
 
-if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9])?$ ]]; then
 	echo "tag ${tag} does not match the format vX.Y.Z"
 	exit 1
 fi	

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -138,7 +138,7 @@ var (
 	}
 
 	ComponentGuardian = Component{
-		Version:  "v3.20.0-2.0",
+		Version:  "v3.20.0-2.3",
 		Image:    "tigera/guardian",
 		Registry: "",
 	}


### PR DESCRIPTION
## Description

Picking up fix so guardian refreshes service account token for forwarding requests.

Also includes a change to allow tagging the release as 1.36.1.1.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
