### PR TITLE
[RS-2297] Run `dashboard-installer` on operator update

### DIFF
--- a/pkg/controller/logstorage/dashboards/dashboards_controller.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	// Check if something modifies resources this controller creates.
 	err = c.WatchObject(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
 		Namespace: helper.InstallNamespace(),
-		Name:      dashboards.Name,
+		Name:      dashboards.GetJobName(),
 	}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return fmt.Errorf("log-storage-dashboards-controller failed to watch installer job: %v", err)

--- a/pkg/controller/logstorage/dashboards/dashboards_controller_test.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ var _ = Describe("LogStorage Dashboards controller", func() {
 			dashboardJob := batchv1.Job{
 				TypeMeta: metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      dashboards.Name,
+					Name:      dashboards.GetJobName(),
 					Namespace: render.ElasticsearchNamespace,
 				},
 			}
@@ -231,7 +231,7 @@ var _ = Describe("LogStorage Dashboards controller", func() {
 			dashboardJob := batchv1.Job{
 				TypeMeta: metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      dashboards.Name,
+					Name:      dashboards.GetJobName(),
 					Namespace: render.ElasticsearchNamespace,
 				},
 			}
@@ -257,12 +257,12 @@ var _ = Describe("LogStorage Dashboards controller", func() {
 			dashboardJob := batchv1.Job{
 				TypeMeta: metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      dashboards.Name,
+					Name:      dashboards.GetJobName(),
 					Namespace: render.ElasticsearchNamespace,
 				},
 			}
 			Expect(test.GetResource(cli, &dashboardJob)).To(BeNil())
-			dashboardInstaller := test.GetContainer(dashboardJob.Spec.Template.Spec.Containers, dashboards.Name)
+			dashboardInstaller := test.GetContainer(dashboardJob.Spec.Template.Spec.Containers, dashboards.GetJobName())
 			Expect(dashboardInstaller).ToNot(BeNil())
 			Expect(dashboardInstaller.Image).To(Equal(fmt.Sprintf("some.registry.org/%s@%s", components.ComponentElasticTseeInstaller.Image, "sha256:dashboardhash")))
 		})

--- a/pkg/controller/logstorage/dashboards/dashboards_controller_test.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller_test.go
@@ -262,7 +262,7 @@ var _ = Describe("LogStorage Dashboards controller", func() {
 				},
 			}
 			Expect(test.GetResource(cli, &dashboardJob)).To(BeNil())
-			dashboardInstaller := test.GetContainer(dashboardJob.Spec.Template.Spec.Containers, dashboards.GetJobName())
+			dashboardInstaller := test.GetContainer(dashboardJob.Spec.Template.Spec.Containers, dashboards.Name)
 			Expect(dashboardInstaller).ToNot(BeNil())
 			Expect(dashboardInstaller.Image).To(Equal(fmt.Sprintf("some.registry.org/%s@%s", components.ComponentElasticTseeInstaller.Image, "sha256:dashboardhash")))
 		})

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -211,7 +211,7 @@ var KubeAPIServerServiceSelectorEntityRule = v3.EntityRule{
 // Helper creates a helper for building network policies for multi-tenant capable components.
 // It takes two arguments:
 // - mt: true if running in multi-tenant mode, false otherwise.
-// - ns: The tenant's namespce.
+// - ns: The tenant's namespace.
 func Helper(mt bool, ns string) *NetworkPolicyHelper {
 	return &NetworkPolicyHelper{
 		multiTenant: mt,

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -48,6 +48,7 @@ var (
 	ServiceAccountName       = "dashboards-installer"
 	ElasticCredentialsSecret = "tigera-ee-dashboards-installer-elasticsearch-user-secret"
 	PolicyName               = networkpolicy.TigeraComponentPolicyPrefix + GetJobName()
+	SelectorContainsName     = "dashboards-installer"
 )
 
 // GetJobName makes a unique job name per operator version.
@@ -182,7 +183,7 @@ func (d *dashboards) AllowTigeraPolicy() *v3.NetworkPolicy {
 		Spec: v3.NetworkPolicySpec{
 			Order:    &networkpolicy.HighPrecedenceOrder,
 			Tier:     networkpolicy.TigeraComponentTierName,
-			Selector: fmt.Sprintf("job-name == '%s'", GetJobName()),
+			Selector: fmt.Sprintf("job-name contains '%s'", SelectorContainsName),
 			Types:    []v3.PolicyType{v3.PolicyTypeEgress},
 			Egress:   egressRules,
 		},

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -45,7 +45,9 @@ import (
 )
 
 var (
-	Name                     = fmt.Sprintf("dashboards-installer-%s", strings.ReplaceAll(version.VERSION, ".", "-"))
+	// Take OperatorVersion up to max dev image length. In production "v1.36.2" is expected
+	OperatorVersion          = strings.ReplaceAll(version.VERSION, ".", "-")[:len("v1.36.0-1-dev-281-g9558bdac82b")]
+	Name                     = fmt.Sprintf("dashboards-installer-%s", OperatorVersion)
 	ServiceAccountName       = "dashboards-installer"
 	ElasticCredentialsSecret = "tigera-ee-dashboards-installer-elasticsearch-user-secret"
 	PolicyName               = networkpolicy.TigeraComponentPolicyPrefix + Name

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -45,10 +45,9 @@ import (
 )
 
 var (
-	ServiceAccountName       = "dashboards-installer"
+	Name                     = "dashboards-installer"
 	ElasticCredentialsSecret = "tigera-ee-dashboards-installer-elasticsearch-user-secret"
-	PolicyName               = networkpolicy.TigeraComponentPolicyPrefix + GetJobName()
-	SelectorContainsName     = "dashboards-installer"
+	PolicyName               = networkpolicy.TigeraComponentPolicyPrefix + Name
 )
 
 // GetJobName makes a unique job name per operator version.
@@ -183,7 +182,7 @@ func (d *dashboards) AllowTigeraPolicy() *v3.NetworkPolicy {
 		Spec: v3.NetworkPolicySpec{
 			Order:    &networkpolicy.HighPrecedenceOrder,
 			Tier:     networkpolicy.TigeraComponentTierName,
-			Selector: fmt.Sprintf("job-name contains '%s'", SelectorContainsName),
+			Selector: fmt.Sprintf("job-name contains '%s'", Name),
 			Types:    []v3.PolicyType{v3.PolicyTypeEgress},
 			Egress:   egressRules,
 		},
@@ -286,7 +285,7 @@ func (d *dashboards) Job() *batchv1.Job {
 			ImagePullSecrets: secret.GetReferenceList(d.cfg.PullSecrets),
 			Containers: []corev1.Container{
 				{
-					Name:            GetJobName(),
+					Name:            Name,
 					Image:           d.image,
 					ImagePullPolicy: render.ImagePullPolicy(),
 					Env:             envVars,
@@ -295,7 +294,7 @@ func (d *dashboards) Job() *batchv1.Job {
 				},
 			},
 			Volumes:            volumes,
-			ServiceAccountName: ServiceAccountName,
+			ServiceAccountName: Name,
 		},
 	}, d.cfg.Credentials).(*corev1.PodTemplateSpec)
 
@@ -343,7 +342,7 @@ func (d *dashboards) ServiceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetJobName(),
+			Name:      Name,
 			Namespace: d.cfg.Namespace,
 		},
 	}
@@ -353,7 +352,7 @@ func (d *dashboards) ClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: GetJobName(),
+			Name: Name,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -370,17 +369,17 @@ func (d *dashboards) ClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: GetJobName(),
+			Name: Name,
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     GetJobName(),
+			Name:     Name,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      GetJobName(),
+				Name:      Name,
 				Namespace: d.cfg.Namespace,
 			},
 		},

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,10 +41,12 @@ import (
 	"github.com/tigera/operator/pkg/render/logstorage"
 	"github.com/tigera/operator/pkg/render/logstorage/kibana"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+	"github.com/tigera/operator/version"
 )
 
 var (
-	Name                     = "dashboards-installer"
+	Name                     = fmt.Sprintf("dashboards-installer-%s", strings.ReplaceAll(version.VERSION, ".", "-"))
+	ServiceAccountName       = "dashboards-installer"
 	ElasticCredentialsSecret = "tigera-ee-dashboards-installer-elasticsearch-user-secret"
 	PolicyName               = networkpolicy.TigeraComponentPolicyPrefix + Name
 )
@@ -281,7 +283,7 @@ func (d *dashboards) Job() *batchv1.Job {
 				},
 			},
 			Volumes:            volumes,
