### PR TITLE
[release-v1.37] Auto pick #3907: Disable license controller for Calico managed clusters

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -209,7 +209,8 @@ func NewElasticsearchKubeControllers(cfg *KubeControllersConfiguration) *kubeCon
 		if cfg.ManagementCluster != nil {
 			enabledControllers = append(enabledControllers, "managedcluster")
 		}
-	} else {
+	} else if !cfg.Tenant.ManagedClusterIsCalico() {
+		// Calico OSS Managed clusters do not need the license controller.
 		enabledControllers = append(enabledControllers, "managedclusterlicensing")
 	}
 


### PR DESCRIPTION
Cherry pick of #3907 on release-v1.37.

#3907: Disable license controller for Calico managed clusters

# Original PR Body below

Cherry pick of #3905 on release-v1.38.

#3905: Disable license controller for Calico managed clusters

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.