### PR TITLE
Update libcalico-go version to the branch, rather than the last relea…

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -2,7 +2,7 @@
 title: v3.20.0-2.2
 components:
   libcalico-go:
-    version: v3.20.0-2.2
+    version: release-calient-v3.20
   cnx-manager:
     image: tigera/cnx-manager
     version: v3.20.0-2.2

--- a/pkg/crds/enterprise/01-crd-eck-agent.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-agent.yaml
@@ -2,12 +2,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -47,10 +47,19 @@ spec:
           description: Agent is the Schema for the Agents API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -62,14 +71,19 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 configRef:
-                  description: ConfigRef contains a reference to an existing Kubernetes Secret holding the Agent configuration. Agent settings must be specified as yaml, under a single "agent.yml" entry. At most one of [`Config`, `ConfigRef`] can be specified.
+                  description: |-
+                    ConfigRef contains a reference to an existing Kubernetes Secret holding the Agent configuration.
+                    Agent settings must be specified as yaml, under a single "agent.yml" entry. At most one of [`Config`, `ConfigRef`]
+                    can be specified.
                   properties:
                     secretName:
                       description: SecretName is the name of the secret.
                       type: string
                   type: object
                 daemonSet:
-                  description: DaemonSet specifies the Agent should be deployed as a DaemonSet, and allows providing its spec. Cannot be used along with `deployment`.
+                  description: |-
+                    DaemonSet specifies the Agent should be deployed as a DaemonSet, and allows providing its spec.
+                    Cannot be used along with `deployment` or `statefulSet`.
                   properties:
                     podTemplate:
                       description: PodTemplateSpec describes the data a pod should have when created from a template
@@ -79,19 +93,51 @@ spec:
                       description: DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
                       properties:
                         rollingUpdate:
-                          description: 'Rolling update config params. Present only if type = "RollingUpdate". --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`. See https://github.com/kubernetes/kubernetes/issues/35345'
+                          description: Rolling update config params. Present only if type = "RollingUpdate".
                           properties:
                             maxSurge:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption.'
+                              description: |-
+                                The maximum number of nodes with an existing available DaemonSet pod that
+                                can have an updated DaemonSet pod during during an update.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                This can not be 0 if MaxUnavailable is 0.
+                                Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                                Default value is 0.
+                                Example: when this is set to 30%, at most 30% of the total number of nodes
+                                that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                can have their a new pod created before the old pod is marked as deleted.
+                                The update starts by launching new pods on 30% of nodes. Once an updated
+                                pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                                on that node is marked deleted. If the old pod becomes unavailable for any
+                                reason (Ready transitions to false, is evicted, or is drained) an updated
+                                pod is immediatedly created on that node without considering surge limits.
+                                Allowing surge implies the possibility that the resources consumed by the
+                                daemonset on any given node can double if the readiness check fails, and
+                                so resource intensive daemonsets should take into account that they may
+                                cause evictions during disruption.
                               x-kubernetes-int-or-string: true
                             maxUnavailable:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.'
+                              description: |-
+                                The maximum number of DaemonSet pods that can be unavailable during the
+                                update. Value can be an absolute number (ex: 5) or a percentage of total
+                                number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                                number is calculated from percentage by rounding up.
+                                This cannot be 0 if MaxSurge is 0
+                                Default value is 1.
+                                Example: when this is set to 30%, at most 30% of the total number of nodes
+                                that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                can have their pods stopped for an update at any given time. The update
+                                starts by stopping at most 30% of those DaemonSet pods and then brings
+                                up new DaemonSet pods in their place. Once the new pods are available,
+                                it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                                70% of original number of DaemonSet pods are available at all times during
+                                the update.
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
@@ -100,7 +146,9 @@ spec:
                       type: object
                   type: object
                 deployment:
-                  description: Deployment specifies the Agent should be deployed as a Deployment, and allows providing its spec. Cannot be used along with `daemonSet`.
+                  description: |-
+                    Deployment specifies the Agent should be deployed as a Deployment, and allows providing its spec.
+                    Cannot be used along with `daemonSet` or `statefulSet`.
                   properties:
                     podTemplate:
                       description: PodTemplateSpec describes the data a pod should have when created from a template
@@ -113,19 +161,42 @@ spec:
                       description: DeploymentStrategy describes how to replace existing pods with new ones.
                       properties:
                         rollingUpdate:
-                          description: 'Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.'
+                          description: |-
+                            Rolling update config params. Present only if DeploymentStrategyType =
+                            RollingUpdate.
                           properties:
                             maxSurge:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                              description: |-
+                                The maximum number of pods that can be scheduled above the desired number of
+                                pods.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                This can not be 0 if MaxUnavailable is 0.
+                                Absolute number is calculated from percentage by rounding up.
+                                Defaults to 25%.
+                                Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                the rolling update starts, such that the total number of old and new pods do not exceed
+                                130% of desired pods. Once old pods have been killed,
+                                new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                at any time during the update is at most 130% of desired pods.
                               x-kubernetes-int-or-string: true
                             maxUnavailable:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                              description: |-
+                                The maximum number of pods that can be unavailable during the update.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                Absolute number is calculated from percentage by rounding down.
+                                This can not be 0 if MaxSurge is 0.
+                                Defaults to 25%.
+                                Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                that the total number of pods available at all times during the update is at
+                                least 70% of desired pods.
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
@@ -134,7 +205,9 @@ spec:
                       type: object
                   type: object
                 elasticsearchRefs:
-                  description: ElasticsearchRefs is a reference to a list of Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single ES cluster is currently supported.
+                  description: |-
+                    ElasticsearchRefs is a reference to a list of Elasticsearch clusters running in the same Kubernetes cluster.
+                    Due to existing limitations, only a single ES cluster is currently supported.
                   items:
                     properties:
                       name:
@@ -146,10 +219,21 @@ spec:
                       outputName:
                         type: string
                       secretName:
-                        description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                        description: |-
+                          SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                          Elastic resource not managed by the operator. The referenced secret must contain the following:
+                          - `url`: the URL to reach the Elastic resource
+                          - `username`: the username of the user to be authenticated to the Elastic resource
+                          - `password`: the password of the user to be authenticated to the Elastic resource
+                          - `ca.crt`: the CA certificate in PEM format (optional)
+                          - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                          This field cannot be used in combination with the other fields name, namespace or serviceName.
                         type: string
                       serviceName:
-                        description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                        description: |-
+                          ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                          object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                          the referenced resource is used.
                         type: string
                     type: object
                   type: array
@@ -157,7 +241,9 @@ spec:
                   description: FleetServerEnabled determines whether this Agent will launch Fleet Server. Don't set unless `mode` is set to `fleet`.
                   type: boolean
                 fleetServerRef:
-                  description: FleetServerRef is a reference to Fleet Server that this Agent should connect to to obtain it's configuration. Don't set unless `mode` is set to `fleet`.
+                  description: |-
+                    FleetServerRef is a reference to Fleet Server that this Agent should connect to to obtain it's configuration.
+                    Don't set unless `mode` is set to `fleet`.
                   properties:
                     name:
                       description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -166,10 +252,21 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 http:
@@ -179,7 +276,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -202,69 +301,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -273,13 +535,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -290,16 +562,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -308,13 +599,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -322,7 +642,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -354,7 +680,9 @@ spec:
                   description: Image is the Agent Docker image to deploy. Version has to match the Agent in the image.
                   type: string
                 kibanaRef:
-                  description: KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set unless `mode` is set to `fleet`.
+                  description: |-
+                    KibanaRef is a reference to Kibana where Fleet should be set up and this Agent should be enrolled. Don't set
+                    unless `mode` is set to `fleet`.
                   properties:
                     name:
                       description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -363,32 +691,54 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 mode:
-                  description: Mode specifies the source of configuration for the Agent. The configuration can be specified locally through `config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode). Defaults to `standalone` mode.
+                  description: |-
+                    Mode specifies the source of configuration for the Agent. The configuration can be specified locally through
+                    `config` or `configRef` (`standalone` mode), or come from Fleet during runtime (`fleet` mode).
+                    Defaults to `standalone` mode.
                   enum:
                     - standalone
                     - fleet
                   type: string
                 policyID:
-                  description: PolicyID optionally determines into which Agent Policy this Agent will be enrolled. If left empty the default policy will be used.
+                  description: |-
+                    PolicyID determines into which Agent Policy this Agent will be enrolled.
+                    This field will become mandatory in a future release, default policies are deprecated since 8.1.0.
                   type: string
                 revisionHistoryLimit:
-                  description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment.
+                  description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying DaemonSet or Deployment or StatefulSet.
                   format: int32
                   type: integer
                 secureSettings:
-                  description: SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Agent. Secrets data can be then referenced in the Agent config using the Secret's keys or as specified in `Entries` field of each SecureSetting.
+                  description: |-
+                    SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Agent.
+                    Secrets data can be then referenced in the Agent config using the Secret's keys or as specified in `Entries` field of
+                    each SecureSetting.
                   items:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -396,7 +746,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key
@@ -410,8 +762,282 @@ spec:
                     type: object
                   type: array
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to an Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to an Elasticsearch resource in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
+                statefulSet:
+                  description: |-
+                    StatefulSet specifies the Agent should be deployed as a StatefulSet, and allows providing its spec.
+                    Cannot be used along with `daemonSet` or `deployment`.
+                  properties:
+                    podManagementPolicy:
+                      default: Parallel
+                      description: |-
+                        PodManagementPolicy controls how pods are created during initial scale up,
+                        when replacing pods on nodes, or when scaling down. The default policy is
+                        `Parallel`, where pods are created in parallel to match the desired scale
+                        without waiting, and on scale down will delete all pods at once.
+                        The alternative policy is `OrderedReady`, the default for vanilla kubernetes
+                        StatefulSets, where pods are created in increasing order in increasing order
+                        (pod-0, then pod-1, etc.) and the controller will wait until each pod is ready before
+                        continuing. When scaling down, the pods are removed in the opposite order.
+                      enum:
+                        - OrderedReady
+                        - Parallel
+                      type: string
+                    podTemplate:
+                      description: PodTemplateSpec describes the data a pod should have when created from a template
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    replicas:
+                      format: int32
+                      type: integer
+                    serviceName:
+                      type: string
+                    volumeClaimTemplates:
+                      description: |-
+                        VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod.
+                        Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+                        Items defined here take precedence over any default claims added by the operator with the same name.
+                      items:
+                        description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          metadata:
+                            description: |-
+                              Standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                          spec:
+                            description: |-
+                              spec defines the desired characteristics of a volume requested by a pod author.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                            properties:
+                              accessModes:
+                                description: |-
+                                  accessModes contains the desired access modes the volume should have.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              dataSource:
+                                description: |-
+                                  dataSource field can be used to specify either:
+                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                  * An existing PVC (PersistentVolumeClaim)
+                                  If the provisioner or an external controller can support the specified data source,
+                                  it will create a new volume based on the contents of the specified data source.
+                                  When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                  and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                  If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the group for the resource being referenced.
+                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being referenced
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              dataSourceRef:
+                                description: |-
+                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                  volume is desired. This may be any object from a non-empty API group (non
+                                  core object) or a PersistentVolumeClaim object.
+                                  When this field is specified, volume binding will only succeed if the type of
+                                  the specified object matches some installed volume populator or dynamic
+                                  provisioner.
+                                  This field will replace the functionality of the dataSource field and as such
+                                  if both fields are non-empty, they must have the same value. For backwards
+                                  compatibility, when namespace isn't specified in dataSourceRef,
+                                  both fields (dataSource and dataSourceRef) will be set to the same
+                                  value automatically if one of them is empty and the other is non-empty.
+                                  When namespace is specified in dataSourceRef,
+                                  dataSource isn't set to the same value and must be empty.
+                                  There are three important differences between dataSource and dataSourceRef:
+                                  * While dataSource only allows two specific types of objects, dataSourceRef
+                                    allows any non-core object, as well as PersistentVolumeClaim objects.
+                                  * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                    preserves all values, and generates an error if a disallowed value is
+                                    specified.
+                                  * While dataSource only allows local objects, dataSourceRef allows objects
+                                    in any namespaces.
+                                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                  (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                properties:
+                                  apiGroup:
+                                    description: |-
+                                      APIGroup is the group for the resource being referenced.
+                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                      For any other third-party types, APIGroup is required.
+                                    type: string
+                                  kind:
+                                    description: Kind is the type of resource being referenced
+                                    type: string
+                                  name:
+                                    description: Name is the name of resource being referenced
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of resource being referenced
+                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              resources:
+                                description: |-
+                                  resources represents the minimum resources the volume should have.
+                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                  status field of the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              selector:
+                                description: selector is a label query over volumes to consider for binding.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              storageClassName:
+                                description: |-
+                                  storageClassName is the name of the StorageClass required by the claim.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                type: string
+                              volumeAttributesClassName:
+                                description: |-
+                                  volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                  If specified, the CSI driver will create or update the volume with the attributes defined
+                                  in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                  will be set by the persistentvolume controller if it exists.
+                                  If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                  set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                  exists.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                  (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                type: string
+                              volumeMode:
+                                description: |-
+                                  volumeMode defines what type of volume is required by the claim.
+                                  Value of Filesystem is implied when not included in claim spec.
+                                type: string
+                              volumeName:
+                                description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                  type: object
                 version:
                   description: Version of the Agent.
                   type: string
@@ -428,7 +1054,9 @@ spec:
                   additionalProperties:
                     description: AssociationStatus is the status of an association resource.
                     type: string
-                  description: AssociationStatusMap is the map of association's namespaced name string to its AssociationStatus. For resources that have a single Association of a given type (for ex. single ES reference), this map contains a single entry.
+                  description: |-
+                    AssociationStatusMap is the map of association's namespaced name string to its AssociationStatus. For resources that
+                    have a single Association of a given type (for ex. single ES reference), this map contains a single entry.
                   type: object
                 expectedNodes:
                   format: int32
@@ -442,11 +1070,17 @@ spec:
                   description: AssociationStatus is the status of an association resource.
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this Elastic Agent. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Elastic Agent controller has not yet processed the changes contained in the Elastic Agent specification.
+                  description: |-
+                    ObservedGeneration is the most recent generation observed for this Elastic Agent.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the Elastic
+                    Agent controller has not yet processed the changes contained in the Elastic Agent specification.
                   format: int64
                   type: integer
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object

--- a/pkg/crds/enterprise/01-crd-eck-apmserver.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-apmserver.yaml
@@ -3,12 +3,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -44,10 +44,19 @@ spec:
           description: ApmServer represents an APM Server resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -72,10 +81,21 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 http:
@@ -85,7 +105,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -108,69 +130,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -179,13 +364,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -196,16 +391,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -214,13 +428,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -228,7 +471,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -260,7 +509,9 @@ spec:
                   description: Image is the APM Server Docker image to deploy.
                   type: string
                 kibanaRef:
-                  description: KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows APM agent central configuration management in Kibana.
+                  description: |-
+                    KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.
+                    It allows APM agent central configuration management in Kibana.
                   properties:
                     name:
                       description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -269,10 +520,21 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 podTemplate:
@@ -289,7 +551,10 @@ spec:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -297,7 +562,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key
@@ -311,7 +578,9 @@ spec:
                     type: object
                   type: array
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
                 version:
                   description: Version of the APM Server.
@@ -340,7 +609,11 @@ spec:
                   description: KibanaAssociationStatus is the status of any auto-linking to Kibana.
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration represents the .metadata.generation that the status is based upon. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the APM Server controller has not yet processed the changes contained in the APM Server specification.
+                  description: |-
+                    ObservedGeneration represents the .metadata.generation that the status is based upon.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the APM Server
+                    controller has not yet processed the changes contained in the APM Server specification.
                   format: int64
                   type: integer
                 secretTokenSecret:
@@ -353,7 +626,9 @@ spec:
                   description: ExternalService is the name of the service the agents should connect to.
                   type: string
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object
@@ -386,10 +661,19 @@ spec:
           description: ApmServer represents an APM Server resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -423,7 +707,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -446,69 +732,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -517,13 +966,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -534,16 +993,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -552,13 +1030,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -566,7 +1073,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -607,7 +1120,10 @@ spec:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -615,7 +1131,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key

--- a/pkg/crds/enterprise/01-crd-eck-autoscaling.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-autoscaling.yaml
@@ -3,12 +3,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -42,10 +42,19 @@ spec:
           description: ElasticsearchAutoscaler represents an ElasticsearchAutoscaler resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -68,7 +77,9 @@ spec:
                         additionalProperties:
                           additionalProperties:
                             type: string
-                          description: DeciderSettings allow the user to tweak autoscaling deciders. The map data structure complies with the <key,value> format expected by Elasticsearch.
+                          description: |-
+                            DeciderSettings allow the user to tweak autoscaling deciders.
+                            The map data structure complies with the <key,value> format expected by Elasticsearch.
                           type: object
                         description: Deciders allow the user to override default settings for autoscaling deciders.
                         type: object
@@ -76,7 +87,13 @@ spec:
                         description: Name identifies the autoscaling policy in the autoscaling specification.
                         type: string
                       resources:
-                        description: AutoscalingResources model the limits, submitted by the user, for the supported resources in an autoscaling policy. Only the node count range is mandatory. For other resources, a limit range is required only if the Elasticsearch autoscaling capacity API returns a requirement for a given resource. For example, the memory limit range is only required if the autoscaling API response contains a memory requirement. If there is no limit range for a resource, and if that resource is not mandatory, then the resources in the NodeSets managed by the autoscaling policy are left untouched.
+                        description: |-
+                          AutoscalingResources model the limits, submitted by the user, for the supported resources in an autoscaling policy.
+                          Only the node count range is mandatory. For other resources, a limit range is required only
+                          if the Elasticsearch autoscaling capacity API returns a requirement for a given resource.
+                          For example, the memory limit range is only required if the autoscaling API response contains a memory requirement.
+                          If there is no limit range for a resource, and if that resource is not mandatory, then the resources in the NodeSets
+                          managed by the autoscaling policy are left untouched.
                         properties:
                           cpu:
                             description: QuantityRange models a resource limit range for resources which can be expressed with resource.Quantity.
@@ -193,6 +210,7 @@ spec:
                   description: PollingPeriod is the period at which to synchronize with the Elasticsearch autoscaling API.
                   type: string
               required:
+                - elasticsearchRef
                 - policies
               type: object
             status:
@@ -200,7 +218,9 @@ spec:
                 conditions:
                   description: Conditions holds the current service state of the autoscaling controller.
                   items:
-                    description: Condition represents Elasticsearch resource's condition. **This API is in technical preview and may be changed or removed in a future release.**
+                    description: |-
+                      Condition represents Elasticsearch resource's condition.
+                      **This API is in technical preview and may be changed or removed in a future release.**
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -250,7 +270,9 @@ spec:
                           type: object
                         type: array
                       resources:
-                        description: ResourcesSpecification holds the resource values common to all the nodeSets managed by a same autoscaling policy. Only the resources managed by the autoscaling controller are saved in the Status.
+                        description: |-
+                          ResourcesSpecification holds the resource values common to all the nodeSets managed by a same autoscaling policy.
+                          Only the resources managed by the autoscaling controller are saved in the Status.
                         properties:
                           limits:
                             additionalProperties:

--- a/pkg/crds/enterprise/01-crd-eck-beat.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-beat.yaml
@@ -3,12 +3,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -52,10 +52,19 @@ spec:
           description: Beat is the Schema for the Beats API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -67,14 +76,19 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 configRef:
-                  description: ConfigRef contains a reference to an existing Kubernetes Secret holding the Beat configuration. Beat settings must be specified as yaml, under a single "beat.yml" entry. At most one of [`Config`, `ConfigRef`] can be specified.
+                  description: |-
+                    ConfigRef contains a reference to an existing Kubernetes Secret holding the Beat configuration.
+                    Beat settings must be specified as yaml, under a single "beat.yml" entry. At most one of [`Config`, `ConfigRef`]
+                    can be specified.
                   properties:
                     secretName:
                       description: SecretName is the name of the secret.
                       type: string
                   type: object
                 daemonSet:
-                  description: DaemonSet specifies the Beat should be deployed as a DaemonSet, and allows providing its spec. Cannot be used along with `deployment`. If both are absent a default for the Type is used.
+                  description: |-
+                    DaemonSet specifies the Beat should be deployed as a DaemonSet, and allows providing its spec.
+                    Cannot be used along with `deployment`. If both are absent a default for the Type is used.
                   properties:
                     podTemplate:
                       description: PodTemplateSpec describes the data a pod should have when created from a template
@@ -84,19 +98,51 @@ spec:
                       description: DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
                       properties:
                         rollingUpdate:
-                          description: 'Rolling update config params. Present only if type = "RollingUpdate". --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`. See https://github.com/kubernetes/kubernetes/issues/35345'
+                          description: Rolling update config params. Present only if type = "RollingUpdate".
                           properties:
                             maxSurge:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption.'
