### PR TITLE
v1.37  Automated cherry pick of #3629: Make ES work with ECK 2.16.0 by setting the appropriate

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -135,7 +135,7 @@ components:
     image: tigera/eck-operator
     version: release-calient-v3.21-1
   eck-elasticsearch-operator:
-    version: 2.6.1
+    version: 2.16.0
   l7-collector:
     image: tigera/l7-collector
     version: release-calient-v3.21-1

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -91,7 +91,7 @@ var (
 	}
 
 	ComponentECKElasticsearchOperator = Component{
-		Version:  "2.6.1",
+		Version:  "2.16.0",
 		Registry: "",
 	}
 

--- a/pkg/controller/logstorage/elastic/elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -860,7 +861,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 					// The Image is not populated for the container so no need to get and check it
 					Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-					Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
+					Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(3))
 					initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 					Expect(initset).ToNot(BeNil())
 					Expect(initset.Image).To(Equal(
@@ -944,7 +945,7 @@ var _ = Describe("LogStorage controller", func() {
 					Expect(escfg.Spec.NodeSets).To(HaveLen(1))
 					// The Image is not populated for the container so no need to get and check it
 					Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.Containers).To(HaveLen(1))
-					Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(1))
+					Expect(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers).To(HaveLen(3))
 					initset := test.GetContainer(escfg.Spec.NodeSets[0].PodTemplate.Spec.InitContainers, "elastic-internal-init-os-settings")
 					Expect(initset).ToNot(BeNil())
 					Expect(initset.Image).To(Equal(

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -407,43 +407,47 @@ func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	}
 
 	initContainers := []corev1.Container{initOSSettingsContainer}
-	annotations := es.cfg.TrustedBundle.HashAnnotations()
-	annotations[ElasticsearchTLSHashAnnotation] = rmeta.SecretsAnnotationHash(es.cfg.ElasticsearchUserSecret)
-	annotations[es.cfg.ElasticsearchKeyPair.HashAnnotationKey()] = es.cfg.ElasticsearchKeyPair.HashAnnotationValue()
+	initFSContainer := corev1.Container{
+		Name:            "elastic-internal-init-filesystem",
+		Image:           es.esImage,
+		ImagePullPolicy: ImagePullPolicy(),
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("50Mi"),
+			},
+			Requests: corev1.ResourceList{
+				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("50Mi"),
+			},
+		},
+		// Without a root context, it is not able to ln and chown.
+		SecurityContext: securitycontext.NewRootContext(true),
+	}
+
+	suspendContainer := corev1.Container{
+		Name:            "elastic-internal-suspend",
+		Image:           es.esImage,
+		ImagePullPolicy: ImagePullPolicy(),
+		// Without a root context, it is not able to start.
+		SecurityContext: securitycontext.NewRootContext(true),
+	}
 
 	var volumes []corev1.Volume
-
 	var autoMountToken bool
-	if es.cfg.Installation.CertificateManagement != nil {
+	if es.cfg.Installation.CertificateManagement == nil {
+		initContainers = append(initContainers, initFSContainer, suspendContainer)
+	} else {
 		// If certificate management is used, we need to override a mounting options for this init container.
-		initFSName := "elastic-internal-init-filesystem"
-		initFSContainer := corev1.Container{
-			Name:            initFSName,
-			Image:           es.esImage,
-			ImagePullPolicy: ImagePullPolicy(),
-			Command:         []string{"bash", "-c", "mkdir /mnt/elastic-internal/transport-certificates/ && touch /mnt/elastic-internal/transport-certificates/$HOSTNAME.tls.key && /mnt/elastic-internal/scripts/prepare-fs.sh"},
-			Resources: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					"cpu":    resource.MustParse("100m"),
-					"memory": resource.MustParse("50Mi"),
-				},
-				Requests: corev1.ResourceList{
-					"cpu":    resource.MustParse("100m"),
-					"memory": resource.MustParse("50Mi"),
-				},
-			},
-			// Without a root context, it is not able to ln and chown.
-			SecurityContext: securitycontext.NewRootContext(true),
-			VolumeMounts: []corev1.VolumeMount{
-				// Create transport mount, such that ECK will not auto-fill this with a secret volume.
-				{
-					Name:      CSRVolumeNameTransport,
-					MountPath: "/csr",
-					ReadOnly:  false,
-				},
+		initFSContainer.Command = []string{"bash", "-c", "mkdir /mnt/elastic-internal/transport-certificates/ && touch /mnt/elastic-internal/transport-certificates/$HOSTNAME.tls.key && /mnt/elastic-internal/scripts/prepare-fs.sh"}
+		initFSContainer.VolumeMounts = []corev1.VolumeMount{
+			// Create transport mount, such that ECK will not auto-fill this with a secret volume.
+			{
+				Name:      CSRVolumeNameTransport,
+				MountPath: "/csr",
+				ReadOnly:  false,
 			},
 		}
-
 		csrInitContainerHTTP := es.cfg.ElasticsearchKeyPair.InitContainer(ElasticsearchNamespace)
 		csrInitContainerHTTP.Name = "key-cert-elastic"
 		csrInitContainerHTTP.VolumeMounts[0].Name = CSRVolumeNameHTTP
@@ -466,6 +470,7 @@ func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 		initContainers = append(
 			initContainers,
 			initFSContainer,
+			suspendContainer,
 			csrInitContainerHTTP,
 			csrInitContainerTransport)
 
@@ -511,6 +516,10 @@ func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 	if es.cfg.Installation.KubernetesProvider.IsGKE() {
 		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
+
+	annotations := es.cfg.TrustedBundle.HashAnnotations()
+	annotations[ElasticsearchTLSHashAnnotation] = rmeta.SecretsAnnotationHash(es.cfg.ElasticsearchUserSecret)
+	annotations[es.cfg.ElasticsearchKeyPair.HashAnnotationKey()] = es.cfg.ElasticsearchKeyPair.HashAnnotationValue()
 
 	podTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/logstorage/eck/eck.go
+++ b/pkg/render/logstorage/eck/eck.go
@@ -147,17 +147,17 @@ func (e *eck) operatorClusterRole() *rbacv1.ClusterRole {
 		},
 		{
 			APIGroups: []string{""},
-			Resources: []string{"pods", "endpoints", "events", "persistentvolumeclaims", "secrets", "services", "configmaps", "serviceaccounts"},
+			Resources: []string{"endpoints"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"pods", "events", "persistentvolumeclaims", "secrets", "services", "configmaps"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
 			APIGroups: []string{"apps"},
 			Resources: []string{"deployments", "statefulsets", "daemonsets"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
-		},
-		{
-			APIGroups: []string{"batch"},
-			Resources: []string{"cronjobs"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
@@ -167,58 +167,68 @@ func (e *eck) operatorClusterRole() *rbacv1.ClusterRole {
 		},
 		{
 			APIGroups: []string{"elasticsearch.k8s.elastic.co"},
-			Resources: []string{"elasticsearches", "elasticsearches/status", "elasticsearches/finalizers", "enterpriselicenses", "enterpriselicenses/status"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Resources: []string{"elasticsearches", "elasticsearches/status", "elasticsearches/finalizers"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"autoscaling.k8s.elastic.co"},
 			Resources: []string{"elasticsearchautoscalers", "elasticsearchautoscalers/status", "elasticsearchautoscalers/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"kibana.k8s.elastic.co"},
 			Resources: []string{"kibanas", "kibanas/status", "kibanas/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"apm.k8s.elastic.co"},
 			Resources: []string{"apmservers", "apmservers/status", "apmservers/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"enterprisesearch.k8s.elastic.co"},
 			Resources: []string{"enterprisesearches", "enterprisesearches/status", "enterprisesearches/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"beat.k8s.elastic.co"},
 			Resources: []string{"beats", "beats/status", "beats/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"agent.k8s.elastic.co"},
 			Resources: []string{"agents", "agents/status", "agents/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"maps.k8s.elastic.co"},
 			Resources: []string{"elasticmapsservers", "elasticmapsservers/status", "elasticmapsservers/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
 			APIGroups: []string{"stackconfigpolicy.k8s.elastic.co"},
 			Resources: []string{"stackconfigpolicies", "stackconfigpolicies/status", "stackconfigpolicies/finalizers"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+		},
+		{
+			APIGroups: []string{"logstash.k8s.elastic.co"},
+			Resources: []string{"logstashes", "logstashes/status", "logstashes/finalizers"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+		},
+		{
+			APIGroups: []string{"storage.k8s.io"},
+			Resources: []string{"storageclasses"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"admissionregistration.k8s.io"},
+			Resources: []string{"validatingwebhookconfigurations"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 		{
-			APIGroups: []string{"associations.k8s.elastic.co"},
-			Resources: []string{"apmserverelasticsearchassociations", "apmserverelasticsearchassociations/status"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
-		},
-		{
-			APIGroups: []string{"autoscaling.k8s.elastic.co"},
-			Resources: []string{"elasticsearchautoscalers", "elasticsearchautoscalers/status", "elasticsearchautoscalers/finalizers"},
-			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 	}
 

--- a/pkg/render/logstorage/eck/eck_test.go
+++ b/pkg/render/logstorage/eck/eck_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/render"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
@@ -148,17 +149,17 @@ var _ = Describe("ECK rendering tests", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"pods", "endpoints", "events", "persistentvolumeclaims", "secrets", "services", "configmaps", "serviceaccounts"},
+					Resources: []string{"endpoints"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods", "events", "persistentvolumeclaims", "secrets", "services", "configmaps"},
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 				{
 					APIGroups: []string{"apps"},
 					Resources: []string{"deployments", "statefulsets", "daemonsets"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
-				},
-				{
-					APIGroups: []string{"batch"},
-					Resources: []string{"cronjobs"},
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 				{
@@ -168,58 +169,68 @@ var _ = Describe("ECK rendering tests", func() {
 				},
 				{
 					APIGroups: []string{"elasticsearch.k8s.elastic.co"},
-					Resources: []string{"elasticsearches", "elasticsearches/status", "elasticsearches/finalizers", "enterpriselicenses", "enterpriselicenses/status"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Resources: []string{"elasticsearches", "elasticsearches/status", "elasticsearches/finalizers"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"autoscaling.k8s.elastic.co"},
 					Resources: []string{"elasticsearchautoscalers", "elasticsearchautoscalers/status", "elasticsearchautoscalers/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"kibana.k8s.elastic.co"},
 					Resources: []string{"kibanas", "kibanas/status", "kibanas/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"apm.k8s.elastic.co"},
 					Resources: []string{"apmservers", "apmservers/status", "apmservers/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"enterprisesearch.k8s.elastic.co"},
 					Resources: []string{"enterprisesearches", "enterprisesearches/status", "enterprisesearches/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"beat.k8s.elastic.co"},
 					Resources: []string{"beats", "beats/status", "beats/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"agent.k8s.elastic.co"},
 					Resources: []string{"agents", "agents/status", "agents/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"maps.k8s.elastic.co"},
 					Resources: []string{"elasticmapsservers", "elasticmapsservers/status", "elasticmapsservers/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
 					APIGroups: []string{"stackconfigpolicy.k8s.elastic.co"},
 					Resources: []string{"stackconfigpolicies", "stackconfigpolicies/status", "stackconfigpolicies/finalizers"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+				},
+				{
+					APIGroups: []string{"logstash.k8s.elastic.co"},
+					Resources: []string{"logstashes", "logstashes/status", "logstashes/finalizers"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+				},
+				{
+					APIGroups: []string{"storage.k8s.io"},
+					Resources: []string{"storageclasses"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{"admissionregistration.k8s.io"},
+					Resources: []string{"validatingwebhookconfigurations"},
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 				{
-					APIGroups: []string{"associations.k8s.elastic.co"},
-					Resources: []string{"apmserverelasticsearchassociations", "apmserverelasticsearchassociations/status"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
-				},
-				{
-					APIGroups: []string{"autoscaling.k8s.elastic.co"},
-					Resources: []string{"elasticsearchautoscalers", "elasticsearchautoscalers/status", "elasticsearchautoscalers/finalizers"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 			}))
 		})

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 
 				// Verify that an initContainer is added
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(initContainers).To(HaveLen(1))
+				Expect(initContainers).To(HaveLen(3))
 				Expect(initContainers[0].Name).To(Equal("elastic-internal-init-os-settings"))
 				Expect(*initContainers[0].SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
 				Expect(*initContainers[0].SecurityContext.Privileged).To(BeTrue())
@@ -350,7 +350,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
 
 				initContainers := resultES.Spec.NodeSets[0].PodTemplate.Spec.InitContainers
-				Expect(initContainers).To(HaveLen(4))
+				Expect(initContainers).To(HaveLen(5))
 				compareInitContainer := func(ic corev1.Container, expectedName string, expectedVolumes []corev1.VolumeMount, privileged bool) {
 					Expect(ic.Name).To(Equal(expectedName))
 					Expect(ic.VolumeMounts).To(HaveLen(len(expectedVolumes)))
@@ -364,10 +364,11 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				compareInitContainer(initContainers[1], "elastic-internal-init-filesystem", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: "/csr"},
 				}, true)
-				compareInitContainer(initContainers[2], "key-cert-elastic", []corev1.VolumeMount{
+				compareInitContainer(initContainers[2], "elastic-internal-suspend", nil, true)
+				compareInitContainer(initContainers[3], "key-cert-elastic", []corev1.VolumeMount{
 					{Name: "elastic-internal-http-certificates", MountPath: certificatemanagement.CSRCMountPath},
 				}, false)
-				compareInitContainer(initContainers[3], "key-cert-elastic-transport", []corev1.VolumeMount{
+				compareInitContainer(initContainers[4], "key-cert-elastic-transport", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: certificatemanagement.CSRCMountPath},
 				}, false)
 			})


### PR DESCRIPTION
Cherry pick of #3629 on release-v1.37.

Original branch name release-v1.37

#3629: Make ES work with ECK 2.16.0 by setting the appropriate