### PR TITLE
Automated cherry pick of #3654: Update dex binary path

### DIFF
--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -266,7 +266,7 @@ func (c *dexComponent) deployment() client.Object {
 							LivenessProbe:   c.probe(),
 							SecurityContext: securitycontext.NewNonRootContext(),
 
-							Command: []string{"/dex", "serve", "/etc/dex/baseCfg/config.yaml"},
+							Command: []string{"/usr/bin/dex", "serve", "/etc/dex/baseCfg/config.yaml"},
 
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
Cherry pick of #3654 on release-v1.36.

Original branch name master

#3654: Update dex binary path