### PR TITLE
Move Calico API server from calico-apiserver namespace to calico-system for OSS

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -155,9 +156,6 @@ func add(c ctrlruntime.Controller, r *ReconcileAPIServer) error {
 	}
 
 	// Watch for the namespace(s) managed by this controller.
-	if err = c.WatchObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.APIServerNamespace}}, &handler.EnqueueRequestForObject{}); err != nil {
-		return fmt.Errorf("apiserver-controller failed to watch resource: %w", err)
-	}
 	if err = c.WatchObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.APIServerNamespace}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("apiserver-controller failed to watch resource: %w", err)
 	}
@@ -513,8 +511,8 @@ func validateAPIServerResource(instance *operatorv1.APIServer) error {
 // prior to the CNI plugin being removed.
 func (r *ReconcileAPIServer) maintainFinalizer(ctx context.Context, apiserver client.Object) error {
 	// These objects require graceful termination before the CNI plugin is torn down.
-	apiServerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.APIServerNamespace}}
-	return utils.MaintainInstallationFinalizer(ctx, r.client, apiserver, render.APIServerFinalizer, apiServerNamespace)
+	apiServerDeployment := v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: render.APIServerNamespace}}
+	return utils.MaintainInstallationFinalizer(ctx, r.client, apiserver, render.APIServerFinalizer, &apiServerDeployment)
 }
 
 // canCleanupLegacyNamespace determines whether the legacy "tigera-system" namespace

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -52,7 +52,6 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/common/authentication"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -78,7 +77,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, opts.K8sClientset, log, r.tierWatchReady)
 
 		go utils.WaitToAddNetworkPolicyWatches(c, opts.K8sClientset, log, []types.NamespacedName{
-			{Name: render.APIServerPolicyName, Namespace: rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise)},
+			{Name: render.APIServerPolicyName, Namespace: render.APIServerNamespace},
 		})
 	}
 
@@ -139,7 +138,7 @@ func add(c ctrlruntime.Controller, r *ReconcileAPIServer) error {
 			return fmt.Errorf("apiserver-controller failed to watch primary resource: %v", err)
 		}
 
-		for _, namespace := range []string{common.OperatorNamespace(), rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise)} {
+		for _, namespace := range []string{common.OperatorNamespace(), render.APIServerNamespace} {
 			for _, secretName := range []string{render.VoltronTunnelSecretName, render.ManagerTLSSecretName} {
 				if err = utils.AddSecretsWatch(c, secretName, namespace); err != nil {
 					return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
@@ -156,10 +155,10 @@ func add(c ctrlruntime.Controller, r *ReconcileAPIServer) error {
 	}
 
 	// Watch for the namespace(s) managed by this controller.
-	if err = c.WatchObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rmeta.APIServerNamespace(operatorv1.Calico)}}, &handler.EnqueueRequestForObject{}); err != nil {
+	if err = c.WatchObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.APIServerNamespace}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("apiserver-controller failed to watch resource: %w", err)
 	}
-	if err = c.WatchObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise)}}, &handler.EnqueueRequestForObject{}); err != nil {
+	if err = c.WatchObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.APIServerNamespace}}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("apiserver-controller failed to watch resource: %w", err)
 	}
 
@@ -261,7 +260,6 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for Installation Variant to be set", nil, reqLogger)
 		return reconcile.Result{}, nil
 	}
-	ns := rmeta.APIServerNamespace(installationSpec.Variant)
 
 	certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.clusterDomain, common.OperatorNamespace())
 	if err != nil {
@@ -271,13 +269,13 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 
 	// We need separate certificates for OSS vs Enterprise.
 	secretName := render.ProjectCalicoAPIServerTLSSecretName(installationSpec.Variant)
-	tlsSecret, err := certificateManager.GetOrCreateKeyPair(r.client, secretName, common.OperatorNamespace(), dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(installationSpec.Variant), rmeta.APIServerNamespace(installationSpec.Variant), r.clusterDomain))
+	tlsSecret, err := certificateManager.GetOrCreateKeyPair(r.client, secretName, common.OperatorNamespace(), dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(installationSpec.Variant), render.APIServerNamespace, r.clusterDomain))
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to get or create tls key pair", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
-	certificateManager.AddToStatusManager(r.status, ns)
+	certificateManager.AddToStatusManager(r.status, render.APIServerNamespace)
 
 	pullSecrets, err := utils.GetNetworkingPullSecrets(installationSpec, r.client)
 	if err != nil {
@@ -439,7 +437,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		MultiTenant:                 r.multiTenant,
 		KeyValidatorConfig:          keyValidatorConfig,
 		KubernetesVersion:           r.kubernetesVersion,
-		CanCleanupOlderResources:    r.canCleanupLegacyNamespace(ctx, reqLogger),
+		CanCleanupOlderResources:    r.canCleanupLegacyNamespace(ctx, installationSpec.Variant, reqLogger),
 	}
 
 	var components []render.Component