+                              description: |-
+                                The maximum number of nodes with an existing available DaemonSet pod that
+                                can have an updated DaemonSet pod during during an update.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                This can not be 0 if MaxUnavailable is 0.
+                                Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                                Default value is 0.
+                                Example: when this is set to 30%, at most 30% of the total number of nodes
+                                that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                can have their a new pod created before the old pod is marked as deleted.
+                                The update starts by launching new pods on 30% of nodes. Once an updated
+                                pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                                on that node is marked deleted. If the old pod becomes unavailable for any
+                                reason (Ready transitions to false, is evicted, or is drained) an updated
+                                pod is immediatedly created on that node without considering surge limits.
+                                Allowing surge implies the possibility that the resources consumed by the
+                                daemonset on any given node can double if the readiness check fails, and
+                                so resource intensive daemonsets should take into account that they may
+                                cause evictions during disruption.
                               x-kubernetes-int-or-string: true
                             maxUnavailable:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.'
+                              description: |-
+                                The maximum number of DaemonSet pods that can be unavailable during the
+                                update. Value can be an absolute number (ex: 5) or a percentage of total
+                                number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                                number is calculated from percentage by rounding up.
+                                This cannot be 0 if MaxSurge is 0
+                                Default value is 1.
+                                Example: when this is set to 30%, at most 30% of the total number of nodes
+                                that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                                can have their pods stopped for an update at any given time. The update
+                                starts by stopping at most 30% of those DaemonSet pods and then brings
+                                up new DaemonSet pods in their place. Once the new pods are available,
+                                it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                                70% of original number of DaemonSet pods are available at all times during
+                                the update.
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
@@ -105,7 +151,9 @@ spec:
                       type: object
                   type: object
                 deployment:
-                  description: Deployment specifies the Beat should be deployed as a Deployment, and allows providing its spec. Cannot be used along with `daemonSet`. If both are absent a default for the Type is used.
+                  description: |-
+                    Deployment specifies the Beat should be deployed as a Deployment, and allows providing its spec.
+                    Cannot be used along with `daemonSet`. If both are absent a default for the Type is used.
                   properties:
                     podTemplate:
                       description: PodTemplateSpec describes the data a pod should have when created from a template
@@ -118,19 +166,42 @@ spec:
                       description: DeploymentStrategy describes how to replace existing pods with new ones.
                       properties:
                         rollingUpdate:
-                          description: 'Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.'
+                          description: |-
+                            Rolling update config params. Present only if DeploymentStrategyType =
+                            RollingUpdate.
                           properties:
                             maxSurge:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                              description: |-
+                                The maximum number of pods that can be scheduled above the desired number of
+                                pods.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                This can not be 0 if MaxUnavailable is 0.
+                                Absolute number is calculated from percentage by rounding up.
+                                Defaults to 25%.
+                                Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                the rolling update starts, such that the total number of old and new pods do not exceed
+                                130% of desired pods. Once old pods have been killed,
+                                new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                at any time during the update is at most 130% of desired pods.
                               x-kubernetes-int-or-string: true
                             maxUnavailable:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                              description: |-
+                                The maximum number of pods that can be unavailable during the update.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                Absolute number is calculated from percentage by rounding down.
+                                This can not be 0 if MaxSurge is 0.
+                                Defaults to 25%.
+                                Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                that the total number of pods available at all times during the update is at
+                                least 70% of desired pods.
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
@@ -148,17 +219,30 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 image:
                   description: Image is the Beat Docker image to deploy. Version and Type have to match the Beat in the image.
                   type: string
                 kibanaRef:
-                  description: KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster. It allows automatic setup of dashboards and visualizations.
+                  description: |-
+                    KibanaRef is a reference to a Kibana instance running in the same Kubernetes cluster.
+                    It allows automatic setup of dashboards and visualizations.
                   properties:
                     name:
                       description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -167,22 +251,40 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 monitoring:
-                  description: Monitoring enables you to collect and ship logs and metrics for this Beat. Metricbeat and/or Filebeat sidecars are configured and send monitoring data to an Elasticsearch monitoring cluster running in the same Kubernetes cluster.
+                  description: |-
+                    Monitoring enables you to collect and ship logs and metrics for this Beat.
+                    Metricbeat and/or Filebeat sidecars are configured and send monitoring data to an
+                    Elasticsearch monitoring cluster running in the same Kubernetes cluster.
                   properties:
                     logs:
                       description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
                       properties:
                         elasticsearchRefs:
-                          description: ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
                           items:
-                            description: ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator or a Secret describing an external Elastic resource not managed by the operator.
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
                             properties:
                               name:
                                 description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -191,10 +293,21 @@ spec:
                                 description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                                 type: string
                               secretName:
-                                description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
                                 type: string
                               serviceName:
-                                description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
                                 type: string
                             type: object
                           type: array
@@ -203,9 +316,13 @@ spec:
                       description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
                       properties:
                         elasticsearchRefs:
-                          description: ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
                           items:
-                            description: ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator or a Secret describing an external Elastic resource not managed by the operator.
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
                             properties:
                               name:
                                 description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -214,10 +331,21 @@ spec:
                                 description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                                 type: string
                               secretName:
-                                description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
                                 type: string
                               serviceName:
-                                description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
                                 type: string
                             type: object
                           type: array
@@ -228,12 +356,18 @@ spec:
                   format: int32
                   type: integer
                 secureSettings:
-                  description: SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Beat. Secrets data can be then referenced in the Beat config using the Secret's keys or as specified in `Entries` field of each SecureSetting.
+                  description: |-
+                    SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Beat.
+                    Secrets data can be then referenced in the Beat config using the Secret's keys or as specified in `Entries` field of
+                    each SecureSetting.
                   items:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -241,7 +375,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key
@@ -255,10 +391,15 @@ spec:
                     type: object
                   type: array
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to Elasticsearch resource in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to Elasticsearch resource in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
                 type:
-                  description: Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, and so on). Any string can be used, but well-known types will have the image field defaulted and have the appropriate Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
+                  description: |-
+                    Type is the type of the Beat to deploy (filebeat, metricbeat, heartbeat, auditbeat, journalbeat, packetbeat, and so on).
+                    Any string can be used, but well-known types will have the image field defaulted and have the appropriate
+                    Elasticsearch roles created automatically. It also allows for dashboard setup when combined with a `KibanaRef`.
                   maxLength: 20
                   pattern: '[a-zA-Z0-9-]+'
                   type: string
@@ -290,14 +431,22 @@ spec:
                   additionalProperties:
                     description: AssociationStatus is the status of an association resource.
                     type: string
-                  description: AssociationStatusMap is the map of association's namespaced name string to its AssociationStatus. For resources that have a single Association of a given type (for ex. single ES reference), this map contains a single entry.
+                  description: |-
+                    AssociationStatusMap is the map of association's namespaced name string to its AssociationStatus. For resources that
+                    have a single Association of a given type (for ex. single ES reference), this map contains a single entry.
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration represents the .metadata.generation that the status is based upon. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Beats controller has not yet processed the changes contained in the Beats specification.
+                  description: |-
+                    ObservedGeneration represents the .metadata.generation that the status is based upon.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the Beats
+                    controller has not yet processed the changes contained in the Beats specification.
                   format: int64
                   type: integer
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object

--- a/pkg/crds/enterprise/01-crd-eck-elasticmapsserver.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-elasticmapsserver.yaml
@@ -3,12 +3,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -44,10 +44,19 @@ spec:
           description: ElasticMapsServer represents an Elastic Map Server resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -59,7 +68,9 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 configRef:
-                  description: ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration. Configuration settings are merged and have precedence over settings specified in `config`.
+                  description: |-
+                    ConfigRef contains a reference to an existing Kubernetes Secret holding the Elastic Maps Server configuration.
+                    Configuration settings are merged and have precedence over settings specified in `config`.
                   properties:
                     secretName:
                       description: SecretName is the name of the secret.
@@ -79,10 +90,21 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 http:
@@ -92,7 +114,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -115,69 +139,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -186,13 +373,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -203,16 +400,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -221,13 +437,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -235,7 +480,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -275,7 +526,9 @@ spec:
                   format: int32
                   type: integer
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
                 version:
                   description: Version of Elastic Maps Server.
@@ -301,14 +554,20 @@ spec:
                   description: Health of the deployment.
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this Elastic Maps Server. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Elastic Maps controller has not yet processed the changes contained in the Elastic Maps specification.
+                  description: |-
+                    ObservedGeneration is the most recent generation observed for this Elastic Maps Server.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the Elastic
+                    Maps controller has not yet processed the changes contained in the Elastic Maps specification.
                   format: int64
                   type: integer
                 selector:
                   description: Selector is the label selector used to find all pods.
                   type: string
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object

--- a/pkg/crds/enterprise/01-crd-eck-elasticsearch.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-elasticsearch.yaml
@@ -3,12 +3,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -47,10 +47,19 @@ spec:
           description: Elasticsearch represents an Elasticsearch resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -60,6 +69,9 @@ spec:
                 auth:
                   description: Auth contains user authentication and authorization security settings for Elasticsearch.
                   properties:
+                    disableElasticUser:
+                      description: DisableElasticUser disables the default elastic user that is created by ECK.
+                      type: boolean
                     fileRealm:
                       description: FileRealm to propagate to the Elasticsearch cluster.
                       items:
@@ -88,7 +100,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -111,69 +125,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -182,13 +359,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -199,16 +386,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -217,13 +423,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -231,7 +466,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -263,15 +504,23 @@ spec:
                   description: Image is the Elasticsearch Docker image to deploy.
                   type: string
                 monitoring:
-                  description: Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster. See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html. Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different Elasticsearch monitoring clusters running in the same Kubernetes cluster.
+                  description: |-
+                    Monitoring enables you to collect and ship log and monitoring data of this Elasticsearch cluster.
+                    See https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html.
+                    Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different
+                    Elasticsearch monitoring clusters running in the same Kubernetes cluster.
                   properties:
                     logs:
                       description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
                       properties:
                         elasticsearchRefs:
-                          description: ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
                           items:
-                            description: ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator or a Secret describing an external Elastic resource not managed by the operator.
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
                             properties:
                               name:
                                 description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -280,10 +529,21 @@ spec:
                                 description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                                 type: string
                               secretName:
