### PR TITLE
Clean up release-prep and release notes generation [master]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -693,7 +693,6 @@ release-prep: release-prep-prereqs check-milestone var-require-all-GIT_PR_BRANCH
 	$(YQ_V4) ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
 	sed -i "s/\"gcr.io.*\"/\"quay.io\/\"/g" pkg/components/images.go
 	sed -i "s/\"gcr.io.*\"/\"quay.io\"/g" hack/gen-versions/main.go
-	git diff-index --quiet HEAD -- config && (echo "   *** No changes were made to the config/*_versions.yml files when updating versions; did you specify a version to change?" && exit 1)
 	$(MAKE) gen-versions release-prep/create-and-push-branch release-prep/create-pr release-prep/set-pr-labels
 
 GIT_REMOTE?=origin

--- a/Makefile
+++ b/Makefile
@@ -683,7 +683,7 @@ endif
 	$(info CALICO_ENTERPRISE_VERSION = $(CALICO_ENTERPRISE_VERSION) (source: $(origin CALICO_ENTERPRISE_VERSION))) 
 	$(info )
 	$(if $(filter-out file, $(origin CALICO_VERSION) $(origin CALICO_ENTERPRISE_VERSION)),,$(error Neither CALICO_VERSION nor CALICO_ENTERPRISE_VERSION were set, please set one or the other (or both) to a new version.))