@@ -460,7 +458,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	components = append(components,
 		component,
 		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
-			Namespace:       rmeta.APIServerNamespace(installationSpec.Variant),
+			Namespace:       render.APIServerNamespace,
 			ServiceAccounts: []string{render.APIServerServiceAccountName(installationSpec.Variant)},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(tlsSecret, true, true),
@@ -515,11 +513,7 @@ func validateAPIServerResource(instance *operatorv1.APIServer) error {
 // prior to the CNI plugin being removed.
 func (r *ReconcileAPIServer) maintainFinalizer(ctx context.Context, apiserver client.Object) error {
 	// These objects require graceful termination before the CNI plugin is torn down.
-	_, spec, err := utils.GetInstallation(context.Background(), r.client)
-	if err != nil {
-		return err
-	}
-	apiServerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rmeta.APIServerNamespace(spec.Variant)}}
+	apiServerNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.APIServerNamespace}}
 	return utils.MaintainInstallationFinalizer(ctx, r.client, apiserver, render.APIServerFinalizer, apiServerNamespace)
 }
 
@@ -529,12 +523,16 @@ func (r *ReconcileAPIServer) maintainFinalizer(ctx context.Context, apiserver cl
 // - The new API server deployment in "calico-system" exists and is available.
 // - The old API server deployment in "tigera-system" is either removed or inactive.
 // - Both the APIServer custom resource and the TigeraStatus for 'apiserver' are in the Ready state
-func (r *ReconcileAPIServer) canCleanupLegacyNamespace(ctx context.Context, logger logr.Logger) bool {
-	const (
-		newNamespace   = "calico-system"
-		oldNamespace   = "tigera-system"
-		deploymentName = "tigera-apiserver"
-	)
+func (r *ReconcileAPIServer) canCleanupLegacyNamespace(ctx context.Context, variant operatorv1.ProductVariant, logger logr.Logger) bool {
+
+	newNamespace := "calico-system"
+	oldNamespace := "tigera-system"
+	deploymentName := "tigera-apiserver"
+
+	if variant == operatorv1.Calico {
+		oldNamespace = "calico-apiserver"
+		deploymentName = "calico-apiserver"
+	}
 
 	// Fetch the new API server deployment in calico-system
 	newDeploy := &appsv1.Deployment{}

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -152,6 +152,7 @@ var _ = Describe("apiserver controller tests", func() {
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("AddCertificateSigningRequests", mock.Anything)
 		mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)
+		mockStatus.On("RemoveDeployments", mock.Anything)
 		mockStatus.On("ReadyToMonitor")
 		mockStatus.On("SetMetaData", mock.Anything).Return()
 		mockStatus.On("SetDegraded", operatorv1.ResourceReadError, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -836,7 +836,7 @@ var _ = Describe("apiserver controller tests", func() {
 			}
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, logf.Log.WithName("test"))
+			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
 			Expect(canCleanedUp).To(BeTrue())
 		})
 
@@ -856,7 +856,7 @@ var _ = Describe("apiserver controller tests", func() {
 			}
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, logf.Log.WithName("test"))
+			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
 			Expect(canCleanedUp).To(BeFalse())
 		})
 
@@ -882,7 +882,7 @@ var _ = Describe("apiserver controller tests", func() {
 			}
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, logf.Log.WithName("test"))
+			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
 			Expect(canCleanedUp).To(BeFalse())
 		})
 
@@ -916,7 +916,7 @@ var _ = Describe("apiserver controller tests", func() {
 			}
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, logf.Log.WithName("test"))
+			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
 			Expect(canCleanedUp).To(BeFalse())
 		})
 	})

--- a/pkg/controller/tiers/tiers_controller.go
+++ b/pkg/controller/tiers/tiers_controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/render"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/logstorage/eck"
 	"github.com/tigera/operator/pkg/render/logstorage/kibana"
