### PR TITLE
Enable Envoy Gateway backend API

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgpfilters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpfilters.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_blockaffinities.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_blockaffinities.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: blockaffinities.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: caliconodestatuses.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_clusterinformations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_clusterinformations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: clusterinformations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: felixconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_globalnetworksets.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_globalnetworksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_hostendpoints.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_hostendpoints.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: hostendpoints.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamblocks.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamblocks.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamblocks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamconfigs.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamconfigs.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipamhandles.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipamhandles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamhandles.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ippools.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ippools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ippools.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_ipreservations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_ipreservations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipreservations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: kubecontrollersconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_networkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_networkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_networksets.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_networksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedglobalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_stagednetworkpolicies.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_stagednetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagednetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/calico/crd.projectcalico.org_tiers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_tiers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: tiers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_alertexceptions.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_alertexceptions.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: alertexceptions.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_bfdconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bfdconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bfdconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgpconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgpfilters.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgpfilters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgpfilters.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: bgppeers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_blockaffinities.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_blockaffinities.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: blockaffinities.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_caliconodestatuses.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_caliconodestatuses.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: caliconodestatuses.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_clusterinformations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_clusterinformations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: clusterinformations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_deeppacketinspections.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_deeppacketinspections.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: deeppacketinspections.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_egressgatewaypolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_egressgatewaypolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: egressgatewaypolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_externalnetworks.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_externalnetworks.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: externalnetworks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: felixconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalalerts.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalalerts.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalalerts.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalalerttemplates.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalalerttemplates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalalerttemplates.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalnetworksets.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalnetworksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalnetworksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalreports.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalreports.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalreports.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalreporttypes.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalreporttypes.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalreporttypes.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_globalthreatfeeds.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_globalthreatfeeds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: globalthreatfeeds.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_hostendpoints.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_hostendpoints.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: hostendpoints.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_ipamblocks.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_ipamblocks.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamblocks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_ipamconfigs.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_ipamconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamconfigs.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_ipamhandles.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_ipamhandles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipamhandles.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_ippools.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_ippools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ippools.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_ipreservations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_ipreservations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: ipreservations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: kubecontrollersconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_licensekeys.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_licensekeys.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: licensekeys.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_managedclusters.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_managedclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: managedclusters.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_networkpolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_networkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_networksets.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_networksets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: networksets.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_packetcaptures.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_packetcaptures.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: packetcaptures.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_policyrecommendationscopes.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_policyrecommendationscopes.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: policyrecommendationscopes.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_remoteclusterconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_remoteclusterconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: remoteclusterconfigurations.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_securityeventwebhooks.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_securityeventwebhooks.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: securityeventwebhooks.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedglobalnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagedkubernetesnetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_stagednetworkpolicies.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_stagednetworkpolicies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: stagednetworkpolicies.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_tiers.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_tiers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: tiers.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_uisettings.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: uisettings.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/crd.projectcalico.org_uisettingsgroups.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_uisettingsgroups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: uisettingsgroups.crd.projectcalico.org
 spec:
   group: crd.projectcalico.org

--- a/pkg/crds/enterprise/usage.tigera.io_licenseusagereports.yaml
+++ b/pkg/crds/enterprise/usage.tigera.io_licenseusagereports.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: licenseusagereports.usage.tigera.io
 spec:
   group: usage.tigera.io

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -444,6 +444,11 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 	}
 	envoyGatewayConfig.Provider.Kubernetes.RateLimitDeployment.Pod.ImagePullSecrets = secret.GetReferenceList(pr.cfg.PullSecrets)
 
+	// Enable backend APIs.
+	envoyGatewayConfig.ExtensionAPIs = &envoyapi.ExtensionAPISettings{
+		EnableBackend: true,
+	}
+
 	// Rebuild the ConfigMap with those changes.
 	envoyGatewayConfigMap := resources.envoyGatewayConfigMap.DeepCopyObject().(*corev1.ConfigMap)
 	if bytes, err := yaml.Marshal(*envoyGatewayConfig); err == nil {

--- a/pkg/render/gateway_api_test.go
+++ b/pkg/render/gateway_api_test.go
@@ -310,6 +310,8 @@ var _ = Describe("Gateway API rendering tests", func() {
 		Expect(*gatewayConfig.Provider.Kubernetes.RateLimitDeployment.Container.Image).To(Equal("myregistry.io/calico/envoy-ratelimit:" + components.ComponentCalicoEnvoyRatelimit.Version))
 		Expect(gatewayConfig.Provider.Kubernetes.RateLimitDeployment.Pod.ImagePullSecrets).To(ContainElement(pullSecretRefs[0]))
 		Expect(*gatewayConfig.Provider.Kubernetes.ShutdownManager.Image).To(Equal("myregistry.io/calico/envoy-gateway:" + components.ComponentCalicoEnvoyGateway.Version))
+		Expect(gatewayConfig.ExtensionAPIs).NotTo(BeNil())
+		Expect(gatewayConfig.ExtensionAPIs.EnableBackend).To(BeTrue())
 	})
 
 	It("should honour private registry (Enterprise)", func() {


### PR DESCRIPTION
This enables the use of the Envoy-specific Backend resource for backend routing
as described here: https://gateway.envoyproxy.io/docs/tasks/traffic/backend/.

(cherry-pick of #3902 for release-v1.38 branch)