-	$(if $(if $(GIT_PR_BRANCH_OVERRIDE),true,$(findstring release-v,$(GIT_PR_BRANCH_BASE))),,$(error Variable GIT_PR_BRANCH_BASE is not set to the name of a release branch. If you're certain you want to use this branch, set GIT_PR_BRANCH_OVERRIDE=true))
+	$(if $(if $(GIT_PR_BRANCH_OVERRIDE),true,$(findstring release-v,$(GIT_PR_BRANCH_BASE))),,$(error Variable GIT_PR_BRANCH_BASE is not set to the name of a release branch. You should only be running `release-prep` on a release branch! If you're certain you want to use this branch, set GIT_PR_BRANCH_OVERRIDE=true))
 ifndef CONFIRM
 	$(info If this is correct, add CONFIRM=true to the command line to continue)
 	$(info )

--- a/Makefile
+++ b/Makefile
@@ -686,7 +686,7 @@ release-prep: release-prep-prereqs check-milestone var-require-all-GIT_PR_BRANCH
 	$(YQ_V4) ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
 	sed -i "s/\"gcr.io.*\"/\"quay.io\/\"/g" pkg/components/images.go
 	sed -i "s/\"gcr.io.*\"/\"quay.io\"/g" hack/gen-versions/main.go
-	git diff-index --quiet --cached HEAD -- && (echo "No changes were made to the repository when updating versions; did you specify a version to change?" && exit 1) || true
+	git diff-index --quiet --cached HEAD -- && (echo "\n*** No changes were made to the repository when updating versions; did you specify a version to change?\n" && exit 1)
 	$(MAKE) gen-versions release-prep/create-and-push-branch release-prep/create-pr release-prep/set-pr-labels
 
 GIT_REMOTE?=origin

--- a/Makefile
+++ b/Makefile
@@ -693,7 +693,7 @@ release-prep: release-prep-prereqs check-milestone var-require-all-GIT_PR_BRANCH
 	$(YQ_V4) ".title = \"$(CALICO_VERSION)\" | .components.[].version = \"$(CALICO_VERSION)\"" -i config/calico_versions.yml
 	sed -i "s/\"gcr.io.*\"/\"quay.io\/\"/g" pkg/components/images.go
 	sed -i "s/\"gcr.io.*\"/\"quay.io\"/g" hack/gen-versions/main.go
-	git diff-index --quiet HEAD -- config && (echo "\n*** No changes were made to the config/*_versions.yml files when updating versions; did you specify a version to change?\n" && exit 1)
+	git diff-index --quiet HEAD -- config && (echo "   *** No changes were made to the config/*_versions.yml files when updating versions; did you specify a version to change?" && exit 1)
 	$(MAKE) gen-versions release-prep/create-and-push-branch release-prep/create-pr release-prep/set-pr-labels
 
 GIT_REMOTE?=origin

--- a/Makefile
+++ b/Makefile
@@ -667,7 +667,8 @@ check-milestone: hack/bin/gh var-require-all-VERSION-GITHUB_TOKEN
 # the release process.
 #
 # Most notably: validate that VERSION is set, and that either CALICO_VERSION or CALICO_ENTERPRISE_VERSION is set
-# by the user. Then, ensure that CONFIRM is set, or tell the user they need to set it first.
+# by the user; next, ensure that GIT_PR_BRANCH_BASE is set to a release branch (or is overridden); finally,
+# ensure that CONFIRM is set, or tell the user they need to set it first.
 release-prep-prereqs:
 ifndef VERSION
 	$(error VERSION is undefined - specify VERSION=vX.Y.Z or set AUTO_VERSION to automatically use the detected version $(AUTO_VERSION_VERSION))
@@ -678,11 +679,12 @@ endif
 	$(info CALICO_VERSION            = $(CALICO_VERSION) (source: $(origin CALICO_VERSION)))
 	$(info CALICO_ENTERPRISE_VERSION = $(CALICO_ENTERPRISE_VERSION) (source: $(origin CALICO_ENTERPRISE_VERSION))) 
 	$(info )
-	$(if $(or $(filter-out file, $(origin CALICO_VERSION) $(origin CALICO_ENTERPRISE_VERSION))),,$(error "Neither CALICO_VERSION nor CALICO_ENTERPRISE_VERSION were set, please set one or the other (or both) to a new version."))
+	$(if $(filter-out file, $(origin CALICO_VERSION) $(origin CALICO_ENTERPRISE_VERSION)),,$(error Neither CALICO_VERSION nor CALICO_ENTERPRISE_VERSION were set, please set one or the other (or both) to a new version.))
+	$(if $(if $(GIT_PR_BRANCH_OVERRIDE),true,$(findstring release-v,$(GIT_PR_BRANCH_BASE))),,$(error Variable GIT_PR_BRANCH_BASE is not set to the name of a release branch. If you're certain you want to use this branch, set GIT_PR_BRANCH_OVERRIDE=true))
 ifndef CONFIRM
 	$(info If this is correct, add CONFIRM=true to the command line to continue)
 	$(info )
-	exit 1
+	@exit 1
 else
 	$(info Variable CONFIRM was specified, continuing with release preparation...)
 	$(info )

--- a/Makefile
+++ b/Makefile
@@ -673,6 +673,9 @@ release-prep-prereqs:
 ifndef VERSION
 	$(error VERSION is undefined - specify VERSION=vX.Y.Z or set AUTO_VERSION to automatically use the detected version $(AUTO_VERSION_VERSION))
 endif
+ifndef GITHUB_TOKEN
+	$(error GITHUB_TOKEN is undefined - A github token is required to create a pull request and set labels. Please set GITHUB_TOKEN to a valid token with repo permissions.)
+endif
 	$(info Preparing for release of $(VERSION) with the following variables:)
 	$(info )
 	$(info GIT_PR_BRANCH_BASE        = $(GIT_PR_BRANCH_BASE))

--- a/config/calico_versions.yml
+++ b/config/calico_versions.yml
@@ -39,4 +39,3 @@ components:
     version: master
   calico/guardian:
     version: master
-

--- a/hack/increment_patch.go
+++ b/hack/increment_patch.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main is a simple utility to increment a patch version
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/blang/semver/v4"
+)
+
+func main() {
+	// Increment the patch version of the current module.
+	// This is used to ensure that the module version is always incremented
+	// when a new patch is released.
+
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: increment_patch <version>")
+		fmt.Println("Example: increment_patch v1.39.0")
+		return
+	}
+
+	inputVersion := os.Args[1]
+
+	// Remove the 'v' prefix if it exists
+	// and parse the version string.
+	strippedVersion := strings.Trim(inputVersion, "v")
+
+	currentVersion, err := semver.Make(strippedVersion)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing version `%s`: %s\n", inputVersion, err)
+		return
+	}
+
+	// There are two possible formats for input version that we're likely to run into:
+	// 1. v1.39.0-0.dev-116-g61909055
+	// 		This means that we've created a 'v1.39.0-0.dev' tag to indicate what the next
+	// 		version will be; this is for when we haven't created a release for this branch yet.
+	// 		In this case, we want to use the version that's already in the tag, minus the -0.dev
+	// 2. v1.36.9-44-g61909055
+	// 		This means we've released v1.36.9 and we're 44 commits after that release, meaning
+	// 		that the next version will be v1.36.10. In this case we want to increment the
+	// 		patch version. This is also the case if we're already on a tag and got `v1.36.9` as input.
+	if !strings.Contains(strippedVersion, ".dev-") {
+		err = currentVersion.IncrementPatch()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error incrementing version `%s`: %s\n", inputVersion, err)
+			return
+		}
+	}
+
+	fmt.Printf("v%s\n", currentVersion.FinalizeVersion())
+}

--- a/hack/release-prep.mk
+++ b/hack/release-prep.mk
@@ -1,0 +1,9 @@
+GIT_PR_BRANCH_BASE ?= $(shell git branch --show-current)
+GIT_DESCRIBE := $(shell git describe --tags --always)
+GIT_REPO_SLUG ?= tigera/operator
+AUTO_VERSION_VERSION = $(shell go run hack/increment_patch.go $(GIT_DESCRIBE))
+ifdef AUTO_VERSION
+VERSION = $(AUTO_VERSION_VERSION)
+endif
+CALICO_VERSION ?= $(shell $(YQ_V4) '.title' config/calico_versions.yml )
+CALICO_ENTERPRISE_VERSION ?= $(shell $(YQ_V4) '.title' config/enterprise_versions.yml )


### PR DESCRIPTION
This PR does two things:

First, we fix up the release notes generation script to resolve a few bugs, and in the process do some linting and code cleanup to last us until this functionality is moved to golang.

Secondly, and more critically, we update the `release-prep` target with a host of quality-of-life changes. Specifically:

1. We set a host of variables automatically, in the `hack/release-prep.mk` makefile. We use this file specifically because the operator Makefile doesn't have a `metadata.mk` file that we can set all of our variables in, so for the goal of cleanliness and clarity I opted to file these variables away in a separate file to make it clear what they are and what they're used for.
2. Wrote a small golang program to take an input version that we would get from `git describe --tags` and produce whatever the next release version would be. For the '0.dev'-style `git describe` output we simply use the version in that tag; otherwise, we increment the patch version.
3. Created a new `release-prep-prereqs` make target to provide some nicer output if things aren't set and let the user know what to do next.

The goal of the release-prep changes is straightforward:

1. Ensure that we use sane defaults for every setting so that we don't need to manually specify every variable we need.
2. Show the user the variables so they can validate them
3. Validate situations that seem invalid, but let the user override them

For example, a user could now run `make release-prep` from scratch and be told each thing they're missing in order to perform a release; set their Github token, set their version (or use `AUTO_VERSION`), specify at least one OSS/Enterprise version (even if it's the same as we already have), and ensure they're on a release branch unless they're really certain.

This will both reduce copy-paste or transcription errors and simplify the workflow immensely.

### Examples

#### You ran `release-prep` without setting anything:

```
❱ make release-prep
Makefile:667: *** VERSION is undefined - specify VERSION=vX.Y.Z or set AUTO_VERSION to automatically use the detected version v1.36.10.  Stop.
```

#### You ran `release-prep` and specified `AUTO_VERSION`:

```
❱ make release-prep AUTO_VERSION=true
Preparing for release of v1.36.10 with the following variables:

GIT_PR_BRANCH_BASE        = cleanup-release-process-master
CALICO_VERSION            = master (source: file)
CALICO_ENTERPRISE_VERSION = master (source: file)

Makefile:681: *** "Neither CALICO_VERSION nor CALICO_ENTERPRISE_VERSION were set, please set one or the other (or both) to a new version.".  Stop.
```

(Note that you can set either of these variables to the same version, if you're e.g. doing an operator-only release for some reason)

#### You ran `release-prep` and specified `AUTO_VERSION` and `CALICO_VERSION`, but not `CONFIRM`:

```
❱ make release-prep AUTO_VERSION=true CALICO_VERSION=v1.2.3
Preparing for release of v1.36.10 with the following variables:

GIT_PR_BRANCH_BASE        = cleanup-release-process-master
CALICO_VERSION            = v1.2.3 (source: command line)
CALICO_ENTERPRISE_VERSION = master (source: file)

If this is correct, add CONFIRM=true to the command line to continue

exit 1
make: *** [Makefile:684: release-prep-prereqs] Error 1
```

#### You ran `release-prep` but you're not on a release branch:

```
❱ make release-prep AUTO_VERSION=true  CALICO_VERSION=cat
Preparing for release of v1.36.10 with the following variables:

GIT_PR_BRANCH_BASE        = cleanup-release-process-master
CALICO_VERSION            = cat (source: command line)
CALICO_ENTERPRISE_VERSION = master (source: file)

Makefile:683: *** Variable GIT_PR_BRANCH_BASE is not set to the name of a release branch. If you're certain you want to use this branch, set GIT_PR_BRANCH_OVERRIDE=true.  Stop.
```

#### You ran `release-prep` and specified everything you need to:

```
❱ make release-prep AUTO_VERSION=true CALICO_VERSION=master CONFIRM=true
Preparing for release of v1.36.10 with the following variables:

GIT_PR_BRANCH_BASE        = cleanup-release-process-master
CALICO_VERSION            = master (source: command line)
CALICO_ENTERPRISE_VERSION = master (source: file)

Variable CONFIRM was specified, continuing with release preparation...

make var-require REQUIRED_VARS=VERSION-GITHUB_TOKEN FAIL_NOT_SET=true
make[1]: Entering directory '/home/dan/source/tigera/operator-master'

<...and so on...>
```