### PR TITLE
EV-5564 Remove unnecessary volume override

### DIFF
--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -241,15 +241,7 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 	var initContainers []corev1.Container
 	var volumes []corev1.Volume
 	var automountToken bool
-	volumeMounts := []corev1.VolumeMount{
-		{
-			// We need to override this mount and change the mountPath. Otherwise, ECK will mount an emptyDir in the
-			// original location (/usr/share/kibana/plugins), which would remove our custom theme resulting in
-			// crash-looping pods, because our custom config is unexpected.
-			Name:      "kibana-plugins",
-			MountPath: "/mnt/dummy-location/",
-		},
-	}
+	var volumeMounts []corev1.VolumeMount
 	if k.cfg.Installation.CertificateManagement != nil {
 		config["elasticsearch.ssl.certificateAuthorities"] = []string{"/mnt/elastic-internal/http-certs/ca.crt"}
 		automountToken = true

--- a/pkg/render/logstorage/kibana/kibana_test.go
+++ b/pkg/render/logstorage/kibana/kibana_test.go
@@ -131,10 +131,6 @@ var _ = Describe("Kibana rendering tests", func() {
 					Drop: []corev1.Capability{"ALL"},
 				},
 			))
-			Expect(kibanaCR.Spec.PodTemplate.Spec.Containers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{
-				Name:      "kibana-plugins",
-				MountPath: "/mnt/dummy-location/",
-			}))
 
 			Expect(kibanaCR.Spec.PodTemplate.Spec.Containers[0].SecurityContext.SeccompProfile).To(Equal(
 				&corev1.SeccompProfile{


### PR DESCRIPTION
Reverts #3692 . Looks like ECK is not rendering this extra plugins container on kbv7 and it was mistakenly picked.