### PR TITLE
[RS-2297]  Recreate dashboard-installer job on image mismatch

### DIFF
--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -446,9 +446,10 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 		cj := current.(*batchv1.Job)
 		dj := desired.(*batchv1.Job)
 
-		// We're only comparing jobs based off of annotations for now so we can send a signal to recreate a job. Later
-		// we might want to have some better comparison of jobs so that a changed in the container spec would trigger
-		// a recreation of the job
+		if cj.Spec.Template.Spec.Containers[0].Image != dj.Spec.Template.Spec.Containers[0].Image {
+			return dj
+		}
+
 		if reflect.DeepEqual(cj.Spec.Template.Annotations, dj.Spec.Template.Annotations) {
 			return nil
 		}

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -446,8 +446,14 @@ func mergeState(desired client.Object, current runtime.Object) client.Object {
 		cj := current.(*batchv1.Job)
 		dj := desired.(*batchv1.Job)
 
-		if cj.Spec.Template.Spec.Containers[0].Image != dj.Spec.Template.Spec.Containers[0].Image {
+		if len(cj.Spec.Template.Spec.Containers) != len(dj.Spec.Template.Spec.Containers) {
 			return dj
+		}
+
+		for i := range cj.Spec.Template.Spec.Containers {
+			if cj.Spec.Template.Spec.Containers[i].Image != dj.Spec.Template.Spec.Containers[i].Image {
+				return dj
+			}
 		}
 
 		if reflect.DeepEqual(cj.Spec.Template.Annotations, dj.Spec.Template.Annotations) {


### PR DESCRIPTION
## Description

https://tigera.atlassian.net/browse/RS-2297 - Honeypods dashboard remains in Kibana on upgrade from v3.19

* The operator needs to delete and recreate the `dashboard-installer` resource with an updated image to ensure the installer runs on cluster upgrade

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
