### PR TITLE
[Pick #3452] Improve OpenShift platform detection accuracy (1.34)

### DIFF
--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -53,14 +53,26 @@ var _ = Describe("provider discovery", func() {
 		Expect(p).To(Equal(operatorv1.ProviderDockerEE))
 	})
 
-	It("should detect openshift based on API resource config.openshift.io existence", func() {
+	It("should detect openshift based on API resource clusterversion.config.openshift.io existence", func() {
 		c := fake.NewSimpleClientset()
 		c.Resources = []*metav1.APIResourceList{{
 			GroupVersion: "config.openshift.io/v1",
+			APIResources: []metav1.APIResource{{SingularName: "clusterversion", Name: "clusterversions", Kind: "ClusterVersion"}},
 		}}
 		p, e := AutoDiscoverProvider(context.Background(), c)
 		Expect(e).To(BeNil())
 		Expect(p).To(Equal(operatorv1.ProviderOpenShift))
+	})
+
+	It("should detect non-openshift based on API resource clusterversion.config.openshift.io absense, however some other config.openshift.io resources are present", func() {
+		c := fake.NewSimpleClientset()
+		c.Resources = []*metav1.APIResourceList{{
+			GroupVersion: "config.openshift.io/v1",
+			APIResources: []metav1.APIResource{{SingularName: "dummy", Name: "dummies", Kind: "Dummy"}},
+		}}
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderNone))
 	})
 
 	It("should detect GKE based on API resource networking.gke.io existence", func() {


### PR DESCRIPTION
## Description
Original PR: https://github.com/tigera/operator/pull/3452

This change improves the accuracy of Openshift platform detection. In some cases (i.e. when one hosts managed Openshift master deployments on a non-Openshift cluster) some portion of the Openshift API resources may be present on a non-Openshift cluster. That tricks Tigera operator atm to think it is operating on an Openshift cluster, leading to various failures.

After the change, the condition becomes more restricted and will be triggered only if the `ClusterVersion` CRD is specifically present, which is the main source of the actual Openshift cluster version, for example:

```shell
$ k get clusterversions.config.openshift.io                                                                                                                         [22:03:33]
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.15.11   True        False         23d     Cluster version is 4.15.11
```  

This custom resource is extremely unlikely (and makes no sense) to be present on non-Openshift clusters.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
