### PR TITLE
Kube-controllers crd and rbac update for autoHEPs

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -71,6 +71,37 @@ spec:
                             description: 'AutoCreate enables automatic creation of
                               host endpoints for every node. [Default: Disabled]'
                             type: string
+                          createDefaultHostEndpoint:
+                            type: string
+                          templates:
+                            description: Templates contains definition for creating
+                              AutoHostEndpoints
+                            items:
+                              properties:
+                                generateName:
+                                  description: GenerateName is appended to the end
+                                    of the generated AutoHostEndpoint name
+                                  type: string
+                                interfaceCIDRs:
+                                  description: InterfaceCIDRs contains a list of CIRDs
+                                    used for matching nodeIPs to the AutoHostEndpoint
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: Labels adds the specified labels to
+                                    the generated AutoHostEndpoint, labels from node
+                                    with the same name will be overwritten by values
+                                    from the template label
+                                  type: object
+                                nodeSelector:
+                                  description: NodeSelector allows the AutoHostEndpoint
+                                    to be created only for specific nodes
+                                  type: string
+                              type: object
+                            type: array
                         type: object
                       leakGracePeriod:
                         description: |-
@@ -190,6 +221,38 @@ spec:
                                 description: 'AutoCreate enables automatic creation
                                   of host endpoints for every node. [Default: Disabled]'
                                 type: string
+                              createDefaultHostEndpoint:
+                                type: string
+                              templates:
+                                description: Templates contains definition for creating
+                                  AutoHostEndpoints
+                                items:
+                                  properties:
+                                    generateName:
+                                      description: GenerateName is appended to the
+                                        end of the generated AutoHostEndpoint name
+                                      type: string
+                                    interfaceCIDRs:
+                                      description: InterfaceCIDRs contains a list
+                                        of CIRDs used for matching nodeIPs to the
+                                        AutoHostEndpoint
+                                      items:
+                                        type: string
+                                      type: array
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Labels adds the specified labels
+                                        to the generated AutoHostEndpoint, labels
+                                        from node with the same name will be overwritten
+                                        by values from the template label
+                                      type: object
+                                    nodeSelector:
+                                      description: NodeSelector allows the AutoHostEndpoint
+                                        to be created only for specific nodes
+                                      type: string
+                                  type: object
+                                type: array
                             type: object
                           leakGracePeriod:
                             description: |-

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -392,7 +392,7 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration, kubeContr
 			// Needs to manage hostendpoints.
 			APIGroups: []string{"crd.projectcalico.org"},
 			Resources: []string{"hostendpoints"},
-			Verbs:     []string{"get", "list", "create", "update", "delete"},
+			Verbs:     []string{"get", "list", "create", "update", "delete", "watch"},
 		},
 		{
 			// Needs to manipulate kubecontrollersconfiguration, which contains


### PR DESCRIPTION
## Description
Updates the RBAC for kubecontrollers to allow the new autoHEP controller to watch for HostEndpoints and updates the kubecontrollersconfiguration CRD
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
