### PR TITLE
[v1.37] fix github release failing due to missing binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,7 +505,7 @@ endif
 maybe-build-release:
 	./hack/maybe-build-release.sh
 
-release-notes: var-require-all-VERSION-GITHUB_TOKEN clean
+release-notes: var-require-all-VERSION-GITHUB_TOKEN
 	@docker build -t tigera/release-notes -f build/Dockerfile.release-notes .
 	@docker run --rm -v $(CURDIR):/workdir -e	GITHUB_TOKEN=$(GITHUB_TOKEN) -e VERSION=$(VERSION) tigera/release-notes
 
@@ -569,7 +569,7 @@ release-publish: release-prereqs
 	@echo "  make VERSION=$(VERSION) release-publish-latest"
 	@echo ""
 
-release-github: hack/bin/gh release-notes
+release-github: release-notes hack/bin/gh
 	@echo "Creating github release for $(VERSION)"
 	hack/bin/gh release create $(VERSION) --title $(VERSION) --draft --notes-file $(VERSION)-release-notes.md
 


### PR DESCRIPTION
## Description

this happens because it depends on `release-notes` target which calls `clean` that cleans up the bin

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
