### PR TITLE
[RS-2418] Add waf-http-filter component to operator

### DIFF
--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -163,6 +163,13 @@ var (
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
+{{ with index .Components "waf-http-filter" }}
+	ComponentWafHTTPFilter = Component{
+		Version:  "{{ .Version }}",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
+	}
+{{- end }}
 {{ with index .Components "webhooks-processor" }}
 	ComponentSecurityEventWebhooksProcessor = Component{
 		Version:  "{{ .Version }}",

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -143,6 +143,12 @@ var (
 		Registry: "",
 	}
 
+	ComponentWafHTTPFilter = Component{
+		Version:  "master",
+		Image:    "tigera/waf-http-filter",
+		Registry: "",
+	}
+
 	ComponentSecurityEventWebhooksProcessor = Component{
 		Version:  "master",
 		Image:    "tigera/webhooks-processor",


### PR DESCRIPTION
## Description

Add `waf-http-filter` component to operator. This is needed to update the release process so that the image is deployed with our hash-release. A follow up PR will then come to setup the new component.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