@@ -194,7 +193,6 @@ func (r *ReconcileTiers) prepareTiersConfig(ctx context.Context, reqLogger logr.
 		render.PacketCaptureNamespace,
 		render.PolicyRecommendationNamespace,
 		common.TigeraPrometheusNamespace,
-		rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise),
 		"tigera-skraper",
 	}
 	if r.multiTenant {

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -2332,7 +2332,7 @@ func (c *apiServerComponent) getDeprecatedResources() []client.Object {
 	}
 
 	// Delete the older namespace for OSS and EE.
-	// this is to support older version OSS update to newer EE and vice versa.
+	// This supports upgrades from older OSS versions to newer EE versions, and vice versa.
 	// CanCleanupOlderResources ensure the newdeployment is up and running in calico-system in both variant.
 	if c.cfg.CanCleanupOlderResources {
 		renamedRscList = append(renamedRscList, &corev1.Namespace{

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -2412,10 +2412,13 @@ func (c *apiServerComponent) l7AdmissionControllerContainer() corev1.Container {
 
 // Both Calico and Calico Enterprise, but different names.
 func (c *apiServerComponent) cleanupDeployment() client.Object {
-	// Determine names based on the configured variant.
+	// Determine the correct name based on the configured variant.
 	_, nameToDelete := c.resourceNameBasedOnVariant("tigera-apiserver", "calico-apiserver")
 	return &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{Kind: "De", APIVersion: "rbac.authorization.k8s.io/v1"},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nameToDelete,
 			Namespace: APIServerNamespace,

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -60,6 +60,7 @@ const (
 
 const (
 	APIServerResourceName  = "apiserver"
+	APIServerNamespace     = common.CalicoNamespace
 	QueryServerPort        = 8080
 	QueryServerPortName    = "queryserver"
 	QueryserverNamespace   = "calico-system"
@@ -250,7 +251,7 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	// deleted, since they will be garbage collected on namespace deletion.
 	namespacedObjects := []client.Object{}
 	// Add in image pull secrets.
-	secrets := secret.CopyToNamespace(rmeta.APIServerNamespace(c.cfg.Installation.Variant), c.cfg.PullSecrets...)
+	secrets := secret.CopyToNamespace(APIServerNamespace, c.cfg.PullSecrets...)
 	namespacedObjects = append(namespacedObjects, secret.ToRuntimeObjects(secrets...)...)
 
 	namespacedObjects = append(namespacedObjects,
@@ -321,29 +322,13 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		objsToDelete = append(objsToDelete, &admregv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: common.SidecarMutatingWebhookConfigName}})
 	}
 
-	podSecurityNamespaceLabel := PodSecurityStandard(PSSRestricted)
-	if c.hostNetwork() {
-		podSecurityNamespaceLabel = PSSPrivileged
-	}
-	// Global OSS-only objects.
-	globalCalicoObjects := []client.Object{
-		CreateNamespace(rmeta.APIServerNamespace(operatorv1.Calico), c.cfg.Installation.KubernetesProvider, podSecurityNamespaceLabel, c.cfg.Installation.Azure),
-		CreateOperatorSecretsRoleBinding(rmeta.APIServerNamespace(operatorv1.Calico)),
-	}
-
 	// Compile the final arrays based on the variant.
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		// Create any enterprise specific objects.
 		globalObjects = append(globalObjects, globalEnterpriseObjects...)
 		namespacedObjects = append(namespacedObjects, namespacedEnterpriseObjects...)
 
-		// Explicitly delete any global OSS objects.
-		// Namespaced objects will be handled by namespace deletion.
-		objsToDelete = append(objsToDelete, globalCalicoObjects...)
 	} else {
-		// Create any Calico-only objects
-		globalObjects = append(globalObjects, globalCalicoObjects...)
-
 		// Add in a NetworkPolicy.
 		namespacedObjects = append(namespacedObjects, c.networkPolicy())
 
@@ -395,7 +380,7 @@ func (c *apiServerComponent) apiServerPodDisruptionBudget() *policyv1.PodDisrupt
 		TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+			Namespace: APIServerNamespace,
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailable,
@@ -421,7 +406,7 @@ func (c *apiServerComponent) apiServiceRegistration(cert []byte) *apiregv1.APISe
 			GroupPriorityMinimum: 1500,
 			Service: &apiregv1.ServiceReference{
 				Name:      ProjectCalicoAPIServerServiceName(c.cfg.Installation.Variant),
-				Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+				Namespace: APIServerNamespace,
 			},
 			Version:  "v3",
 			CABundle: cert,
@@ -446,7 +431,7 @@ func (c *apiServerComponent) delegateAuthClusterRoleBinding() (client.Object, cl
 				{
 					Kind:      "ServiceAccount",
 					Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-					Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+					Namespace: APIServerNamespace,
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -484,7 +469,7 @@ func (c *apiServerComponent) authReaderRoleBinding() (client.Object, client.Obje
 				{
 					Kind:      "ServiceAccount",
 					Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-					Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+					Namespace: APIServerNamespace,
 				},
 			},
 		}, &rbacv1.RoleBinding{
@@ -504,7 +489,7 @@ func (c *apiServerComponent) apiServerServiceAccount() *corev1.ServiceAccount {
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-			Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+			Namespace: APIServerNamespace,
 		},
 	}
 }
@@ -565,7 +550,7 @@ func allowTigeraAPIServerPolicy(cfg *APIServerConfiguration) *v3.NetworkPolicy {
 		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      APIServerPolicyName,
-			Namespace: rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise),
+			Namespace: APIServerNamespace,
 		},
 		Spec: v3.NetworkPolicySpec{
 			Order:    &networkpolicy.HighPrecedenceOrder,
@@ -717,7 +702,7 @@ func (c *apiServerComponent) calicoCustomResourcesClusterRoleBinding() *rbacv1.C
 			{
 				Kind:      "ServiceAccount",
 				Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-				Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+				Namespace: APIServerNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -827,7 +812,7 @@ func (c *apiServerComponent) multiTenantSecretsRBAC() []client.Object {
 				{
 					Kind:      "ServiceAccount",
 					Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-					Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+					Namespace: APIServerNamespace,
 				},
 			},
 		},
@@ -859,7 +844,7 @@ func (c *apiServerComponent) secretsRBAC() []client.Object {
 			TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      APIServerSecretsRBACName,
-				Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+				Namespace: APIServerNamespace,
 			},
 			Rules: rules,
 		},
@@ -869,7 +854,7 @@ func (c *apiServerComponent) secretsRBAC() []client.Object {
 			TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      APIServerSecretsRBACName,
-				Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+				Namespace: APIServerNamespace,
 			},
 			RoleRef: rbacv1.RoleRef{
 				Kind:     "Role",
@@ -880,7 +865,7 @@ func (c *apiServerComponent) secretsRBAC() []client.Object {
 				{
 					Kind:      "ServiceAccount",
 					Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-					Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+					Namespace: APIServerNamespace,
 				},
 			},
 		},
@@ -901,7 +886,7 @@ func (c *apiServerComponent) authClusterRoleBinding() (client.Object, client.Obj
 				{
 					Kind:      "ServiceAccount",
 					Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-					Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+					Namespace: APIServerNamespace,
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -971,7 +956,7 @@ func (c *apiServerComponent) webhookReaderClusterRoleBinding() (client.Object, c
 				{
 					Kind:      "ServiceAccount",
 					Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-					Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+					Namespace: APIServerNamespace,
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -1031,7 +1016,7 @@ func (c *apiServerComponent) apiServerService() *corev1.Service {
 		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ProjectCalicoAPIServerServiceName(c.cfg.Installation.Variant),
-			Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+			Namespace: APIServerNamespace,
 			Labels:    map[string]string{"k8s-app": QueryserverServiceName},
 		},
 		Spec: corev1.ServiceSpec{
@@ -1090,7 +1075,7 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 	var initContainers []corev1.Container
 	if c.cfg.TLSKeyPair.UseCertificateManagement() {
 		// Use the same CSR init container name for both OSS and Enterprise.
-		initContainer := c.cfg.TLSKeyPair.InitContainer(rmeta.APIServerNamespace(c.cfg.Installation.Variant))
+		initContainer := c.cfg.TLSKeyPair.InitContainer(APIServerNamespace)
 		initContainer.Name = fmt.Sprintf("%s-%s", calicoAPIServerTLSSecretName, certificatemanagement.CSRInitContainerName)
 		initContainers = append(initContainers, initContainer)
 	}
@@ -1111,7 +1096,7 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+			Namespace: APIServerNamespace,
 			Labels: map[string]string{
 				"apiserver": "true",
 			},
@@ -1125,7 +1110,7 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
-					Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+					Namespace: APIServerNamespace,
 					Labels: map[string]string{
 						"apiserver": "true",
 					},
@@ -1147,7 +1132,7 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 	}
 
 	if c.cfg.Installation.ControlPlaneReplicas != nil && *c.cfg.Installation.ControlPlaneReplicas > 1 {
-		d.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(name, rmeta.APIServerNamespace(c.cfg.Installation.Variant))
+		d.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(name, APIServerNamespace)
 	}
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
@@ -1468,7 +1453,7 @@ func (c *apiServerComponent) networkPolicy() *netv1.NetworkPolicy {
 	p := intstr.FromInt32(apiServerPort)
 	return &netv1.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "networking.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "allow-apiserver", Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant)},
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-apiserver", Namespace: APIServerNamespace},
 		Spec: netv1.NetworkPolicySpec{
 			PodSelector: *c.deploymentSelector(),
 			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress},
@@ -1563,7 +1548,7 @@ func (c *apiServerComponent) tigeraApiServerClusterRoleBinding() *rbacv1.Cluster
 			{
 				Kind:      "ServiceAccount",
 				Name:      APIServerServiceAccountName(c.cfg.Installation.Variant),
-				Namespace: rmeta.APIServerNamespace(c.cfg.Installation.Variant),
+				Namespace: APIServerNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -2261,7 +2246,7 @@ rules:
 		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			// This object is for Enterprise only, so pass it explicitly.
-			Namespace: rmeta.APIServerNamespace(operatorv1.TigeraSecureEnterprise),
+			Namespace: APIServerNamespace,
 			Name:      auditPolicyVolumeName,
 		},
 		Data: map[string]string{
@@ -2344,16 +2329,25 @@ func (c *apiServerComponent) getDeprecatedResources() []client.Object {
 				Name: "tigera-tier-getter",
 			},
 		})
+	}
 
-		// Delete the older namespace for enterprise
-		if c.cfg.CanCleanupOlderResources {
-			renamedRscList = append(renamedRscList, &corev1.Namespace{
-				TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "tigera-system",
-				},
-			})
-		}
+	// Delete the older namespace for OSS and EE.
+	// this is to support older version OSS update to newer EE and vice versa.
+	// CanCleanupOlderResources ensure the newdeployment is up and running in calico-system in both variant.
+	if c.cfg.CanCleanupOlderResources {
+		renamedRscList = append(renamedRscList, &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "calico-apiserver",
+			},
+		})
+
+		renamedRscList = append(renamedRscList, &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "tigera-system",
+			},
+		})
 	}
 
 	return renamedRscList

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -84,7 +84,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Variant:              operatorv1.TigeraSecureEnterprise,
 		}
 		apiserver = &operatorv1.APIServerSpec{}
-		dnsNames = dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
+		dnsNames = dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), render.APIServerNamespace, clusterDomain)
 		scheme := runtime.NewScheme()
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 
@@ -146,7 +146,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-apiserver-webhook-reader"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 		}
 