-                                description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
                                 type: string
                               serviceName:
-                                description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
                                 type: string
                             type: object
                           type: array
@@ -292,9 +552,13 @@ spec:
                       description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
                       properties:
                         elasticsearchRefs:
-                          description: ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
                           items:
-                            description: ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator or a Secret describing an external Elastic resource not managed by the operator.
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
                             properties:
                               name:
                                 description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -303,10 +567,21 @@ spec:
                                 description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                                 type: string
                               secretName:
-                                description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
                                 type: string
                               serviceName:
-                                description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
                                 type: string
                             type: object
                           type: array
@@ -322,7 +597,9 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       count:
-                        description: Count of Elasticsearch nodes to deploy. If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
+                        description: |-
+                          Count of Elasticsearch nodes to deploy.
+                          If the node set is managed by an autoscaling policy the initial value is automatically set by the autoscaling controller.
                         format: int32
                         type: integer
                       name:
@@ -335,18 +612,32 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       volumeClaimTemplates:
-                        description: VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
+                        description: |-
+                          VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet.
+                          Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+                          Items defined here take precedence over any default claims added by the operator with the same name.
                         items:
                           description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                           properties:
                             apiVersion:
-                              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              description: |-
+                                APIVersion defines the versioned schema of this representation of an object.
+                                Servers should convert recognized schemas to the latest internal value, and
+                                may reject unrecognized values.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                               type: string
                             kind:
-                              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              description: |-
+                                Kind is a string value representing the REST resource this object represents.
+                                Servers may infer this from the endpoint the client submits requests to.
+                                Cannot be updated.
+                                In CamelCase.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                               type: string
                             metadata:
-                              description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              description: |-
+                                Standard object's metadata.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -366,18 +657,34 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                spec defines the desired characteristics of a volume requested by a pod author.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 accessModes:
-                                  description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 dataSource:
-                                  description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim)
+                                    If the provisioner or an external controller can support the specified data source,
+                                    it will create a new volume based on the contents of the specified data source.
+                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
                                       description: Kind is the type of resource being referenced
@@ -391,10 +698,36 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired. This may be any object from a non-empty API group (non
+                                    core object) or a PersistentVolumeClaim object.
+                                    When this field is specified, volume binding will only succeed if the type of
+                                    the specified object matches some installed volume populator or dynamic
+                                    provisioner.
+                                    This field will replace the functionality of the dataSource field and as such
+                                    if both fields are non-empty, they must have the same value. For backwards
+                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                    value automatically if one of them is empty and the other is non-empty.
+                                    When namespace is specified in dataSourceRef,
+                                    dataSource isn't set to the same value and must be empty.
+                                    There are three important differences between dataSource and dataSourceRef:
+                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                      preserves all values, and generates an error if a disallowed value is
+                                      specified.
+                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                      in any namespaces.
+                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
                                       description: Kind is the type of resource being referenced
@@ -402,13 +735,23 @@ spec:
                                     name:
                                       description: Name is the name of resource being referenced
                                       type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      type: string
                                   required:
                                     - kind
                                     - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 resources:
-                                  description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  description: |-
+                                    resources represents the minimum resources the volume should have.
+                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                    status field of the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -417,7 +760,9 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -426,7 +771,11 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
@@ -435,101 +784,71 @@ spec:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                           - key
                                           - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                  type: string
+                                volumeAttributesClassName:
+                                  description: |-
+                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
+                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                    exists.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
-                                  description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
                                   description: volumeName is the binding reference to the PersistentVolume backing this claim.
-                                  type: string
-                              type: object
-                            status:
-                              description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                              properties:
-                                accessModes:
-                                  description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                  items:
-                                    type: string
-                                  type: array
-                                allocatedResources:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: allocatedResources is the storage resource within AllocatedResources tracks the capacity allocated to a PVC. It may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
-                                  type: object
-                                capacity:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: capacity represents the actual resources of the underlying volume.
-                                  type: object
-                                conditions:
-                                  description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
-                                  items:
-                                    description: PersistentVolumeClaimCondition contails details about state of pvc
-                                    properties:
-                                      lastProbeTime:
-                                        description: lastProbeTime is the time we probed the condition.
-                                        format: date-time
-                                        type: string
-                                      lastTransitionTime:
-                                        description: lastTransitionTime is the time the condition transitioned from one status to another.
-                                        format: date-time
-                                        type: string
-                                      message:
-                                        description: message is the human-readable message indicating details about last transition.
-                                        type: string
-                                      reason:
-                                        description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
-                                        type: string
-                                      status:
-                                        type: string
-                                      type:
-                                        description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
-                                        type: string
-                                    required:
-                                      - status
-                                      - type
-                                    type: object
-                                  type: array
-                                phase:
-                                  description: phase represents the current phase of PersistentVolumeClaim.
-                                  type: string
-                                resizeStatus:
-                                  description: resizeStatus stores status of resize operation. ResizeStatus is not set by default but when expansion is complete resizeStatus is set to empty string by resize controller or kubelet. This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
                                   type: string
                               type: object
                           type: object
@@ -540,10 +859,16 @@ spec:
                   minItems: 1
                   type: array
                 podDisruptionBudget:
-                  description: PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster. The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
+                  description: |-
+                    PodDisruptionBudget provides access to the default Pod disruption budget for the Elasticsearch cluster.
+                    The default budget doesn't allow any Pod to be removed in case the cluster is not green or if there is only one node of type `data` or `master`.
+                    In all other cases the default PodDisruptionBudget sets `minUnavailable` equal to the total number of nodes minus 1.
+                    To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
                   properties:
                     metadata:
-                      description: ObjectMeta is the metadata of the PDB. The name and namespace provided here are managed by ECK and will be ignored.
+                      description: |-
+                        ObjectMeta is the metadata of the PDB.
+                        The name and namespace provided here are managed by ECK and will be ignored.
                       properties:
                         annotations:
                           additionalProperties:
@@ -569,52 +894,160 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                          description: |-
+                            An eviction is allowed if at most "maxUnavailable" pods selected by
+                            "selector" are unavailable after the eviction, i.e. even in absence of
+                            the evicted pod. For example, one can prevent all voluntary evictions
+                            by specifying 0. This is a mutually exclusive setting with "minAvailable".
                           x-kubernetes-int-or-string: true
                         minAvailable:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+                          description: |-
+                            An eviction is allowed if at least "minAvailable" pods selected by
+                            "selector" will still be available after the eviction, i.e. even in the
+                            absence of the evicted pod.  So for example you can prevent all voluntary
+                            evictions by specifying "100%".
                           x-kubernetes-int-or-string: true
                         selector:
-                          description: Label query over pods whose evictions are managed by the disruption budget. A null selector will match no pods, while an empty ({}) selector will select all pods within the namespace.
+                          description: |-
+                            Label query over pods whose evictions are managed by the disruption
+                            budget.
+                            A null selector will match no pods, while an empty ({}) selector will select
+                            all pods within the namespace.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
                                     description: key is the label key that the selector applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                   - key
                                   - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        unhealthyPodEvictionPolicy:
+                          description: |-
+                            UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods
+                            should be considered for eviction. Current implementation considers healthy pods,
+                            as pods that have status.conditions item with type="Ready",status="True".
+                            
+                            Valid policies are IfHealthyBudget and AlwaysAllow.
+                            If no policy is specified, the default behavior will be used,
+                            which corresponds to the IfHealthyBudget policy.
+                            
+                            IfHealthyBudget policy means that running pods (status.phase="Running"),
+                            but not yet healthy can be evicted only if the guarded application is not
+                            disrupted (status.currentHealthy is at least equal to status.desiredHealthy).
+                            Healthy pods will be subject to the PDB for eviction.
+                            
+                            AlwaysAllow policy means that all running pods (status.phase="Running"),
+                            but not yet healthy are considered disrupted and can be evicted regardless
+                            of whether the criteria in a PDB is met. This means perspective running
+                            pods of a disrupted application might not get a chance to become healthy.
+                            Healthy pods will be subject to the PDB for eviction.
+                            
+                            Additional policies may be added in the future.
+                            Clients making eviction decisions should disallow eviction of unhealthy pods
+                            if they encounter an unrecognized policy in this field.
+                            
+                            This field is beta-level. The eviction API uses this field when
+                            the feature gate PDBUnhealthyPodEvictionPolicy is enabled (enabled by default).
+                          type: string
                       type: object
+                  type: object
+                remoteClusterServer:
+                  description: |-
+                    RemoteClusterServer specifies if the remote cluster server should be enabled.
+                    This must be enabled if this cluster is a remote cluster which is expected to be accessed using API key authentication.
+                  properties:
+                    enabled:
+                      type: boolean
                   type: object
                 remoteClusters:
                   description: RemoteClusters enables you to establish uni-directional connections to a remote Elasticsearch cluster.
                   items:
                     description: RemoteCluster declares a remote Elasticsearch cluster connection.
                     properties:
+                      apiKey:
+                        description: 'APIKey can be used to enable remote cluster access using Cross-Cluster API keys: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html'
+                        properties:
+                          access:
+                            description: Access is the name of the API Key. It is automatically generated if not set or empty.
+                            properties:
+                              replication:
+                                properties:
+                                  names:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                  - names
+                                type: object
+                              search:
+                                properties:
+                                  allow_restricted_indices:
+                                    type: boolean
+                                  field_security:
+                                    properties:
+                                      except:
+                                        items:
+                                          type: string
+                                        type: array
+                                      grant:
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - except
+                                      - grant
+                                    type: object
+                                  names:
+                                    items:
+                                      type: string
+                                    type: array
+                                  query:
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                required:
+                                  - names
+                                type: object
+                            type: object
+                        required:
+                          - access
+                        type: object
                       elasticsearchRef:
                         description: ElasticsearchRef is a reference to an Elasticsearch cluster running within the same k8s cluster.
                         properties:
@@ -625,11 +1058,16 @@ spec:
                             description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                             type: string
                           serviceName:
-                            description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                            description: |-
+                              ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                              object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                              the referenced resource is used.
                             type: string
                         type: object
                       name:
-                        description: Name is the name of the remote cluster as it is set in the Elasticsearch settings. The name is expected to be unique for each remote clusters.
+                        description: |-
+                          Name is the name of the remote cluster as it is set in the Elasticsearch settings.
+                          The name is expected to be unique for each remote clusters.
                         minLength: 1
                         type: string
                     required:
@@ -646,7 +1084,10 @@ spec:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -654,7 +1095,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key
@@ -668,7 +1111,9 @@ spec:
                     type: object
                   type: array
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to a resource (for ex. a remote Elasticsearch cluster) in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
                 transport:
                   description: Transport holds transport layer settings for Elasticsearch.
@@ -677,7 +1122,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -700,69 +1147,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -771,13 +1381,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -788,16 +1408,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -806,13 +1445,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -820,15 +1488,40 @@ spec:
                       description: TLS defines options for configuring TLS on the transport layer.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the CA certificate and private key for generating node certificates. The referenced secret should contain the following: \n - `ca.crt`: The CA certificate in PEM format. - `ca.key`: The private key for the CA certificate in PEM format."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the CA certificate
+                            and private key for generating node certificates.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The CA certificate in PEM format.
+                            - `ca.key`: The private key for the CA certificate in PEM format.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
                               type: string
                           type: object
+                        certificateAuthorities:
+                          description: |-
+                            CertificateAuthorities is a reference to a config map that contains one or more x509 certificates for
+                            trusted authorities in PEM format. The certificates need to be in a file called `ca.crt`.
+                          properties:
+                            configMapName:
+                              type: string
+                          type: object
                         otherNameSuffix:
-                          description: 'OtherNameSuffix when defined will be prefixed with the Pod name and used as the common name, and the first DNSName, as well as an OtherName required by Elasticsearch in the Subject Alternative Name extension of each Elasticsearch node''s transport TLS certificate. Example: if set to "node.cluster.local", the generated certificate will have its otherName set to "<pod_name>.node.cluster.local".'
+                          description: |-
+                            OtherNameSuffix when defined will be prefixed with the Pod name and used as the common name,
+                            and the first DNSName, as well as an OtherName required by Elasticsearch in the Subject Alternative Name
+                            extension of each Elasticsearch node's transport TLS certificate.
+                            Example: if set to "node.cluster.local", the generated certificate will have its otherName set to "<pod_name>.node.cluster.local".
                           type: string
+                        selfSignedCertificates:
+                          description: SelfSignedCertificates allows configuring the self-signed certificate generated by the operator.
+                          properties:
+                            disabled:
+                              description: Disabled indicates that provisioning of the self-signed certificates should be disabled.
+                              type: boolean
+                          type: object
                         subjectAltNames:
                           description: SubjectAlternativeNames is a list of SANs to include in the generated node transport TLS certificates.
                           items:
@@ -851,11 +1544,17 @@ spec:
                       description: ChangeBudget defines the constraints to consider when applying changes to the Elasticsearch cluster.
                       properties:
                         maxSurge:
-                          description: MaxSurge is the maximum number of new pods that can be created exceeding the original number of pods defined in the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will disable the restriction. Defaults to unbounded if not specified.
+                          description: |-
+                            MaxSurge is the maximum number of new Pods that can be created exceeding the original number of Pods defined in
+                            the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will
+                            disable the restriction. Defaults to unbounded if not specified.
                           format: int32
                           type: integer
                         maxUnavailable:
-                          description: MaxUnavailable is the maximum number of pods that can be unavailable (not ready) during the update due to circumstances under the control of the operator. Setting a negative value will disable this restriction. Defaults to 1 if not specified.
+                          description: |-
+                            MaxUnavailable is the maximum number of Pods that can be unavailable (not ready) during the update due to
+                            circumstances under the control of the operator. Setting a negative value will disable this restriction.
+                            Defaults to 1 if not specified.
                           format: int32
                           type: integer
                       type: object
@@ -864,7 +1563,9 @@ spec:
                   description: Version of Elasticsearch.
                   type: string
                 volumeClaimDeletePolicy:
-                  description: VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets. Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion.
+                  description: |-
+                    VolumeClaimDeletePolicy sets the policy for handling deletion of PersistentVolumeClaims for all NodeSets.
+                    Possible values are DeleteOnScaledownOnly and DeleteOnScaledownAndClusterDeletion. Defaults to DeleteOnScaledownAndClusterDeletion.
                   enum:
                     - DeleteOnScaledownOnly
                     - DeleteOnScaledownAndClusterDeletion
@@ -881,9 +1582,13 @@ spec:
                   format: int32
                   type: integer
                 conditions:
-                  description: Conditions holds the current service state of an Elasticsearch cluster. **This API is in technical preview and may be changed or removed in a future release.**
+                  description: |-
+                    Conditions holds the current service state of an Elasticsearch cluster.
+                    **This API is in technical preview and may be changed or removed in a future release.**
                   items:
-                    description: Condition represents Elasticsearch resource's condition. **This API is in technical preview and may be changed or removed in a future release.**
+                    description: |-
+                      Condition represents Elasticsearch resource's condition.
+                      **This API is in technical preview and may be changed or removed in a future release.**
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -904,10 +1609,14 @@ spec:
                   description: ElasticsearchHealth is the health of the cluster as returned by the health API.
                   type: string
                 inProgressOperations:
-                  description: InProgressOperations represents changes being applied by the operator to the Elasticsearch cluster. **This API is in technical preview and may be changed or removed in a future release.**
+                  description: |-
+                    InProgressOperations represents changes being applied by the operator to the Elasticsearch cluster.
+                    **This API is in technical preview and may be changed or removed in a future release.**
                   properties:
                     downscale:
