### PR TITLE
Update the upstream versions of alertmanager and prometheus

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -103,14 +103,14 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v2.48.1
+    version: v2.54.1
   prometheus:
     image: tigera/prometheus
     version: v3.19.4
   # coreos-prometheus holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
-    version: v0.25.0
+    version: v0.27.0
   alertmanager:
     image: tigera/alertmanager
     version: v3.19.4

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = component{
-		Version:  "v2.48.1",
+		Version:  "v2.54.1",
 		Registry: "",
 	}
 
@@ -233,7 +233,7 @@ var (
 	}
 
 	ComponentCoreOSAlertmanager = component{
-		Version:  "v0.25.0",
+		Version:  "v0.27.0",
 		Registry: "",
 	}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c4347d3c-0c65-4a71-acde-a6fc4b1d2f1e)

Officially this operator version combined with this prometheus version is not supported, but it works fine.
As for alertmanager it matches the compatibility matrix.