-		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
+		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), render.APIServerNamespace, clusterDomain)
 		kp, err := certificateManager.GetOrCreateKeyPair(cli, render.ProjectCalicoAPIServerTLSSecretName(instance.Variant), common.OperatorNamespace(), dnsNames)
 		Expect(err).NotTo(HaveOccurred())
 		cfg.TLSKeyPair = kp
@@ -1192,7 +1192,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Create and add the TLS keypair so the initContainer is rendered.
-			dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
+			dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), render.APIServerNamespace, clusterDomain)
 			kp, err := certificateManager.GetOrCreateKeyPair(cli, render.ProjectCalicoAPIServerTLSSecretName(instance.Variant), common.OperatorNamespace(), dnsNames)
 			Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 			cfg.TLSKeyPair = kp
@@ -1389,9 +1389,9 @@ func verifyAPIService(service *apiregv1.APIService, enterprise bool, clusterDoma
 	} else {
 		expectedDNSNames = []string{
 			"calico-api",
-			"calico-api.calico-apiserver",
-			"calico-api.calico-apiserver.svc",
-			"calico-api.calico-apiserver.svc." + clusterDomain,
+			"calico-api.calico-system",
+			"calico-api.calico-system.svc",
+			"calico-api.calico-system.svc." + clusterDomain,
 		}
 	}
 	test.VerifyCertSANs(ca, expectedDNSNames...)
