### PR TITLE
Automated cherry pick of #3814: Fix certificate management with ECK 2.16.1. The prepare-fs.sh

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -908,6 +908,8 @@ func (es elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentVo
 
 	if es.cfg.Installation.CertificateManagement != nil {
 		config["xpack.security.http.ssl.certificate_authorities"] = []string{"/usr/share/elasticsearch/config/http-certs/ca.crt"}
+		config["xpack.security.transport.ssl.key"] = "/usr/share/elasticsearch/config/transport-certs/transport.tls.key"
+		config["xpack.security.transport.ssl.certificate"] = "/usr/share/elasticsearch/config/transport-certs/transport.tls.crt"
 	}
 	if operatorv1.IsFIPSModeEnabled(es.cfg.Installation.FIPSMode) {
 		config["xpack.security.fips_mode.enabled"] = "true"

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
+	v1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -666,6 +667,19 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				compareInitContainer(initContainers[4], "key-cert-elastic-transport", []corev1.VolumeMount{
 					{Name: "elastic-internal-transport-certificates", MountPath: certificatemanagement.CSRCMountPath},
 				}, false)
+				Expect(resultES.Spec.NodeSets[0].Config).To(Equal(&v1.Config{Data: map[string]interface{}{
+					"node.roles": []string{
+						"data",
+						"ingest",
+						"master",
+						"remote_cluster_client",
+					},
+					"cluster.max_shards_per_node":                     10000,
+					"ingest.geoip.downloader.enabled":                 false,
+					"xpack.security.http.ssl.certificate_authorities": []string{"/usr/share/elasticsearch/config/http-certs/ca.crt"},
+					"xpack.security.transport.ssl.key":                "/usr/share/elasticsearch/config/transport-certs/transport.tls.key",
+					"xpack.security.transport.ssl.certificate":        "/usr/share/elasticsearch/config/transport-certs/transport.tls.crt",
+				}}))
 			})
 		})
 


### PR DESCRIPTION
Cherry pick of #3814 on release-v1.34.

Original branch name automated-cherry-pick-of-#3761-origin-release-v1.36

#3814: Fix certificate management with ECK 2.16.1. The prepare-fs.sh