### PR TITLE
Add default versioning to version generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -631,8 +631,8 @@ check-milestone: hack/bin/gh var-require-all-VERSION-GITHUB_TOKEN
 	$(if $(CLOSED_MILESTONE),,$(error Milestone $(VERSION) is not closed))
 
 release-prep: check-milestone var-require-all-GIT_PR_BRANCH_BASE-GIT_REPO_SLUG-VERSION-CALICO_VERSION-COMMON_VERSION-CALICO_ENTERPRISE_VERSION
-	$(YQ_V4) ".title = \"$(CALICO_ENTERPRISE_VERSION)\" | .components |= with_entries(select(.key | test(\"^(eck-|coreos-).*\") | not)) |= with(.[]; .version = \"$(CALICO_ENTERPRISE_VERSION)\")" -i config/enterprise_versions.yml
-	$(YQ_V4) ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
+	$(YQ_V4) ".title = \"$(CALICO_ENTERPRISE_VERSION)\"" -i config/enterprise_versions.yml
+	$(YQ_V4) ".title = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
 	sed -i "s/\"gcr.io.*\"/\"quay.io\/\"/g" pkg/components/images.go
 	sed -i "s/\"gcr.io.*\"/\"quay.io\"/g" hack/gen-versions/main.go
 	$(MAKE) gen-versions release-prep/create-and-push-branch release-prep/create-pr release-prep/set-pr-labels

--- a/config/calico_versions.yml
+++ b/config/calico_versions.yml
@@ -2,41 +2,22 @@
 title: master
 components:
   libcalico-go:
-    version: master
   typha:
-    version: master
   calico/node:
-    version: master
   calico/cni:
-    version: master
   calico/node-windows:
-    version: master
   calico/cni-windows:
-    version: master
   calico/kube-controllers:
-    version: master
   calico/goldmane:
-    version: master
   flexvol:
-    version: master
   calico/apiserver:
-    version: master
   calico/csi:
-    version: master
   csi-node-driver-registrar:
-    version: master
   key-cert-provisioner:
-    version: master
   calico/whisker:
-    version: master
   calico/whisker-backend:
-    version: master
   calico/envoy-gateway:
-    version: master
   calico/envoy-proxy:
-    version: master
   calico/envoy-ratelimit:
-    version: master
   calico/guardian:
-    version: master
 

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -2,164 +2,115 @@
 title: master
 components:
   libcalico-go:
-    version: master
   cnx-manager:
     image: tigera/cnx-manager
-    version: master
   voltron:
     image: tigera/voltron
-    version: master
   cnx-apiserver:
     image: tigera/cnx-apiserver
-    version: master
   cnx-queryserver:
     image: tigera/cnx-queryserver
-    version: master
   cnx-kube-controllers:
     image: tigera/kube-controllers
-    version: master
   typha:
     image: tigera/typha
-    version: master
   cnx-node:
     image: tigera/cnx-node
-    version: master
   cnx-node-windows:
     image: tigera/cnx-node-windows
-    version: master
   fluentd:
     image: tigera/fluentd
-    version: master
   fluentd-windows:
     image: tigera/fluentd-windows
-    version: master
   ui-apis:
     image: tigera/ui-apis
-    version: master
   linseed:
     image: tigera/linseed
-    version: master
   es-gateway:
     image: tigera/es-gateway
-    version: master
   dex:
     image: tigera/dex
-    version: master
   eck-kibana:
     version: 8.17.1
   kibana:
     image: tigera/kibana
-    version: master
   eck-elasticsearch:
     version: 8.17.1
   elasticsearch:
     image: tigera/elasticsearch
-    version: master
   elastic-tsee-installer:
     image: tigera/intrusion-detection-job-installer
-    version: master
   es-curator:
     image: tigera/es-curator
-    version: master
   intrusion-detection-controller:
     image: tigera/intrusion-detection-controller
-    version: master
   webhooks-processor:
     image: tigera/webhooks-processor
-    version: master
   compliance-controller:
     image: tigera/compliance-controller
-    version: master
   compliance-reporter:
     image: tigera/compliance-reporter
-    version: master
   compliance-snapshotter:
     image: tigera/compliance-snapshotter
-    version: master
   compliance-server:
     image: tigera/compliance-server
-    version: master
   compliance-benchmarker:
     image: tigera/compliance-benchmarker
-    version: master
   guardian:
     image: tigera/guardian
-    version: master
   tigera-cni:
     image: tigera/cni
-    version: master
   tigera-cni-windows:
     image: tigera/cni-windows
-    version: master
   elasticsearch-metrics:
     image: tigera/elasticsearch-metrics
-    version: master
   packetcapture:
     image: tigera/packetcapture
-    version: master
   policy-recommendation:
     image: tigera/policy-recommendation
-    version: master
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
     version: v2.54.1
   prometheus:
     image: tigera/prometheus
-    version: master
   # coreos-prometheus holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
     version: v0.28.0
   alertmanager:
     image: tigera/alertmanager
-    version: master
   tigera-prometheus-service:
     image: tigera/prometheus-service
-    version: master
   deep-packet-inspection:
     image: tigera/deep-packet-inspection
-    version: master
   flexvol:
     image: tigera/pod2daemon-flexvol
-    version: master
   csi:
     image: tigera/csi
-    version: master
   csi-node-driver-registrar:
     image: tigera/node-driver-registrar
-    version: master
   # The components below are third-party images that have been retagged under
   # quay.io/tigera so all enterprise images come from the same repository and org.
   elasticsearch-operator:
     image: tigera/eck-operator
-    version: master
   eck-elasticsearch-operator:
     version: 2.16.0
   l7-collector:
     image: tigera/l7-collector
-    version: master
   envoy:
     image: tigera/envoy
-    version: master
   dikastes:
     image: tigera/dikastes
-    version: master
   l7-admission-controller:
     image: tigera/l7-admission-controller
-    version: master
   egress-gateway:
     image: tigera/egress-gateway
-    version: master
   key-cert-provisioner:
     image: tigera/key-cert-provisioner
-    version: master
   gateway-api-envoy-gateway:
     image: tigera/envoy-gateway
-    version: master
   gateway-api-envoy-proxy:
     image: tigera/envoy-proxy
-    version: master
   gateway-api-envoy-ratelimit:
     image: tigera/envoy-ratelimit
-    version: master

--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -103,6 +103,10 @@ func GetComponents(versionsPath string) (Release, error) {
 			continue
 		}
 
+		if component == nil {
+			component = &Component{}
+		}
+
 		if component.Image == "" {
 			image := defaultImages[key]
 			if image == "" {
@@ -110,6 +114,10 @@ func GetComponents(versionsPath string) (Release, error) {
 					"Either fill in the 'image' field or update this code with a defaultImage.", key)
 			}
 			component.Image = image
+		}
+
+		if component.Version == "" {
+			component.Version = cv.Title
 		}
 
 		cv.Components[key] = component


### PR DESCRIPTION
Instead of repeating ourselves ad nauseum, use the `title` field in the `config/{calico,enterprise}_versions.yml` file as a sane default if no version is specified for a given component.

Also update get-manifests to be able to figure out this default for typha if it's not explicitly specified.