@@ -1791,7 +1791,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		var err error
 		certificateManager, err = certificatemanager.Create(cli, nil, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
-		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
+		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), render.APIServerNamespace, clusterDomain)
 		kp, err := certificateManager.GetOrCreateKeyPair(cli, render.ProjectCalicoAPIServerTLSSecretName(instance.Variant), common.OperatorNamespace(), dnsNames)
 		Expect(err).NotTo(HaveOccurred())
 		replicas = 2
@@ -1806,9 +1806,8 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 
 	DescribeTable("should render an API server with default configuration", func(clusterDomain string) {
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-crds"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
+			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-access-calico-crds"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-tier-getter"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-tier-getter"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -1819,16 +1818,15 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-delegate-auth"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-auth-reader", Namespace: "kube-system"}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&apiregv1.APIService{ObjectMeta: metav1.ObjectMeta{Name: "v3.projectcalico.org"}, TypeMeta: metav1.TypeMeta{Kind: "APIService", APIVersion: "apiregistration.k8s.io/v1"}},
-			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
-			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "calico-api", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
-			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"}},
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "calico-api", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhook-reader"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-webhook-reader"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
-			&netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "networking.k8s.io/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+			&netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "networking.k8s.io/v1"}},
 		}
 
-		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
+		dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), render.APIServerNamespace, clusterDomain)
 		kp, err := certificateManager.GetOrCreateKeyPair(cli, render.ProjectCalicoAPIServerTLSSecretName(instance.Variant), common.OperatorNamespace(), dnsNames)
 		Expect(err).NotTo(HaveOccurred())
 		cfg.TLSKeyPair = kp
