### PR TITLE
[RS-2325] Add rbac for waf api

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1655,9 +1655,10 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 		},
 		// Access for WAF API to read in coreruleset configmap
 		{
-			APIGroups: []string{""},
-			Resources: []string{"configmaps"},
-			Verbs:     []string{"get"},
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{"coreruleset-default"},
+			Verbs:         []string{"get"},
 		},
 		// Access to statistics.
 		{
@@ -1851,9 +1852,10 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 		},
 		// Access for WAF API to read in coreruleset configmap
 		{
-			APIGroups: []string{""},
-			Resources: []string{"configmaps"},
-			Verbs:     []string{"get"},
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{"coreruleset-default"},
+			Verbs:         []string{"get"},
 		},
 		// Access to statistics.
 		{

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1653,6 +1653,12 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Resources: []string{"serviceaccounts"},
 			Verbs:     []string{"list"},
 		},
+		// Access for WAF API to read in coreruleset configmap
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get"},
+		},
 		// Access to statistics.
 		{
 			APIGroups: []string{""},
@@ -1842,6 +1848,12 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{""},
 			Resources: []string{"serviceaccounts"},
 			Verbs:     []string{"list"},
+		},
+		// Access for WAF API to read in coreruleset configmap
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get"},
 		},
 		// Access to statistics.
 		{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1371,6 +1371,11 @@ var (
 		},
 		{
 			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{""},
 			Resources: []string{"services/proxy"},
 			ResourceNames: []string{
 				"https:tigera-api:8080", "calico-node-prometheus:9090",
@@ -1517,6 +1522,11 @@ var (
 			APIGroups: []string{""},
 			Resources: []string{"serviceaccounts"},
 			Verbs:     []string{"list"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get"},
 		},
 		{
 			APIGroups: []string{""},

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1370,9 +1370,10 @@ var (
 			Verbs:     []string{"list"},
 		},
 		{
-			APIGroups: []string{""},
-			Resources: []string{"configmaps"},
-			Verbs:     []string{"get"},
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{"coreruleset-default"},
+			Verbs:         []string{"get"},
 		},
 		{
 			APIGroups: []string{""},
@@ -1524,9 +1525,10 @@ var (
 			Verbs:     []string{"list"},
 		},
 		{
-			APIGroups: []string{""},
-			Resources: []string{"configmaps"},
-			Verbs:     []string{"get"},
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{"coreruleset-default"},
+			Verbs:         []string{"get"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
## Description

Add RBAC to get configmap resource for the new WAF API to be able to get the configmap containing the coreruleset used by WAF. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
