### PR TITLE
hardcode /var/run/calico as the location of the endpoint-status dir

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1665,7 +1665,7 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		*c.cfg.Installation.CalicoNetwork.LinuxPolicySetupTimeoutSeconds > 0 {
 		nodeEnv = append(nodeEnv, corev1.EnvVar{
 			Name:  "FELIX_ENDPOINTSTATUSPATHPREFIX",
-			Value: c.varRunCalicoVolume().VolumeSource.HostPath.Path,
+			Value: "/var/run/calico",
 		})
 	}
 


### PR DESCRIPTION
Path inside Calico container should not use host-path value of the mount.
`var-run-calico` mount will always be at `/var/run/calico` inside the container.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
