### PR TITLE
Add tenant id for Linseed metrics on single tenant with internal elas…

### DIFF
--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -370,10 +370,8 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 
 	replicas := l.cfg.Installation.ControlPlaneReplicas
 	if l.cfg.Tenant != nil {
-		if l.cfg.ExternalElastic {
-			// If a tenant was provided, set the expected tenant ID and enable the shared index backend.
-			envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_EXPECTED_TENANT_ID", Value: l.cfg.Tenant.Spec.ID})
-		}
+		// If a tenant was provided, set the expected tenant ID and enable the shared index backend.
+		envVars = append(envVars, corev1.EnvVar{Name: "LINSEED_EXPECTED_TENANT_ID", Value: l.cfg.Tenant.Spec.ID})
 
 		if l.cfg.Tenant.MultiTenant() {
 			// For clusters shared between multiple tenants, we need to configure Linseed with the correct namespace information for its tenant.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -565,10 +565,8 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 	linseedEndpointEnv := corev1.EnvVar{Name: "VOLTRON_LINSEED_ENDPOINT", Value: fmt.Sprintf("https://tigera-linseed.%s.svc.%s", ElasticsearchNamespace, c.cfg.ClusterDomain)}
 	if c.cfg.Tenant != nil {
 		// Configure the tenant id in order to read /write linseed data using the correct tenant ID
-		// Multi-tenant and single tenant with external elastic needs this variable set
-		if c.cfg.ExternalElastic {
-			env = append(env, corev1.EnvVar{Name: "VOLTRON_TENANT_ID", Value: c.cfg.Tenant.Spec.ID})
-		}
+		// Multi-tenant and single tenant needs this variable set
+		env = append(env, corev1.EnvVar{Name: "VOLTRON_TENANT_ID", Value: c.cfg.Tenant.Spec.ID})
 
 		// Always configure the Tenant Claim for all multi-tenancy setups (single tenant and multi tenant)
 		// This will check the tenant claim when a Bearer token is presented to Voltron


### PR DESCRIPTION
…ticsearch

## Description

Single tenant clusters with internal elastic search are missing tenant id from Linseed metrics. This label is populated with the value from x-tenant-id header, extracted from the request. x-tenant-id is set by Voltron. 

Making this change will impact tokens inside the managed clusters, as they need to be recrated to include tenant id.

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
