### PR TITLE
migrate to operator with loadbalancer controller enabled (#3933)

### DIFF
--- a/pkg/controller/migration/convert/core_test.go
+++ b/pkg/controller/migration/convert/core_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -587,6 +587,13 @@ var _ = Describe("core handler", func() {
 				comps.kubeControllers.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{
 					Name:  "ENABLED_CONTROLLERS",
 					Value: "node",
+				}}
+				Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
+			})
+			It("should not error if ENABLED_CONTROLLERS is expected value", func() {
+				comps.kubeControllers.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{{
+					Name:  "ENABLED_CONTROLLERS",
+					Value: "node,loadbalancer",
 				}}
 				Expect(handleCore(&comps, i)).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
## Description
Allows the migration to operator based installation with loadbalancer kube-controller enabled

Cherry pick of:
https://github.com/tigera/operator/pull/3933

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