-			ServiceAccountName: Name,
+			ServiceAccountName: ServiceAccountName,
 		},
 	}, d.cfg.Credentials).(*corev1.PodTemplateSpec)
 

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -68,10 +68,10 @@ var _ = Describe("Dashboards rendering tests", func() {
 
 		expectedResources := []resourceTestObj{
 			{PolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
-			{GetJobName(), render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
+			{Name, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
 			{GetJobName(), render.ElasticsearchNamespace, &batchv1.Job{}, nil},
-			{GetJobName(), "", &rbacv1.ClusterRole{}, nil},
-			{GetJobName(), "", &rbacv1.ClusterRoleBinding{}, nil},
+			{Name, "", &rbacv1.ClusterRole{}, nil},
+			{Name, "", &rbacv1.ClusterRoleBinding{}, nil},
 		}
 
 		BeforeEach(func() {
@@ -109,7 +109,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			Expect(component.ResolveImages(nil)).To(BeNil())
 			resources, _ := component.Objects()
 
-			role := rtest.GetResource(resources, "dashboards-installer", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			role := rtest.GetResource(resources, Name, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
@@ -289,9 +289,9 @@ var _ = Describe("Dashboards rendering tests", func() {
 			resources, _ := component.Objects()
 			job := rtest.GetResource(resources, GetJobName(), cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job).NotTo(BeNil())
-			sa := rtest.GetResource(resources, GetJobName(), cfg.Namespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
+			sa := rtest.GetResource(resources, Name, cfg.Namespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
 			Expect(sa).NotTo(BeNil())
-			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", GetJobName()), cfg.Namespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(resources, PolicyName, cfg.Namespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 		})
 
@@ -325,7 +325,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 					Template: &operatorv1.DashboardsJobPodTemplateSpec{
 						Spec: &operatorv1.DashboardsJobPodSpec{
 							Containers: []operatorv1.DashboardsJobContainer{{
-								Name:      GetJobName(),
+								Name:      Name,
 								Resources: &dashboardsJobResources,
 							}},
 						},
@@ -338,7 +338,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			resources, _ := component.Objects()
 			job := rtest.GetResource(resources, GetJobName(), cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
-			Expect(job.Spec.Template.Spec.Containers[0].Name).To(Equal(GetJobName()))
+			Expect(job.Spec.Template.Spec.Containers[0].Name).To(Equal(Name))
 			Expect(job.Spec.Template.Spec.Containers[0].Resources).To(Equal(dashboardsJobResources))
 		})
 
@@ -423,7 +423,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
 				Name: "KIBANA_MTLS_ENABLED", Value: "true",
 			}))
-			netPol := rtest.GetResource(createResources, fmt.Sprintf("allow-tigera.%s", GetJobName()), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(createResources, PolicyName, render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 			Expect(netPol.Spec.Egress).To(HaveLen(2))
 			Expect(netPol.Spec.Egress[1].Destination).To(Equal(v3.EntityRule{
@@ -438,9 +438,9 @@ var _ = Describe("Dashboards rendering tests", func() {
 			resources, _ := component.Objects()
 			job := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job).NotTo(BeNil())
-			sa := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
+			sa := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
 			Expect(sa).NotTo(BeNil())
-			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", GetJobName()), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(resources, PolicyName, render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 			Expect(netPol.Spec.Egress).To(HaveLen(2))
 			Expect(netPol.Spec.Egress[1].Destination).To(Equal(kibana.EntityRule))
@@ -501,9 +501,9 @@ var _ = Describe("Dashboards rendering tests", func() {
 			resources, _ := component.Objects()
 			job := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job).NotTo(BeNil())
-			sa := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
+			sa := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
 			Expect(sa).NotTo(BeNil())
-			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", GetJobName()), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(resources, PolicyName, render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 		})
 
@@ -578,12 +578,12 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 	ExpectWithOffset(1, job.Spec.Template.Annotations).To(HaveKeyWithValue("hash.operator.tigera.io/elasticsearch-secrets", Not(BeEmpty())))
 
 	// Check permissions
-	clusterRoleBinding := rtest.GetResource(resources, GetJobName(), "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-	Expect(clusterRoleBinding.RoleRef.Name).To(Equal(GetJobName()))
+	clusterRoleBinding := rtest.GetResource(resources, Name, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+	Expect(clusterRoleBinding.RoleRef.Name).To(Equal(Name))
 	Expect(clusterRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
-			Name:      ServiceAccountName,
+			Name:      Name,
 			Namespace: render.ElasticsearchNamespace,
 		},
 	}))
@@ -607,7 +607,7 @@ func expectedVolumes() []corev1.Volume {
 func expectedContainers() []corev1.Container {
 	return []corev1.Container{
 		{
-			Name:            GetJobName(),
+			Name:            Name,
 			ImagePullPolicy: render.ImagePullPolicy(),
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},

--- a/pkg/render/logstorage/dashboards/dashboards_test.go
+++ b/pkg/render/logstorage/dashboards/dashboards_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,10 +68,10 @@ var _ = Describe("Dashboards rendering tests", func() {
 
 		expectedResources := []resourceTestObj{
 			{PolicyName, render.ElasticsearchNamespace, &v3.NetworkPolicy{}, nil},
-			{Name, render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
-			{Name, render.ElasticsearchNamespace, &batchv1.Job{}, nil},
-			{Name, "", &rbacv1.ClusterRole{}, nil},
-			{Name, "", &rbacv1.ClusterRoleBinding{}, nil},
+			{GetJobName(), render.ElasticsearchNamespace, &corev1.ServiceAccount{}, nil},
+			{GetJobName(), render.ElasticsearchNamespace, &batchv1.Job{}, nil},
+			{GetJobName(), "", &rbacv1.ClusterRole{}, nil},
+			{GetJobName(), "", &rbacv1.ClusterRoleBinding{}, nil},
 		}
 
 		BeforeEach(func() {
@@ -124,7 +124,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 
 			resources, _ := component.Objects()
-			job, ok := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
+			job, ok := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
 			Expect(ok).To(BeTrue(), "Job not found")
 			Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"foo": "bar"}))
 		})
@@ -135,7 +135,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 
 			resources, _ := component.Objects()
-			job, ok := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
+			job, ok := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
 			Expect(ok).To(BeTrue(), "Job not found")
 			Expect(job.Spec.Template.Spec.Tolerations).To(ContainElement(corev1.Toleration{
 				Key:      "kubernetes.io/arch",
@@ -156,7 +156,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 
 			resources, _ := component.Objects()
-			job, ok := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
+			job, ok := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
 			Expect(ok).To(BeTrue(), "Job not found")
 			Expect(job.Spec.Template.Spec.Tolerations).To(ConsistOf(t))
 		})
@@ -252,7 +252,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			}
 			component := Dashboards(cfg)
 			createResources, _ := component.Objects()
-			d, ok := rtest.GetResource(createResources, Name, cfg.Namespace, "batch", "v1", "Job").(*batchv1.Job)
+			d, ok := rtest.GetResource(createResources, GetJobName(), cfg.Namespace, "batch", "v1", "Job").(*batchv1.Job)
 			Expect(ok).To(BeTrue(), "Job not found")
 
 			// The deployment should have the hash annotation set, as well as a volume and volume mount for the client secret.
@@ -287,11 +287,11 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			job := rtest.GetResource(resources, Name, cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
+			job := rtest.GetResource(resources, GetJobName(), cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job).NotTo(BeNil())
-			sa := rtest.GetResource(resources, Name, cfg.Namespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
+			sa := rtest.GetResource(resources, GetJobName(), cfg.Namespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
 			Expect(sa).NotTo(BeNil())
-			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", Name), cfg.Namespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", GetJobName()), cfg.Namespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 		})
 
@@ -299,7 +299,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			job := rtest.GetResource(resources, Name, cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
+			job := rtest.GetResource(resources, GetJobName(), cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			envs := job.Spec.Template.Spec.Containers[0].Env
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "KIBANA_SPACE_ID", Value: cfg.Tenant.Spec.ID}))
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "KIBANA_SCHEME", Value: "https"}))
@@ -325,7 +325,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 					Template: &operatorv1.DashboardsJobPodTemplateSpec{
 						Spec: &operatorv1.DashboardsJobPodSpec{
 							Containers: []operatorv1.DashboardsJobContainer{{
-								Name:      Name,
+								Name:      GetJobName(),
 								Resources: &dashboardsJobResources,
 							}},
 						},
@@ -336,9 +336,9 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 
 			resources, _ := component.Objects()
-			job := rtest.GetResource(resources, Name, cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
+			job := rtest.GetResource(resources, GetJobName(), cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
-			Expect(job.Spec.Template.Spec.Containers[0].Name).To(Equal(Name))
+			Expect(job.Spec.Template.Spec.Containers[0].Name).To(Equal(GetJobName()))
 			Expect(job.Spec.Template.Spec.Containers[0].Resources).To(Equal(dashboardsJobResources))
 		})
 
@@ -394,7 +394,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			}
 			component := Dashboards(cfg)
 			createResources, _ := component.Objects()
-			d, ok := rtest.GetResource(createResources, Name, render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
+			d, ok := rtest.GetResource(createResources, GetJobName(), render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
 			Expect(ok).To(BeTrue(), "Job not found")
 
 			// The deployment should have the hash annotation set, as well as a volume and volume mount for the client secret.
@@ -423,7 +423,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
 				Name: "KIBANA_MTLS_ENABLED", Value: "true",
 			}))
-			netPol := rtest.GetResource(createResources, fmt.Sprintf("allow-tigera.%s", Name), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(createResources, fmt.Sprintf("allow-tigera.%s", GetJobName()), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 			Expect(netPol.Spec.Egress).To(HaveLen(2))
 			Expect(netPol.Spec.Egress[1].Destination).To(Equal(v3.EntityRule{
@@ -436,11 +436,11 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			job := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
+			job := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job).NotTo(BeNil())
-			sa := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
+			sa := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
 			Expect(sa).NotTo(BeNil())
-			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", Name), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", GetJobName()), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 			Expect(netPol.Spec.Egress).To(HaveLen(2))
 			Expect(netPol.Spec.Egress[1].Destination).To(Equal(kibana.EntityRule))
@@ -450,7 +450,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			d := rtest.GetResource(resources, Name, cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
+			d := rtest.GetResource(resources, GetJobName(), cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			envs := d.Spec.Template.Spec.Containers[0].Env
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "KIBANA_SPACE_ID", Value: cfg.Tenant.Spec.ID}))
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "KIBANA_SCHEME", Value: "https"}))
@@ -499,11 +499,11 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			job := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
+			job := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			Expect(job).NotTo(BeNil())
-			sa := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
+			sa := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, corev1.GroupName, "v1", "ServiceAccount").(*corev1.ServiceAccount)
 			Expect(sa).NotTo(BeNil())
-			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", Name), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+			netPol := rtest.GetResource(resources, fmt.Sprintf("allow-tigera.%s", GetJobName()), render.ElasticsearchNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
 			Expect(netPol).NotTo(BeNil())
 		})
 
@@ -511,7 +511,7 @@ var _ = Describe("Dashboards rendering tests", func() {
 			component := Dashboards(cfg)
 			Expect(component).NotTo(BeNil())
 			resources, _ := component.Objects()
-			d := rtest.GetResource(resources, Name, cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
+			d := rtest.GetResource(resources, GetJobName(), cfg.Namespace, batchv1.GroupName, "v1", "Job").(*batchv1.Job)
 			envs := d.Spec.Template.Spec.Containers[0].Env
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "KIBANA_SPACE_ID", Value: cfg.Tenant.Spec.ID}))
 			Expect(envs).To(ContainElement(corev1.EnvVar{Name: "KIBANA_SCHEME", Value: "https"}))
@@ -551,7 +551,7 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 	}
 
 	// Check job
-	job := rtest.GetResource(resources, Name, render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
+	job := rtest.GetResource(resources, GetJobName(), render.ElasticsearchNamespace, "batch", "v1", "Job").(*batchv1.Job)
 	ExpectWithOffset(1, job).NotTo(BeNil())
 
 	// Check containers
@@ -578,12 +578,12 @@ func compareResources(resources []client.Object, expectedResources []resourceTes
 	ExpectWithOffset(1, job.Spec.Template.Annotations).To(HaveKeyWithValue("hash.operator.tigera.io/elasticsearch-secrets", Not(BeEmpty())))
 
 	// Check permissions
-	clusterRoleBinding := rtest.GetResource(resources, Name, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-	Expect(clusterRoleBinding.RoleRef.Name).To(Equal(Name))
+	clusterRoleBinding := rtest.GetResource(resources, GetJobName(), "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+	Expect(clusterRoleBinding.RoleRef.Name).To(Equal(GetJobName()))
 	Expect(clusterRoleBinding.Subjects).To(ConsistOf([]rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
-			Name:      Name,
+			Name:      ServiceAccountName,
 			Namespace: render.ElasticsearchNamespace,
 		},
 	}))
@@ -607,7 +607,7 @@ func expectedVolumes() []corev1.Volume {
 func expectedContainers() []corev1.Container {
 	return []corev1.Container{
 		{
-			Name:            Name,
+			Name:            GetJobName(),
 			ImagePullPolicy: render.ImagePullPolicy(),
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},

--- a/pkg/render/testutils/expected_policies/dashboards.json
+++ b/pkg/render/testutils/expected_policies/dashboards.json
@@ -8,7 +8,7 @@
   "spec": {
     "order": 1,
     "tier": "allow-tigera",
-    "selector": "job-name == 'dashboards-installer'",
+    "selector": "job-name contains 'dashboards-installer'",
     "types": [
       "Egress"
     ],

--- a/pkg/render/testutils/expected_policies/dashboards_ocp.json
+++ b/pkg/render/testutils/expected_policies/dashboards_ocp.json
@@ -8,7 +8,7 @@
   "spec": {
     "order": 1,
     "tier": "allow-tigera",
-    "selector": "job-name == 'dashboards-installer'",
+    "selector": "job-name contains 'dashboards-installer'",
     "types": [
       "Egress"
     ],


### PR DESCRIPTION
## Description

https://tigera.atlassian.net/browse/RS-2297 - Honeypods dashboard remains in Kibana on upgrade from `v3.19`

* Make the operator generate a new job name per operator version. This will ensure a new `dashboard-installer` Job runs so that new Kibana dashboards are installed and deprecated ones are removed. Works in combination with https://github.com/tigera/calico-private/pull/8613

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
