### PR TITLE
[release-v1.35] Auto pick #3709: Move skip tenant crds to generic GetCRDS function

### DIFF
--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -170,6 +170,10 @@ func GetCRDs(variant opv1.ProductVariant) []*apiextenv1.CustomResourceDefinition
 	// our original copy of the definitions are not tainted with a ResourceVersion
 	copy := []*apiextenv1.CustomResourceDefinition{}
 	for _, crd := range crds {
+		// Skip the Tenant CRD - this is only used in Calico Cloud.
+		if crd.Name == "tenants.operator.tigera.io" {
+			continue
+		}
 		copy = append(copy, crd.DeepCopy())
 	}
 
@@ -193,10 +197,6 @@ func ToRuntimeObjects(crds ...*apiextenv1.CustomResourceDefinition) []client.Obj
 func Ensure(c client.Client, variant string) error {
 	// Ensure Calico CRDs exist, which will allow us to bootstrap.
 	for _, crd := range GetCRDs(opv1.ProductVariant(variant)) {
-		// Skip the Tenant CRD - this is only used in Calico Cloud.
-		if crd.Name == "tenants.operator.tigera.io" {
-			continue
-		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		if err := c.Create(ctx, crd); err != nil {


### PR DESCRIPTION
Cherry pick of tigera/operator/pull/3709 on release-v1.35.

#3709: Move skip tenant crds to generic GetCRDS function

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.