### PR TITLE
Enable ClusterInfo controller in es-kube-controller to fetch ManagedC…

### DIFF
--- a/pkg/crds/enterprise/crd.projectcalico.org_managedclusters.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_managedclusters.yaml
@@ -52,6 +52,8 @@ spec:
                       - type
                     type: object
                   type: array
+                version:
+                  type: string
               type: object
           type: object
       served: true


### PR DESCRIPTION
…luster version info.

Changes include granting access to fetch ClusterInformation from ManagedCluster and updating the ManagedCluster resource with version info in the management cluster

enabled cluster info for both single tenant and multitenant

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
