### PR TITLE
Add guardian to whisker

### DIFF
--- a/api/v1/managementclusterconnection_types.go
+++ b/api/v1/managementclusterconnection_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2012,2015-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2012,2015-2025 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,4 +92,13 @@ type ManagementClusterConnectionStatus struct {
 
 func init() {
 	SchemeBuilder.Register(&ManagementClusterConnection{}, &ManagementClusterConnectionList{})
+}
+
+func (cr *ManagementClusterConnection) FillDefaults() {
+	if cr.Spec.TLS == nil {
+		cr.Spec.TLS = &ManagementClusterTLS{}
+	}
+	if cr.Spec.TLS.CA == "" {
+		cr.Spec.TLS.CA = CATypeTigera
+	}
 }

--- a/config/calico_versions.yml
+++ b/config/calico_versions.yml
@@ -37,3 +37,6 @@ components:
     version: master
   calico/envoy-ratelimit:
     version: master
+  calico/guardian:
+    version: master
+

--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -226,5 +226,6 @@ var (
 		ComponentCalicoEnvoyGateway,
 		ComponentCalicoEnvoyProxy,
 		ComponentCalicoEnvoyRatelimit,
+		ComponentCalicoGuardian,
 	}
 )

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -166,6 +166,11 @@ var (
 		Registry: "",
 	}
 
+	ComponentCalicoGuardian = Component{
+		Version:  "master",
+		Image:    "calico/guardian",
+		Registry: "",
+	}
 	ComponentOperatorInit = Component{
 		Version: version.VERSION,
 		Image:   "tigera/operator",
@@ -196,5 +201,6 @@ var (
 		ComponentCalicoEnvoyGateway,
 		ComponentCalicoEnvoyProxy,
 		ComponentCalicoEnvoyRatelimit,
+		ComponentCalicoGuardian,
 	}
 )

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -59,7 +59,9 @@ func GetReference(c Component, registry, imagePath, imagePrefix string, is *oper
 			ComponentCalicoCSIRegistrarFIPS,
 			ComponentCalicoGoldmane,
 			ComponentCalicoWhisker,
-			ComponentCalicoWhiskerBackend:
+			ComponentCalicoWhiskerBackend,
+			ComponentCalicoGuardian:
+
 			registry = CalicoRegistry
 		case ComponentOperatorInit:
 			registry = InitRegistry

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1201,6 +1201,14 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 
 		calicoVersion = components.EnterpriseRelease
+	} else {
+		cert, err := certificateManager.GetCertificate(r.client, render.VoltronLinseedPublicCert, common.OperatorNamespace())
+		if err != nil {
+			r.status.SetDegraded(operator.CertificateError, fmt.Sprintf("Failed to retrieve / validate  %s", render.VoltronLinseedPublicCert), err, reqLogger)
+			return reconcile.Result{}, err
+		} else if cert != nil {
+			typhaNodeTLS.TrustedBundle.AddCertificates(cert)
+		}
 	}
 
 	kubeControllersMetricsPort, err := utils.GetKubeControllerMetricsPort(ctx, r.client)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -474,6 +474,23 @@ func GetIfExists[E any, ClientObj ClientObjType[E]](ctx context.Context, key cli
 	return obj, nil
 }
 