-                      description: DownscaleOperation provides details about in progress downscale operations. **This API is in technical preview and may be changed or removed in a future release.**
+                      description: |-
+                        DownscaleOperation provides details about in progress downscale operations.
+                        **This API is in technical preview and may be changed or removed in a future release.**
                       properties:
                         lastUpdatedTime:
                           format: date-time
@@ -915,16 +1624,23 @@ spec:
                         nodes:
                           description: Nodes which are scheduled to be removed from the cluster.
                           items:
-                            description: DownscaledNode provides an overview of in progress changes applied by the operator to remove Elasticsearch nodes from the cluster. **This API is in technical preview and may be changed or removed in a future release.**
+                            description: |-
+                              DownscaledNode provides an overview of in progress changes applied by the operator to remove Elasticsearch nodes from the cluster.
+                              **This API is in technical preview and may be changed or removed in a future release.**
                             properties:
                               explanation:
-                                description: Explanation provides details about an in progress node shutdown. It is only available for clusters managed with the Elasticsearch shutdown API.
+                                description: |-
+                                  Explanation provides details about an in progress node shutdown. It is only available for clusters managed with the
+                                  Elasticsearch shutdown API.
                                 type: string
                               name:
                                 description: Name of the Elasticsearch node that should be removed.
                                 type: string
                               shutdownStatus:
-                                description: Shutdown status as returned by the Elasticsearch shutdown API. If the Elasticsearch shutdown API is not available, the shutdown status is then inferred from the remaining shards on the nodes, as observed by the operator.
+                                description: |-
+                                  Shutdown status as returned by the Elasticsearch shutdown API.
+                                  If the Elasticsearch shutdown API is not available, the shutdown status is then inferred from the remaining
+                                  shards on the nodes, as observed by the operator.
                                 type: string
                             required:
                               - name
@@ -932,11 +1648,15 @@ spec:
                             type: object
                           type: array
                         stalled:
-                          description: Stalled represents a state where no progress can be made. It is only available for clusters managed with the Elasticsearch shutdown API.
+                          description: |-
+                            Stalled represents a state where no progress can be made.
+                            It is only available for clusters managed with the Elasticsearch shutdown API.
                           type: boolean
                       type: object
                     upgrade:
-                      description: UpgradeOperation provides an overview of the pending or in progress changes applied by the operator to update the Elasticsearch nodes in the cluster. **This API is in technical preview and may be changed or removed in a future release.**
+                      description: |-
+                        UpgradeOperation provides an overview of the pending or in progress changes applied by the operator to update the Elasticsearch nodes in the cluster.
+                        **This API is in technical preview and may be changed or removed in a future release.**
                       properties:
                         lastUpdatedTime:
                           format: date-time
@@ -944,7 +1664,9 @@ spec:
                         nodes:
                           description: Nodes that must be restarted for upgrade.
                           items:
-                            description: UpgradedNode provides details about the status of nodes which are expected to be updated. **This API is in technical preview and may be changed or removed in a future release.**
+                            description: |-
+                              UpgradedNode provides details about the status of nodes which are expected to be updated.
+                              **This API is in technical preview and may be changed or removed in a future release.**
                             properties:
                               message:
                                 description: Optional message to explain why a node may not be immediately restarted for upgrade.
@@ -956,7 +1678,9 @@ spec:
                                 description: Predicate is the name of the predicate currently preventing this node from being deleted for an upgrade.
                                 type: string
                               status:
-                                description: Status states if the node is either in the process of being deleted for an upgrade, or blocked by a predicate or another condition stated in the message field.
+                                description: |-
+                                  Status states if the node is either in the process of being deleted for an upgrade,
+                                  or blocked by a predicate or another condition stated in the message field.
                                 type: string
                             required:
                               - name
@@ -965,7 +1689,9 @@ spec:
                           type: array
                       type: object
                     upscale:
-                      description: UpscaleOperation provides an overview of in progress changes applied by the operator to add Elasticsearch nodes to the cluster. **This API is in technical preview and may be changed or removed in a future release.**
+                      description: |-
+                        UpscaleOperation provides an overview of in progress changes applied by the operator to add Elasticsearch nodes to the cluster.
+                        **This API is in technical preview and may be changed or removed in a future release.**
                       properties:
                         lastUpdatedTime:
                           format: date-time
@@ -998,17 +1724,25 @@ spec:
                   additionalProperties:
                     description: AssociationStatus is the status of an association resource.
                     type: string
-                  description: AssociationStatusMap is the map of association's namespaced name string to its AssociationStatus. For resources that have a single Association of a given type (for ex. single ES reference), this map contains a single entry.
+                  description: |-
+                    AssociationStatusMap is the map of association's namespaced name string to its AssociationStatus. For resources that
+                    have a single Association of a given type (for ex. single ES reference), this map contains a single entry.
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this Elasticsearch cluster. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Elasticsearch controller has not yet processed the changes contained in the Elasticsearch specification.
+                  description: |-
+                    ObservedGeneration is the most recent generation observed for this Elasticsearch cluster.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the Elasticsearch
+                    controller has not yet processed the changes contained in the Elasticsearch specification.
                   format: int64
                   type: integer
                 phase:
                   description: ElasticsearchOrchestrationPhase is the phase Elasticsearch is in from the controller point of view.
                   type: string
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object
@@ -1040,10 +1774,19 @@ spec:
           description: Elasticsearch represents an Elasticsearch resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -1057,7 +1800,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -1080,69 +1825,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -1151,13 +2059,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -1168,16 +2086,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -1186,13 +2123,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -1200,7 +2166,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -1253,18 +2225,32 @@ spec:
                         description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Pods belonging to this NodeSet.
                         type: object
                       volumeClaimTemplates:
-                        description: VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet. Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate. Items defined here take precedence over any default claims added by the operator with the same name.
+                        description: |-
+                          VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod in this NodeSet.
+                          Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+                          Items defined here take precedence over any default claims added by the operator with the same name.
                         items:
                           description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                           properties:
                             apiVersion:
-                              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              description: |-
+                                APIVersion defines the versioned schema of this representation of an object.
+                                Servers should convert recognized schemas to the latest internal value, and
+                                may reject unrecognized values.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                               type: string
                             kind:
-                              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              description: |-
+                                Kind is a string value representing the REST resource this object represents.
+                                Servers may infer this from the endpoint the client submits requests to.
+                                Cannot be updated.
+                                In CamelCase.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                               type: string
                             metadata:
-                              description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              description: |-
+                                Standard object's metadata.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1284,18 +2270,34 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: 'spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: |-
+                                spec defines the desired characteristics of a volume requested by a pod author.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 accessModes:
-                                  description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 dataSource:
-                                  description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim)
+                                    If the provisioner or an external controller can support the specified data source,
+                                    it will create a new volume based on the contents of the specified data source.
+                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
                                       description: Kind is the type of resource being referenced
@@ -1309,10 +2311,36 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired. This may be any object from a non-empty API group (non
+                                    core object) or a PersistentVolumeClaim object.
+                                    When this field is specified, volume binding will only succeed if the type of
+                                    the specified object matches some installed volume populator or dynamic
+                                    provisioner.
+                                    This field will replace the functionality of the dataSource field and as such
+                                    if both fields are non-empty, they must have the same value. For backwards
+                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                    value automatically if one of them is empty and the other is non-empty.
+                                    When namespace is specified in dataSourceRef,
+                                    dataSource isn't set to the same value and must be empty.
+                                    There are three important differences between dataSource and dataSourceRef:
+                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                      preserves all values, and generates an error if a disallowed value is
+                                      specified.
+                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                      in any namespaces.
+                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
                                       description: Kind is the type of resource being referenced
@@ -1320,13 +2348,23 @@ spec:
                                     name:
                                       description: Name is the name of resource being referenced
                                       type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      type: string
                                   required:
                                     - kind
                                     - name
                                   type: object
-                                  x-kubernetes-map-type: atomic
                                 resources:
-                                  description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  description: |-
+                                    resources represents the minimum resources the volume should have.
+                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                    status field of the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -1335,7 +2373,9 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1344,7 +2384,11 @@ spec:
                                           - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
@@ -1353,101 +2397,71 @@ spec:
                                     matchExpressions:
                                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         required:
                                           - key
                                           - operator
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                  type: string
+                                volumeAttributesClassName:
+                                  description: |-
+                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
+                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                    exists.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
-                                  description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
                                   description: volumeName is the binding reference to the PersistentVolume backing this claim.
-                                  type: string
-                              type: object
-                            status:
-                              description: 'status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                              properties:
-                                accessModes:
-                                  description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                  items:
-                                    type: string
-                                  type: array
-                                allocatedResources:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: allocatedResources is the storage resource within AllocatedResources tracks the capacity allocated to a PVC. It may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity. This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
-                                  type: object
-                                capacity:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: capacity represents the actual resources of the underlying volume.
-                                  type: object
-                                conditions:
-                                  description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
-                                  items:
-                                    description: PersistentVolumeClaimCondition contails details about state of pvc
-                                    properties:
-                                      lastProbeTime:
-                                        description: lastProbeTime is the time we probed the condition.
-                                        format: date-time
-                                        type: string
-                                      lastTransitionTime:
-                                        description: lastTransitionTime is the time the condition transitioned from one status to another.
-                                        format: date-time
-                                        type: string
-                                      message:
-                                        description: message is the human-readable message indicating details about last transition.
-                                        type: string
-                                      reason:
-                                        description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
-                                        type: string
-                                      status:
-                                        type: string
-                                      type:
-                                        description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
-                                        type: string
-                                    required:
-                                      - status
-                                      - type
-                                    type: object
-                                  type: array
-                                phase:
-                                  description: phase represents the current phase of PersistentVolumeClaim.
-                                  type: string
-                                resizeStatus:
-                                  description: resizeStatus stores status of resize operation. ResizeStatus is not set by default but when expansion is complete resizeStatus is set to empty string by resize controller or kubelet. This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
                                   type: string
                               type: object
                           type: object
@@ -1459,10 +2473,15 @@ spec:
                   minItems: 1
                   type: array
                 podDisruptionBudget:
