### PR TITLE
Fix Dex policy test flake

### DIFF
--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -15,7 +15,6 @@
 package render_test
 
 import (
-	"encoding/json"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -527,9 +526,14 @@ var _ = Describe("dex rendering tests", func() {
 
 					policy := testutils.GetAllowTigeraPolicyFromResources(policyName, resources)
 					expectedPolicy := getExpectedPolicy(scenario)
-					policyJ, _ := json.Marshal(policy)
-					expectedPolicyJ, _ := json.Marshal(expectedPolicy)
-					Expect(string(policyJ)).To(Equal(string(expectedPolicyJ)))
+					Expect(policy.Spec.Selector).To(Equal(policy.Spec.Selector))
+					Expect(policy.Spec.Tier).To(Equal(policy.Spec.Tier))
+					Expect(policy.Spec.Order).To(Equal(policy.Spec.Order))
+					Expect(policy.Spec.Types).To(Equal(policy.Spec.Types))
+
+					// The order of insertion of rules is not guaranteed by the render implementation.
+					Expect(policy.Spec.Ingress).To(ContainElements(expectedPolicy.Spec.Ingress))
+					Expect(policy.Spec.Egress).To(ContainElements(expectedPolicy.Spec.Egress))
 				},
 				// Dex only renders in the presence of an Authentication CR, therefore does not have a config option for managed clusters.
 				Entry("for management/standalone, kube-dns", testutils.AllowTigeraScenario{ManagedCluster: false, OpenShift: false}),


### PR DESCRIPTION
## Description
After some refactors to policy rendering in #3636, the Dex component inserts rules into rendered policy based on a map iteration. Since map iteration order is random, this was causing flakes when comparing the rendered policy to the expected policy. This PR adjusts the expectation to support differences in ordering.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