@@ -1840,18 +1838,11 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 
 		rtest.ExpectResources(resources, expectedResources)
 
-		ns := rtest.GetResource(resources, "calico-apiserver", "", "", "v1", "Namespace").(*corev1.Namespace)
-		rtest.ExpectResourceTypeAndObjectMetadata(ns, "calico-apiserver", "", "", "v1", "Namespace")
-		meta := ns.GetObjectMeta()
-		Expect(meta.GetLabels()["name"]).To(Equal("calico-apiserver"))
-		Expect(meta.GetLabels()).NotTo(ContainElement("openshift.io/run-level"))
-		Expect(meta.GetAnnotations()).NotTo(ContainElement("openshift.io/node-selector"))
-
 		apiService, ok := rtest.GetResource(resources, "v3.projectcalico.org", "", "apiregistration.k8s.io", "v1", "APIService").(*apiregv1.APIService)
 		Expect(ok).To(BeTrue(), "Expected v1.APIService")
 		verifyAPIService(apiService, false, clusterDomain)
 
-		d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 
 		Expect(d.Name).To(Equal("calico-apiserver"))
 		Expect(len(d.Labels)).To(Equal(1))
@@ -1863,7 +1854,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(d.Spec.Selector.MatchLabels).To(HaveKeyWithValue("apiserver", "true"))
 
 		Expect(d.Spec.Template.Name).To(Equal("calico-apiserver"))
-		Expect(d.Spec.Template.Namespace).To(Equal("calico-apiserver"))
+		Expect(d.Spec.Template.Namespace).To(Equal("calico-system"))
 		Expect(len(d.Spec.Template.Labels)).To(Equal(1))
 		Expect(d.Spec.Template.Labels).To(HaveKeyWithValue("apiserver", "true"))
 
@@ -1925,9 +1916,6 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		clusterRoleBinding := rtest.GetResource(resources, "calico-extension-apiserver-auth-access", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
 		Expect(clusterRoleBinding.RoleRef.Name).To(Equal("calico-extension-apiserver-auth-access"))
 
-		operatorSecretsRoleBinding := rtest.GetResource(resources, "tigera-operator-secrets", "calico-apiserver", "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
-		Expect(operatorSecretsRoleBinding.RoleRef.Name).To(Equal("tigera-operator-secrets"))
-
 	},
 		Entry("default cluster domain", dns.DefaultClusterDomain),
 		Entry("custom cluster domain", "custom-domain.internal"),
@@ -1935,8 +1923,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 
 	It("should render an API server with custom configuration", func() {
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"}},
+			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ServiceAccount"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-crds"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-access-calico-crds"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-tier-getter"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"}},
@@ -1948,13 +1935,12 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-delegate-auth"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}},
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-auth-reader", Namespace: "kube-system"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"}},
 			&apiregv1.APIService{ObjectMeta: metav1.ObjectMeta{Name: "v3.projectcalico.org"}, TypeMeta: metav1.TypeMeta{APIVersion: "apiregistration.k8s.io/v1", Kind: "APIService"}},
-			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}},
-			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "calico-api", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"}},
-			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "policy/v1", Kind: "PodDisruptionBudget"}},
+			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "calico-api", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"}},
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{APIVersion: "policy/v1", Kind: "PodDisruptionBudget"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhook-reader"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-webhook-reader"}, TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}},
-			&netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-apiserver", Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "NetworkPolicy"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: "calico-apiserver"}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+			&netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-apiserver", Namespace: "calico-system"}, TypeMeta: metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "NetworkPolicy"}},
 		}
 
 		component, err := render.APIServer(cfg)
@@ -1978,12 +1964,12 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		// Expect same number as above
 		Expect(len(resources)).To(Equal(len(expectedResources)))
 
-		dep := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment")
-		rtest.ExpectResourceTypeAndObjectMetadata(dep, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment")
+		dep := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
+		rtest.ExpectResourceTypeAndObjectMetadata(dep, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
 		d := dep.(*appsv1.Deployment)
 		Expect(len(d.Spec.Template.Spec.Volumes)).To(Equal(1))
 
-		svc := rtest.GetResource(resources, "calico-api", "calico-apiserver", "", "v1", "Service").(*corev1.Service)
+		svc := rtest.GetResource(resources, "calico-api", "calico-system", "", "v1", "Service").(*corev1.Service)
 		Expect(len(svc.Spec.Ports)).To(Equal(1))
 		Expect(svc.Spec.Ports[0].Name).To(Equal(render.APIServerPortName))
 		Expect(svc.Spec.Ports[0].Port).To(Equal(int32(443)))
@@ -1996,7 +1982,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
-		d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(d.Spec.Template.Spec.NodeSelector).To(HaveLen(1))
 		Expect(d.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("nodeName", "control01"))
 	})
