### PR TITLE
Handle replicas override generically instead of specially for EgressGateway

### DIFF
--- a/pkg/render/egressgateway/egressgateway.go
+++ b/pkg/render/egressgateway/egressgateway.go
@@ -146,7 +146,6 @@ func (c *component) egwDeployment() *appsv1.Deployment {
 			Labels:    c.config.EgressGW.Spec.Template.Metadata.Labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: c.config.EgressGW.Spec.Replicas,
 			Selector: &metav1.LabelSelector{MatchLabels: c.config.EgressGW.Spec.Template.Metadata.Labels},
 			Template: *c.deploymentPodTemplate(),
 		},

--- a/pkg/render/egressgateway/egressgateway_test.go
+++ b/pkg/render/egressgateway/egressgateway_test.go
@@ -153,6 +153,8 @@ var _ = Describe("Egress Gateway rendering tests", func() {
 		}
 
 		dep := rtest.GetResource(resources, "egress-test", "test-ns", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(dep.Spec.Replicas).NotTo(BeNil())
+		Expect(*dep.Spec.Replicas).To(BeNumerically("==", 2))
 		Expect(len(dep.Spec.Template.Spec.Containers)).To(Equal(1))
 		Expect(len(dep.Spec.Template.Spec.InitContainers)).To(Equal(1))
 		Expect(len(dep.Spec.Template.Spec.Volumes)).To(Equal(1))


### PR DESCRIPTION
Replicas override is needed as part of #3852, and that prompted this change, but I think it makes sense to test it for EgressGateway and review that separately in advance.
