### PR TITLE
cherry-pick #3670 Include dex secrets when oidc is non tigera or nil

### DIFF
--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -138,10 +138,11 @@ func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 	// TODO the RequiredSecrets in the dex condig to not pass back secrets of this type.
 	if !c.cfg.DeleteDex {
 		objs = append(objs, secret.ToRuntimeObjects(c.cfg.DexConfig.RequiredSecrets(common.OperatorNamespace())...)...)
-	}
 
-	objs = append(objs, secret.ToRuntimeObjects(c.cfg.DexConfig.RequiredSecrets(DexNamespace)...)...)
-	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(DexNamespace, c.cfg.PullSecrets...)...)...)
+		// The Dex namespace exists only for non-Tigera OIDC types to create secrets within the namespace.
+		objs = append(objs, secret.ToRuntimeObjects(c.cfg.DexConfig.RequiredSecrets(DexNamespace)...)...)
+		objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(DexNamespace, c.cfg.PullSecrets...)...)...)
+	}
 
 	if c.cfg.Installation.CertificateManagement != nil {
 		objs = append(objs, certificatemanagement.CSRClusterRoleBinding(DexObjectName, DexNamespace))


### PR DESCRIPTION
cherry-pick https://github.com/tigera/operator/pull/3670
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
