### PR TITLE
Render CSR roles when NonClusterHost feature is enabled

### DIFF
--- a/pkg/controller/csr/csr_controller.go
+++ b/pkg/controller/csr/csr_controller.go
@@ -203,6 +203,16 @@ func (r *reconcileCSR) Reconcile(ctx context.Context, request reconcile.Request)
 			return reconcile.Result{}, err
 		}
 		needsCSRRole = monitorCR.Spec.ExternalPrometheus != nil
+
+		// Check whether the non-cluster host feature is enabled.
+		// Non-cluster hosts generate CSRs to establish mTLS connections with the cluster.
+		if !needsCSRRole {
+			nonclusterhost, err := utils.GetNonClusterHost(ctx, r.client)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			needsCSRRole = nonclusterhost != nil
+		}
 	}
 
 	componentHandler := utils.NewComponentHandler(log, r.client, r.scheme, instance)


### PR DESCRIPTION
## Description

This change adds the NonClusterHost resource check to render CSR roles for the CSR controller. It is required to validate and sign CSRs generated from non-cluster hosts.

Should be part of https://github.com/tigera/operator/pull/3817.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
