### PR TITLE
Skip Typha scaling checks when we're terminating

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -952,19 +952,21 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, nil
 	}
 
-	// If the autoscalar is degraded then trigger a run and recheck the degraded status. If it is still degraded after the
-	// the run the reset the degraded status and requeue the request.
-	if r.typhaAutoscaler.isDegraded() {
-		if err := r.typhaAutoscaler.triggerRun(); err != nil {
-			r.status.SetDegraded(operator.ResourceScalingError, "Failed to scale typha", err, reqLogger)
-			return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+	if !installationMarkedForDeletion {
+		// If the autoscalar is degraded then trigger a run and recheck the degraded status. If it is still degraded after the
+		// the run the reset the degraded status and requeue the request.
+		if r.typhaAutoscaler.isDegraded() {
+			if err := r.typhaAutoscaler.triggerRun(); err != nil {
+				r.status.SetDegraded(operator.ResourceScalingError, "Failed to scale typha", err, reqLogger)
+				return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+			}
 		}
-	}
 
-	if r.typhaAutoscalerNonClusterHost != nil && r.typhaAutoscalerNonClusterHost.isDegraded() {
-		if err := r.typhaAutoscalerNonClusterHost.triggerRun(); err != nil {
-			r.status.SetDegraded(operator.ResourceScalingError, "Failed to scale typha for noncluster hosts", err, reqLogger)
-			return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+		if r.typhaAutoscalerNonClusterHost != nil && r.typhaAutoscalerNonClusterHost.isDegraded() {
+			if err := r.typhaAutoscalerNonClusterHost.triggerRun(); err != nil {
+				r.status.SetDegraded(operator.ResourceScalingError, "Failed to scale typha for noncluster hosts", err, reqLogger)
+				return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This blocks uninstall when, for example, the cluster nodes are cordoned.

We shouldn't care about Typha autoscaling when Calico is mid-uninstall.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.