### PR TITLE
[release-v1.37] Auto pick #3713: Fix TLSTerminatedRoute ForwardingMTLS secret mount path

### DIFF
--- a/pkg/render/manager/manager_route_config.go
+++ b/pkg/render/manager/manager_route_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -446,7 +446,7 @@ func (builder *voltronRouteConfigBuilder) mountSecretReference(name, key string)
 		builder.mountedSecrets[name] = struct{}{}
 	}
 
-	return fmt.Sprintf("%s/%s/%s", configMapFolder, name, key), nil
+	return fmt.Sprintf("%s/%s/%s", secretsFolder, name, key), nil
 }
 
 // VoltronRouteConfig contains everything needed to configure the voltron pod / container with routes via a mounted file.

--- a/pkg/render/manager/manager_route_config_test.go
+++ b/pkg/render/manager/manager_route_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -248,7 +248,7 @@ var _ = Describe("VoltronRouteConfigBuilder", func() {
 					"hash.operator.tigera.io/routeconf-s-verylongnametoforceconfli10": "b64f683d0e588b7b03b62f62460efd553df9491e",
 					"hash.operator.tigera.io/routeconf-s-verylongnametoforceconfli11": "b64f683d0e588b7b03b62f62460efd553df9491e",
 					"hash.operator.tigera.io/routeconf-cm-ca-bundle-bundle":           "ed2e97c745074a9d7ed51a99ea4dfb8b337a3109",
-					"hash.operator.tigera.io/routeconf-cm-voltron-routes-uitlstermro": "b23457c4614fa00a609dc47aaa630bb8ea54b078",
+					"hash.operator.tigera.io/routeconf-cm-voltron-routes-uitlstermro": "05f3ffd328b6f86f89a9fb6814b6d2a8d8b12299",
 				}))
 			})
 		})
@@ -343,7 +343,7 @@ var _ = Describe("VoltronRouteConfigBuilder", func() {
 					"hash.operator.tigera.io/routeconf-cm-ca-bundle-bundle":  "ed2e97c745074a9d7ed51a99ea4dfb8b337a3109",
 					"hash.operator.tigera.io/routeconf-s-mtls-cert-cert.pem": "e50bc7ce05be499174194858aaf077b556de4d4a",
 					"hash.operator.tigera.io/routeconf-s-mtls-key-key.pem":   "6b519c7eea53167b5fe03c86b7650ada4e7a4784",
-					routeCMKey: "907bc0d66a81235ae423c36bda0ed50fa73f7f51",
+					routeCMKey: "89372dff23323c2dc393016ffa370df893ec0dd7",
 				}))
 				Expect(config.VolumeMounts()).Should(Equal([]corev1.VolumeMount{caBundleVolumeMount, routesConfigMapVolumeMount, mtlsCertVolumeMount, mtlsKeyVolumeMount}))
 
@@ -352,7 +352,7 @@ var _ = Describe("VoltronRouteConfigBuilder", func() {
 				cm := config.RoutesConfigMap("tigera-manager")
 				cm.Data[fileName] = compactJSONString(cm.Data[fileName])
 
-				routesConfigMap.Data[fileName] = `[{"destination":"","path":"/foobar","caBundlePath":"/config_maps/ca-bundle/ca.bundle","pathRegexp":"^/foobar$","pathReplace":"/","clientCertPath":"/config_maps/mtls-cert/cert.pem","clientKeyPath":"/config_maps/mtls-key/key.pem"}]`
+				routesConfigMap.Data[fileName] = `[{"destination":"","path":"/foobar","caBundlePath":"/config_maps/ca-bundle/ca.bundle","pathRegexp":"^/foobar$","pathReplace":"/","clientCertPath":"/secrets/mtls-cert/cert.pem","clientKeyPath":"/secrets/mtls-key/key.pem"}]`
 				Expect(cm).Should(Equal(routesConfigMap))
 			},
 				Entry("UI target", operatorv1.TargetTypeUI, "uiTLSTermRoutes.json", "hash.operator.tigera.io/routeconf-cm-voltron-routes-uitlstermro"),


### PR DESCRIPTION
Cherry pick of #3713 on release-v1.37.

#3713: Fix TLSTerminatedRoute ForwardingMTLS secret mount path

# Original PR Body below

## Description

This PR fixes the `TLSTerminatedRoute.mtlsCert` configuration mount path for `tigera-voltron`.

**How to reproduce**: Configure the `mtlsCert` in a `TLSTerminatedRoute` CR with a valid secret certificate and key.
**Current result**: The `tigera-voltron` pod enters `CrashLoopBackOff` state with an error message indicating it is unable to find the configured `mtlsCert` certificate.
**Expected result**: The `tigera-voltron` pod should be healthy.

### Background

Setting the `mtlsCert` fields in a `TLSTerminatedRoute` CR results in VolumeMount MountPaths set under the `/secrets` directory, while the `clientCertPath` and `clientKeyPath` values in `uiTLSTermRoutes.json` are defined under the `/config_maps/` path, which causes `tigera-voltron` pod to error (and enter `CrashLoopBackOff` status eventually) since it is unable to find the client certificate and key files.

#### Error example
```
tigera-manager-bc7578c85-fv4fg tigera-voltron 2025-01-16 13:53:49.547 [FATAL][1] voltron/main.go 405: Failed to create a default k8s proxy. error=error load cert key pair for linseed client: open /config_maps/my-secret/tls.crt: no such file or directory
```
### Fix
- Change the `clientCertPath` and `clientKeyPath` values to follow MountPaths set under the `/secrets` directory.

### Tests
Tested manually with the following steps:
- Configured the `mtlsCert` fields in a `TLSTerminatedRoute` CR with a valid secret on a cluster
  - `tigera-voltron` enters `CrashLoopBackOff` status
- Built a custom operator image with the fix from this PR
- Deployed the custom operator image on the cluster
  - The `tigera-voltron` pod was healthy

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.