### PR TITLE
[Cherry-pick][v1.37] Add rbac to delete secrets (#3870)

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -250,7 +250,11 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 		toCreate = append(toCreate, es.elasticsearchClusterRole(), es.elasticsearchClusterRoleBinding())
 	}
 
-	roles, bindings := es.elasticsearchRolesAndBindings()
+	// We need to allow to es-kube-controllers to managed secrets in the management clusters
+	// before pushing the Linseed - Voltron certificate to the tunnel. This certificate is pushed
+	// from es-kube-controllers for zero tenants and single tenant management clusters. Single tenant management
+	// cluster with external ES have these permissions configured with external elasticsearch renderer.
+	roles, bindings := es.kubecControllersRolesAndBindings()
 	for _, r := range roles {
 		toCreate = append(toCreate, r)
 	}
@@ -1014,7 +1018,7 @@ func (es *elasticsearchComponent) elasticsearchInternalAllowTigeraPolicy() *v3.N
 	}
 }
 
-func (es *elasticsearchComponent) elasticsearchRolesAndBindings() ([]*rbacv1.Role, []*rbacv1.RoleBinding) {
+func (es *elasticsearchComponent) kubecControllersRolesAndBindings() ([]*rbacv1.Role, []*rbacv1.RoleBinding) {
 
 	secretsRole := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/logstorage/externalelasticsearch/externalelasticsearch.go
+++ b/pkg/render/logstorage/externalelasticsearch/externalelasticsearch.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -29,11 +30,12 @@ import (
 
 // ExternalElasticsearch is used when Elasticsearch doesn't exist in this cluster, but we still need to set up resources
 // related to Elasticsearch in the cluster.
-func ExternalElasticsearch(install *operatorv1.InstallationSpec, clusterConfig *relasticsearch.ClusterConfig, pullSecrets []*corev1.Secret) render.Component {
+func ExternalElasticsearch(install *operatorv1.InstallationSpec, clusterConfig *relasticsearch.ClusterConfig, pullSecrets []*corev1.Secret, multiTenant bool) render.Component {
 	return &externalElasticsearch{
 		installation:  install,
 		clusterConfig: clusterConfig,
 		pullSecrets:   pullSecrets,
+		multiTenant:   multiTenant,
 	}
 }
 
@@ -41,6 +43,7 @@ type externalElasticsearch struct {
 	installation  *operatorv1.InstallationSpec
 	clusterConfig *relasticsearch.ClusterConfig
 	pullSecrets   []*corev1.Secret
+	multiTenant   bool
 }
 
 func (e externalElasticsearch) ResolveImages(is *operatorv1.ImageSet) error {
@@ -56,6 +59,23 @@ func (e externalElasticsearch) Objects() (toCreate, toDelete []client.Object) {
 	if len(e.pullSecrets) > 0 {
 		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(render.ElasticsearchNamespace, e.pullSecrets...)...)...)
 	}
+
+	if !e.multiTenant {
+		// We need to allow to es-kube-controllers to managed secrets in the management clusters
+		// before pushing the Linseed - Voltron certificate to the tunnel. This certificate is pushed
+		// from es-kube-controllers for Single Tenant Management cluster. These types of cluster
+		// are using external ES. Similar RBAC is created in logstorage renderer that gets executed
+		// for management clusters with zero tenants or single tenant management clusters with internal
+		// elasticsearch
+		roles, bindings := e.kubeControllersRolesAndBindings()
+		for _, r := range roles {
+			toCreate = append(toCreate, r)
+		}
+		for _, b := range bindings {
+			toCreate = append(toCreate, b)
+		}
+	}
+
 	return toCreate, toDelete
 }
 
@@ -111,4 +131,81 @@ func (e externalElasticsearch) oidcUserRoleBinding() client.Object {
 			},
 		},
 	}
+}
+
+func (e externalElasticsearch) kubeControllersRolesAndBindings() ([]*rbacv1.Role, []*rbacv1.RoleBinding) {
+
+	secretsRole := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.CalicoKubeControllerSecret,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"create", "delete", "deletecollection", "update"},
+			},
+		},
+	}
+
+	operatorSecretsRole := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.CalicoKubeControllerSecret,
+			Namespace: common.OperatorNamespace(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"create", "delete", "deletecollection", "update"},
+			},
+		},
+	}
+
+	secretBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.CalicoKubeControllerSecret,
+			Namespace: render.ElasticsearchNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     render.CalicoKubeControllerSecret,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "calico-kube-controllers",
+				Namespace: common.CalicoNamespace,
+			},
+		},
+	}
+
+	// Bind the secrets permission to the operator namespace. This binding now adds permissions for kube controllers to manipulate
+	// secrets in the tigera-operator namespace
+	operatorSecretBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.CalicoKubeControllerSecret,
+			Namespace: common.OperatorNamespace(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     render.CalicoKubeControllerSecret,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "calico-kube-controllers",
+				Namespace: common.CalicoNamespace,
+			},
+		},
+	}
+
+	return []*rbacv1.Role{secretsRole, operatorSecretsRole}, []*rbacv1.RoleBinding{secretBinding, operatorSecretBinding}
 }

