### PR TITLE
Add Talos kubernetes provider to support Kubeprism endpoint

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -82,7 +82,7 @@ type InstallationSpec struct {
 	// If the specified value is not empty, the Operator will still attempt auto-detection, but
 	// will additionally compare the auto-detected value to the specified value to confirm they match.
 	// +optional
-	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;RKE2;TKG;
+	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;RKE2;TKG;Talos;
 	KubernetesProvider Provider `json:"kubernetesProvider,omitempty"`
 
 	// CNI specifies the CNI that will be used by this installation.
@@ -366,7 +366,7 @@ type ComponentResource struct {
 }
 
 // Provider represents a particular provider or flavor of Kubernetes. Valid options
-// are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
+// are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG, Talos.
 type Provider string
 
 var (
@@ -378,6 +378,7 @@ var (
 	ProviderOpenShift Provider = "OpenShift"
 	ProviderDockerEE  Provider = "DockerEnterprise"
 	ProviderTKG       Provider = "TKG"
+	ProviderTalos     Provider = "Talos"
 )
 
 func (p Provider) IsNone() bool {
@@ -410,6 +411,10 @@ func (p Provider) IsRKE2() bool {
 
 func (p Provider) IsTKG() bool {
 	return p == ProviderTKG
+}
+
+func (p Provider) IsTalos() bool {
+	return p == ProviderTalos
 }
 
 // ProductVariant represents the variant of the product.

--- a/pkg/controller/k8sapi/k8s-endpoint.go
+++ b/pkg/controller/k8sapi/k8s-endpoint.go
@@ -27,6 +27,8 @@ import (
 )
 
 const dockerEEProxyLocal = "proxy.local"
+const talosKubePrismHost = "localhost"
+const talosKubePrismPort = "7445"
 
 // Endpoint is the default ServiceEndpoint learned from environment variables.
 var Endpoint ServiceEndpoint
@@ -59,6 +61,10 @@ func (k8s ServiceEndpoint) EnvVars(hostNetworked bool, provider operator.Provide
 		// namespace.  Don't try to use it from non-host network pods.
 		//
 		// It's also possible for the user to configure a different route to the API server; we let those through.
+		return nil
+	}
+
+	if provider == operator.ProviderTalos && !hostNetworked && k8s.Host == talosKubePrismHost && k8s.Port == talosKubePrismPort {
 		return nil
 	}
 

--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -95,6 +95,23 @@ var _ = Describe("provider discovery", func() {
 		Expect(p).To(Equal(operatorv1.ProviderTKG))
 	})
 
+	It("should detect Talos if a control-plane node has annotations prefixed with talos.dev", func() {
+		c := fake.NewSimpleClientset(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "control-plane-1",
+				Labels: map[string]string{
+					"node-role.kubernetes.io/control-plane": "",
+				},
+				Annotations: map[string]string{
+					"talos.dev/owned-labels": "[\"node-role.kubernetes.io/control-plane\"]",
+				},
+			},
+		})
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderTalos))
+	})
+
 	It("should detect EKS based on eks-certificates-controller ConfigMap", func() {
 		c := fake.NewSimpleClientset(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -6816,6 +6816,7 @@ spec:
                     - DockerEnterprise
                     - RKE2
                     - TKG
+                    - Talos
                   type: string
                 logging:
                   description: Logging Configuration for Components
@@ -15689,6 +15690,7 @@ spec:
                         - DockerEnterprise
                         - RKE2
                         - TKG
+                        - Talos
                       type: string
                     logging:
                       description: Logging Configuration for Components

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -996,6 +996,21 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		rtest.ExpectNoK8sServiceEpEnvVars(deployment.Spec.Template.Spec)
 	})
 
+	It("should not add the KUBERNETES_SERVICE_... variables on Talos using KubePrism", func() {
+		k8sServiceEp.Host = "localhost"
+		k8sServiceEp.Port = "7445"
+		instance.KubernetesProvider = operatorv1.ProviderTalos
+
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		depResource := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment")
+		Expect(depResource).ToNot(BeNil())
+		deployment := depResource.(*appsv1.Deployment)
+		rtest.ExpectNoK8sServiceEpEnvVars(deployment.Spec.Template.Spec)
+	})
+
 	It("should add prometheus annotations to metrics service", func() {
 		for _, variant := range []operatorv1.ProductVariant{operatorv1.Calico, operatorv1.TigeraSecureEnterprise} {
 			cfg.Installation.Variant = variant


### PR DESCRIPTION
## Description

Fixes #3470 by adding a new kubenetes provider for Talos, which detects setting the k8s service endpoint up for kubeprism and handling it similarly to the existing DockerEE provider. I couldn't find any other existing way to get the operator to use the kubeprism endpoint for host networked pods, but the k8s service for non-host networked pods.

Added unit tests for the new provider as well as tested deploying on my physical homelab cluster of RPIs.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