@@ -2012,7 +1998,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		component, err := render.APIServer(cfg)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
-		d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(append(rmeta.TolerateControlPlane, tol)))
 	})
 
@@ -2027,7 +2013,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
-		deploymentResource := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment")
+		deploymentResource := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
 		Expect(deploymentResource).ToNot(BeNil())
 
 		deployment := deploymentResource.(*appsv1.Deployment)
@@ -2039,7 +2025,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		component, err := render.APIServer(cfg)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
-		d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(d.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
 	})
 
@@ -2053,7 +2039,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
-		deploymentResource := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment")
+		deploymentResource := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
 		Expect(deploymentResource).ToNot(BeNil())
 
 		deployment := deploymentResource.(*appsv1.Deployment)
@@ -2070,7 +2056,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(component.ResolveImages(nil)).To(BeNil())
 		resources, _ := component.Objects()
 
-		deploymentResource := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment")
+		deploymentResource := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
 		Expect(deploymentResource).ToNot(BeNil())
 
 		deployment := deploymentResource.(*appsv1.Deployment)
@@ -2085,7 +2071,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
-		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.Affinity).To(BeNil())
 	})
@@ -2098,10 +2084,10 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
-		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
-		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", "calico-apiserver")))
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", "calico-system")))
 	})
 
 	It("should render with EKS provider without CNI.Type", func() {
@@ -2123,7 +2109,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
-		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.HostNetwork).To(BeTrue())
 	})
@@ -2223,7 +2209,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Create and add the TLS keypair so the initContainer is rendered.
-			dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), rmeta.APIServerNamespace(instance.Variant), clusterDomain)
+			dnsNames := dns.GetServiceDNSNames(render.ProjectCalicoAPIServerServiceName(instance.Variant), render.APIServerNamespace, clusterDomain)
 			kp, err := certificateManager.GetOrCreateKeyPair(cli, render.ProjectCalicoAPIServerTLSSecretName(instance.Variant), common.OperatorNamespace(), dnsNames)
 			Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 			cfg.TLSKeyPair = kp
@@ -2232,7 +2218,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 			resources, _ := component.Objects()
 
-			d, ok := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			d, ok := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue())
 
 			// API server has apiserver: true label
@@ -2277,7 +2263,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(d.Spec.Template.Spec.Tolerations[0]).To(Equal(toleration))
 			Expect(d.Spec.Template.Spec.PriorityClassName).To(Equal(priorityclassname))
 
-			svc := rtest.GetResource(resources, "calico-api", "calico-apiserver", "", "v1", "Service").(*corev1.Service)
+			svc := rtest.GetResource(resources, "calico-api", "calico-system", "", "v1", "Service").(*corev1.Service)
 			Expect(svc).NotTo(BeNil())
 			Expect(svc.Spec.Ports).To(HaveLen(1))
 			Expect(svc.Spec.Ports[0].Name).To(Equal(render.APIServerPortName))
@@ -2305,7 +2291,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 			Expect(component.ResolveImages(nil)).To(BeNil())
 			resources, _ := component.Objects()
-			d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 			// nodeSelectors are merged
 			Expect(d.Spec.Template.Spec.NodeSelector).To(HaveLen(2))
 			Expect(d.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("nodeName", "control01"))
@@ -2335,7 +2321,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 			Expect(component.ResolveImages(nil)).To(BeNil())
 			resources, _ := component.Objects()
-			d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(d.Spec.Template.Spec.Tolerations).To(HaveLen(1))
 			Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(tol))
 		})
@@ -2347,7 +2333,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(err).NotTo(HaveOccurred(), "Expected APIServer to create successfully %s", err)
 			Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
 			resources, _ := component.Objects()
-			d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(d).NotTo(BeNil())
 			Expect(d.Spec.Template.Spec.Tolerations).To(ContainElement(corev1.Toleration{
 				Key:      "kubernetes.io/arch",
@@ -2367,7 +2353,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(component.ResolveImages(nil)).To(BeNil())
 			resources, _ := component.Objects()
 
-			d := rtest.GetResource(resources, "calico-apiserver", "calico-apiserver", "apps", "v1", "Deployment").(*appsv1.Deployment)
+			d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(d.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
 		})
 	})

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -109,14 +108,6 @@ func SecretsAnnotationHash(secrets ...*corev1.Secret) string {
 	}
 
 	return AnnotationHash(annoteArr)
