### PR TITLE
[EV-5614] Add CLUSTER_CONN_TYPE to Policy Recommendation deployment

### DIFF
--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in policy recommendation with the License.
@@ -445,6 +445,7 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 		ClusterDomain:                  r.clusterDomain,
 		Installation:                   installation,
 		ManagedCluster:                 isManagedCluster,
+		ManagementCluster:              managementCluster != nil,
 		PullSecrets:                    pullSecrets,
 		OpenShift:                      r.provider.IsOpenShift(),
 		Namespace:                      helper.InstallNamespace(),

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ type PolicyRecommendationConfiguration struct {
 	ClusterDomain                  string
 	Installation                   *operatorv1.InstallationSpec
 	ManagedCluster                 bool
+	ManagementCluster              bool
 	OpenShift                      bool
 	PullSecrets                    []*corev1.Secret
 	TrustedBundle                  certificatemanagement.TrustedBundleRO
@@ -310,6 +311,12 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 		if pr.cfg.Tenant.MultiTenant() {
 			envs = append(envs, corev1.EnvVar{Name: "TENANT_NAMESPACE", Value: pr.cfg.Tenant.Namespace})
 		}
+	}
+
+	if pr.cfg.ManagementCluster {
+		envs = append(envs, corev1.EnvVar{Name: "CLUSTER_CONNECTION_TYPE", Value: "management"})
+	} else {
+		envs = append(envs, corev1.EnvVar{Name: "CLUSTER_CONNECTION_TYPE", Value: "standalone"})
 	}
 
 	volumeMounts := pr.cfg.TrustedBundle.VolumeMounts(pr.SupportedOSType())

--- a/pkg/render/policyrecommendation_test.go
+++ b/pkg/render/policyrecommendation_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -344,6 +344,32 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 		Expect(idc.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 		Expect(idc.Spec.Template.Spec.InitContainers[0].Name).To(Equal("policy-recommendation-tls-key-cert-provisioner"))
 		Expect(idc.Spec.Template.Spec.InitContainers[0].Resources).To(Equal(prResources))
+	})
+
+	It("should render a depoloyment with the expected cluster connection type for a stadalone cluster", func() {
+		// Test for cluster connection type
+		cfg.ManagedCluster = false
+		cfg.ManagementCluster = false
+		component := render.PolicyRecommendation(cfg)
+
+		resources, _ := component.Objects()
+		deployment := rtest.GetResource(resources, "tigera-policy-recommendation", render.PolicyRecommendationNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deployment).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "CLUSTER_CONNECTION_TYPE", Value: "standalone"}))
+	})
+
+	It("should render a depoloyment with the expected cluster connection type for a management cluster", func() {
+		// Test for cluster connection type
+		cfg.ManagedCluster = false
+		cfg.ManagementCluster = true
+		component := render.PolicyRecommendation(cfg)
+
+		resources, _ := component.Objects()
+		deployment := rtest.GetResource(resources, "tigera-policy-recommendation", render.PolicyRecommendationNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deployment).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "CLUSTER_CONNECTION_TYPE", Value: "management"}))
 	})
 
 	Context("allow-tigera rendering", func() {


### PR DESCRIPTION
## Description

* Adds the CLUSTER_CONN_TYPE to Policy Recommendation deployment.
  * The type is either "standalone" or "management"
  * The configuration variable is used in Policy Recommendation to determine if the managed cluster watcher should be started.

See: [EV-5614]: https://github.com/tigera/calico-private/pull/8668

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.


[EV-5614]: https://tigera.atlassian.net/browse/EV-5614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