### PR TITLE
Use our own build of the Envoy proxy image

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -158,9 +158,8 @@ components:
     image: tigera/envoy-gateway
     version: release-calient-v3.21-1
   gateway-api-envoy-proxy:
-    image: envoyproxy/envoy
-    version: distroless-v1.31.0
-    registry: docker.io/
+    image: tigera/envoy-proxy
+    version: release-calient-v3.21-1
   gateway-api-envoy-ratelimit:
     image: tigera/envoy-ratelimit
     version: release-calient-v3.21-1

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -316,9 +316,9 @@ var (
 	}
 
 	ComponentGatewayAPIEnvoyProxy = Component{
-		Version:  "distroless-v1.31.0",
-		Image:    "envoyproxy/envoy",
-		Registry: "docker.io/",
+		Version:  "release-calient-v3.21-1",
+		Image:    "tigera/envoy-proxy",
+		Registry: "",
 	}
 
 	ComponentGatewayAPIEnvoyRatelimit = Component{

--- a/pkg/render/gateway_api_test.go
+++ b/pkg/render/gateway_api_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Gateway API rendering tests", func() {
 		Expect(gatewayComp.ResolveImages(nil)).NotTo(HaveOccurred())
 		Expect(gatewayComp.(*gatewayAPIImplementationComponent).envoyGatewayImage).To(Equal("myregistry.io/tigera/envoy-gateway:" + components.ComponentGatewayAPIEnvoyGateway.Version))
 		Expect(gatewayComp.(*gatewayAPIImplementationComponent).envoyRatelimitImage).To(Equal("myregistry.io/tigera/envoy-ratelimit:" + components.ComponentGatewayAPIEnvoyRatelimit.Version))
-		Expect(gatewayComp.(*gatewayAPIImplementationComponent).envoyProxyImage).To(Equal("myregistry.io/envoyproxy/envoy:distroless-v1.31.0"))
+		Expect(gatewayComp.(*gatewayAPIImplementationComponent).envoyProxyImage).To(Equal("myregistry.io/tigera/envoy-proxy:" + components.ComponentGatewayAPIEnvoyProxy.Version))
 
 		objsToCreate, objsToDelete := gatewayComp.Objects()
 		Expect(objsToDelete).To(HaveLen(0))
@@ -297,7 +297,7 @@ var _ = Describe("Gateway API rendering tests", func() {
 
 		proxy, err := rtest.GetResourceOfType[*envoyapi.EnvoyProxy](objsToCreate, "envoy-proxy-config", "tigera-gateway")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(*proxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.Image).To(Equal("myregistry.io/envoyproxy/envoy:distroless-v1.31.0"))
+		Expect(*proxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.Image).To(Equal("myregistry.io/tigera/envoy-proxy:" + components.ComponentGatewayAPIEnvoyProxy.Version))
 		Expect(proxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.ImagePullSecrets).To(ContainElement(pullSecretRefs[0]))
 
 		gatewayCM, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, "envoy-gateway-config", "tigera-gateway")


### PR DESCRIPTION
(cherry-pick of https://github.com/tigera/operator/pull/3725 for the 3.21 branch)