### PR TITLE
[v1.36] fix github release failing due to missing binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ endif
 maybe-build-release:
 	./hack/maybe-build-release.sh
 
-release-notes: var-require-all-VERSION-GITHUB_TOKEN clean
+release-notes: var-require-all-VERSION-GITHUB_TOKEN
 	@docker build -t tigera/release-notes -f build/Dockerfile.release-notes .
 	@docker run --rm -v $(CURDIR):/workdir -e	GITHUB_TOKEN=$(GITHUB_TOKEN) -e VERSION=$(VERSION) tigera/release-notes
 
@@ -544,7 +544,7 @@ release-publish: release-prereqs
 	@echo "  make VERSION=$(VERSION) release-publish-latest"
 	@echo ""
 
-release-github: hack/bin/gh release-notes
+release-github: release-notes hack/bin/gh
 	@echo "Creating github release for $(VERSION)"
 	hack/bin/gh release create $(VERSION) --title $(VERSION) --draft --notes-file $(VERSION)-release-notes.md
 

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -102,6 +102,73 @@ spec:
                   This will be deprecated. Use BPFConnectTimeLoadBalancing [Default:
                   true]'
                 type: boolean
+              bpfConntrackTimeouts:
+                description: "BPFConntrackTimers overrides the default values for
+                  the specified conntrack timer if set. Each value can be either a
+                  duration or `Auto` to pick the value from a Linux conntrack timeout.
+                  \n Configurable timers are: CreationGracePeriod, TCPSynSent, TCPEstablished,
+                  TCPFinsSeen, TCPResetSeen, UDPTimeout, GenericTimeout, ICMPTimeout.
+                  \n Unset values are replaced by the default values with a warning
+                  log for incorrect values."
+                properties:
+                  creationGracePeriod:
+                    description: ' CreationGracePeriod gives a generic grace period
+                      to new connection  before they are considered for cleanup [Default:
+                      10s].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                  genericTimeout:
+                    description: 'GenericTimeout controls how long it takes before
+                      considering this entry for cleanup after the connection became
+                      idle. If set to ''Auto'', the value from nf_conntrack_generic_timeout
+                      is used. If nil, Calico uses its own default value. [Default:
+                      10m].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                  icmpTimeout:
+                    description: 'ICMPTimeout controls how long it takes before considering
+                      this entry for cleanup after the connection became idle. If
+                      set to ''Auto'', the value from nf_conntrack_icmp_timeout is
+                      used. If nil, Calico uses its own default value. [Default: 5s].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                  tcpEstablished:
+                    description: 'TCPEstablished controls how long it takes before
+                      considering this entry for cleanup after the connection became
+                      idle. If set to ''Auto'', the value from nf_conntrack_tcp_timeout_established
+                      is used. If nil, Calico uses its own default value. [Default:
+                      1h].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                  tcpFinsSeen:
+                    description: 'TCPFinsSeen controls how long it takes before considering
+                      this entry for cleanup after the connection was closed gracefully.
+                      If set to ''Auto'', the value from nf_conntrack_tcp_timeout_time_wait
+                      is used. If nil, Calico uses its own default value. [Default:
+                      Auto].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                  tcpResetSeen:
+                    description: 'TCPFinsSeen controls how long it takes before considering
+                      this entry for cleanup after the connection was aborted. If
+                      nil, Calico uses its own default value. [Default: 40s].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                  tcpSynSent:
+                    description: 'TCPSynSent controls how long it takes before considering
+                      this entry for cleanup after the last SYN without a response.
+                      If set to ''Auto'', the value from nf_conntrack_tcp_timeout_syn_sent
+                      is used. If nil, Calico uses its own default value. [Default:
+                      20s].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                  udpTimeout:
+                    description: 'UDPTimeout controls how long it takes before considering
+                      this entry for cleanup after the connection became idle. If
+                      nil, Calico uses its own default value. [Default: 60s].'
+                    pattern: ^(([0-9]*(\.[0-9]*)?(ms|s|h|m|us)+)+|Auto)$
+                    type: string
+                type: object
               bpfDNSPolicyMode:
                 description: 'BPFDNSPolicyMode specifies how DNS policy programming
                   will be handled. Inline - BPF parses DNS response inline with DNS


### PR DESCRIPTION
## Description

this happens because it depends on `release-notes` target which calls `clean` that cleans up the bin

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
