### PR TITLE
Rename tigera-guardian components to guardian

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -191,7 +191,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
 			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
-			dexC := test.GetContainer(d.Spec.Template.Spec.Containers, render.GuardianDeploymentName)
+			dexC := test.GetContainer(d.Spec.Template.Spec.Containers, render.GuardianContainerName)
 			Expect(dexC).ToNot(BeNil())
 			Expect(dexC.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s:%s",
@@ -222,7 +222,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 			}
 			Expect(test.GetResource(c, &d)).To(BeNil())
 			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
-			apiserver := test.GetContainer(d.Spec.Template.Spec.Containers, render.GuardianDeploymentName)
+			apiserver := test.GetContainer(d.Spec.Template.Spec.Containers, render.GuardianContainerName)
 			Expect(apiserver).ToNot(BeNil())
 			Expect(apiserver.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s@%s",

--- a/pkg/controller/logstorage/managedcluster/managed_cluster_controller_test.go
+++ b/pkg/controller/logstorage/managedcluster/managed_cluster_controller_test.go
@@ -120,8 +120,8 @@ var _ = Describe("LogStorageManagedCluster controller", func() {
 					Expect(svc.Spec.ExternalName).Should(Equal(expectedSvcName))
 					Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
 				},
-					Entry("default cluster domain", dns.DefaultClusterDomain, "tigera-guardian.calico-system.svc.cluster.local"),
-					Entry("custom cluster domain", "custom-domain.internal", "tigera-guardian.calico-system.svc.custom-domain.internal"),
+					Entry("default cluster domain", dns.DefaultClusterDomain, "guardian.calico-system.svc.cluster.local"),
+					Entry("custom cluster domain", "custom-domain.internal", "guardian.calico-system.svc.custom-domain.internal"),
 				)
 			})
 

