### PR TITLE
Don't create resources in terminating Namespaces

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1355,7 +1355,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 		if len(needsCleanup) > 0 {
 			// Add a component to remove the finalizers from the objects that need it.
-			reqLogger.Info("Removing finalizers from objects that are wronly marked for deletion")
+			reqLogger.Info("Removing finalizers from objects that are wrongly marked for deletion")
 			components = append(components, render.NewPassthrough(needsCleanup...))
 		}
 	}

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -132,12 +132,32 @@ func (c *componentHandler) createOrUpdateObject(ctx context.Context, obj client.
 		logCtx.V(2).Info("Failed converting object", "obj", obj)
 		return fmt.Errorf("failed converting object %+v", obj)
 	}
-	// Check to see if the object exists or not.
+	// Check to see if the object's Namespace exists, and whether the Namespace
+	// is currently terminating. We cannot create objects in a terminating Namespace.
+	namespaceTerminating := false
+	if ns := cur.GetNamespace(); ns != "" {
+		nsKey := client.ObjectKey{Name: ns}
+		namespace, err := GetIfExists[v1.Namespace](ctx, nsKey, c.client)
+		if err != nil {
+			logCtx.WithValues("key", nsKey).Error(err, "Failed to get Namespace.")
+			return err
+		}
+		if namespace != nil {
+			namespaceTerminating = namespace.GetDeletionTimestamp() != nil
+		}
+	}
+
+	// Check to see if the object exists or not - this determines whether we should create or update.
 	err := c.client.Get(ctx, key, cur)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			// Anything other than "Not found" we should retry.
 			return err
+		}
+
+		if namespaceTerminating {
+			logCtx.Info("Object's Namespace is terminating, skipping creation.")
+			return nil
 		}
 
 		// Otherwise, if it was not found, we should create it and move on.

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -58,7 +58,6 @@ const (
 )
 
 var _ = Describe("Component handler tests", func() {
-
 	var (
 		c        client.Client
 		instance *operatorv1.Manager
@@ -543,7 +542,6 @@ var _ = Describe("Component handler tests", func() {
 		default:
 			Expect(true).To(Equal(false), "Unexpected kind in test")
 		}
-
 	},
 		TableEntry{
 			Description: "set ImagePullPolicy on a DaemonSet",
@@ -635,7 +633,9 @@ var _ = Describe("Component handler tests", func() {
 							},
 						},
 					}},
-				}, client.ObjectKey{Name: "test-podtemplate"}, &corev1.PodTemplate{},
+				},
+				client.ObjectKey{Name: "test-podtemplate"},
+				&corev1.PodTemplate{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -654,7 +654,9 @@ var _ = Describe("Component handler tests", func() {
 							},
 						},
 					}},
-				}, client.ObjectKey{Name: "test-podtemplate"}, &corev1.PodTemplate{},
+				},
+				client.ObjectKey{Name: "test-podtemplate"},
+				&corev1.PodTemplate{},
 				map[string]string{
 					"kubernetes.io/os": "windows",
 				},
