### PR TITLE
Allow non-cluster host process to list and update HEPs

### DIFF
--- a/pkg/render/nonclusterhost/nonclusterhost.go
+++ b/pkg/render/nonclusterhost/nonclusterhost.go
@@ -209,6 +209,15 @@ func (c *nonClusterHostComponent) clusterRole() *rbacv1.ClusterRole {
 		},
 	}...)
 
+	// For non-cluster host init process to update labels.
+	rules = append(rules, []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"hostendpoints"},
+			Verbs:     []string{"list", "update"},
+		},
+	}...)
+
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description

This change adds RBAC for non-cluster init process to list and update HEPs.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
