### PR TITLE
[release-v1.36] Auto pick #3631: Disable the ValidatingAdmissionPolicy API on k8s v1.28 and

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -100,6 +100,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions) *ReconcileAPISe
 		clusterDomain:       opts.ClusterDomain,
 		tierWatchReady:      &utils.ReadyFlag{},
 		multiTenant:         opts.MultiTenant,
+		kubernetesVersion:   opts.KubernetesVersion,
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r
@@ -202,6 +203,7 @@ type ReconcileAPIServer struct {
 	clusterDomain       string
 	tierWatchReady      *utils.ReadyFlag
 	multiTenant         bool
+	kubernetesVersion   *common.VersionInfo
 }
 
 // Reconcile reads that state of the cluster for a APIServer object and makes changes based on the state read
@@ -437,6 +439,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		TrustedBundle:               trustedBundle,
 		MultiTenant:                 r.multiTenant,
 		KeyValidatorConfig:          keyValidatorConfig,
+		KubernetesVersion:           r.kubernetesVersion,
 	}
 
 	component, err := render.APIServer(&apiServerCfg)

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -101,6 +101,10 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			OpenShift:          true,
 			TLSKeyPair:         kp,
 			TrustedBundle:      trustedBundle,
+			KubernetesVersion: &common.VersionInfo{
+				Major: 1,
+				Minor: 31,
+			},
 		}
 	})
 
@@ -343,6 +347,21 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		svc := rtest.GetResource(resources, "tigera-api", "tigera-system", "", "v1", "Service").(*corev1.Service)
 		Expect(svc.GetObjectMeta().GetLabels()).To(HaveLen(1))
 		Expect(svc.GetObjectMeta().GetLabels()).To(HaveKeyWithValue("k8s-app", "tigera-api"))
+
+		apiserverClusterRole := rtest.GetResource(resources,
+			"calico-crds", "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(apiserverClusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"admissionregistration.k8s.io"},
+			Resources: []string{
+				"validatingadmissionpolicies",
+				"validatingadmissionpolicybindings",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		}))
 	},
 		Entry("default cluster domain", dns.DefaultClusterDomain),
 		Entry("custom cluster domain", "custom-domain.internal"),
@@ -1171,6 +1190,25 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Expect(ok).To(BeTrue())
 			Expect(d.Spec.Template.Spec.Tolerations).To(HaveLen(1))
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(tol))
+		})
+
+		It("should disable ValidatingAdmissionPolicy on older k8s versions", func() {
+			cfg.KubernetesVersion = &common.VersionInfo{
+				Major: 1,
+				Minor: 28,
+			}
+			component, err := render.APIServer(cfg)
+			Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+			resources, _ := component.Objects()
+			d := rtest.GetResource(resources, "tigera-apiserver", "tigera-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(d.Spec.Template.Spec.Containers[0].Args).To(ConsistOf([]string{
+				"--secure-port=5443",
+				"--tls-private-key-file=/tigera-apiserver-certs/tls.key",
+				"--tls-cert-file=/tigera-apiserver-certs/tls.crt",
+				"--audit-policy-file=/etc/tigera/audit/policy.conf",
+				"--audit-log-path=/var/log/calico/audit/tsee-audit.log",
+				"--enable-validating-admission-policy=false",
+			}))
 		})
 	})
 })


### PR DESCRIPTION
Cherry pick of #3631 on release-v1.36.

#3631: Disable the ValidatingAdmissionPolicy API on k8s v1.28 and

# Original PR Body below

The Validating Admission Policy went GA with k8s 1.30 and is now enabled by default. Because of this, the apiserver project will automatically establish watches for this feature gate and so does our aggregated ApiServer.

However, for k8s 1.28 and older establishing these watches will result in crash-loops.