@@ -665,17 +667,21 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeLinux,
-					objs: []client.Object{&apps.Deployment{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
-						Spec: apps.DeploymentSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&apps.Deployment{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+							Spec: apps.DeploymentSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										NodeSelector: map[string]string{},
+									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				},
+				client.ObjectKey{Name: "test-deployment"},
+				&apps.Deployment{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -686,17 +692,21 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeWindows,
-					objs: []client.Object{&apps.Deployment{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
-						Spec: apps.DeploymentSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&apps.Deployment{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+							Spec: apps.DeploymentSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										NodeSelector: map[string]string{},
+									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				},
+				client.ObjectKey{Name: "test-deployment"},
+				&apps.Deployment{},
 				map[string]string{
 					"kubernetes.io/os": "windows",
 				},
@@ -707,17 +717,21 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeLinux,
-					objs: []client.Object{&apps.DaemonSet{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset"},
-						Spec: apps.DaemonSetSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&apps.DaemonSet{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset"},
+							Spec: apps.DaemonSetSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										NodeSelector: map[string]string{},
+									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-daemonset"}, &apps.DaemonSet{},
+				},
+				client.ObjectKey{Name: "test-daemonset"},
+				&apps.DaemonSet{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -728,17 +742,21 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeWindows,
-					objs: []client.Object{&apps.DaemonSet{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset"},
-						Spec: apps.DaemonSetSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&apps.DaemonSet{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-daemonset"},
+							Spec: apps.DaemonSetSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										NodeSelector: map[string]string{},
+									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-daemonset"}, &apps.DaemonSet{},
+				},
+				client.ObjectKey{Name: "test-daemonset"},
+				&apps.DaemonSet{},
 				map[string]string{
 					"kubernetes.io/os": "windows",
 				},
@@ -749,17 +767,21 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeLinux,
-					objs: []client.Object{&apps.StatefulSet{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset"},
-						Spec: apps.StatefulSetSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&apps.StatefulSet{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset"},
+							Spec: apps.StatefulSetSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										NodeSelector: map[string]string{},
+									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-statefulset"}, &apps.StatefulSet{},
+				},
+				client.ObjectKey{Name: "test-statefulset"},
+				&apps.StatefulSet{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -770,17 +792,21 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeWindows,
-					objs: []client.Object{&apps.StatefulSet{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset"},
-						Spec: apps.StatefulSetSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&apps.StatefulSet{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-statefulset"},
+							Spec: apps.StatefulSetSpec{
+								Template: corev1.PodTemplateSpec{
+									Spec: corev1.PodSpec{
+										NodeSelector: map[string]string{},
+									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-statefulset"}, &apps.StatefulSet{},
+				},
+				client.ObjectKey{Name: "test-statefulset"},
+				&apps.StatefulSet{},
 				map[string]string{
 					"kubernetes.io/os": "windows",
 				},
@@ -791,21 +817,25 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeLinux,
-					objs: []client.Object{&batchv1.CronJob{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-cronjob"},
-						Spec: batchv1.CronJobSpec{
-							JobTemplate: batchv1.JobTemplateSpec{
-								Spec: batchv1.JobSpec{
-									Template: corev1.PodTemplateSpec{
-										Spec: corev1.PodSpec{
-											NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&batchv1.CronJob{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-cronjob"},
+							Spec: batchv1.CronJobSpec{
+								JobTemplate: batchv1.JobTemplateSpec{
+									Spec: batchv1.JobSpec{
+										Template: corev1.PodTemplateSpec{
+											Spec: corev1.PodSpec{
+												NodeSelector: map[string]string{},
+											},
 										},
 									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-cronjob"}, &batchv1.CronJob{},
+				},
+				client.ObjectKey{Name: "test-cronjob"},
+				&batchv1.CronJob{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -816,21 +846,25 @@ var _ = Describe("Component handler tests", func() {
 			Parameters: []interface{}{
 				&fakeComponent{
 					supportedOSType: rmeta.OSTypeWindows,
-					objs: []client.Object{&batchv1.CronJob{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-cronjob"},
-						Spec: batchv1.CronJobSpec{
-							JobTemplate: batchv1.JobTemplateSpec{
-								Spec: batchv1.JobSpec{
-									Template: corev1.PodTemplateSpec{
-										Spec: corev1.PodSpec{
-											NodeSelector: map[string]string{},
+					objs: []client.Object{
+						&batchv1.CronJob{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-cronjob"},
+							Spec: batchv1.CronJobSpec{
+								JobTemplate: batchv1.JobTemplateSpec{
+									Spec: batchv1.JobSpec{
+										Template: corev1.PodTemplateSpec{
+											Spec: corev1.PodSpec{
+												NodeSelector: map[string]string{},
+											},
 										},
 									},
 								},
 							},
-						}},
+						},
 					},
-				}, client.ObjectKey{Name: "test-cronjob"}, &batchv1.CronJob{},
+				},
+				client.ObjectKey{Name: "test-cronjob"},
+				&batchv1.CronJob{},
 				map[string]string{
 					"kubernetes.io/os": "windows",
 				},
@@ -852,7 +886,8 @@ var _ = Describe("Component handler tests", func() {
 						},
 					}},
 				},
-				client.ObjectKey{Name: "test-job"}, &batchv1.Job{},
+				client.ObjectKey{Name: "test-job"},
+				&batchv1.Job{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -874,7 +909,8 @@ var _ = Describe("Component handler tests", func() {
 						},
 					}},
 				},
-				client.ObjectKey{Name: "test-job"}, &batchv1.Job{},
+				client.ObjectKey{Name: "test-job"},
+				&batchv1.Job{},
 				map[string]string{
 					"kubernetes.io/os": "windows",
 				},
@@ -896,7 +932,8 @@ var _ = Describe("Component handler tests", func() {
 						},
 					}},
 				},
-				client.ObjectKey{Name: "test-kibana"}, &kbv1.Kibana{},
+				client.ObjectKey{Name: "test-kibana"},
+				&kbv1.Kibana{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -929,7 +966,8 @@ var _ = Describe("Component handler tests", func() {
 						},
 					}},
 				},
-				client.ObjectKey{Name: "test-elasticsearch"}, &esv1.Elasticsearch{},
+				client.ObjectKey{Name: "test-elasticsearch"},
+				&esv1.Elasticsearch{},
 				map[string]string{
 					"kubernetes.io/os": "linux",
 				},
@@ -952,7 +990,9 @@ var _ = Describe("Component handler tests", func() {
 							},
 						},
 					}},
-				}, client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				},
+				client.ObjectKey{Name: "test-deployment"},
+				&apps.Deployment{},
 				map[string]string{
 					"kubernetes.io/foo": "bar",
 					"kubernetes.io/os":  "linux",
@@ -976,7 +1016,9 @@ var _ = Describe("Component handler tests", func() {
 							},
 						},
 					}},
-				}, client.ObjectKey{Name: "test-deployment"}, &apps.Deployment{},
+				},
+				client.ObjectKey{Name: "test-deployment"},
+				&apps.Deployment{},
 				map[string]string{
 					"kubernetes.io/foo": "bar",
 					"kubernetes.io/os":  "windows",
@@ -996,7 +1038,9 @@ var _ = Describe("Component handler tests", func() {
 							},
 						},
 					}},
-				}, client.ObjectKey{Name: "test-alertmanager"}, &monitoringv1.Alertmanager{},
+				},
+				client.ObjectKey{Name: "test-alertmanager"},
+				&monitoringv1.Alertmanager{},
 				map[string]string{
 					"kubernetes.io/a":  "b",
 					"kubernetes.io/os": "linux",
@@ -1018,7 +1062,9 @@ var _ = Describe("Component handler tests", func() {
 							},
 						},
 					}},
-				}, client.ObjectKey{Name: "test-prometheus"}, &monitoringv1.Prometheus{},
+				},
+				client.ObjectKey{Name: "test-prometheus"},
+				&monitoringv1.Prometheus{},
 				map[string]string{
 					"kubernetes.io/a":  "b",
 					"kubernetes.io/os": "linux",
@@ -1763,13 +1809,11 @@ var _ = Describe("Component handler tests", func() {
 				corev1.VolumeMount{Name: "y"},
 				corev1.VolumeMount{Name: "z"},
 			))
-
 		})
 	})
 })
 
 var _ = Describe("Mocked client Component handler tests", func() {
-
 	var (
 		c       client.Client
 		mc      mockClient
@@ -1804,8 +1848,9 @@ var _ = Describe("Mocked client Component handler tests", func() {
 			},
 		}
 		setToDS := func(object client.Object) {
-			dsToSet := object.(*apps.DaemonSet)
-			ds.DeepCopyInto(dsToSet)
+			if dsToSet, ok := object.(*apps.DaemonSet); ok {
+				ds.DeepCopyInto(dsToSet)
+			}
 		}
 		fc := &fakeComponent{
 			supportedOSType: rmeta.OSTypeLinux,
@@ -1888,8 +1933,9 @@ var _ = Describe("Mocked client Component handler tests", func() {
 			},
 		}
 		setToBaseNP := func(object client.Object) {
-			npToSet := object.(*v3.NetworkPolicy)
-			baseNP.DeepCopyInto(npToSet)
+			if npToSet, ok := object.(*v3.NetworkPolicy); ok {
+				baseNP.DeepCopyInto(npToSet)
+			}
 		}
 		fc := &fakeComponent{
 			supportedOSType: rmeta.OSTypeLinux,
@@ -1912,8 +1958,9 @@ var _ = Describe("Mocked client Component handler tests", func() {
 			modifiedNP := baseNP.DeepCopy()
 			modifiedNP.Spec.Selector = "k8s-app == 'invalid-component'"
 			setToModifiedNP := func(object client.Object) {
-				npToSet := object.(*v3.NetworkPolicy)
-				modifiedNP.DeepCopyInto(npToSet)
+				if npToSet, ok := object.(*v3.NetworkPolicy); ok {
+					modifiedNP.DeepCopyInto(npToSet)
+				}
 			}
 
 			mc.Info = append(mc.Info, mockReturn{
@@ -1942,8 +1989,9 @@ var _ = Describe("Mocked client Component handler tests", func() {
 			Spec:       v3.TierSpec{Order: &order},
 		}
 		setToBaseTier := func(object client.Object) {
-			tierToSet := object.(*v3.Tier)
-			baseTier.DeepCopyInto(tierToSet)
+			if tierToSet, ok := object.(*v3.Tier); ok {
+				baseTier.DeepCopyInto(tierToSet)
+			}
 		}
 		fc := &fakeComponent{
 			supportedOSType: rmeta.OSTypeLinux,
@@ -1967,8 +2015,9 @@ var _ = Describe("Mocked client Component handler tests", func() {
 			modifiedTier := baseTier.DeepCopy()
 			modifiedTier.Spec.Order = &over9000
 			setToModifiedTier := func(object client.Object) {
-				tierToSet := object.(*v3.Tier)
-				modifiedTier.DeepCopyInto(tierToSet)
+				if tierToSet, ok := object.(*v3.Tier); ok {
+					modifiedTier.DeepCopyInto(tierToSet)
+				}
 			}
 
 			mc.Info = append(mc.Info, mockReturn{
@@ -2058,9 +2107,11 @@ func (mc *mockClient) Get(ctx context.Context, key client.ObjectKey, obj client.
 func (mc *mockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	panic("List not implemented in mockClient")
 }
+
 func (mc *mockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	panic("Create not implemented in mockClient")
 }
+
 func (mc *mockClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 	panic("Delete not implemented in mockClient")
 }
@@ -2088,9 +2139,11 @@ func (mc *mockClient) Update(ctx context.Context, obj client.Object, opts ...cli
 
 	return v
 }
+
 func (mc *mockClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 	panic("Patch not implemented in mockClient")
 }
+
 func (mc *mockClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
 	panic("DeleteAll not implemented in mockClient")
 }
@@ -2098,9 +2151,11 @@ func (mc *mockClient) DeleteAllOf(ctx context.Context, obj client.Object, opts .
 func (mc *mockClient) Status() client.StatusWriter {
 	panic("Status not implemented in mockClient")
 }
+
 func (mc *mockClient) Scheme() *runtime.Scheme {
 	panic("Scheme not implemented in mockClient")
 }
+
 func (mc *mockClient) RESTMapper() restMeta.RESTMapper {
 	panic("RESTMapper not implemented in mockClient")
 }

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -610,11 +610,6 @@ spec:
                 description: FlowLogGoldmaneServer is the flow server endpoint to
                   which flow data should be published.
                 type: string
-              flowLogsMaxOriginalIPsIncluded:
-                description: FlowLogsMaxOriginalIPsIncluded specifies the number of
-                  unique IP addresses (if relevant) that should be included in Flow
-                  logs.
-                type: integer
               genericXDPEnabled:
                 description: |-
                   GenericXDPEnabled enables Generic XDP so network cards that don't support XDP offload or driver
@@ -904,12 +899,6 @@ spec:
                   NetlinkTimeout is the timeout when talking to the kernel over the netlink protocol, used for programming
                   routes, rules, and other kernel objects. [Default: 10s]
                 pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
-                type: string
-              nfNetlinkBufSize:
-                description: |-
-                  NfNetlinkBufSize controls the size of NFLOG messages that the kernel will try to send to Felix.  NFLOG messages
-                  are used to report flow verdicts from the kernel.  Warning: currently increasing the value may cause errors
-                  due to a bug in the netlink library.
                 type: string
               nftablesFilterAllowAction:
                 description: |-


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In some cases, the operator can attempt to create new resources within a
terminating Namespace with fianlizers set on objects within. If this happens, an error will occur, which
prevents reaching the NodeComponent who is responsible for removing
those finalizers. As a result, we deadlock. 

We should never be installing resources into Namespaces that are being torn down, since it will never succeed! 

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.