+type Defaultable[E any, O ClientObjType[E]] interface {
+	ClientObjType[E]
+	client.Object
+	FillDefaults()
+	DeepCopy() O
+}
+
+// ApplyDefaults sets any defaults that haven't been set on the given object and writes it to the k8s server.
+func ApplyDefaults[E any, O ClientObjType[E], D Defaultable[E, O]](ctx context.Context, c client.Client, obj D) error {
+	preDefaultPatchFrom := client.MergeFrom(obj.DeepCopy())
+	obj.FillDefaults()
+
+	// Write the discovered configuration back to the API. This is essentially a poor-man's defaulting, and
+	// ensures that we don't surprise anyone by changing defaults in a future version of the operator.
+	return c.Patch(ctx, obj, preDefaultPatchFrom)
+}
+
 // GetNonClusterHost finds the NonClusterHost CR in your cluster.
 func GetNonClusterHost(ctx context.Context, cli client.Client) (*operatorv1.NonClusterHost, error) {
 	nonclusterhost := &operatorv1.NonClusterHost{}

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -53,7 +53,7 @@ var (
 func init() {
 	yamlDelimRe = regexp.MustCompile(`\n---`)
 
-	calicoCRDNames := []string{"installation", "apiserver", "imageset", "tigerastatus", "whisker"}
+	calicoCRDNames := []string{"installation", "apiserver", "imageset", "tigerastatus", "whisker", "managementclusterconnection"}
 	calicoOprtrCRDsRe = regexp.MustCompile(fmt.Sprintf("(%s)", strings.Join(calicoCRDNames, "|")))
 }
 

--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -15,6 +15,8 @@
 package whisker
 
 import (
+	"fmt"
+
 	"github.com/tigera/operator/pkg/components"
 
 	"github.com/tigera/operator/pkg/common"
@@ -30,6 +32,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 // The names of the components related to the Guardian related rendered objects.
@@ -40,6 +43,7 @@ const (
 	WhiskerDeploymentName     = WhiskerName
 	WhiskerRoleName           = WhiskerName
 
+	GuardianContainerName              = "guardian"
 	GoldmaneContainerName              = "goldmane"
 	WhiskerContainerName               = "whisker"
 	WhiskerBackendContainerName        = "whisker-backend"
@@ -54,15 +58,19 @@ func Whisker(cfg *Configuration) render.Component {
 
 // Configuration contains all the config information needed to render the component.
 type Configuration struct {
-	PullSecrets  []*corev1.Secret
-	OpenShift    bool
-	Installation *operatorv1.InstallationSpec
+	PullSecrets                 []*corev1.Secret
+	OpenShift                   bool
+	Installation                *operatorv1.InstallationSpec
+	TunnelSecret                *corev1.Secret
+	TrustedCertBundle           certificatemanagement.TrustedBundleRO
+	ManagementClusterConnection *operatorv1.ManagementClusterConnection
 }
 
 type Component struct {
 	cfg *Configuration
 
 	goldmaneImage       string
+	guardianImage       string
 	whiskerImage        string
 	whiskerBackendImage string
 }
@@ -89,6 +97,11 @@ func (c *Component) ResolveImages(is *operatorv1.ImageSet) error {
 		return err
 	}
 
+	c.guardianImage, err = components.GetReference(components.ComponentCalicoGuardian, reg, path, prefix, is)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -106,8 +119,11 @@ func (c *Component) Objects() ([]client.Object, []client.Object) {
 		c.role(),
 		c.roleBinding(),
 		c.goldmaneService(),
-		c.whiskerService(),
-	)
+		c.whiskerService())
+
+	if c.cfg.ManagementClusterConnection != nil && c.cfg.TunnelSecret != nil {
+		objs = append(objs, secret.CopyToNamespace(WhiskerNamespace, c.cfg.TunnelSecret)[0])
+	}
 
 	objs = append(objs, c.deployment())
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(WhiskerNamespace, c.cfg.PullSecrets...)...)...)
@@ -175,8 +191,19 @@ func (c *Component) whiskerBackendContainer() corev1.Container {
 func (c *Component) goldmaneContainer() corev1.Container {
 	env := []corev1.EnvVar{
 		{Name: "LOG_LEVEL", Value: "INFO"},
-		{Name: "CA_CERT_PATH", Value: "/certs/tls.crt"},
 		{Name: "PORT", Value: "7443"},
+	}
+	var volumeMounts []corev1.VolumeMount
+	if c.cfg.ManagementClusterConnection != nil {
+		env = append(env,
+			corev1.EnvVar{
+				Name:  "PUSH_URL",
+				Value: "https://localhost:8080/api/v1/flows/bulk"},
+			corev1.EnvVar{
+				Name:  "CA_CERT_PATH",
+				Value: c.cfg.TrustedCertBundle.MountPath()},
+		)
+		volumeMounts = c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType())
 	}
 
 	return corev1.Container{
@@ -185,6 +212,7 @@ func (c *Component) goldmaneContainer() corev1.Container {
 		ImagePullPolicy: render.ImagePullPolicy(),
 		Env:             env,
 		SecurityContext: securitycontext.NewNonRootContext(),
+		VolumeMounts:    volumeMounts,
 	}
 }
 
@@ -203,6 +231,27 @@ func (c *Component) goldmaneService() *corev1.Service {
 	}
 }
 
+func (c *Component) guardianContainer() corev1.Container {
+	tunnelCAType := c.cfg.ManagementClusterConnection.Spec.TLS.CA
+	voltronURL := c.cfg.ManagementClusterConnection.Spec.ManagementClusterAddr
+
+	return corev1.Container{
+		Name:            GuardianContainerName,
+		Image:           c.guardianImage,
+		ImagePullPolicy: render.ImagePullPolicy(),
+		Env: append([]corev1.EnvVar{
+			{Name: "GUARDIAN_PORT", Value: "9443"},
+			{Name: "GUARDIAN_LOGLEVEL", Value: "INFO"},
+			{Name: "GUARDIAN_VOLTRON_URL", Value: voltronURL},
+			{Name: "GUARDIAN_VOLTRON_CA_TYPE", Value: string(tunnelCAType)},
+		}, c.cfg.Installation.Proxy.EnvVars()...),
+		SecurityContext: securitycontext.NewNonRootContext(),
+		VolumeMounts: append([]corev1.VolumeMount{
+			secretMount("/certs", c.cfg.TunnelSecret),
+		}, c.cfg.TrustedCertBundle.VolumeMounts(rmeta.OSTypeLinux)...),
+	}
+}
+
 func (c *Component) deployment() *appsv1.Deployment {
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
@@ -210,6 +259,12 @@ func (c *Component) deployment() *appsv1.Deployment {
 	}
 
 	ctrs := []corev1.Container{c.whiskerContainer(), c.whiskerBackendContainer(), c.goldmaneContainer()}
+	volumes := []corev1.Volume{c.cfg.TrustedCertBundle.Volume()}
+
+	if c.cfg.ManagementClusterConnection != nil {
+		ctrs = append(ctrs, c.guardianContainer())
+		volumes = append(volumes, secretVolume(c.cfg.TunnelSecret))
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
@@ -232,15 +287,30 @@ func (c *Component) deployment() *appsv1.Deployment {
 					Tolerations:        tolerations,
 					ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 					Containers:         ctrs,
+					Volumes:            volumes,
 				},
 			},
 		},
 	}
 }
 