-                  description: PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster. The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget` to the empty value (`{}` in YAML).
+                  description: |-
+                    PodDisruptionBudget provides access to the default pod disruption budget for the Elasticsearch cluster.
+                    The default budget selects all cluster pods and sets `maxUnavailable` to 1. To disable, set `PodDisruptionBudget`
+                    to the empty value (`{}` in YAML).
                   properties:
                     metadata:
-                      description: ObjectMeta is the metadata of the PDB. The name and namespace provided here are managed by ECK and will be ignored.
+                      description: |-
+                        ObjectMeta is the metadata of the PDB.
+                        The name and namespace provided here are managed by ECK and will be ignored.
                       properties:
                         annotations:
                           additionalProperties:
@@ -1488,45 +2507,99 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                          description: |-
+                            An eviction is allowed if at most "maxUnavailable" pods selected by
+                            "selector" are unavailable after the eviction, i.e. even in absence of
+                            the evicted pod. For example, one can prevent all voluntary evictions
+                            by specifying 0. This is a mutually exclusive setting with "minAvailable".
                           x-kubernetes-int-or-string: true
                         minAvailable:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+                          description: |-
+                            An eviction is allowed if at least "minAvailable" pods selected by
+                            "selector" will still be available after the eviction, i.e. even in the
+                            absence of the evicted pod.  So for example you can prevent all voluntary
+                            evictions by specifying "100%".
                           x-kubernetes-int-or-string: true
                         selector:
-                          description: Label query over pods whose evictions are managed by the disruption budget. A null selector selects no pods. An empty selector ({}) also selects no pods, which differs from standard behavior of selecting all pods. In policy/v1, an empty selector will select all pods in the namespace.
+                          description: |-
+                            Label query over pods whose evictions are managed by the disruption
+                            budget.
+                            A null selector selects no pods.
+                            An empty selector ({}) also selects no pods, which differs from standard behavior of selecting all pods.
+                            In policy/v1, an empty selector will select all pods in the namespace.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
                                     description: key is the label key that the selector applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                   - key
                                   - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        unhealthyPodEvictionPolicy:
+                          description: |-
+                            UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods
+                            should be considered for eviction. Current implementation considers healthy pods,
+                            as pods that have status.conditions item with type="Ready",status="True".
+                            
+                            Valid policies are IfHealthyBudget and AlwaysAllow.
+                            If no policy is specified, the default behavior will be used,
+                            which corresponds to the IfHealthyBudget policy.
+                            
+                            IfHealthyBudget policy means that running pods (status.phase="Running"),
+                            but not yet healthy can be evicted only if the guarded application is not
+                            disrupted (status.currentHealthy is at least equal to status.desiredHealthy).
+                            Healthy pods will be subject to the PDB for eviction.
+                            
+                            AlwaysAllow policy means that all running pods (status.phase="Running"),
+                            but not yet healthy are considered disrupted and can be evicted regardless
+                            of whether the criteria in a PDB is met. This means perspective running
+                            pods of a disrupted application might not get a chance to become healthy.
+                            Healthy pods will be subject to the PDB for eviction.
+                            
+                            Additional policies may be added in the future.
+                            Clients making eviction decisions should disallow eviction of unhealthy pods
+                            if they encounter an unrecognized policy in this field.
+                            
+                            This field is beta-level. The eviction API uses this field when
+                            the feature gate PDBUnhealthyPodEvictionPolicy is enabled (enabled by default).
+                          type: string
                       type: object
                   type: object
                 secureSettings:
@@ -1535,7 +2608,10 @@ spec:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -1543,7 +2619,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key
@@ -1563,11 +2641,17 @@ spec:
                       description: ChangeBudget defines the constraints to consider when applying changes to the Elasticsearch cluster.
                       properties:
                         maxSurge:
-                          description: MaxSurge is the maximum number of new pods that can be created exceeding the original number of pods defined in the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will disable the restriction. Defaults to unbounded if not specified.
+                          description: |-
+                            MaxSurge is the maximum number of new pods that can be created exceeding the original number of pods defined in
+                            the specification. MaxSurge is only taken into consideration when scaling up. Setting a negative value will
+                            disable the restriction. Defaults to unbounded if not specified.
                           format: int32
                           type: integer
                         maxUnavailable:
-                          description: MaxUnavailable is the maximum number of pods that can be unavailable (not ready) during the update due to circumstances under the control of the operator. Setting a negative value will disable this restriction. Defaults to 1 if not specified.
+                          description: |-
+                            MaxUnavailable is the maximum number of pods that can be unavailable (not ready) during the update due to
+                            circumstances under the control of the operator. Setting a negative value will disable this restriction.
+                            Defaults to 1 if not specified.
                           format: int32
                           type: integer
                       type: object

--- a/pkg/crds/enterprise/01-crd-eck-enterprisesearch.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-enterprisesearch.yaml
@@ -3,12 +3,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -44,10 +44,19 @@ spec:
           description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -59,7 +68,9 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 configRef:
-                  description: ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration. Configuration settings are merged and have precedence over settings specified in `config`.
+                  description: |-
+                    ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration.
+                    Configuration settings are merged and have precedence over settings specified in `config`.
                   properties:
                     secretName:
                       description: SecretName is the name of the secret.
@@ -79,10 +90,21 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 http:
@@ -92,7 +114,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -115,69 +139,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -186,13 +373,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -203,16 +400,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -221,13 +437,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -235,7 +480,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -267,7 +518,9 @@ spec:
                   description: Image is the Enterprise Search Docker image to deploy.
                   type: string
                 podTemplate:
-                  description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Enterprise Search pods.
+                  description: |-
+                    PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on)
+                    for the Enterprise Search pods.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 revisionHistoryLimit:
@@ -275,7 +528,9 @@ spec:
                   format: int32
                   type: integer
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
                 version:
                   description: Version of Enterprise Search.
@@ -299,7 +554,11 @@ spec:
                   description: Health of the deployment.
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration represents the .metadata.generation that the status is based upon. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Enterprise Search controller has not yet processed the changes contained in the Enterprise Search specification.
+                  description: |-
+                    ObservedGeneration represents the .metadata.generation that the status is based upon.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the Enterprise Search
+                    controller has not yet processed the changes contained in the Enterprise Search specification.
                   format: int64
                   type: integer
                 selector:
@@ -309,7 +568,9 @@ spec:
                   description: ExternalService is the name of the service associated to the Enterprise Search Pods.
                   type: string
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object
@@ -342,10 +603,19 @@ spec:
           description: EnterpriseSearch is a Kubernetes CRD to represent Enterprise Search.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -357,7 +627,9 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 configRef:
-                  description: ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration. Configuration settings are merged and have precedence over settings specified in `config`.
+                  description: |-
+                    ConfigRef contains a reference to an existing Kubernetes Secret holding the Enterprise Search configuration.
+                    Configuration settings are merged and have precedence over settings specified in `config`.
                   properties:
                     secretName:
                       description: SecretName is the name of the secret.
@@ -377,10 +649,21 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 http:
@@ -390,7 +673,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -413,69 +698,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -484,13 +932,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -501,16 +959,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -519,13 +996,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -533,7 +1039,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -565,11 +1077,15 @@ spec:
                   description: Image is the Enterprise Search Docker image to deploy.
                   type: string
                 podTemplate:
-                  description: PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on) for the Enterprise Search pods.
+                  description: |-
+                    PodTemplate provides customisation options (labels, annotations, affinity rules, resource requests, and so on)
+                    for the Enterprise Search pods.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
                 version:
                   description: Version of Enterprise Search.
@@ -599,7 +1115,9 @@ spec:
                   description: ExternalService is the name of the service associated to the Enterprise Search Pods.
                   type: string
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object

--- a/pkg/crds/enterprise/01-crd-eck-kibana.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-kibana.yaml
@@ -3,12 +3,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -44,10 +44,19 @@ spec:
           description: Kibana represents a Kibana resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -72,14 +81,27 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 enterpriseSearchRef:
-                  description: EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster. Kibana provides the default Enterprise Search UI starting version 7.14.
+                  description: |-
+                    EnterpriseSearchRef is a reference to an EnterpriseSearch running in the same Kubernetes cluster.
+                    Kibana provides the default Enterprise Search UI starting version 7.14.
                   properties:
                     name:
                       description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -88,10 +110,21 @@ spec:
                       description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                       type: string
                     secretName:
-                      description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                      description: |-
+                        SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                        Elastic resource not managed by the operator. The referenced secret must contain the following:
+                        - `url`: the URL to reach the Elastic resource
+                        - `username`: the username of the user to be authenticated to the Elastic resource
+                        - `password`: the password of the user to be authenticated to the Elastic resource
+                        - `ca.crt`: the CA certificate in PEM format (optional)
+                        - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                        This field cannot be used in combination with the other fields name, namespace or serviceName.
                       type: string
                     serviceName:
-                      description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                      description: |-
+                        ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                        object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                        the referenced resource is used.
                       type: string
                   type: object
                 http:
@@ -101,7 +134,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -124,69 +159,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -195,13 +393,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -212,16 +420,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -230,13 +457,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -244,7 +500,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -276,15 +538,23 @@ spec:
                   description: Image is the Kibana Docker image to deploy.
                   type: string
                 monitoring:
-                  description: Monitoring enables you to collect and ship log and monitoring data of this Kibana. See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html. Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different Elasticsearch monitoring clusters running in the same Kubernetes cluster.
+                  description: |-
+                    Monitoring enables you to collect and ship log and monitoring data of this Kibana.
+                    See https://www.elastic.co/guide/en/kibana/current/xpack-monitoring.html.
+                    Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different
+                    Elasticsearch monitoring clusters running in the same Kubernetes cluster.
                   properties:
                     logs:
                       description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
                       properties:
                         elasticsearchRefs:
-                          description: ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
                           items:
-                            description: ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator or a Secret describing an external Elastic resource not managed by the operator.
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
                             properties:
                               name:
                                 description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -293,10 +563,21 @@ spec:
                                 description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                                 type: string
                               secretName:
-                                description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
                                 type: string
                               serviceName:
-                                description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
                                 type: string
                             type: object
                           type: array
@@ -305,9 +586,13 @@ spec:
                       description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
                       properties:
                         elasticsearchRefs:
-                          description: ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster. Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
                           items:
-                            description: ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator or a Secret describing an external Elastic resource not managed by the operator.
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
                             properties:
                               name:
                                 description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
@@ -316,10 +601,21 @@ spec:
                                 description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
                                 type: string
                               secretName:
-                                description: 'SecretName is the name of an existing Kubernetes secret that contains connection information for associating an Elastic resource not managed by the operator. The referenced secret must contain the following: - `url`: the URL to reach the Elastic resource - `username`: the username of the user to be authenticated to the Elastic resource - `password`: the password of the user to be authenticated to the Elastic resource - `ca.crt`: the CA certificate in PEM format (optional). This field cannot be used in combination with the other fields name, namespace or serviceName.'
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
                                 type: string
                               serviceName:
-                                description: ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of the referenced resource is used.
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
                                 type: string
                             type: object
                           type: array
@@ -339,7 +635,10 @@ spec:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -347,7 +646,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key
@@ -361,7 +662,9 @@ spec:
                     type: object
                   type: array
                 serviceAccountName:
-                  description: ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace. Can only be used if ECK is enforcing RBAC on references.
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to a resource (for ex. Elasticsearch) in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
                   type: string
                 version:
                   description: Version of Kibana.
@@ -373,7 +676,9 @@ spec:
               description: KibanaStatus defines the observed state of Kibana
               properties:
                 associationStatus:
-                  description: AssociationStatus is the status of any auto-linking to Elasticsearch clusters. This field is deprecated and will be removed in a future release. Use ElasticsearchAssociationStatus instead.
+                  description: |-
+                    AssociationStatus is the status of any auto-linking to Elasticsearch clusters.
+                    This field is deprecated and will be removed in a future release. Use ElasticsearchAssociationStatus instead.
                   type: string
                 availableNodes:
                   description: AvailableNodes is the number of available replicas in the deployment.
@@ -399,14 +704,20 @@ spec:
                   description: MonitoringAssociationStatus is the status of any auto-linking to monitoring Elasticsearch clusters.
                   type: object
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this Kibana instance. It corresponds to the metadata generation, which is updated on mutation by the API Server. If the generation observed in status diverges from the generation in metadata, the Kibana controller has not yet processed the changes contained in the Kibana specification.
+                  description: |-
+                    ObservedGeneration is the most recent generation observed for this Kibana instance.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the Kibana
+                    controller has not yet processed the changes contained in the Kibana specification.
                   format: int64
                   type: integer
                 selector:
                   description: Selector is the label selector used to find all pods.
                   type: string
                 version:
-                  description: 'Version of the stack resource currently running. During version upgrades, multiple versions may run in parallel: this value specifies the lowest version currently running.'
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
                   type: string
               type: object
           type: object
@@ -439,10 +750,19 @@ spec:
           description: Kibana represents a Kibana resource in a Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -476,7 +796,9 @@ spec:
                       description: Service defines the template for the associated Kubernetes Service object.
                       properties:
                         metadata:
-                          description: ObjectMeta is the metadata of the service. The name and namespace provided here are managed by ECK and will be ignored.
+                          description: |-
+                            ObjectMeta is the metadata of the service.
+                            The name and namespace provided here are managed by ECK and will be ignored.
                           properties:
                             annotations:
                               additionalProperties:
@@ -499,69 +821,232 @@ spec:
                           description: Spec is the specification of the service.
                           properties:
                             allocateLoadBalancerNodePorts:
-                              description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+                              description: |-
+                                allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                allocated for services with type LoadBalancer.  Default is "true". It
+                                may be set to "false" if the cluster load-balancer does not rely on
+                                NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                value), those requests will be respected, regardless of this field.
+                                This field may only be set for services with type LoadBalancer and will
+                                be cleared if the type is changed to any other type.
                               type: boolean
                             clusterIP:
-                              description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                clusterIP is the IP address of the service and is usually assigned
+                                randomly. If an address is specified manually, is in-range (as per
+                                system configuration), and is not in use, it will be allocated to the
+                                service; otherwise creation of the service will fail. This field may not
+                                be changed through updates unless the type field is also being changed
+                                to ExternalName (which requires this field to be blank) or the type
+                                field is being changed from ExternalName (in which case this field may
+                                optionally be specified, as describe above).  Valid values are "None",
+                                empty string (""), or a valid IP address. Setting this to "None" makes a
+                                "headless service" (no virtual IP), which is useful when direct endpoint
+                                connections are preferred and proxying is not required.  Only applies to
+                                types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                when creating a Service of type ExternalName, creation will fail. This
+                                field will be wiped when updating a Service to type ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             clusterIPs:
-                              description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                              description: |-
+                                ClusterIPs is a list of IP addresses assigned to this service, and are
+                                usually assigned randomly.  If an address is specified manually, is
+                                in-range (as per system configuration), and is not in use, it will be
+                                allocated to the service; otherwise creation of the service will fail.
+                                This field may not be changed through updates unless the type field is
+                                also being changed to ExternalName (which requires this field to be
+                                empty) or the type field is being changed from ExternalName (in which
+                                case this field may optionally be specified, as describe above).  Valid
+                                values are "None", empty string (""), or a valid IP address.  Setting
+                                this to "None" makes a "headless service" (no virtual IP), which is
+                                useful when direct endpoint connections are preferred and proxying is
+                                not required.  Only applies to types ClusterIP, NodePort, and
+                                LoadBalancer. If this field is specified when creating a Service of type
+                                ExternalName, creation will fail. This field will be wiped when updating
+                                a Service to type ExternalName.  If this field is not specified, it will
+                                be initialized from the clusterIP field.  If this field is specified,
+                                clients must ensure that clusterIPs[0] and clusterIP have the same
+                                value.
+                                
+                                This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                These IPs must correspond to the values of the ipFamilies field. Both
+                                clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             externalIPs:
-                              description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                              description: |-
+                                externalIPs is a list of IP addresses for which nodes in the cluster
+                                will also accept traffic for this service.  These IPs are not managed by
+                                Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                at a node with this IP.  A common example is external load-balancers
+                                that are not part of the Kubernetes system.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             externalName:
-                              description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                              description: |-
+                                externalName is the external reference that discovery mechanisms will
+                                return as an alias for this service (e.g. a DNS CNAME record). No
+                                proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
                               type: string
                             externalTrafficPolicy:
-                              description: externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+                              description: |-
+                                externalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                the service in a way that assumes that external load balancers will take care
+                                of balancing the service traffic between nodes, and so each node will deliver
+                                traffic only to the node-local endpoints of the service, without masquerading
+                                the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                be dropped.) The default value, "Cluster", uses the standard behavior of
+                                routing to all endpoints evenly (possibly modified by topology and other
+                                features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                within the cluster will always get "Cluster" semantics, but clients sending to
+                                a NodePort from within the cluster may need to take traffic policy into account
+                                when picking a node.
                               type: string
                             healthCheckNodePort:
-                              description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+                              description: |-
+                                healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                This only applies when type is set to LoadBalancer and
+                                externalTrafficPolicy is set to Local. If a value is specified, is
+                                in-range, and is not in use, it will be used.  If not specified, a value
+                                will be automatically allocated.  External systems (e.g. load-balancers)
+                                can use this port to determine if a given node holds endpoints for this
+                                service or not.  If this field is specified when creating a Service
+                                which does not need it, creation will fail. This field will be wiped
+                                when updating a Service to no longer need it (e.g. changing type).
+                                This field cannot be updated once set.
                               format: int32
                               type: integer
                             internalTrafficPolicy:
-                              description: InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+                              description: |-
+                                InternalTrafficPolicy describes how nodes distribute service traffic they
+                                receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                only want to talk to endpoints of the service on the same node as the pod,
+                                dropping the traffic if there are no local endpoints. The default value,
+                                "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                (possibly modified by topology and other features).
                               type: string
                             ipFamilies:
-                              description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services. This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                              description: |-
+                                IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                service. This field is usually assigned automatically based on cluster
+                                configuration and the ipFamilyPolicy field. If this field is specified
+                                manually, the requested family is available in the cluster,
+                                and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                the service will fail. This field is conditionally mutable: it allows
+                                for adding or removing a secondary IP family, but it does not allow
+                                changing the primary IP family of the Service. Valid values are "IPv4"
+                                and "IPv6".  This field only applies to Services of types ClusterIP,
+                                NodePort, and LoadBalancer, and does apply to "headless" services.
+                                This field will be wiped when updating a Service to type ExternalName.
+                                
+                                This field may hold a maximum of two entries (dual-stack families, in
+                                either order).  These families must correspond to the values of the
+                                clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                governed by the ipFamilyPolicy field.
                               items:
-                                description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                description: |-
+                                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                  to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             ipFamilyPolicy:
-                              description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+                              description: |-
+                                IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                this Service. If there is no value provided, then this field will be set
+                                to SingleStack. Services can be "SingleStack" (a single IP family),
+                                "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                a single IP family on single-stack clusters), or "RequireDualStack"
+                                (two IP families on dual-stack configured clusters, otherwise fail). The
+                                ipFamilies and clusterIPs fields depend on the value of this field. This
+                                field will be wiped when updating a service to type ExternalName.
                               type: string
                             loadBalancerClass:
-                              description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                              description: |-
+                                loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                balancer implementation is used, today this is typically done through the cloud provider integration,
+                                but should apply for any default implementation. If set, it is assumed that a load balancer
+                                implementation is watching for Services with a matching class. Any default load balancer
+                                implementation (e.g. cloud providers) should ignore Services that set this field.
+                                This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
                               type: string
                             loadBalancerIP:
-                              description: 'Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations, and it cannot support dual-stack. As of Kubernetes v1.24, users are encouraged to use implementation-specific annotations when available. This field may be removed in a future API version.'
+                              description: |-
+                                Only applies to Service Type: LoadBalancer.
+                                This feature depends on whether the underlying cloud-provider supports specifying
+                                the loadBalancerIP when a load balancer is created.
+                                This field will be ignored if the cloud-provider does not support the feature.
+                                Deprecated: This field was under-specified and its meaning varies across implementations.
+                                Using it is non-portable and it may not support dual-stack.
+                                Users are encouraged to use implementation-specific annotations when available.
                               type: string
                             loadBalancerSourceRanges:
-                              description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              description: |-
+                                If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                cloud-provider does not support the feature."
+                                More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             ports:
-                              description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                The list of ports that are exposed by this service.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               items:
                                 description: ServicePort contains information on service's port.
                                 properties:
                                   appProtocol:
-                                    description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                                    description: |-
+                                      The application protocol for this port.
+                                      This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                      This field follows standard Kubernetes label syntax.
+                                      Valid values are either:
+                                      
+                                      * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                      RFC-6335 and https://www.iana.org/assignments/service-names).
+                                      
+                                      * Kubernetes-defined prefixed names:
+                                        * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                      
+                                      * Other protocols should use implementation-defined prefixed names such as
+                                      mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
-                                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                                    description: |-
+                                      The name of this port within the service. This must be a DNS_LABEL.
+                                      All ports within a ServiceSpec must have unique names. When considering
+                                      the endpoints for a Service, this must match the 'name' field in the
+                                      EndpointPort.
+                                      Optional if only one ServicePort is defined on this service.
                                     type: string
                                   nodePort:
-                                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                    description: |-
+                                      The port on each node on which this service is exposed when type is
+                                      NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                      specified, in-range, and not in use it will be used, otherwise the
+                                      operation will fail.  If not specified, a port will be allocated if this
+                                      Service requires one.  If this field is specified when creating a
+                                      Service which does not need it, creation will fail. This field will be
+                                      wiped when updating a Service to no longer need it (e.g. changing type
+                                      from NodePort to ClusterIP).
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                                     format: int32
                                     type: integer
                                   port:
@@ -570,13 +1055,23 @@ spec:
                                     type: integer
                                   protocol:
                                     default: TCP
-                                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                                    description: |-
+                                      The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                      Default is TCP.
                                     type: string
                                   targetPort:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                    description: |-
+                                      Number or name of the port to access on the pods targeted by the service.
+                                      Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      If this is a string, it will be looked up as a named port in the
+                                      target Pod's container ports. If this is not specified, the value
+                                      of the 'port' field is used (an identity map).
+                                      This field is ignored for services with clusterIP=None, and should be
+                                      omitted or set equal to the 'port' field.
+                                      More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -587,16 +1082,35 @@ spec:
                                 - protocol
                               x-kubernetes-list-type: map
                             publishNotReadyAddresses:
-                              description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                              description: |-
+                                publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                Service should disregard any indications of ready/not-ready.
+                                The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                Services interpret this to mean that all endpoints are considered "ready" even if the
+                                Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                through the Endpoints or EndpointSlice resources can safely assume this behavior.
                               type: boolean
                             selector:
                               additionalProperties:
                                 type: string
-                              description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                              description: |-
+                                Route service traffic to pods with label keys and values matching this
+                                selector. If empty or not present, the service is assumed to have an
+                                external process managing its endpoints, which Kubernetes will not
+                                modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                Ignored if type is ExternalName.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/
                               type: object
                               x-kubernetes-map-type: atomic
                             sessionAffinity:
-                              description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                              description: |-
+                                Supports "ClientIP" and "None". Used to maintain session affinity.
+                                Enable client IP based session affinity.
+                                Must be ClientIP or None.
+                                Defaults to None.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
                               type: string
                             sessionAffinityConfig:
                               description: sessionAffinityConfig contains the configurations of session affinity.
@@ -605,13 +1119,42 @@ spec:
                                   description: clientIP contains the configurations of Client IP based session affinity.
                                   properties:
                                     timeoutSeconds:
-                                      description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                      description: |-
+                                        timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                        The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                        Default value is 10800(for 3 hours).
                                       format: int32
                                       type: integer
                                   type: object
                               type: object
+                            trafficDistribution:
+                              description: |-
+                                TrafficDistribution offers a way to express preferences for how traffic is
+                                distributed to Service endpoints. Implementations can use this field as a
+                                hint, but are not required to guarantee strict adherence. If the field is
+                                not set, the implementation will apply its default routing strategy. If set
+                                to "PreferClose", implementations should prioritize endpoints that are
+                                topologically close (e.g., same zone).
+                                This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                              type: string
                             type:
-                              description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                              description: |-
+                                type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                to endpoints. Endpoints are determined by the selector or if that is not
+                                specified, by manual construction of an Endpoints object or
+                                EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                allocated and the endpoints are published as a set of endpoints rather
+                                than a virtual IP.
+                                "NodePort" builds on ClusterIP and allocates a port on every node which
+                                routes to the same endpoints as the clusterIP.
+                                "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                (if supported in the current cloud) which routes to the same endpoints
+                                as the clusterIP.
+                                "ExternalName" aliases this service to the specified externalName.
+                                Several other fields do not apply to ExternalName services.
+                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
                               type: string
                           type: object
                       type: object
@@ -619,7 +1162,13 @@ spec:
                       description: TLS defines options for configuring TLS for HTTP.
                       properties:
                         certificate:
-                          description: "Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS. The referenced secret should contain the following: \n - `ca.crt`: The certificate authority (optional). - `tls.crt`: The certificate (or a chain). - `tls.key`: The private key to the first certificate in the certificate chain."
+                          description: |-
+                            Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                            The referenced secret should contain the following:
+                            
+                            - `ca.crt`: The certificate authority (optional).
+                            - `tls.crt`: The certificate (or a chain).
+                            - `tls.key`: The private key to the first certificate in the certificate chain.
                           properties:
                             secretName:
                               description: SecretName is the name of the secret.
@@ -660,7 +1209,10 @@ spec:
                     description: SecretSource defines a data source based on a Kubernetes Secret.
                     properties:
                       entries:
-                        description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
                         items:
                           description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
                           properties:
@@ -668,7 +1220,9 @@ spec:
                               description: Key is the key contained in the secret.
                               type: string
                             path:
-                              description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
                               type: string
                           required:
                             - key

--- a/pkg/crds/enterprise/01-crd-eck-logstash.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-logstash.yaml
@@ -1,0 +1,1133 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: 'elastic-operator'
+    app.kubernetes.io/name: 'eck-operator-crds'
+    app.kubernetes.io/version: '2.16.0'
+  name: logstashes.logstash.k8s.elastic.co
+spec:
+  group: logstash.k8s.elastic.co
+  names:
+    categories:
+      - elastic
+    kind: Logstash
+    listKind: LogstashList
+    plural: logstashes
+    shortNames:
+      - ls
+    singular: logstash
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Health
+          jsonPath: .status.health
+          name: health
+          type: string
+        - description: Available nodes
+          jsonPath: .status.availableNodes
+          name: available
+          type: integer
+        - description: Expected nodes
+          jsonPath: .status.expectedNodes
+          name: expected
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+        - description: Logstash version
+          jsonPath: .status.version
+          name: version
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Logstash is the Schema for the logstashes API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: LogstashSpec defines the desired state of Logstash
+              properties:
+                config:
+                  description: Config holds the Logstash configuration. At most one of [`Config`, `ConfigRef`] can be specified.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                configRef:
+                  description: |-
+                    ConfigRef contains a reference to an existing Kubernetes Secret holding the Logstash configuration.
+                    Logstash settings must be specified as yaml, under a single "logstash.yml" entry. At most one of [`Config`, `ConfigRef`]
+                    can be specified.
+                  properties:
+                    secretName:
+                      description: SecretName is the name of the secret.
+                      type: string
+                  type: object
+                count:
+                  format: int32
+                  type: integer
+                elasticsearchRefs:
+                  description: ElasticsearchRefs are references to Elasticsearch clusters running in the same Kubernetes cluster.
+                  items:
+                    description: ElasticsearchCluster is a named reference to an Elasticsearch cluster which can be used in a Logstash pipeline.
+                    properties:
+                      clusterName:
+                        description: |-
+                          ClusterName is an alias for the cluster to be used to refer to the Elasticsearch cluster in Logstash
+                          configuration files, and will be used to identify "named clusters" in Logstash
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                        type: string
+                      namespace:
+                        description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                        type: string
+                      secretName:
+                        description: |-
+                          SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                          Elastic resource not managed by the operator. The referenced secret must contain the following:
+                          - `url`: the URL to reach the Elastic resource
+                          - `username`: the username of the user to be authenticated to the Elastic resource
+                          - `password`: the password of the user to be authenticated to the Elastic resource
+                          - `ca.crt`: the CA certificate in PEM format (optional)
+                          - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                          This field cannot be used in combination with the other fields name, namespace or serviceName.
+                        type: string
+                      serviceName:
+                        description: |-
+                          ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                          object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                          the referenced resource is used.
+                        type: string
+                    required:
+                      - clusterName
+                    type: object
+                  type: array
+                image:
+                  description: Image is the Logstash Docker image to deploy. Version and Type have to match the Logstash in the image.
+                  type: string
+                monitoring:
+                  description: |-
+                    Monitoring enables you to collect and ship log and monitoring data of this Logstash.
+                    Metricbeat and Filebeat are deployed in the same Pod as sidecars and each one sends data to one or two different
+                    Elasticsearch monitoring clusters running in the same Kubernetes cluster.
+                  properties:
+                    logs:
+                      description: Logs holds references to Elasticsearch clusters which receive log data from an associated resource.
+                      properties:
+                        elasticsearchRefs:
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          items:
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
+                            properties:
+                              name:
+                                description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                                type: string
+                              namespace:
+                                description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                                type: string
+                              secretName:
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
+                                type: string
+                              serviceName:
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    metrics:
+                      description: Metrics holds references to Elasticsearch clusters which receive monitoring data from this resource.
+                      properties:
+                        elasticsearchRefs:
+                          description: |-
+                            ElasticsearchRefs is a reference to a list of monitoring Elasticsearch clusters running in the same Kubernetes cluster.
+                            Due to existing limitations, only a single Elasticsearch cluster is currently supported.
+                          items:
+                            description: |-
+                              ObjectSelector defines a reference to a Kubernetes object which can be an Elastic resource managed by the operator
+                              or a Secret describing an external Elastic resource not managed by the operator.
+                            properties:
+                              name:
+                                description: Name of an existing Kubernetes object corresponding to an Elastic resource managed by ECK.
+                                type: string
+                              namespace:
+                                description: Namespace of the Kubernetes object. If empty, defaults to the current namespace.
+                                type: string
+                              secretName:
+                                description: |-
+                                  SecretName is the name of an existing Kubernetes secret that contains connection information for associating an
+                                  Elastic resource not managed by the operator. The referenced secret must contain the following:
+                                  - `url`: the URL to reach the Elastic resource
+                                  - `username`: the username of the user to be authenticated to the Elastic resource
+                                  - `password`: the password of the user to be authenticated to the Elastic resource
+                                  - `ca.crt`: the CA certificate in PEM format (optional)
+                                  - `api-key`: the key to authenticate against the Elastic resource instead of a username and password (supported only for `elasticsearchRefs` in AgentSpec and in BeatSpec)
+                                  This field cannot be used in combination with the other fields name, namespace or serviceName.
+                                type: string
+                              serviceName:
+                                description: |-
+                                  ServiceName is the name of an existing Kubernetes service which is used to make requests to the referenced
+                                  object. It has to be in the same namespace as the referenced resource. If left empty, the default HTTP service of
+                                  the referenced resource is used.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                pipelines:
+                  description: Pipelines holds the Logstash Pipelines. At most one of [`Pipelines`, `PipelinesRef`] can be specified.
+                  items:
+                    type: object
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                pipelinesRef:
+                  description: |-
+                    PipelinesRef contains a reference to an existing Kubernetes Secret holding the Logstash Pipelines.
+                    Logstash pipelines must be specified as yaml, under a single "pipelines.yml" entry. At most one of [`Pipelines`, `PipelinesRef`]
+                    can be specified.
+                  properties:
+                    secretName:
+                      description: SecretName is the name of the secret.
+                      type: string
+                  type: object
+                podTemplate:
+                  description: PodTemplate provides customisation options for the Logstash pods.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                revisionHistoryLimit:
+                  description: RevisionHistoryLimit is the number of revisions to retain to allow rollback in the underlying StatefulSet.
+                  format: int32
+                  type: integer
+                secureSettings:
+                  description: |-
+                    SecureSettings is a list of references to Kubernetes Secrets containing sensitive configuration options for the Logstash.
+                    Secrets data can be then referenced in the Logstash config using the Secret's keys or as specified in `Entries` field of
+                    each SecureSetting.
+                  items:
+                    description: SecretSource defines a data source based on a Kubernetes Secret.
+                    properties:
+                      entries:
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
+                        items:
+                          description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                          properties:
+                            key:
+                              description: Key is the key contained in the secret.
+                              type: string
+                            path:
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        type: array
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    required:
+                      - secretName
+                    type: object
+                  type: array
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is used to check access from the current resource to Elasticsearch resource in a different namespace.
+                    Can only be used if ECK is enforcing RBAC on references.
+                  type: string
+                services:
+                  description: |-
+                    Services contains details of services that Logstash should expose - similar to the HTTP layer configuration for the
+                    rest of the stack, but also applicable for more use cases than the metrics API, as logstash may need to
+                    be opened up for other services: Beats, TCP, UDP, etc, inputs.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      service:
+                        description: Service defines the template for the associated Kubernetes Service object.
+                        properties:
+                          metadata:
+                            description: |-
+                              ObjectMeta is the metadata of the service.
+                              The name and namespace provided here are managed by ECK and will be ignored.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                          spec:
+                            description: Spec is the specification of the service.
+                            properties:
+                              allocateLoadBalancerNodePorts:
+                                description: |-
+                                  allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                  allocated for services with type LoadBalancer.  Default is "true". It
+                                  may be set to "false" if the cluster load-balancer does not rely on
+                                  NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                  value), those requests will be respected, regardless of this field.
+                                  This field may only be set for services with type LoadBalancer and will
+                                  be cleared if the type is changed to any other type.
+                                type: boolean
+                              clusterIP:
+                                description: |-
+                                  clusterIP is the IP address of the service and is usually assigned
+                                  randomly. If an address is specified manually, is in-range (as per
+                                  system configuration), and is not in use, it will be allocated to the
+                                  service; otherwise creation of the service will fail. This field may not
+                                  be changed through updates unless the type field is also being changed
+                                  to ExternalName (which requires this field to be blank) or the type
+                                  field is being changed from ExternalName (in which case this field may
+                                  optionally be specified, as describe above).  Valid values are "None",
+                                  empty string (""), or a valid IP address. Setting this to "None" makes a
+                                  "headless service" (no virtual IP), which is useful when direct endpoint
+                                  connections are preferred and proxying is not required.  Only applies to
+                                  types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                  when creating a Service of type ExternalName, creation will fail. This
+                                  field will be wiped when updating a Service to type ExternalName.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                type: string
+                              clusterIPs:
+                                description: |-
+                                  ClusterIPs is a list of IP addresses assigned to this service, and are
+                                  usually assigned randomly.  If an address is specified manually, is
+                                  in-range (as per system configuration), and is not in use, it will be
+                                  allocated to the service; otherwise creation of the service will fail.
+                                  This field may not be changed through updates unless the type field is
+                                  also being changed to ExternalName (which requires this field to be
+                                  empty) or the type field is being changed from ExternalName (in which
+                                  case this field may optionally be specified, as describe above).  Valid
+                                  values are "None", empty string (""), or a valid IP address.  Setting
+                                  this to "None" makes a "headless service" (no virtual IP), which is
+                                  useful when direct endpoint connections are preferred and proxying is
+                                  not required.  Only applies to types ClusterIP, NodePort, and
+                                  LoadBalancer. If this field is specified when creating a Service of type
+                                  ExternalName, creation will fail. This field will be wiped when updating
+                                  a Service to type ExternalName.  If this field is not specified, it will
+                                  be initialized from the clusterIP field.  If this field is specified,
+                                  clients must ensure that clusterIPs[0] and clusterIP have the same
+                                  value.
+                                  
+                                  This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                  These IPs must correspond to the values of the ipFamilies field. Both
+                                  clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              externalIPs:
+                                description: |-
+                                  externalIPs is a list of IP addresses for which nodes in the cluster
+                                  will also accept traffic for this service.  These IPs are not managed by
+                                  Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                  at a node with this IP.  A common example is external load-balancers
+                                  that are not part of the Kubernetes system.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              externalName:
+                                description: |-
+                                  externalName is the external reference that discovery mechanisms will
+                                  return as an alias for this service (e.g. a DNS CNAME record). No
+                                  proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                  (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                                type: string
+                              externalTrafficPolicy:
+                                description: |-
+                                  externalTrafficPolicy describes how nodes distribute service traffic they
+                                  receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                  ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                  the service in a way that assumes that external load balancers will take care
+                                  of balancing the service traffic between nodes, and so each node will deliver
+                                  traffic only to the node-local endpoints of the service, without masquerading
+                                  the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                  be dropped.) The default value, "Cluster", uses the standard behavior of
+                                  routing to all endpoints evenly (possibly modified by topology and other
+                                  features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                  within the cluster will always get "Cluster" semantics, but clients sending to
+                                  a NodePort from within the cluster may need to take traffic policy into account
+                                  when picking a node.
+                                type: string
+                              healthCheckNodePort:
+                                description: |-
+                                  healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                  This only applies when type is set to LoadBalancer and
+                                  externalTrafficPolicy is set to Local. If a value is specified, is
+                                  in-range, and is not in use, it will be used.  If not specified, a value
+                                  will be automatically allocated.  External systems (e.g. load-balancers)
+                                  can use this port to determine if a given node holds endpoints for this
+                                  service or not.  If this field is specified when creating a Service
+                                  which does not need it, creation will fail. This field will be wiped
+                                  when updating a Service to no longer need it (e.g. changing type).
+                                  This field cannot be updated once set.
+                                format: int32
+                                type: integer
+                              internalTrafficPolicy:
+                                description: |-
+                                  InternalTrafficPolicy describes how nodes distribute service traffic they
+                                  receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                  only want to talk to endpoints of the service on the same node as the pod,
+                                  dropping the traffic if there are no local endpoints. The default value,
+                                  "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                  (possibly modified by topology and other features).
+                                type: string
+                              ipFamilies:
+                                description: |-
+                                  IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                  service. This field is usually assigned automatically based on cluster
+                                  configuration and the ipFamilyPolicy field. If this field is specified
+                                  manually, the requested family is available in the cluster,
+                                  and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                  the service will fail. This field is conditionally mutable: it allows
+                                  for adding or removing a secondary IP family, but it does not allow
+                                  changing the primary IP family of the Service. Valid values are "IPv4"
+                                  and "IPv6".  This field only applies to Services of types ClusterIP,
+                                  NodePort, and LoadBalancer, and does apply to "headless" services.
+                                  This field will be wiped when updating a Service to type ExternalName.
+                                  
+                                  This field may hold a maximum of two entries (dual-stack families, in
+                                  either order).  These families must correspond to the values of the
+                                  clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                  governed by the ipFamilyPolicy field.
+                                items:
+                                  description: |-
+                                    IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                    to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ipFamilyPolicy:
+                                description: |-
+                                  IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                  this Service. If there is no value provided, then this field will be set
+                                  to SingleStack. Services can be "SingleStack" (a single IP family),
+                                  "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                  a single IP family on single-stack clusters), or "RequireDualStack"
+                                  (two IP families on dual-stack configured clusters, otherwise fail). The
+                                  ipFamilies and clusterIPs fields depend on the value of this field. This
+                                  field will be wiped when updating a service to type ExternalName.
+                                type: string
+                              loadBalancerClass:
+                                description: |-
+                                  loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                  If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                  e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                  This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                  balancer implementation is used, today this is typically done through the cloud provider integration,
+                                  but should apply for any default implementation. If set, it is assumed that a load balancer
+                                  implementation is watching for Services with a matching class. Any default load balancer
+                                  implementation (e.g. cloud providers) should ignore Services that set this field.
+                                  This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                  Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                                type: string
+                              loadBalancerIP:
+                                description: |-
+                                  Only applies to Service Type: LoadBalancer.
+                                  This feature depends on whether the underlying cloud-provider supports specifying
+                                  the loadBalancerIP when a load balancer is created.
+                                  This field will be ignored if the cloud-provider does not support the feature.
+                                  Deprecated: This field was under-specified and its meaning varies across implementations.
+                                  Using it is non-portable and it may not support dual-stack.
+                                  Users are encouraged to use implementation-specific annotations when available.
+                                type: string
+                              loadBalancerSourceRanges:
+                                description: |-
+                                  If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                  load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                  cloud-provider does not support the feature."
+                                  More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ports:
+                                description: |-
+                                  The list of ports that are exposed by this service.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                items:
+                                  description: ServicePort contains information on service's port.
+                                  properties:
+                                    appProtocol:
+                                      description: |-
+                                        The application protocol for this port.
+                                        This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                        This field follows standard Kubernetes label syntax.
+                                        Valid values are either:
+                                        
+                                        * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                        RFC-6335 and https://www.iana.org/assignments/service-names).
+                                        
+                                        * Kubernetes-defined prefixed names:
+                                          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                                        
+                                        * Other protocols should use implementation-defined prefixed names such as
+                                        mycompany.com/my-custom-protocol.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        The name of this port within the service. This must be a DNS_LABEL.
+                                        All ports within a ServiceSpec must have unique names. When considering
+                                        the endpoints for a Service, this must match the 'name' field in the
+                                        EndpointPort.
+                                        Optional if only one ServicePort is defined on this service.
+                                      type: string
+                                    nodePort:
+                                      description: |-
+                                        The port on each node on which this service is exposed when type is
+                                        NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                        specified, in-range, and not in use it will be used, otherwise the
+                                        operation will fail.  If not specified, a port will be allocated if this
+                                        Service requires one.  If this field is specified when creating a
+                                        Service which does not need it, creation will fail. This field will be
+                                        wiped when updating a Service to no longer need it (e.g. changing type
+                                        from NodePort to ClusterIP).
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      description: The port that will be exposed by this service.
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      default: TCP
+                                      description: |-
+                                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                        Default is TCP.
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: |-
+                                        Number or name of the port to access on the pods targeted by the service.
+                                        Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        If this is a string, it will be looked up as a named port in the
+                                        target Pod's container ports. If this is not specified, the value
+                                        of the 'port' field is used (an identity map).
+                                        This field is ignored for services with clusterIP=None, and should be
+                                        omitted or set equal to the 'port' field.
+                                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - port
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                description: |-
+                                  publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                  Service should disregard any indications of ready/not-ready.
+                                  The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                  propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                  The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                  Services interpret this to mean that all endpoints are considered "ready" even if the
+                                  Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                  through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Route service traffic to pods with label keys and values matching this
+                                  selector. If empty or not present, the service is assumed to have an
+                                  external process managing its endpoints, which Kubernetes will not
+                                  modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                  Ignored if type is ExternalName.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sessionAffinity:
+                                description: |-
+                                  Supports "ClientIP" and "None". Used to maintain session affinity.
+                                  Enable client IP based session affinity.
+                                  Must be ClientIP or None.
+                                  Defaults to None.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                type: string
+                              sessionAffinityConfig:
+                                description: sessionAffinityConfig contains the configurations of session affinity.
+                                properties:
+                                  clientIP:
+                                    description: clientIP contains the configurations of Client IP based session affinity.
+                                    properties:
+                                      timeoutSeconds:
+                                        description: |-
+                                          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                          The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                          Default value is 10800(for 3 hours).
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              trafficDistribution:
+                                description: |-
+                                  TrafficDistribution offers a way to express preferences for how traffic is
+                                  distributed to Service endpoints. Implementations can use this field as a
+                                  hint, but are not required to guarantee strict adherence. If the field is
+                                  not set, the implementation will apply its default routing strategy. If set
+                                  to "PreferClose", implementations should prioritize endpoints that are
+                                  topologically close (e.g., same zone).
+                                  This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                                type: string
+                              type:
+                                description: |-
+                                  type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                  options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                  "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                  to endpoints. Endpoints are determined by the selector or if that is not
+                                  specified, by manual construction of an Endpoints object or
+                                  EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                  allocated and the endpoints are published as a set of endpoints rather
+                                  than a virtual IP.
+                                  "NodePort" builds on ClusterIP and allocates a port on every node which
+                                  routes to the same endpoints as the clusterIP.
+                                  "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                  (if supported in the current cloud) which routes to the same endpoints
+                                  as the clusterIP.
+                                  "ExternalName" aliases this service to the specified externalName.
+                                  Several other fields do not apply to ExternalName services.
+                                  More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                                type: string
+                            type: object
+                        type: object
+                      tls:
+                        description: TLS defines options for configuring TLS for HTTP.
+                        properties:
+                          certificate:
+                            description: |-
+                              Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
+                              The referenced secret should contain the following:
+                              
+                              - `ca.crt`: The certificate authority (optional).
+                              - `tls.crt`: The certificate (or a chain).
+                              - `tls.key`: The private key to the first certificate in the certificate chain.
+                            properties:
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                type: string
+                            type: object
+                          selfSignedCertificate:
+                            description: SelfSignedCertificate allows configuring the self-signed certificate generated by the operator.
+                            properties:
+                              disabled:
+                                description: Disabled indicates that the provisioning of the self-signed certifcate should be disabled.
+                                type: boolean
+                              subjectAltNames:
+                                description: SubjectAlternativeNames is a list of SANs to include in the generated HTTP TLS certificate.
+                                items:
+                                  description: SubjectAlternativeName represents a SAN entry in a x509 certificate.
+                                  properties:
+                                    dns:
+                                      description: DNS is the DNS name of the subject.
+                                      type: string
+                                    ip:
+                                      description: IP is the IP address of the subject.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+                updateStrategy:
+                  description: UpdateStrategy is a StatefulSetUpdateStrategy. The default type is "RollingUpdate".
+                  properties:
+                    rollingUpdate:
+                      description: RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+                      properties:
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: |-
+                            The maximum number of pods that can be unavailable during the update.
+                            Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            Absolute number is calculated from percentage by rounding up. This can not be 0.
+                            Defaults to 1. This field is alpha-level and is only honored by servers that enable the
+                            MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to
+                            Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it
+                            will be counted towards MaxUnavailable.
+                          x-kubernetes-int-or-string: true
+                        partition:
+                          description: |-
+                            Partition indicates the ordinal at which the StatefulSet should be partitioned
+                            for updates. During a rolling update, all pods from ordinal Replicas-1 to
+                            Partition are updated. All pods from ordinal Partition-1 to 0 remain untouched.
+                            This is helpful in being able to do a canary based deployment. The default value is 0.
+                          format: int32
+                          type: integer
+                      type: object
+                    type:
+                      description: |-
+                        Type indicates the type of the StatefulSetUpdateStrategy.
+                        Default is RollingUpdate.
+                      type: string
+                  type: object
+                version:
+                  description: Version of the Logstash.
+                  type: string
+                volumeClaimTemplates:
+                  description: |-
+                    VolumeClaimTemplates is a list of persistent volume claims to be used by each Pod.
+                    Every claim in this list must have a matching volumeMount in one of the containers defined in the PodTemplate.
+                    Items defined here take precedence over any default claims added by the operator with the same name.
+                  items:
+                    description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      metadata:
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        description: |-
+                          spec defines the desired characteristics of a volume requested by a pod author.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                        properties:
+                          accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                              * An existing PVC (PersistentVolumeClaim)
+                              If the provisioner or an external controller can support the specified data source,
+                              it will create a new volume based on the contents of the specified data source.
+                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                              If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any object from a non-empty API group (non
+                              core object) or a PersistentVolumeClaim object.
+                              When this field is specified, volume binding will only succeed if the type of
+                              the specified object matches some installed volume populator or dynamic
+                              provisioner.
+                              This field will replace the functionality of the dataSource field and as such
+                              if both fields are non-empty, they must have the same value. For backwards
+                              compatibility, when namespace isn't specified in dataSourceRef,
+                              both fields (dataSource and dataSourceRef) will be set to the same
+                              value automatically if one of them is empty and the other is non-empty.
+                              When namespace is specified in dataSourceRef,
+                              dataSource isn't set to the same value and must be empty.
+                              There are three important differences between dataSource and dataSourceRef:
+                              * While dataSource only allows two specific types of objects, dataSourceRef
+                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                              * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                preserves all values, and generates an error if a disallowed value is
+                                specified.
+                              * While dataSource only allows local objects, dataSourceRef allows objects
+                                in any namespaces.
+                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                  (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          resources:
+                            description: |-
+                              resources represents the minimum resources the volume should have.
+                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                              that are lower than previous value but must still be higher than capacity recorded in the
+                              status field of the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          selector:
+                            description: selector is a label query over volumes to consider for binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                            type: string
+                          volumeAttributesClassName:
+                            description: |-
+                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                              If specified, the CSI driver will create or update the volume with the attributes defined
+                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
+                              If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                              set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                              exists.
+                              More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                            type: string
+                          volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
+                            type: string
+                          volumeName:
+                            description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                      status:
+                        description: |-
+                          status represents the current information/status of a persistent volume claim.
+                          Read-only.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                        properties:
+                          accessModes:
+                            description: |-
+                              accessModes contains the actual access modes the volume backing the PVC has.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          allocatedResourceStatuses:
+                            additionalProperties:
+                              description: |-
+                                When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource
+                                that it does not recognizes, then it should ignore that update and let other controllers
+                                handle it.
+                              type: string
+                            description: "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                            type: object
+                            x-kubernetes-map-type: granular
+                          allocatedResources:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature."
+                            type: object
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: capacity represents the actual resources of the underlying volume.
+                            type: object
+                          conditions:
+                            description: |-
+                              conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
+                              resized then the Condition will be set to 'Resizing'.
+                            items:
+                              description: PersistentVolumeClaimCondition contains details about state of pvc
+                              properties:
+                                lastProbeTime:
+                                  description: lastProbeTime is the time we probed the condition.
+                                  format: date-time
+                                  type: string
+                                lastTransitionTime:
+                                  description: lastTransitionTime is the time the condition transitioned from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: message is the human-readable message indicating details about last transition.
+                                  type: string
+                                reason:
+                                  description: |-
+                                    reason is a unique, this should be a short, machine understandable string that gives the reason
+                                    for condition's last transition. If it reports "Resizing" that means the underlying
+                                    persistent volume is being resized.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: |-
+                                    PersistentVolumeClaimConditionType defines the condition of PV claim.
+                                    Valid values are:
+                                      - "Resizing", "FileSystemResizePending"
+                                    
+                                    If RecoverVolumeExpansionFailure feature gate is enabled, then following additional values can be expected:
+                                      - "ControllerResizeError", "NodeResizeError"
+                                    
+                                    If VolumeAttributesClass feature gate is enabled, then following additional values can be expected:
+                                      - "ModifyVolumeError", "ModifyingVolume"
+                                  type: string
+                              required:
+                                - status
+                                - type
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - type
+                            x-kubernetes-list-type: map
+                          currentVolumeAttributesClassName:
+                            description: |-
+                              currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
+                              When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                              This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
+                            type: string
+                          modifyVolumeStatus:
+                            description: |-
+                              ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
+                              When this is unset, there is no ModifyVolume operation being attempted.
+                              This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
+                            properties:
+                              status:
+                                description: "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately."
+                                type: string
+                              targetVolumeAttributesClassName:
+                                description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled
+                                type: string
+                            required:
+                              - status
+                            type: object
+                          phase:
+                            description: phase represents the current phase of PersistentVolumeClaim.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+              required:
+                - version
+              type: object
+            status:
+              description: LogstashStatus defines the observed state of Logstash
+              properties:
+                availableNodes:
+                  format: int32
+                  type: integer
+                elasticsearchAssociationsStatus:
+                  additionalProperties:
+                    description: AssociationStatus is the status of an association resource.
+                    type: string
+                  description: ElasticsearchAssociationStatus is the status of any auto-linking to Elasticsearch clusters.
+                  type: object
+                expectedNodes:
+                  format: int32
+                  type: integer
+                health:
+                  type: string
+                monitoringAssociationStatus:
+                  additionalProperties:
+                    description: AssociationStatus is the status of an association resource.
+                    type: string
+                  description: MonitoringAssociationStatus is the status of any auto-linking to monitoring Elasticsearch clusters.
+                  type: object
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the most recent generation observed for this Logstash instance.
+                    It corresponds to the metadata generation, which is updated on mutation by the API Server.
+                    If the generation observed in status diverges from the generation in metadata, the Logstash
+                    controller has not yet processed the changes contained in the Logstash specification.
+                  format: int64
+                  type: integer
+                selector:
+                  type: string
+                version:
+                  description: |-
+                    Version of the stack resource currently running. During version upgrades, multiple versions may run
+                    in parallel: this value specifies the lowest version currently running.
+                  type: string
+              required:
+                - selector
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.count
+          statusReplicasPath: .status.expectedNodes
+        status: {}

--- a/pkg/crds/enterprise/01-crd-eck-stackconfigpolicy.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-stackconfigpolicy.yaml
@@ -3,199 +3,358 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.6.1'
+    app.kubernetes.io/version: '2.16.0'
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co
   names:
     categories:
-    - elastic
+      - elastic
     kind: StackConfigPolicy
     listKind: StackConfigPolicyList
     plural: stackconfigpolicies
     shortNames:
-    - scp
+      - scp
     singular: stackconfigpolicy
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resources configured
-      jsonPath: .status.readyCount
-      name: Ready
-      type: string
-    - jsonPath: .status.phase
-      name: Phase
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: StackConfigPolicy represents a StackConfigPolicy resource in a Kubernetes cluster.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              elasticsearch:
-                properties:
-                  clusterSettings:
-                    description: ClusterSettings holds the Elasticsearch cluster settings (/_cluster/settings)
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  indexLifecyclePolicies:
-                    description: IndexLifecyclePolicies holds the Index Lifecycle policies settings (/_ilm/policy)
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  indexTemplates:
-                    description: IndexTemplates holds the Index and Component Templates settings
-                    properties:
-                      componentTemplates:
-                        description: ComponentTemplates holds the Component Templates settings (/_component_template)
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      composableIndexTemplates:
-                        description: ComposableIndexTemplates holds the Index Templates settings (/_index_template)
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  ingestPipelines:
-                    description: IngestPipelines holds the Ingest Pipelines settings (/_ingest/pipeline)
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  securityRoleMappings:
-                    description: SecurityRoleMappings holds the Role Mappings settings (/_security/role_mapping)
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  snapshotLifecyclePolicies:
-                    description: SnapshotLifecyclePolicies holds the Snapshot Lifecycle Policies settings (/_slm/policy)
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  snapshotRepositories:
-                    description: SnapshotRepositories holds the Snapshot Repositories settings (/_snapshot)
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              resourceSelector:
-                description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                    items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies to.
-                          type: string
-                        operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                          type: string
-                        values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
-              secureSettings:
-                items:
-                  description: SecretSource defines a data source based on a Kubernetes Secret.
+    - additionalPrinterColumns:
+        - description: Resources configured
+          jsonPath: .status.readyCount
+          name: Ready
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: StackConfigPolicy represents a StackConfigPolicy resource in a Kubernetes cluster.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                elasticsearch:
                   properties:
-                    entries:
-                      description: Entries define how to project each key-value pair in the secret to filesystem paths. If not defined, all keys will be projected to similarly named paths in the filesystem. If defined, only the specified keys will be projected to the corresponding paths.
+                    clusterSettings:
+                      description: ClusterSettings holds the Elasticsearch cluster settings (/_cluster/settings)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    config:
+                      description: Config holds the settings that go into elasticsearch.yml.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    indexLifecyclePolicies:
+                      description: IndexLifecyclePolicies holds the Index Lifecycle policies settings (/_ilm/policy)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    indexTemplates:
+                      description: IndexTemplates holds the Index and Component Templates settings
+                      properties:
+                        componentTemplates:
+                          description: ComponentTemplates holds the Component Templates settings (/_component_template)
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        composableIndexTemplates:
+                          description: ComposableIndexTemplates holds the Index Templates settings (/_index_template)
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    ingestPipelines:
+                      description: IngestPipelines holds the Ingest Pipelines settings (/_ingest/pipeline)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    secretMounts:
+                      description: SecretMounts are additional Secrets that need to be mounted into the Elasticsearch pods.
                       items:
-                        description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                        description: SecretMount contains information about additional secrets to be mounted to the elasticsearch pods
                         properties:
-                          key:
-                            description: Key is the key contained in the secret.
+                          mountPath:
+                            description: MountPath denotes the path to which the secret should be mounted to inside the elasticsearch pod
                             type: string
-                          path:
-                            description: Path is the relative file path to map the key to. Path must not be an absolute file path and must not contain any ".." components.
+                          secretName:
+                            description: SecretName denotes the name of the secret that needs to be mounted to the elasticsearch pod
                             type: string
-                        required:
-                        - key
                         type: object
                       type: array
-                    secretName:
-                      description: SecretName is the name of the secret.
-                      type: string
-                  required:
-                  - secretName
+                      x-kubernetes-preserve-unknown-fields: true
+                    secureSettings:
+                      description: SecureSettings are additional Secrets that contain data to be configured to Elasticsearch's keystore.
+                      items:
+                        description: SecretSource defines a data source based on a Kubernetes Secret.
+                        properties:
+                          entries:
+                            description: |-
+                              Entries define how to project each key-value pair in the secret to filesystem paths.
+                              If not defined, all keys will be projected to similarly named paths in the filesystem.
+                              If defined, only the specified keys will be projected to the corresponding paths.
+                            items:
+                              description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                              properties:
+                                key:
+                                  description: Key is the key contained in the secret.
+                                  type: string
+                                path:
+                                  description: |-
+                                    Path is the relative file path to map the key to.
+                                    Path must not be an absolute file path and must not contain any ".." components.
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            type: array
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            type: string
+                        required:
+                          - secretName
+                        type: object
+                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
+                    securityRoleMappings:
+                      description: SecurityRoleMappings holds the Role Mappings settings (/_security/role_mapping)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    snapshotLifecyclePolicies:
+                      description: SnapshotLifecyclePolicies holds the Snapshot Lifecycle Policies settings (/_slm/policy)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    snapshotRepositories:
+                      description: SnapshotRepositories holds the Snapshot Repositories settings (/_snapshot)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
-                type: array
-            type: object
-          status:
-            properties:
-              errors:
-                description: Errors is the number of resources which have an incorrect configuration
-                type: integer
-              observedGeneration:
-                description: ObservedGeneration is the most recent generation observed for this StackConfigPolicy.
-                format: int64
-                type: integer
-              phase:
-                description: Phase is the phase of the StackConfigPolicy.
-                type: string
-              ready:
-                description: Ready is the number of resources successfully configured.
-                type: integer
-              readyCount:
-                description: ReadyCount is a human representation of the number of resources successfully configured.
-                type: string
-              resources:
-                description: Resources is the number of resources to be configured.
-                type: integer
-              resourcesStatuses:
-                additionalProperties:
-                  description: ResourcePolicyStatus models the status of the policy for one resource to be configured.
+                kibana:
                   properties:
-                    currentVersion:
-                      format: int64
-                      type: integer
-                    error:
+                    config:
+                      description: Config holds the settings that go into kibana.yml.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    secureSettings:
+                      description: SecureSettings are additional Secrets that contain data to be configured to Kibana's keystore.
+                      items:
+                        description: SecretSource defines a data source based on a Kubernetes Secret.
+                        properties:
+                          entries:
+                            description: |-
+                              Entries define how to project each key-value pair in the secret to filesystem paths.
+                              If not defined, all keys will be projected to similarly named paths in the filesystem.
+                              If defined, only the specified keys will be projected to the corresponding paths.
+                            items:
+                              description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                              properties:
+                                key:
+                                  description: Key is the key contained in the secret.
+                                  type: string
+                                path:
+                                  description: |-
+                                    Path is the relative file path to map the key to.
+                                    Path must not be an absolute file path and must not contain any ".." components.
+                                  type: string
+                              required:
+                                - key
+                              type: object
+                            type: array
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            type: string
+                        required:
+                          - secretName
+                        type: object
+                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                resourceSelector:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                secureSettings:
+                  description: 'Deprecated: SecureSettings only applies to Elasticsearch and is deprecated. It must be set per application instead.'
+                  items:
+                    description: SecretSource defines a data source based on a Kubernetes Secret.
+                    properties:
+                      entries:
+                        description: |-
+                          Entries define how to project each key-value pair in the secret to filesystem paths.
+                          If not defined, all keys will be projected to similarly named paths in the filesystem.
+                          If defined, only the specified keys will be projected to the corresponding paths.
+                        items:
+                          description: KeyToPath defines how to map a key in a Secret object to a filesystem path.
+                          properties:
+                            key:
+                              description: Key is the key contained in the secret.
+                              type: string
+                            path:
+                              description: |-
+                                Path is the relative file path to map the key to.
+                                Path must not be an absolute file path and must not contain any ".." components.
+                              type: string
+                          required:
+                            - key
+                          type: object
+                        type: array
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    required:
+                      - secretName
+                    type: object
+                  type: array
+              type: object
+            status:
+              properties:
+                details:
+                  additionalProperties:
+                    additionalProperties:
+                      description: ResourcePolicyStatus models the status of the policy for one resource to be configured.
                       properties:
-                        message:
-                          type: string
-                        version:
+                        currentVersion:
+                          description: |-
+                            CurrentVersion denotes the current version of filesettings applied to the Elasticsearch cluster
+                            This field does not apply to Kibana resources
                           format: int64
                           type: integer
+                        error:
+                          properties:
+                            message:
+                              type: string
+                            version:
+                              format: int64
+                              type: integer
+                          type: object
+                        expectedVersion:
+                          description: |-
+                            ExpectedVersion denotes the expected version of filesettings that should be applied to the Elasticsearch cluster
+                            This field does not apply to Kibana resources
+                          format: int64
+                          type: integer
+                        phase:
+                          type: string
                       type: object
-                    expectedVersion:
-                      format: int64
-                      type: integer
-                    phase:
-                      type: string
+                    type: object
+                  description: Details holds the status details for each resource to be configured.
                   type: object
-                description: ResourcesStatuses holds the status for each resource to be configured.
-                type: object
-            required:
-            - resourcesStatuses
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                errors:
+                  description: Errors is the number of resources which have an incorrect configuration
+                  type: integer
+                observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed for this StackConfigPolicy.
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase is the phase of the StackConfigPolicy.
+                  type: string
+                ready:
+                  description: Ready is the number of resources successfully configured.
+                  type: integer
+                readyCount:
+                  description: ReadyCount is a human representation of the number of resources successfully configured.
+                  type: string
+                resources:
+                  description: Resources is the number of resources to be configured.
+                  type: integer
+                resourcesStatuses:
+                  additionalProperties:
+                    description: ResourcePolicyStatus models the status of the policy for one resource to be configured.
+                    properties:
+                      currentVersion:
+                        description: |-
+                          CurrentVersion denotes the current version of filesettings applied to the Elasticsearch cluster
+                          This field does not apply to Kibana resources
+                        format: int64
+                        type: integer
+                      error:
+                        properties:
+                          message:
+                            type: string
+                          version:
+                            format: int64
+                            type: integer
+                        type: object
+                      expectedVersion:
+                        description: |-
+                          ExpectedVersion denotes the expected version of filesettings that should be applied to the Elasticsearch cluster
+                          This field does not apply to Kibana resources
+                        format: int64
+                        type: integer
+                      phase:
+                        type: string
+                    type: object
+                  description: |-
+                    ResourcesStatuses holds the status for each resource to be configured.
+                    Deprecated: Details is used to store the status of resources from ECK 2.11
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgpconfigurations.yaml
@@ -105,8 +105,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
@@ -102,8 +102,14 @@ spec:
                           a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        default: ""
+                        description: 'Name of the referent. This field is effectively
+                          required, but due to backwards compatibility is allowed
+                          to be empty. Instances of this type with an empty value
+                          here are almost certainly wrong. TODO: Add other useful
+                          fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Drop `kubebuilder:default` when controller-gen doesn''t
+                          need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                         type: string
                       optional:
                         description: Specify whether the Secret or its key must be

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalthreatfeeds.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalthreatfeeds.yaml
@@ -116,10 +116,16 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
+                                      default: ""
+                                      description: 'Name of the referent. This field
+                                        is effectively required, but due to backwards
+                                        compatibility is allowed to be empty. Instances
+                                        of this type with an empty value here are
+                                        almost certainly wrong. TODO: Add other useful
+                                        fields. apiVersion, kind, uid? More info:
                                         https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                        TODO: Drop `kubebuilder:default` when controller-gen
+                                        doesn''t need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -137,10 +143,16 @@ spec:
                                         from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
+                                      default: ""
+                                      description: 'Name of the referent. This field
+                                        is effectively required, but due to backwards
+                                        compatibility is allowed to be empty. Instances
+                                        of this type with an empty value here are
+                                        almost certainly wrong. TODO: Add other useful
+                                        fields. apiVersion, kind, uid? More info:
                                         https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                        TODO: Drop `kubebuilder:default` when controller-gen
+                                        doesn''t need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its

--- a/pkg/crds/enterprise/crd.projectcalico.org_securityeventwebhooks.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_securityeventwebhooks.yaml
@@ -50,8 +50,14 @@ spec:
                               description: The key to select.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              default: ""
+                              description: 'Name of the referent. This field is effectively
+                                required, but due to backwards compatibility is allowed
+                                to be empty. Instances of this type with an empty
+                                value here are almost certainly wrong. TODO: Add other
+                                useful fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen
+                                doesn''t need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -68,8 +74,14 @@ spec:
                                 be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              default: ""
+                              description: 'Name of the referent. This field is effectively
+                                required, but due to backwards compatibility is allowed
+                                to be empty. Instances of this type with an empty
+                                value here are almost certainly wrong. TODO: Add other
+                                useful fields. apiVersion, kind, uid? More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen
+                                doesn''t need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must

--- a/pkg/crds/enterprise/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
@@ -85,6 +85,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     to:
                       description: to is a list of destinations for outgoing traffic
                         of pods selected for this rule. Items in this list are combined
@@ -114,6 +115,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - cidr
                             type: object
@@ -154,11 +156,13 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   required:
                                   - key
                                   - operator
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
@@ -205,11 +209,13 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   required:
                                   - key
                                   - operator
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
@@ -222,6 +228,7 @@ spec:
                             type: object
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
                 type: array
               ingress:
@@ -267,6 +274,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - cidr
                             type: object
@@ -307,11 +315,13 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   required:
                                   - key
                                   - operator
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
@@ -358,11 +368,13 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   required:
                                   - key
                                   - operator
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
@@ -375,6 +387,7 @@ spec:
                             type: object
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     ports:
                       description: ports is a list of ports which should be made accessible
                         on the pods selected for this rule. Each item in this list
@@ -413,6 +426,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
                 type: array
               podSelector:
@@ -449,11 +463,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string


### PR DESCRIPTION
Update libcalico-go version to the branch, rather than the last released tag

As a consequence of fixing libcalico-go being pinned to the latest tag, we do not update CRD changes between that tag and the branch, which is problematic for the new feature where the operator deploys CRDs itself. ECK therefore, was still pinned to ECK 2.6.1, whereas we are currently deploying v2.16.0, due to CVE fixes, etc.