-}
-
-// APIServerNamespace returns the namespace to use for the API server component.
-func APIServerNamespace(v operatorv1.ProductVariant) string {
-	if v == operatorv1.Calico {
-		return "calico-apiserver"
-	}
-	return "calico-system"
 }
 
 // APIServerDeploymentName returns the deployment to use for the API server component.

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -282,7 +282,7 @@ func (h *NetworkPolicyHelper) ManagerSourceEntityRule() v3.EntityRule {
 }
 
 func (h *NetworkPolicyHelper) APIServerSourceEntityRule(v operatorv1.ProductVariant) v3.EntityRule {
-	return CreateSourceEntityRule(h.namespace(meta.APIServerNamespace(v)), meta.APIServerDeploymentName(v))
+	return CreateSourceEntityRule(h.namespace("calico-system"), meta.APIServerDeploymentName(v))
 }
 
 func (h *NetworkPolicyHelper) PolicyRecommendationSourceEntityRule() v3.EntityRule {

--- a/pkg/render/testutils/expected_policies/dns.json
+++ b/pkg/render/testutils/expected_policies/dns.json
@@ -12,7 +12,7 @@
       {
         "action": "Allow",
         "source": {
-          "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','calico-system','tigera-skraper'}",
+          "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-skraper'}",
           "namespaceSelector": "all()"
         },
         "destination": {}

--- a/pkg/render/testutils/expected_policies/dns_ocp.json
+++ b/pkg/render/testutils/expected_policies/dns_ocp.json
@@ -12,7 +12,7 @@
       {
         "action":"Allow",
         "source":{
-          "selector":"projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','calico-system','tigera-skraper'}",
+          "selector":"projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-skraper'}",
           "namespaceSelector":"all()"
         },
         "destination":{}

--- a/pkg/render/testutils/expected_policies/node_local_dns_dual.json
+++ b/pkg/render/testutils/expected_policies/node_local_dns_dual.json
@@ -7,7 +7,7 @@
   "spec": {
     "tier":"allow-tigera",
     "order":10,
-    "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','calico-system','tigera-skraper'}",
+    "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-skraper'}",
     "egress":[
        {
          "action":"Allow",

--- a/pkg/render/testutils/expected_policies/node_local_dns_ipv4.json
+++ b/pkg/render/testutils/expected_policies/node_local_dns_ipv4.json
@@ -7,7 +7,7 @@
   "spec": {
     "tier":"allow-tigera",
     "order":10,
-    "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','calico-system','tigera-skraper'}",
+    "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-skraper'}",
     "egress":[
        {
          "action":"Allow",

--- a/pkg/render/testutils/expected_policies/node_local_dns_ipv6.json
+++ b/pkg/render/testutils/expected_policies/node_local_dns_ipv6.json
@@ -7,7 +7,7 @@
   "spec": {
     "tier":"allow-tigera",
     "order":10,
-    "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','calico-system','tigera-skraper'}",
+    "selector": "projectcalico.org/namespace in {'calico-system','tigera-compliance','tigera-dex','tigera-elasticsearch','tigera-fluentd','tigera-intrusion-detection','tigera-kibana','tigera-manager','tigera-eck-operator','tigera-packetcapture','tigera-policy-recommendation','tigera-prometheus','tigera-skraper'}",
     "egress":[
        {
          "action":"Allow",

--- a/pkg/render/tiers/tiers_test.go
+++ b/pkg/render/tiers/tiers_test.go
@@ -19,10 +19,8 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-	v1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/render"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/logstorage/eck"
 	"github.com/tigera/operator/pkg/render/logstorage/kibana"
@@ -82,7 +80,6 @@ var _ = Describe("Tiers rendering tests", func() {
 				render.PacketCaptureNamespace,
 				render.PolicyRecommendationNamespace,
 				common.TigeraPrometheusNamespace,
-				rmeta.APIServerNamespace(v1.TigeraSecureEnterprise),
 				"tigera-skraper",
 			},
 		}

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -467,7 +467,7 @@ func removeInstallation(ctx context.Context, c client.Client, name string) {
 
 func verifyAPIServerHasDeployed(c client.Client) {
 	By("Verifying API server was created")
-	apiserver := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-apiserver"}}
+	apiserver := &apps.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"}}
 	ExpectResourceCreated(c, apiserver)
 
 	By("Verifying the API server resources are ready")


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Component Migration: To support a minimal footprint and simplify resource management, the calico-apiserver component and its associated resources have been moved from the calico-apiserver namespace to the calico-system namespace in Calico OSS .
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
