### PR TITLE
Improve certificate management

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -468,9 +468,31 @@ func (cm *certificateManager) getKeyPair(cli client.Client, secretName, secretNa
 		}
 
 		if timeInvalid {
-			return nil, nil, fmt.Errorf("secret %s/%s is not valid at this date", secretNamespace, secretName)
+			if readCertOnly {
+				cm.log.Info("secret %s/%s is not valid at this date, so we return nil and continue as though it does not exist", secretNamespace, secretName)
+				return nil, nil, nil
+			}
+			return nil, nil, fmt.Errorf("secret %s/%s is not valid at this date for a certificate not created by the operator, user action required", secretNamespace, secretName)
 		}
 		return nil, nil, newCertExtKeyUsageError(secretName, secretNamespace, requiredKeyUsages)
+	}
+
+	if !readCertOnly && x509Cert.NotAfter.Before(time.Now().Add(30*24*time.Hour)) {
+		// The certificate is not valid one month from now. Let's start the rotation process, so there will be plenty of time
+		// to roll out the changes without disruption. All components that need to trust this certificate are already
+		// trusting the issuer, so there will be no disruption.
+		if !strings.HasPrefix(x509Cert.Issuer.CommonName, rmeta.TigeraOperatorCAIssuerPrefix) {
+			cm.log.Info("this certificate will soon expire and is not managed by the operator, user action required", "name", secretName)
+		} else {
+			if cm.keyPair.CertificateManagement != nil {
+				// When certificate management is enabled, we can simply return a certificate management key pair;
+				// the old secret will be deleted automatically.
+				return certificateManagementKeyPair(cm, secretName, secretNamespace, dnsNames), nil, nil
+			}
+			cm.log.Info("this certificate will soon expire, so we rotate it now", "name", secretName)
+			// By returning nil, the controller will issue a new certificate.
+			return nil, nil, nil
+		}
 	}
 
 	var issuer certificatemanagement.KeyPairInterface

--- a/pkg/controller/certificatemanager/certificatemanager_suite_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Rotate certificates 1 month before expiry (if issued by operator) to minimize potential for down time. (Currently certificates are valid for 825 days.)
- If a certificate is expired, a controller that is fetching a cert for the purpose of adding it to a trusted bundle will skip it. This is similar to the behaviour if a certificate does not exist at all.
- If a certificate is expired, a controller that is responsible for creating it will replace it. (This is already the current behaviour, just mentioning it here for completeness.)
- Improve the test suite, such that cert creation for some certs is done once, and not BeforeEach, cutting down run time of the suite from 40s -> 10s.