--- a/pkg/render/goldmane/component_test.go
+++ b/pkg/render/goldmane/component_test.go
@@ -131,7 +131,7 @@ var _ = Describe("ComponentRendering", func() {
 										{Name: "SERVER_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
 										{Name: "SERVER_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
 										{Name: "CA_CERT_PATH", Value: defaultTrustedCertBundle.MountPath()},
-										{Name: "PUSH_URL", Value: "https://tigera-guardian.calico-system.svc.cluster.local:443/api/v1/flows/bulk"},
+										{Name: "PUSH_URL", Value: "https://guardian.calico-system.svc.cluster.local:443/api/v1/flows/bulk"},
 										{Name: "FILE_CONFIG_PATH", Value: "/config/config.json"},
 										{Name: "HEALTH_ENABLED", Value: "true"},
 									},

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -52,18 +52,22 @@ import (
 
 // The names of the components related to the Guardian related rendered objects.
 const (
-	GuardianName                   = "tigera-guardian"
+	GuardianName                   = "guardian"
 	GuardianNamespace              = common.CalicoNamespace
 	GuardianServiceAccountName     = GuardianName
-	GuardianClusterRoleName        = GuardianName
-	GuardianClusterRoleBindingName = GuardianName
+	GuardianClusterRoleName        = "calico-guardian"
+	GuardianClusterRoleBindingName = "calico-guardian"
 	GuardianDeploymentName         = GuardianName
-	GuardianServiceName            = "tigera-guardian"
-	GuardianVolumeName             = "tigera-guardian-certs"
-	GuardianSecretName             = "tigera-managed-cluster-connection"
-	GuardianTargetPort             = 8080
-	GuardianPolicyName             = networkpolicy.TigeraComponentPolicyPrefix + "guardian-access"
-	GuardianKeyPairSecret          = "guardian-key-pair"
+
+	// GuardianContainerName name is the name of the container running guardian. It's named `tigera-guardian`, instead
+	// of `guardian` so that the API for the container overrides don't have to change (`tigera-guardian` is a legacy name).
+	GuardianContainerName = "tigera-guardian"
+	GuardianServiceName   = "guardian"
+	GuardianVolumeName    = "guardian-certs"
+	GuardianSecretName    = "tigera-managed-cluster-connection"
+	GuardianTargetPort    = 8080
+	GuardianPolicyName    = networkpolicy.TigeraComponentPolicyPrefix + "guardian-access"
+	GuardianKeyPairSecret = "guardian-key-pair"
 
 	GoldmaneDeploymentName = "goldmane"
 )
@@ -404,7 +408,7 @@ func (c *GuardianComponent) container() []corev1.Container {
 
 	return []corev1.Container{
 		{
-			Name:            GuardianDeploymentName,
+			Name:            GuardianContainerName,
 			Image:           c.image,
 			ImagePullPolicy: ImagePullPolicy(),
 			Env:             envVars,
@@ -452,7 +456,7 @@ func (c *GuardianComponent) annotations() map[string]string {
 func (c *GuardianComponent) networkPolicy() *netv1.NetworkPolicy {
 	return &netv1.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "networking.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "guardian", Namespace: GuardianNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: GuardianName, Namespace: GuardianNamespace},
 		Spec: netv1.NetworkPolicySpec{
 			PodSelector: *selector.PodLabelSelector(GuardianDeploymentName),
 			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
@@ -683,6 +687,16 @@ func deprecatedObjects() []client.Object {
 		// Namespace and everything within it should be removed.
 		&corev1.Namespace{
 			TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-guardian"},
+		},
+		// All the Guardian objects were moved to "calico-system" circa Calico v3.30, and so the legacy `tigera-`
+		// prefix is replaced with `calico-` for consistency, which means removing the old global resources.
+		&rbacv1.ClusterRole{
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-guardian"},
+		},
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-guardian"},
 		},
 	}

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Rendering tests", func() {
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
-		role := rtest.GetResource(resources, "tigera-guardian", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		role := rtest.GetResource(resources, render.GuardianClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
 			APIGroups:     []string{"security.openshift.io"},
 			Resources:     []string{"securitycontextconstraints"},

--- a/pkg/render/testutils/expected_policies/compliance_managed.json
+++ b/pkg/render/testutils/expected_policies/compliance_managed.json
@@ -38,7 +38,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'",
           "ports": [
             8080

--- a/pkg/render/testutils/expected_policies/compliance_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/compliance_managed_ocp.json
@@ -49,7 +49,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'",
           "ports": [
             8080

--- a/pkg/render/testutils/expected_policies/dpi_managed.json
+++ b/pkg/render/testutils/expected_policies/dpi_managed.json
@@ -39,7 +39,7 @@
         "destination": {
           "services": {
             "namespace": "calico-system",
-            "name": "tigera-guardian"
+            "name": "guardian"
           }
         }
       }

--- a/pkg/render/testutils/expected_policies/dpi_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/dpi_managed_ocp.json
@@ -49,7 +49,7 @@
         "destination": {
           "services": {
             "namespace": "calico-system",
-            "name": "tigera-guardian"
+            "name": "guardian"
           }
         }
       }

--- a/pkg/render/testutils/expected_policies/fluentd_managed.json
+++ b/pkg/render/testutils/expected_policies/fluentd_managed.json
@@ -35,7 +35,7 @@
         "source": {
         },
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'",
           "notPorts": [
             8080

--- a/pkg/render/testutils/expected_policies/guardian.json
+++ b/pkg/render/testutils/expected_policies/guardian.json
@@ -6,7 +6,7 @@
     "namespace": "calico-system"
   },
   "spec": {
-    "selector": "k8s-app == 'tigera-guardian'",
+    "selector": "k8s-app == 'guardian'",
     "order": 1,
     "tier": "allow-tigera",
     "types": [

--- a/pkg/render/testutils/expected_policies/guardian_ocp.json
+++ b/pkg/render/testutils/expected_policies/guardian_ocp.json
@@ -6,7 +6,7 @@
     "namespace": "calico-system"
   },
   "spec": {
-    "selector": "k8s-app == 'tigera-guardian'",
+    "selector": "k8s-app == 'guardian'",
     "order": 1,
     "tier": "allow-tigera",
     "types": [

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'",
           "ports": [
             8080

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
@@ -63,7 +63,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'",
           "ports": [
             8080

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
@@ -39,7 +39,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'",
           "ports": [
             8080

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
@@ -50,7 +50,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'",
           "ports": [
             8080

--- a/pkg/render/testutils/expected_policies/packetcapture_managed.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed.json
@@ -18,7 +18,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
@@ -18,7 +18,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-guardian'",
+          "selector": "k8s-app == 'guardian'",
           "namespaceSelector": "projectcalico.org/name == 'calico-system'"
         },
         "destination": {


### PR DESCRIPTION
## Description

Since tigera-guardian has been moved to the calico-system namespace we've decided to remove the tigera prefix since it's redundant

The container name needs to stay the same so the overrides API doesn't break.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The tigera-guardian deployment and resources previously in the tigera-guardian namespace have been moved to the calico-system namespace. The `tigera-` prefix has been remove for all namespaced resources and replaced with `calico-` for all cluster resources.

Custom policies or RBAC written for these moved components will need to account for the namespace and name changes.
```
