### PR TITLE
[release-v1.38] Auto pick #3910: Fix manager RBAC for mixed mode management clusters

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -629,7 +629,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	managedCalicoNamespaces, err := helper.FilteredTenantNamespaces(r.client, utils.ManagedCalicoOnly)
+	ossTenantNamespaces, err := helper.FilteredTenantNamespaces(r.client, utils.ManagedCalicoOnly)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -677,7 +677,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		Tenant:                  tenant,
 		ExternalElastic:         r.elasticExternal,
 		BindingNamespaces:       namespaces,
-		ManagedCalicoNamespaces: managedCalicoNamespaces,
+		OSSTenantNamespaces:     ossTenantNamespaces,
 		Manager:                 instance,
 	}
 

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -629,6 +629,10 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	managedCalicoNamespaces, err := helper.ManagedCalicoNamespaces(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	routeConfig, err := getVoltronRouteConfig(ctx, r.client, helper.InstallNamespace())
 	if err != nil {

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -625,11 +625,11 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	// Determine the namespaces to which we must bind the cluster role.
-	namespaces, err := helper.TenantNamespaces(r.client)
+	namespaces, err := helper.FilteredTenantNamespaces(r.client, utils.ManagedEnterpriseOnly)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	managedCalicoNamespaces, err := helper.ManagedCalicoNamespaces(r.client)
+	managedCalicoNamespaces, err := helper.FilteredTenantNamespaces(r.client, utils.ManagedCalicoOnly)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -677,6 +677,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		Tenant:                  tenant,
 		ExternalElastic:         r.elasticExternal,
 		BindingNamespaces:       namespaces,
+		ManagedCalicoNamespaces: managedCalicoNamespaces,
 		Manager:                 instance,
 	}
 

--- a/pkg/controller/tiers/tiers_controller.go
+++ b/pkg/controller/tiers/tiers_controller.go
@@ -199,7 +199,7 @@ func (r *ReconcileTiers) prepareTiersConfig(ctx context.Context, reqLogger logr.
 	}
 	if r.multiTenant {
 		// For multi-tenant clusters, we need to include well-known namespaces as well as per-tenant namespaces.
-		tenantNamespaces, err := utils.TenantNamespaces(ctx, r.client)
+		tenantNamespaces, err := utils.TenantNamespaces(ctx, r.client, nil)
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying tenant namespaces", err, reqLogger)
 			return nil, &reconcile.Result{RequeueAfter: utils.StandardRetry}

--- a/pkg/controller/utils/namespace_helper.go
+++ b/pkg/controller/utils/namespace_helper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/utils/namespace_helper.go
+++ b/pkg/controller/utils/namespace_helper.go
@@ -57,7 +57,7 @@ type NamespaceHelper interface {
 	// For single-tenant clusters, this simply returns the InstallNamespace.
 	TenantNamespaces(client.Client) ([]string, error)
 
-	// FilteredTenantNamespaces returns all namespaces for all Tenants that have Calico OSS managed clusters.
+	// FilteredTenantNamespaces returns all namespaces for all Tenants that match the given filter.
 	FilteredTenantNamespaces(client.Client, TenantFilter) ([]string, error)
 
 	// Returns whether or not this is a multi-tenant helper.

--- a/pkg/controller/utils/namespace_helper.go
+++ b/pkg/controller/utils/namespace_helper.go
@@ -37,6 +37,10 @@ func NewNamespaceHelper(mt bool, singleTenantNS, multiTenantNS string) Namespace
 	}
 }
 
+// TenantFilter is a function that accepts a tenant and returns true if the Tenant should be included
+// in the query, and false otherwise.
+type TenantFilter func(*operator.Tenant) bool
+
 type NamespaceHelper interface {
 	// InstallNamespace returns the namespace that components will be installed into.
 	// for single-tenant clusters, this is generally a well-known namespace of the form tigera-*.
@@ -53,8 +57,8 @@ type NamespaceHelper interface {
 	// For single-tenant clusters, this simply returns the InstallNamespace.
 	TenantNamespaces(client.Client) ([]string, error)
 
-	// ManagedCalicoNamespaces returns all namespaces for all Tenants that have Calico OSS managed clusters.
-	ManagedCalicoNamespaces(client.Client) ([]string, error)
+	// FilteredTenantNamespaces returns all namespaces for all Tenants that have Calico OSS managed clusters.
+	FilteredTenantNamespaces(client.Client, TenantFilter) ([]string, error)
 
 	// Returns whether or not this is a multi-tenant helper.
 	MultiTenant() bool
@@ -91,13 +95,19 @@ func (r *namespacer) TenantNamespaces(c client.Client) ([]string, error) {
 	return []string{r.InstallNamespace()}, nil
 }
 
-func (r *namespacer) ManagedCalicoNamespaces(c client.Client) ([]string, error) {
+func (r *namespacer) FilteredTenantNamespaces(c client.Client, f TenantFilter) ([]string, error) {
 	if r.multiTenant {
-		return TenantNamespaces(context.Background(), c, calicoOnly)
+		return TenantNamespaces(context.Background(), c, f)
 	}
 	return []string{r.InstallNamespace()}, nil
 }
 
-func calicoOnly(t *operator.Tenant) bool {
+// ManagedCalicoOnly is a TenantFilter that matches tenants who manage Calico OSS clusters.
+func ManagedCalicoOnly(t *operator.Tenant) bool {
 	return t.ManagedClusterIsCalico()
+}
+
+// ManagedEnterpriseOnly is a TenantFilter that matches tenants who manage Calico Enterprise clusters.
+func ManagedEnterpriseOnly(t *operator.Tenant) bool {
+	return t != nil && !t.ManagedClusterIsCalico()
 }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -538,7 +538,8 @@ func GetTenant(ctx context.Context, mt bool, cli client.Client, ns string) (*ope
 }
 
 // TenantNamespaces returns all namespaces that contain a tenant.
-func TenantNamespaces(ctx context.Context, cli client.Client) ([]string, error) {
+// include is an optional filter function that returns true if the tenant should be included, false otherwise.
+func TenantNamespaces(ctx context.Context, cli client.Client, include func(*operatorv1.Tenant) bool) ([]string, error) {
 	namespaces := []string{}
 	tenants := operatorv1.TenantList{}
 	err := cli.List(ctx, &tenants)
@@ -546,7 +547,9 @@ func TenantNamespaces(ctx context.Context, cli client.Client) ([]string, error) 
 		return nil, err
 	}
 	for _, t := range tenants.Items {
-		namespaces = append(namespaces, t.Namespace)
+		if include == nil || include(&t) {
+			namespaces = append(namespaces, t.Namespace)
+		}
 	}
 
 	// Sort the namespaces, so that the output is deterministic.

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -539,7 +539,7 @@ func GetTenant(ctx context.Context, mt bool, cli client.Client, ns string) (*ope
 
 // TenantNamespaces returns all namespaces that contain a tenant.
 // include is an optional filter function that returns true if the tenant should be included, false otherwise.
-func TenantNamespaces(ctx context.Context, cli client.Client, include func(*operatorv1.Tenant) bool) ([]string, error) {
+func TenantNamespaces(ctx context.Context, cli client.Client, include TenantFilter) ([]string, error) {
 	namespaces := []string{}
 	tenants := operatorv1.TenantList{}
 	err := cli.List(ctx, &tenants)

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -154,7 +154,7 @@ func (c *GuardianComponent) Objects() ([]client.Object, []client.Object) {
 			CreateNamespace(ManagerNamespace, c.cfg.Installation.KubernetesProvider, PSSRestricted, c.cfg.Installation.Azure),
 			managerServiceAccount(ManagerNamespace),
 			managerClusterRole(true, c.cfg.Installation.KubernetesProvider, nil),
-			managerClusterRoleBinding([]string{ManagerNamespace}),
+			managerClusterRoleBinding(nil, []string{ManagerNamespace}, []string{}),
 
 			// Install default UI settings for this managed cluster.
 			managerClusterWideSettingsGroup(),

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -173,7 +173,7 @@ type ManagerConfiguration struct {
 	BindingNamespaces []string
 
 	// List of namespaces for Tenants who manage Calico OSS clusters, in a multi-tenant system.
-	ManagedCalicoNamespaces []string
+	OSSTenantNamespaces []string
 
 	// Whether to run the rendered components in multi-tenant, single-tenant, or zero-tenant mode
 	Tenant          *operatorv1.Tenant
@@ -242,7 +242,7 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	}
 
 	objs = append(objs,
-		managerClusterRoleBinding(c.cfg.Tenant, c.cfg.BindingNamespaces, c.cfg.ManagedCalicoNamespaces),
+		managerClusterRoleBinding(c.cfg.Tenant, c.cfg.BindingNamespaces, c.cfg.OSSTenantNamespaces),
 		managerClusterRole(false, c.cfg.Installation.KubernetesProvider, c.cfg.Tenant),
 	)
 

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -49,14 +49,21 @@ import (
 )
 
 const (
-	managerPort                  = 9443
-	managerTargetPort            = 9443
-	ManagerServiceName           = "tigera-manager"
-	ManagerDeploymentName        = "tigera-manager"
-	ManagerNamespace             = "tigera-manager"
-	ManagerServiceAccount        = "tigera-manager"
-	ManagerClusterRole           = "tigera-manager-role"
-	ManagerClusterRoleBinding    = "tigera-manager-binding"
+	managerPort           = 9443
+	managerTargetPort     = 9443
+	ManagerServiceName    = "tigera-manager"
+	ManagerDeploymentName = "tigera-manager"
+	ManagerNamespace      = "tigera-manager"
+	ManagerServiceAccount = "tigera-manager"
+
+	// Default manager RBAC resources.
+	ManagerClusterRole        = "tigera-manager-role"
+	ManagerClusterRoleBinding = "tigera-manager-binding"
+
+	// Manager RBAC resources for Calico managed clusters.
+	ManagerManagedCalicoClusterRole        = "tigera-manager-managed-calico"
+	ManagerManagedCalicoClusterRoleBinding = "tigera-manager-managed-calico"
+
 	ManagerTLSSecretName         = "manager-tls"
 	ManagerInternalTLSSecretName = "internal-manager-tls"
 	ManagerPolicyName            = networkpolicy.TigeraComponentPolicyPrefix + "manager-access"
@@ -158,9 +165,15 @@ type ManagerConfiguration struct {
 	ComplianceLicenseActive bool
 	ComplianceNamespace     string
 
-	Namespace         string
-	TruthNamespace    string
+	Namespace      string
+	TruthNamespace string
+
+	// Single namespace to which RBAC should be bound, in single-tenant systems.
+	// List of all tenant namespaces, in a multi-tenant system.
 	BindingNamespaces []string
+
+	// List of namespaces for Tenants who manage Calico OSS clusters, in a multi-tenant system.
+	ManagedCalicoNamespaces []string
 
 	// Whether to run the rendered components in multi-tenant, single-tenant, or zero-tenant mode
 	Tenant          *operatorv1.Tenant
@@ -229,7 +242,7 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	}
 
 	objs = append(objs,
-		managerClusterRoleBinding(c.cfg.BindingNamespaces),
+		managerClusterRoleBinding(c.cfg.Tenant, c.cfg.BindingNamespaces, c.cfg.ManagedCalicoNamespaces),
 		managerClusterRole(false, c.cfg.Installation.KubernetesProvider, c.cfg.Tenant),
 	)
 
@@ -695,17 +708,30 @@ func managerServiceAccount(ns string) *corev1.ServiceAccount {
 	}
 }
 
-func managerClusterRoleBinding(namespaces []string) client.Object {
-	return rcomponents.ClusterRoleBinding(ManagerClusterRoleBinding, ManagerClusterRole, ManagerServiceAccount, namespaces)
+func managerClusterRoleBinding(tenant *operatorv1.Tenant, namespaces, calicoNamespaces []string) client.Object {
+	// Different tenant types use different permission sets.
+	roleName := ManagerClusterRole
+	bindingName := ManagerClusterRoleBinding
+	chosenNamespaces := namespaces
+	if tenant.ManagedClusterIsCalico() {
+		roleName = ManagerManagedCalicoClusterRole
+		bindingName = ManagerManagedCalicoClusterRoleBinding
+		chosenNamespaces = calicoNamespaces
+	}
+	return rcomponents.ClusterRoleBinding(bindingName, roleName, ManagerServiceAccount, chosenNamespaces)
 }
 
 // managerClusterRole returns a clusterrole that allows authn/authz review requests.
 func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provider, tenant *operatorv1.Tenant) *rbacv1.ClusterRole {
+	// Different tenant types use different permission sets.
+	name := ManagerClusterRole
+	if tenant.ManagedClusterIsCalico() {
+		name = ManagerManagedCalicoClusterRole
+	}
+
 	cr := &rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ManagerClusterRole,
-		},
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"authorization.k8s.io"},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1425,7 +1425,7 @@ func renderObjects(roc renderConfig) []client.Object {
 		OpenShift:               roc.openshift,
 		Namespace:               roc.ns,
 		BindingNamespaces:       roc.bindingNamespaces,
-		ManagedCalicoNamespaces: roc.ossBindingNamepsaces,
+		OSSTenantNamespaces:     roc.ossBindingNamepsaces,
 		TruthNamespace:          common.OperatorNamespace(),
 		Tenant:                  roc.tenant,
 		Manager:                 roc.manager,

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1089,6 +1089,39 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			}))
 		})
 
+		It("should render distinct RBAC for Calico OSS managed cluster tenants", func() {
+			resources := renderObjects(renderConfig{
+				oidc:                    false,
+				managementCluster:       nil,
+				installation:            installation,
+				compliance:              compliance,
+				complianceFeatureActive: true,
+				ns:                      tenantBNamespace,
+				bindingNamespaces:       []string{tenantANamespace, tenantBNamespace},
+				ossBindingNamepsaces:    []string{tenantBNamespace},
+				tenant: &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tenantB",
+						Namespace: tenantBNamespace,
+					},
+					Spec: operatorv1.TenantSpec{
+						ID:                    "tenant-b",
+						ManagedClusterVariant: &operatorv1.Calico,
+					},
+				},
+			})
+
+			// It should only bind to the ossBindingNamepsaces.
+			crb := rtest.GetResource(resources, render.ManagerManagedCalicoClusterRoleBinding, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(crb.Subjects).To(Equal([]rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      render.ManagerServiceAccount,
+					Namespace: tenantBNamespace,
+				},
+			}))
+		})
+
 		It("should render cluster role/roles with additional RBAC", func() {
 			resources := renderObjects(renderConfig{
 				oidc:                    false,
@@ -1326,6 +1359,7 @@ type renderConfig struct {
 	openshift               bool
 	ns                      string
 	bindingNamespaces       []string
+	ossBindingNamepsaces    []string
 	tenant                  *operatorv1.Tenant
 	manager                 *operatorv1.Manager
 	externalElastic         bool
@@ -1391,6 +1425,7 @@ func renderObjects(roc renderConfig) []client.Object {
 		OpenShift:               roc.openshift,
 		Namespace:               roc.ns,
 		BindingNamespaces:       roc.bindingNamespaces,
+		ManagedCalicoNamespaces: roc.ossBindingNamepsaces,
 		TruthNamespace:          common.OperatorNamespace(),
 		Tenant:                  roc.tenant,
 		Manager:                 roc.manager,


### PR DESCRIPTION
Cherry pick of #3910 on release-v1.38.

#3910: Fix manager RBAC for mixed mode management clusters

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We need a ClusterRole/Binding per Tenant class, rather than shared RBAC
for all.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.