+func secretMount(path string, secret *corev1.Secret) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      fmt.Sprintf("%s-%s", secret.Name, "s"),
+		MountPath: path,
+	}
+}
+
+func secretVolume(secret *corev1.Secret) corev1.Volume {
+	return corev1.Volume{
+		Name:         fmt.Sprintf("%s-%s", secret.Name, "s"),
+		VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secret.Name}},
+	}
+}
+
 func (c *Component) roleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      WhiskerRoleName,
 			Namespace: WhiskerNamespace,

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/whisker"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,6 +45,7 @@ var _ = Describe("ComponentRendering", func() {
 					KubernetesProvider: operatorv1.ProviderGKE,
 					Variant:            operatorv1.Calico,
 				},
+				TrustedCertBundle: certificatemanagement.CreateTrustedBundle(nil),
 			},
 			7, 0,
 		),
@@ -53,6 +55,7 @@ var _ = Describe("ComponentRendering", func() {
 					KubernetesProvider: operatorv1.ProviderGKE,
 					Variant:            operatorv1.TigeraSecureEnterprise,
 				},
+				TrustedCertBundle: certificatemanagement.CreateTrustedBundle(nil),
 			},
 			0, 7,
 		),
@@ -72,6 +75,7 @@ var _ = Describe("ComponentRendering", func() {
 					KubernetesProvider: operatorv1.ProviderGKE,
 					Variant:            operatorv1.Calico,
 				},
+				TrustedCertBundle: certificatemanagement.CreateTrustedBundle(nil),
 			},
 			&appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
