### PR TITLE
Don't modify user-provided registry string

### DIFF
--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -81,7 +81,6 @@ func GetReference(c Component, registry, imagePath, imagePrefix string, is *oper
 	} else if !strings.HasSuffix(registry, "/") {
 		// If the registry is explicitly set, make sure it ends with a slash so that the
 		// image can be appended correctly below.
-		// Make sure registry, except for the special case "UseDefault", always ends with a slash.
 		registry = fmt.Sprintf("%s/", registry)
 	}
 

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -78,6 +78,11 @@ func GetReference(c Component, registry, imagePath, imagePrefix string, is *oper
 		if c.Registry != "" {
 			registry = c.Registry
 		}
+	} else if !strings.HasSuffix(registry, "/") {
+		// If the registry is explicitly set, make sure it ends with a slash so that the
+		// image can be appended correctly below.
+		// Make sure registry, except for the special case "UseDefault", always ends with a slash.
+		registry = fmt.Sprintf("%s/", registry)
 	}
 
 	image := c.Image

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -438,12 +438,6 @@ func MergeAndFillDefaults(i *operator.Installation, awsNode *appsv1.DaemonSet, c
 
 // fillDefaults populates the default values onto an Installation object.
 func fillDefaults(instance *operator.Installation, currentPools *crdv1.IPPoolList) error {
-	// Populate the instance with defaults for any fields not provided by the user.
-	if len(instance.Spec.Registry) != 0 && instance.Spec.Registry != components.UseDefault && !strings.HasSuffix(instance.Spec.Registry, "/") {
-		// Make sure registry, except for the special case "UseDefault", always ends with a slash.
-		instance.Spec.Registry = fmt.Sprintf("%s/", instance.Spec.Registry)
-	}
-
 	if len(instance.Spec.Variant) == 0 {
 		// Default to installing Calico.
 		instance.Spec.Variant = operator.Calico

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -337,7 +337,9 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 	})
 
-	It("should correct missing slashes on registry", func() {
+	It("should not change user provided registry", func() {
+		// Older versions of the operator would update the registry such that it would always
+		// end with a slash. This test ensures that we do not change the user provided registry.
 		instance := &operator.Installation{
 			Spec: operator.InstallationSpec{
 				Registry: "test-reg",
@@ -345,10 +347,10 @@ var _ = Describe("Defaulting logic tests", func() {
 		}
 		err := fillDefaults(instance, nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(instance.Spec.Registry).To(Equal("test-reg/"))
+		Expect(instance.Spec.Registry).To(Equal("test-reg"))
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 
-		// But "UseDefault" should not be modified.
+		// "UseDefault" should not be modified.
 		instance.Spec.Registry = components.UseDefault
 		err = fillDefaults(instance, nil)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We shouldn't re-write any user-provided fields. This one in particular can cause issues where CI/CD systems fight with the operator.

Fixes https://github.com/tigera/operator/issues/1776

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Don't modify user-provided registry in Installation specification.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.