### PR TITLE
[CORE-11328] Upgrading envoyproxy/gateway and envoyproxy/ratelimit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ else
 endif
 
 ENVOY_GATEWAY_HELM_CHART ?= oci://docker.io/envoyproxy/gateway-helm
-ENVOY_GATEWAY_VERSION ?= v1.2.6
+ENVOY_GATEWAY_VERSION ?= v1.2.8
 ENVOY_GATEWAY_PREFIX ?= tigera-gateway-api
 ENVOY_GATEWAY_NAMESPACE ?= tigera-gateway
 ENVOY_GATEWAY_RESOURCES = pkg/render/gateway_api_resources.yaml

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containernetworking/cni v1.2.3
 	github.com/corazawaf/coraza-coreruleset/v4 v4.7.0
 	github.com/elastic/cloud-on-k8s/v2 v2.14.0
-	github.com/envoyproxy/gateway v1.2.6
+	github.com/envoyproxy/gateway v1.2.8
 	github.com/go-ldap/ldap v3.0.3+incompatible
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUt
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/envoyproxy/gateway v1.2.6 h1:QxHBcJUdF2Rvof1Om6GQnSGKnq+l57zp60AGfFuql1Q=
-github.com/envoyproxy/gateway v1.2.6/go.mod h1:lDELg4TDh0CdlGHnWR4XJL1+O36KxSm68tT6zD2gTDQ=
+github.com/envoyproxy/gateway v1.2.8 h1:p/YkLz0xVfTJPE7Gdj1+EgEC60/RzOAz0aEp5pP6Oo4=
+github.com/envoyproxy/gateway v1.2.8/go.mod h1:Z7d3qn/ZErpQ5yZelsdFLSXHuvgIQdsfkA708aU7FV8=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=

--- a/pkg/render/gateway_api_resources.yaml
+++ b/pkg/render/gateway_api_resources.yaml
@@ -38471,10 +38471,10 @@ metadata:
   name: envoy-gateway
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: gateway-helm/templates/envoy-gateway-config.yaml
@@ -38484,10 +38484,10 @@ metadata:
   name: envoy-gateway-config
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 data:
   envoy-gateway.yaml: |
@@ -38502,7 +38502,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:49af5cca
+            image: docker.io/envoyproxy/ratelimit:ae4cee11
           patch:
             type: StrategicMerge
             value:
@@ -38513,7 +38513,7 @@ data:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
         shutdownManager:
-          image: docker.io/envoyproxy/gateway:v1.2.6
+          image: docker.io/envoyproxy/gateway:v1.2.8
       type: Kubernetes
 ---
 # Source: gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -38658,10 +38658,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-infra-manager
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -38707,10 +38707,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-leader-election-role
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -38752,10 +38752,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-infra-manager
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -38773,10 +38773,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-leader-election-rolebinding
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -38795,10 +38795,10 @@ metadata:
   namespace: 'tigera-gateway'
   labels:
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -38827,10 +38827,10 @@ metadata:
   namespace: 'tigera-gateway'
   labels:
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -38861,7 +38861,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway:v1.2.6
+        image: docker.io/envoyproxy/gateway:v1.2.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -38928,10 +38928,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
@@ -38943,10 +38943,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
@@ -38967,10 +38967,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install
@@ -38990,10 +38990,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.2.6
+    helm.sh/chart: gateway-helm-v1.2.8
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.2.6"
+    app.kubernetes.io/version: "v1.2.8"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
@@ -39018,7 +39018,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway:v1.2.6
+        image: docker.io/envoyproxy/gateway:v1.2.8
         imagePullPolicy: IfNotPresent
         name: envoy-gateway-certgen
         securityContext:


### PR DESCRIPTION
## Description

- envoyproxy/gateway from 1.2.6 to 1.2.8
- envoyproxy/ratelimit from 49af5cca to ae4cee11

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