@@ -118,10 +122,123 @@ var _ = Describe("ComponentRendering", func() {
 									ImagePullPolicy: render.ImagePullPolicy(),
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},
-										{Name: "CA_CERT_PATH", Value: "/certs/tls.crt"},
 										{Name: "PORT", Value: "7443"},
 									},
 									SecurityContext: securitycontext.NewNonRootContext(),
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "tigera-ca-bundle",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: "tigera-ca-bundle"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		),
+		Entry("Should configure guardian",
+			&whisker.Configuration{
+				Installation: &operatorv1.InstallationSpec{
+					KubernetesProvider: operatorv1.ProviderGKE,
+					Variant:            operatorv1.Calico,
+				},
+				TrustedCertBundle: certificatemanagement.CreateTrustedBundle(nil),
+				ManagementClusterConnection: &operatorv1.ManagementClusterConnection{
+					Spec: operatorv1.ManagementClusterConnectionSpec{
+						TLS: &operatorv1.ManagementClusterTLS{
+							CA: operatorv1.CATypeTigera,
+						},
+					},
+				},
+				TunnelSecret: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-tunnel-secret"}},
+			},
+			&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      whisker.WhiskerDeploymentName,
+					Namespace: whisker.WhiskerNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.ToPtr(int32(1)),
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: whisker.WhiskerDeploymentName,
+						},
+						Spec: corev1.PodSpec{
+							ServiceAccountName: whisker.WhiskerServiceAccountName,
+							Tolerations:        append(rmeta.TolerateCriticalAddonsAndControlPlane, rmeta.TolerateGKEARM64NoSchedule),
+							Containers: []corev1.Container{
+								{
+									Name:            whisker.WhiskerContainerName,
+									Image:           "",
+									ImagePullPolicy: render.ImagePullPolicy(),
+									Env: []corev1.EnvVar{
+										{Name: "LOG_LEVEL", Value: "INFO"},
+									},
+									SecurityContext: securitycontext.NewNonRootContext(),
+								},
+								{
+									Name:            whisker.WhiskerBackendContainerName,
+									Image:           "",
+									ImagePullPolicy: render.ImagePullPolicy(),
+									Env: []corev1.EnvVar{
+										{Name: "LOG_LEVEL", Value: "INFO"},
+										{Name: "PORT", Value: "3002"},
+										{Name: "GOLDMANE_HOST", Value: "localhost:7443"},
+									},
+									SecurityContext: securitycontext.NewNonRootContext(),
+								},
+								{
+									Name:            whisker.GoldmaneContainerName,
+									Image:           "",
+									ImagePullPolicy: render.ImagePullPolicy(),
+									Env: []corev1.EnvVar{
+										{Name: "LOG_LEVEL", Value: "INFO"},
+										{Name: "PORT", Value: "7443"},
+										{Name: "PUSH_URL", Value: "https://localhost:8080/api/v1/flows/bulk"},
+										{Name: "CA_CERT_PATH", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
+									},
+									VolumeMounts:    []corev1.VolumeMount{{Name: "tigera-ca-bundle", ReadOnly: true, MountPath: "/etc/pki/tls/certs"}},
+									SecurityContext: securitycontext.NewNonRootContext(),
+								},
+								{
+									Name:            whisker.GuardianContainerName,
+									Image:           "",
+									ImagePullPolicy: render.ImagePullPolicy(),
+									Env: []corev1.EnvVar{
+										{Name: "GUARDIAN_PORT", Value: "9443"},
+										{Name: "GUARDIAN_LOGLEVEL", Value: "INFO"},
+										{Name: "GUARDIAN_VOLTRON_URL"},
+										{Name: "GUARDIAN_VOLTRON_CA_TYPE", Value: "Tigera"},
+									},
+									SecurityContext: securitycontext.NewNonRootContext(),
+									VolumeMounts: []corev1.VolumeMount{
+										{Name: "tigera-tunnel-secret-s", MountPath: "/certs"},
+										{Name: "tigera-ca-bundle", ReadOnly: true, MountPath: "/etc/pki/tls/certs"},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "tigera-ca-bundle",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: "tigera-ca-bundle"},
+										},
+									},
+								},
+								{
+									Name:         "tigera-tunnel-secret-s",
+									VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "tigera-tunnel-secret"}},
 								},
 							},
 						},


### PR DESCRIPTION
## Description

This commit adds guardian to the whisker deployment, and is only launched if the ManagementClusterConnection CR exists.

This adds the ManagementClusterConnection CRD to open source.

Guardian might not stay in this deployment (and likely won't), but it's a good temporary place for it alongside goldmane (where the service isn't exposed).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
