### PR TITLE
fix tigera-operator secrets RBAC permission for  egressgateway

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpfilters.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_blockaffinities.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_blockaffinities.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: blockaffinities.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: caliconodestatuses.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_clusterinformations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_clusterinformations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: clusterinformations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: felixconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_globalnetworksets.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_globalnetworksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_hostendpoints.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_hostendpoints.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: hostendpoints.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamblocks.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamblocks.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamblocks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamconfigs.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamconfigs.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamhandles.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamhandles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamhandles.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ippools.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ippools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ippools.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipreservations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipreservations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipreservations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: kubecontrollersconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_networkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_networkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_networksets.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_networksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedglobalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagednetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagednetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagednetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_tiers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_tiers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: tiers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgpconfigurations.yaml
@@ -94,6 +94,16 @@ spec:
                   maximum: 65535
                   minimum: 1
                   type: integer
+                localWorkloadPeeringIPV4:
+                  description: |-
+                    The virtual IPv4 address of the node with which its local workload is expected to peer.
+                    It is recommended to use a link-local address.
+                  type: string
+                localWorkloadPeeringIPV6:
+                  description: |-
+                    The virtual IPv6 address of the node with which its local workload is expected to peer.
+                    It is recommended to use a link-local address.
+                  type: string
                 logSeverityScreen:
                   description:
                     "LogSeverityScreen is the log severity above which logs

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
@@ -76,6 +76,11 @@ spec:
                     Setting "true" configures the selected BGP Peers node to use the "next hop keep;"
                     instead of "next hop self;"(default) in the specific branch of the Node on "bird.cfg".
                   type: boolean
+                localWorkloadSelector:
+                  description: |-
+                    Selector for the local workload that the node should peer with. When this is set, the peerSelector and peerIP fields must be empty,
+                    and the ASNumber must not be empty.
+                  type: string
                 maxRestartTime:
                   description: |-
                     Time to allow for software restart.  When specified, this is configured as the graceful

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			version string
 			kind    string
 		}{
+			{"tigera-operator-secrets", "test-ns", "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"test-secret", "test-ns", "", "v1", "Secret"},
 			{"egress-test", "test-ns", "", "v1", "ServiceAccount"},
 			{"egress-test", "test-ns", "apps", "v1", "Deployment"},
@@ -273,7 +274,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			VXLANPort:    4790,
 		})
 		resources, _ := component.Objects()
-		Expect(resources).To(HaveLen(2))
+		Expect(resources).To(HaveLen(3))
 		dep := rtest.GetResource(resources, "egress-test", "test-ns", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(dep.Spec.Template.Spec.Containers[0].Resources).To(Equal(expectedResource))
 		elasticIPAnnotation := dep.Spec.Template.ObjectMeta.Annotations["cni.projectcalico.org/awsElasticIPs"]
@@ -288,6 +289,7 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 			version string
 			kind    string
 		}{
+			{"tigera-operator-secrets", "test-ns", "rbac.authorization.k8s.io", "v1", "RoleBinding"},
 			{"egress-test", "test-ns", "", "v1", "ServiceAccount"},
 			{"egress-test", "test-ns", rbac, "v1", "Role"},
 			{"egress-test", "test-ns", rbac, "v1", "RoleBinding"},


### PR DESCRIPTION
## Description

If the operator needs to create, update, or delete a secret in any namespace within the cluster (whether a product-specific or user-specific namespace), it must have a RoleBinding that grants the necessary RBAC permissions for secrets in that namespace.

```vara:~/bzprofiles/Clusters/testcycles/tc_egw_321$ k get rolebinding -n calico-egress -oyaml
apiVersion: v1
items:
- apiVersion: rbac.authorization.k8s.io/v1
  kind: RoleBinding
  metadata:
    creationTimestamp: "2025-04-04T15:10:45Z"
    name: tigera-operator-secrets
    namespace: calico-egress
    ownerReferences:
    - apiVersion: operator.tigera.io/v1
      kind: EgressGateway
      name: egress-gateway-red
      uid: 0dcb2194-0e64-447c-bf2e-a6de8907839c
    - apiVersion: operator.tigera.io/v1
      kind: EgressGateway
      name: egress-gateway-blue
      uid: 03270136-c8b9-4233-9042-7279aecd0cd6
    resourceVersion: "36674"
    uid: 44b58cfe-d7da-407e-8f8a-21f88c2a25dd
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
    name: tigera-operator-secrets
  subjects:
  - kind: ServiceAccount
    name: tigera-operator
    namespace: tigera-operator
kind: List
metadata:
  resourceVersion: ""
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