--- a/pkg/render/logstorage/externalelasticsearch/externalelasticsearch_test.go
+++ b/pkg/render/logstorage/externalelasticsearch/externalelasticsearch_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package externalelasticsearch
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -53,13 +54,58 @@ var _ = Describe("External Elasticsearch rendering tests", func() {
 				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.EsManagerRole, Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.EsManagerRoleBinding, Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: render.ElasticsearchNamespace}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: render.ElasticsearchNamespace}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: common.OperatorNamespace()}},
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: common.OperatorNamespace()}},
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			}
 
-			component := ExternalElasticsearch(installation, clusterConfig, pullSecrets)
+			component := ExternalElasticsearch(installation, clusterConfig, pullSecrets, false)
 			createResources, _ := component.Objects()
 
 			rtest.ExpectResources(createResources, expectedResources)
+		})
+
+		It("should delete secrets from elasticsearch and operator namespace", func() {
+
+			component := ExternalElasticsearch(installation, clusterConfig, pullSecrets, false)
+			createResources, _ := component.Objects()
+
+			secretsRules := rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"create", "delete", "deletecollection", "update"},
+			}
+
+			esRole := rtest.GetResource(createResources, render.CalicoKubeControllerSecret, render.ElasticsearchNamespace, rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
+			Expect(esRole.Rules).To(ContainElement(secretsRules))
+
+			esRoleBinding := rtest.GetResource(createResources, render.CalicoKubeControllerSecret, render.ElasticsearchNamespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(esRoleBinding.RoleRef.Kind).To(Equal("Role"))
+			Expect(esRoleBinding.RoleRef.Name).To(Equal(render.CalicoKubeControllerSecret))
+			Expect(esRoleBinding.Subjects).To(ContainElements([]rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "calico-kube-controllers",
+					Namespace: "calico-system",
+				},
+			}))
+
+			operatorRole := rtest.GetResource(createResources, render.CalicoKubeControllerSecret, common.OperatorNamespace(), rbacv1.GroupName, "v1", "Role").(*rbacv1.Role)
+			Expect(operatorRole.Rules).To(ContainElement(secretsRules))
+
+			opRoleBinding := rtest.GetResource(createResources, render.CalicoKubeControllerSecret, render.ElasticsearchNamespace, rbacv1.GroupName, "v1", "RoleBinding").(*rbacv1.RoleBinding)
+			Expect(opRoleBinding.RoleRef.Kind).To(Equal("Role"))
+			Expect(opRoleBinding.RoleRef.Name).To(Equal(render.CalicoKubeControllerSecret))
+			Expect(opRoleBinding.Subjects).To(ContainElements([]rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "calico-kube-controllers",
+					Namespace: "calico-system",
+				},
+			}))
+
 		})
 	})
 })


### PR DESCRIPTION
* Add rbac to delete secrets for external controller

When connecting a managed cluster to a management single tenant cluster, es-kube-controllers are responsible for copying the voltron linseed certificate via the tunnel. Before this operation, es kube controllers will first reconcile users. Any failure in reconciling users will lead to the certificate not being copied over. The first step in user reconciliation is to delete secret for decommisioned users or components, like curator. A failure because of missing RBAC will result the certificate not copied over, namespaces for fluentD, commpliance and intrusion controller not being created in the managed cluster. Single tenant management clusters with external elasticsearch are configured using external elasticsearch controller and rendered.

* Fix! Update CRDs

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
