### PR TITLE
Enable Envoy Gateway backend API

### DIFF
--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -444,6 +444,9 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 	}
 	envoyGatewayConfig.Provider.Kubernetes.RateLimitDeployment.Pod.ImagePullSecrets = secret.GetReferenceList(pr.cfg.PullSecrets)
 
+	// Enable backend APIs.
+	envoyGatewayConfig.ExtensionAPIs.EnableBackend = true
+
 	// Rebuild the ConfigMap with those changes.
 	envoyGatewayConfigMap := resources.envoyGatewayConfigMap.DeepCopyObject().(*corev1.ConfigMap)
 	if bytes, err := yaml.Marshal(*envoyGatewayConfig); err == nil {

--- a/pkg/render/gateway_api_test.go
+++ b/pkg/render/gateway_api_test.go
@@ -310,6 +310,7 @@ var _ = Describe("Gateway API rendering tests", func() {
 		Expect(*gatewayConfig.Provider.Kubernetes.RateLimitDeployment.Container.Image).To(Equal("myregistry.io/calico/envoy-ratelimit:" + components.ComponentCalicoEnvoyRatelimit.Version))
 		Expect(gatewayConfig.Provider.Kubernetes.RateLimitDeployment.Pod.ImagePullSecrets).To(ContainElement(pullSecretRefs[0]))
 		Expect(*gatewayConfig.Provider.Kubernetes.ShutdownManager.Image).To(Equal("myregistry.io/calico/envoy-gateway:" + components.ComponentCalicoEnvoyGateway.Version))
+		Expect(gatewayConfig.ExtensionAPIs.EnableBackend).To(BeTrue())
 	})
 
 	It("should honour private registry (Enterprise)", func() {


### PR DESCRIPTION
This enables the use of the Envoy-specific Backend resource for backend routing as described here: https://gateway.envoyproxy.io/docs/tasks/traffic/backend/.