### PR TITLE
Set explicit DNS nameservers for calico/node when needed

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -393,6 +393,7 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 	if err != nil {
 		log.Error(err, "Couldn't find the nameservers from the resolv.conf")
 	}
+	log.Infof("Found nameservers: %v", nameservers)
 
 	kubernetesVersion, err := common.GetKubernetesVersion(clientset)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -389,6 +389,11 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 		log.Error(err, fmt.Sprintf("Couldn't find the cluster domain from the resolv.conf, defaulting to %s", clusterDomain))
 	}
 
+	nameservers, err := dns.Nameservers(dns.DefaultResolveConfPath)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Couldn't find the nameservers from the resolv.conf, defaulting to %s", nameservers))
+	}
+
 	kubernetesVersion, err := common.GetKubernetesVersion(clientset)
 	if err != nil {
 		log.Error(err, "Unable to resolve Kubernetes version, defaulting to v1.18")
@@ -436,6 +441,7 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 		DetectedProvider:    provider,
 		EnterpriseCRDExists: enterpriseCRDExists,
 		ClusterDomain:       clusterDomain,
+		Nameservers:         nameservers,
 		KubernetesVersion:   kubernetesVersion,
 		ManageCRDs:          manageCRDs,
 		ShutdownContext:     ctx,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -391,7 +391,7 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 
 	nameservers, err := dns.Nameservers(dns.DefaultResolveConfPath)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("Couldn't find the nameservers from the resolv.conf, defaulting to %s", nameservers))
+		log.Error(err, "Couldn't find the nameservers from the resolv.conf")
 	}
 
 	kubernetesVersion, err := common.GetKubernetesVersion(clientset)

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1414,6 +1414,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		BirdTemplates:                 birdTemplates,
 		TLS:                           typhaNodeTLS,
 		ClusterDomain:                 r.clusterDomain,
+		Nameservers:                   r.nameservers,
 		NodeReporterMetricsPort:       nodeReporterMetricsPort,
 		BGPLayouts:                    bgpLayout,
 		NodeAppArmorProfile:           nodeAppArmorProfile,

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -185,6 +185,7 @@ func newReconciler(mgr manager.Manager, opts options.AddOptions) (*ReconcileInst
 		namespaceMigration:   nm,
 		enterpriseCRDsExist:  opts.EnterpriseCRDExists,
 		clusterDomain:        opts.ClusterDomain,
+		nameservers:          opts.Nameservers,
 		manageCRDs:           opts.ManageCRDs,
 		tierWatchReady:       &utils.ReadyFlag{},
 		newComponentHandler:  utils.NewComponentHandler,
@@ -368,6 +369,7 @@ type ReconcileInstallation struct {
 	enterpriseCRDsExist           bool
 	migrationChecked              bool
 	clusterDomain                 string
+	nameservers                   []string
 	manageCRDs                    bool
 	tierWatchReady                *utils.ReadyFlag
 	// newComponentHandler returns a new component handler. Useful stub for unit testing.

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -34,6 +34,12 @@ type AddOptions struct {
 	ManageCRDs          bool
 	ShutdownContext     context.Context
 
+	// Nameservers contains the nameservers configured for the operator. Most pods do not need explicit
+	// nameservers specified, as they will use the default nameservers configured in the cluster. However, any pods
+	// that must function prior to cluster DNS being available (e.g., the operator itself and calico/node)
+	// may need to have the nameservers explicitly set if configured to access the Kubernetes API via a domain name.
+	Nameservers []string
+
 	// Kubernetes clientset used by controllers to create watchers and informers.
 	K8sClientset *kubernetes.Clientset
 

--- a/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpfilters.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_blockaffinities.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_blockaffinities.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: blockaffinities.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: caliconodestatuses.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_clusterinformations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_clusterinformations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: clusterinformations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: felixconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_globalnetworksets.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_globalnetworksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_hostendpoints.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_hostendpoints.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: hostendpoints.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamblocks.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamblocks.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamblocks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamconfigs.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamconfigs.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamhandles.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamhandles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamhandles.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ippools.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ippools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ippools.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipreservations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipreservations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipreservations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: kubecontrollersconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_networkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_networkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_networksets.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_networksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedglobalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagednetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagednetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagednetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_tiers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_tiers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: tiers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -60,7 +60,7 @@ func GetClusterDomain(resolvConfPath string) (string, error) {
 	return clusterDomain, nil
 }
 
-// IsDomainName checks if the given name is a domain name and returns truee if it is.
+// IsDomainName checks if the given name is a domain name and returns true if it is.
 func IsDomainName(name string) bool {
 	// Attempt to parse it as an IP.
 	if net.ParseIP(name) != nil {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -63,10 +63,7 @@ func GetClusterDomain(resolvConfPath string) (string, error) {
 // IsDomainName checks if the given name is a domain name and returns true if it is.
 func IsDomainName(name string) bool {
 	// Attempt to parse it as an IP.
-	if net.ParseIP(name) != nil {
-		return false
-	}
-	return true
+	return net.ParseIP(name) != nil
 }
 
 // Nameservers returns the list of nameservers from the resolv.conf file.

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -63,7 +63,7 @@ func GetClusterDomain(resolvConfPath string) (string, error) {
 // IsDomainName checks if the given name is a domain name and returns true if it is.
 func IsDomainName(name string) bool {
 	// Attempt to parse it as an IP.
-	return net.ParseIP(name) != nil
+	return net.ParseIP(name) == nil
 }
 
 // Nameservers returns the list of nameservers from the resolv.conf file.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In eBPF mode (and theoretically any time KUBERNETES_SERVICE_HOST is a domain name instead of an IP), calico/node needs explicit nameserver configuration in order to resolve the address. Inherit this from the operator pod's configuration itself.

This is needed as a consequence of adjusting the DNS policy on calico/node to ClusterFirstWithHostNet, which was done as part of enabling DNS resolution of `goldmane` running as an in-cluster service.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.