### PR TITLE
[Cherry pick 1.34] Allow kube-controllers to read its own configuration

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -369,7 +369,7 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration, kubeContr
 			// as well.
 			APIGroups: []string{"crd.projectcalico.org"},
 			Resources: []string{"kubecontrollersconfigurations"},
-			Verbs:     []string{"get", "create", "update", "watch"},
+			Verbs:     []string{"get", "create", "list", "update", "watch"},
 		},
 	}
 


### PR DESCRIPTION
Previously we had optimisations in libcalico-go that translated a list of one item into a get.  But that wasn't sound and was removed in #8469.  So there can be places where we were previously OK with a "get" permission but now need "list" as well.

Specifically in the latest 3.21 hashrelease ("snowdrift"), we see:

    2025-01-15 16:51:10.404 [WARNING][13] kube-controllers/runconfig.go 219: unable to list KubeControllersConfiguration(default) error=connection is unauthorized: kubecontrollersconfigurations.crd.projectcalico.org "default" is forbidden: User "system:serviceaccount:calico-system:calico-kube-controllers" cannot list resource "kubecontrollersconfigurations" in API group "crd.projectcalico.org" at the cluster scope
