### PR TITLE
[release-v1.37] Auto pick #3917: Don't run kube-controllers if there are no enabled

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -273,6 +273,7 @@ func (c *kubeControllersComponent) SupportedOSType() rmeta.OSType {
 
 func (c *kubeControllersComponent) Objects() ([]client.Object, []client.Object) {
 	objectsToCreate := []client.Object{}
+	objectsToDelete := []client.Object{}
 
 	if c.kubeControllerAllowTigeraPolicy != nil {
 		objectsToCreate = append(objectsToCreate, c.kubeControllerAllowTigeraPolicy)
@@ -288,13 +289,18 @@ func (c *kubeControllersComponent) Objects() ([]client.Object, []client.Object) 
 		c.controllersServiceAccount(),
 		c.controllersClusterRole(),
 		c.controllersClusterRoleBinding(),
-		c.controllersDeployment(),
 	)
+	if len(c.enabledControllers) > 0 {
+		// There's something to run, so create the deployment.
+		objectsToCreate = append(objectsToCreate, c.controllersDeployment())
+	} else {
+		// No controllers are enabled, so delete the deployment.
+		objectsToDelete = append(objectsToDelete, c.controllersDeployment())
+	}
 
 	if c.cfg.Installation.KubernetesProvider.IsOpenShift() {
 		objectsToCreate = append(objectsToCreate, c.controllersOCPFederationRoleBinding())
 	}
-	objectsToDelete := []client.Object{}
 	if c.cfg.KubeControllersGatewaySecret != nil {
 		objectsToCreate = append(objectsToCreate, secret.ToRuntimeObjects(
 			secret.CopyToNamespace(c.cfg.Namespace, c.cfg.KubeControllersGatewaySecret)...)...)


### PR DESCRIPTION
Cherry pick of #3917 on release-v1.37.

#3917: Don't run kube-controllers if there are no enabled

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.