### PR TITLE
Add release note check from Calico OSS [master]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,23 @@ Please include
 - links to issues that this PR addresses
 -->
 
+## Release Note
+
+<!-- Writing a release note:
+
+- By default, your PR will be set to require a release note and a docs PR!
+- If you do not need a release note, swap the `release-note-required` label for
+  the `release-note-not-required` label
+- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
+- If you're not certain if you need a release note or docs PR, please check
+  with your reviewer or team lead.
+
+-->
+
+```release-note
+TBD
+```
+
 ## For PR author
 
 - [ ] Tests for change.

--- a/.github/workflows/check_release_notes.yml
+++ b/.github/workflows/check_release_notes.yml
@@ -1,0 +1,19 @@
+# This workflow will perform the following checks:
+# 1. Check the PR for a specific label (by default 'release-note-required'); if it's not there, exit
+# 2. Check the PR body for a matching release-note code block; if missing, fail
+# 3. Check the contents of the code block to ensure it's not empty or 'TBD'; otherwise, fail
+# 4. Success!
+
+name: Validate Release Notes
+on:
+  pull_request:
+    types: [labeled, unlabeled, edited, synchronize, ready_for_review]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Validate Release Notes
+        uses: tigera/check-release-notes@main


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds the release note check from Calico OSS into the Operator workflow.

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
