### PR TITLE
Pull secrets and namspace will be created by a setup component

### DIFF
--- a/internal/controller/logstorage_controller.go
+++ b/internal/controller/logstorage_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020,2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020,2024-2025 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,5 +108,11 @@ func (r *LogStorageReconciler) SetupWithManager(mgr ctrl.Manager, opts options.A
 	if err := kubecontrollers.Add(mgr, opts); err != nil {
 		return err
 	}
+
+	// This controller runs only on management clusters configured to use an external Elasticsearch cluster.
+	if err := elastic.AddExternalES(mgr, opts); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -472,7 +472,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		PullSecrets:     pullSecrets,
 		Namespace:       helper.InstallNamespace(),
 		PSS:             getPSS(lc),
-		CreateNamespace: shouldCreateNamespace(tenant, hasNoLicense),
+		CreateNamespace: !tenant.MultiTenant(),
 	})
 	intrusionDetectionComponent := render.IntrusionDetection(intrusionDetectionCfg)
 
@@ -602,13 +602,6 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
-}
-
-func shouldCreateNamespace(tenant *operatorv1.Tenant, hasNoLicense bool) bool {
-	if hasNoLicense || tenant.MultiTenant() {
-		return false
-	}
-	return true
 }
 
 func getPSS(logCollector *operatorv1.LogCollector) render.PodSecurityStandard {

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -466,13 +466,13 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		ExternalElastic:              r.elasticExternal,
 		SyslogForwardingIsEnabled:    syslogForwardingIsEnabled(lc),
 	}
-	intrusionDetectionNamespaceComponent := render.IntrusionDetectionNamespaceComponent(&render.IntrusionDetectionNamespaceConfiguration{
-		KubernetesProvider:        network.KubernetesProvider,
-		Namespace:                 helper.InstallNamespace(),
-		Tenant:                    tenant,
-		HasNoLicense:              hasNoLicense,
-		SyslogForwardingIsEnabled: syslogForwardingIsEnabled(lc),
-		Azure:                     network.Azure,
+	setUp := render.NewSetup(&render.SetUpConfiguration{
+		OpenShift:       r.provider.IsOpenShift(),
+		Installation:    network,
+		PullSecrets:     pullSecrets,
+		Namespace:       helper.InstallNamespace(),
+		PSS:             getPSS(lc),
+		CreateNamespace: shouldCreateNamespace(tenant, hasNoLicense),
 	})
 	intrusionDetectionComponent := render.IntrusionDetection(intrusionDetectionCfg)
 
@@ -493,7 +493,6 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	}
 
 	components := []render.Component{
-		intrusionDetectionNamespaceComponent,
 		rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{
 			Namespace:       helper.InstallNamespace(),
 			TruthNamespace:  helper.TruthNamespace(),
@@ -565,6 +564,16 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		components = append(components, dpiComponent)
 	}
 
+	setupHandler := handler
+	if tenant.MultiTenant() {
+		// In standard installs, the IntrusionDetection CR owns all the objects. For multi-tenant, pull secrets are owned by the Tenant instance.
+		setupHandler = utils.NewComponentHandler(log, r.client, r.scheme, tenant)
+	}
+	if err := setupHandler.CreateOrUpdateOrDelete(ctx, setUp, r.status); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	for _, comp := range components {
 		if err := handler.CreateOrUpdateOrDelete(context.Background(), comp, r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
@@ -593,6 +602,25 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
+}
+
+func shouldCreateNamespace(tenant *operatorv1.Tenant, hasNoLicense bool) bool {
+	if hasNoLicense || tenant.MultiTenant() {
+		return false
+	}
+	return true
+}
+
+func getPSS(logCollector *operatorv1.LogCollector) render.PodSecurityStandard {
+	// Configure pod security standard. If syslog forwarding is enabled, we
+	// need hostpath volumes which require a privileged PSS.
+	pss := render.PSSRestricted
+
+	if syslogForwardingIsEnabled(logCollector) {
+		pss = render.PSSPrivileged
+	}
+
+	return render.PodSecurityStandard(pss)
 }
 
 // Determine whether this component's configuration has syslog forwarding enabled or not.

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
@@ -117,6 +117,9 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 				Spec: operatorv1.InstallationSpec{
 					Variant:  operatorv1.TigeraSecureEnterprise,
 					Registry: "some.registry.org/",
+					ImagePullSecrets: []corev1.LocalObjectReference{{
+						Name: "tigera-pull-secret",
+					}},
 				},
 				Status: operatorv1.InstallationStatus{
 					Variant: operatorv1.TigeraSecureEnterprise,
@@ -148,6 +151,7 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 				Phase: esv1.ElasticsearchReadyPhase,
 			},
 		})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}})).NotTo(HaveOccurred())
 
 		certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
@@ -396,6 +400,33 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 				Name:      render.IntrusionDetectionControllerName,
 				Namespace: render.IntrusionDetectionNamespace,
 			}, &deployment)).NotTo(HaveOccurred())
+			Expect(namespace.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("restricted"))
+			Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
+
+			// Expect operator rolebinding to be created
+			rb := rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			Expect(c.Get(ctx, client.ObjectKey{
+				Name:      render.TigeraOperatorSecrets,
+				Namespace: render.IntrusionDetectionNamespace,
+			}, &rb)).NotTo(HaveOccurred())
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			ownerRoleBinding := rb.OwnerReferences[0]
+			Expect(ownerRoleBinding.Kind).To(Equal("IntrusionDetection"))
+
+			// Expect pull secrets to be created
+			pullSecrets := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			}
+			Expect(c.Get(ctx, client.ObjectKey{
+				Name:      "tigera-pull-secret",
+				Namespace: render.IntrusionDetectionNamespace,
+			}, &pullSecrets)).NotTo(HaveOccurred())
+			Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+			pullSecret := pullSecrets.OwnerReferences[0]
+			Expect(pullSecret.Kind).To(Equal("IntrusionDetection"))
+
 		})
 
 		It("should Reconcile with default values for intrusion detection resource", func() {
@@ -734,6 +765,35 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 
 			err = test.GetResource(c, &clusterRoleBinding)
 			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should reconcile pull secrets and role binding", func() {
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tenantANamespace}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Expect operator role binding to be created
+			rb := rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			Expect(c.Get(ctx, client.ObjectKey{
+				Name:      render.TigeraOperatorSecrets,
+				Namespace: tenantANamespace,
+			}, &rb)).NotTo(HaveOccurred())
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			ownerRoleBinding := rb.OwnerReferences[0]
+			Expect(ownerRoleBinding.Kind).To(Equal("Tenant"))
+
+			// Expect pull secrets to be created
+			pullSecrets := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			}
+			Expect(c.Get(ctx, client.ObjectKey{
+				Name:      "tigera-pull-secret",
+				Namespace: tenantANamespace,
+			}, &pullSecrets)).NotTo(HaveOccurred())
+			Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+			pullSecret := pullSecrets.OwnerReferences[0]
+			Expect(pullSecret.Kind).To(Equal("Tenant"))
 		})
 	})
 })

--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -626,7 +626,16 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
+	setUp := render.NewSetup(&render.SetUpConfiguration{
+		OpenShift:       r.provider.IsOpenShift(),
+		Installation:    installation,
+		PullSecrets:     pullSecrets,
+		Namespace:       render.LogCollectorNamespace,
+		PSS:             render.PSSPrivileged,
+		CreateNamespace: true,
+	})
 	components := []render.Component{
+		setUp,
 		comp,
 		rcertificatemanagement.CertificateManagement(&certificateComponent),
 	}

--- a/pkg/controller/logstorage/elastic/external_elastic_controller.go
+++ b/pkg/controller/logstorage/elastic/external_elastic_controller.go
@@ -100,6 +100,11 @@ func AddExternalES(mgr manager.Manager, opts options.AddOptions) error {
 	if err = utils.AddConfigMapWatch(c, "cloud-kibana-config", common.OperatorNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("log-storage-external-es-controller failed to watch the ConfigMap resource: %w", err)
 	}
+
+	if err = utils.AddNamespaceWatch(c, render.ElasticsearchNamespace); err != nil {
+		return fmt.Errorf("log-storage-external-es-controller failed to watch tigera-elasticsearch namespace: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/controller/logstorage/elastic/external_elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/external_elastic_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package elastic
 
 import (
 	"context"
+	"time"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/render/logstorage"
@@ -116,6 +117,9 @@ var _ = Describe("External ES Controller", func() {
 			Spec: operatorv1.InstallationSpec{
 				Variant:  operatorv1.TigeraSecureEnterprise,
 				Registry: "some.registry.org/",
+				ImagePullSecrets: []corev1.LocalObjectReference{{
+					Name: "tigera-pull-secret",
+				}},
 			},
 		}
 		Expect(cli.Create(ctx, install)).ShouldNot(HaveOccurred())
@@ -173,6 +177,10 @@ var _ = Describe("External ES Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: utils.DefaultTSEEInstanceKey.Name},
 			})).NotTo(HaveOccurred())
 
+		Expect(cli.Create(ctx,
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()},
+			})).NotTo(HaveOccurred())
 		mockStatus = &status.MockStatus{}
 		mockStatus.On("Run").Return()
 		mockStatus.On("OnCRFound").Return()
@@ -195,6 +203,57 @@ var _ = Describe("External ES Controller", func() {
 		Expect(result).Should(Equal(reconcile.Result{}))
 		mockStatus.AssertExpectations(GinkgoT())
 	})
+
+	It("create namespace, operator secrets role and pull secrets", func() {
+		CreateLogStorage(cli, &operatorv1.LogStorage{
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			Spec:       operatorv1.LogStorageSpec{},
+			Status:     operatorv1.LogStorageStatus{State: operatorv1.TigeraStatusReady},
+		})
+
+		// Run the reconciler and expect it to reach the end successfully.
+		mockStatus.On("ClearDegraded")
+		r, err := NewExternalESReconcilerWithShims(cli, scheme, mockStatus, operatorv1.ProviderNone, dns.DefaultClusterDomain)
+		Expect(err).ShouldNot(HaveOccurred())
+		result, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(0 * time.Second))
+
+		// Expect namespace to be created
+		namespace := corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		}
+		Expect(cli.Get(ctx, client.ObjectKey{
+			Name: render.ElasticsearchNamespace,
+		}, &namespace)).NotTo(HaveOccurred())
+		Expect(namespace.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("baseline"))
+		Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
+
+		// Expect operator rolebinding to be created
+		rb := rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{},
+		}
+		Expect(cli.Get(ctx, client.ObjectKey{
+			Name:      render.TigeraOperatorSecrets,
+			Namespace: render.ElasticsearchNamespace,
+		}, &rb)).NotTo(HaveOccurred())
+		Expect(rb.OwnerReferences).To(HaveLen(1))
+		ownerRoleBinding := rb.OwnerReferences[0]
+		Expect(ownerRoleBinding.Kind).To(Equal("LogStorage"))
+
+		// Expect pull secrets to be created
+		pullSecrets := corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		}
+		Expect(cli.Get(ctx, client.ObjectKey{
+			Name:      "tigera-pull-secret",
+			Namespace: render.ElasticsearchNamespace,
+		}, &pullSecrets)).NotTo(HaveOccurred())
+		Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+		pullSecret := pullSecrets.OwnerReferences[0]
+		Expect(pullSecret.Kind).To(Equal("LogStorage"))
+	})
+
 })
 
 func NewExternalESReconcilerWithShims(

--- a/pkg/controller/logstorage/initializer/initializing_controller.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,6 +59,10 @@ const (
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.AddOptions) error {
 	if !opts.EnterpriseCRDExists {
+		return nil
+	}
+
+	if opts.ElasticExternal {
 		return nil
 	}
 
@@ -238,30 +242,37 @@ func (r *LogStorageInitializer) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	// Before we can create secrets, we need to ensure the tigera-elasticsearch namespace exists.
-	hdler := utils.NewComponentHandler(reqLogger, r.client, r.scheme, ls)
-	esNamespace := render.CreateNamespace(render.ElasticsearchNamespace, install.KubernetesProvider, render.PSSPrivileged, install.Azure)
-	if err = hdler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(esNamespace), r.status); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
+	pullSecrets, err := utils.GetNetworkingPullSecrets(install, r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurring while retrieving the pull secrets", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
-	esRoleBinding := render.CreateOperatorSecretsRoleBinding(render.ElasticsearchNamespace)
-	if err = hdler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(esRoleBinding), r.status); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
-		return reconcile.Result{}, err
-	}
+	// Before we can create secrets, we need to ensure the tigera-elasticsearch namespace exists.
+	hdler := utils.NewComponentHandler(reqLogger, r.client, r.scheme, ls)
+	components := []render.Component{render.NewSetup(&render.SetUpConfiguration{
+		OpenShift:       r.provider.IsOpenShift(),
+		Installation:    install,
+		PullSecrets:     pullSecrets,
+		Namespace:       render.ElasticsearchNamespace,
+		PSS:             render.PSSPrivileged,
+		CreateNamespace: true,
+	})}
 
 	// Multitenant clusters do not get kibana, so namespace creation can be skipped.
 	if !r.multiTenant {
-		kbNamespace := render.CreateNamespace(kibana.Namespace, install.KubernetesProvider, render.PSSBaseline, install.Azure)
-		if err = hdler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(kbNamespace), r.status); err != nil {
-			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
-			return reconcile.Result{}, err
-		}
+		components = append(components, render.NewSetup(&render.SetUpConfiguration{
+			OpenShift:       r.provider.IsOpenShift(),
+			Installation:    install,
+			PullSecrets:     pullSecrets,
+			Namespace:       kibana.Namespace,
+			PSS:             render.PSSBaseline,
+			CreateNamespace: true,
+		}))
+	}
 
-		kbRoleBinding := render.CreateOperatorSecretsRoleBinding(kibana.Namespace)
-		if err = hdler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(kbRoleBinding), r.status); err != nil {
+	for _, component := range components {
+		if err = hdler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,6 +130,9 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 				ControlPlaneReplicas: &replicas,
 				Variant:              operatorv1.TigeraSecureEnterprise,
 				Registry:             "some.registry.org/",
+				ImagePullSecrets: []corev1.LocalObjectReference{{
+					Name: "tigera-pull-secret",
+				}},
 			},
 		}
 		Expect(cli.Create(ctx, install)).ShouldNot(HaveOccurred())
@@ -147,6 +150,11 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 		es.Namespace = render.ElasticsearchNamespace
 		es.Status.Phase = esv1.ElasticsearchReadyPhase
 		Expect(cli.Create(ctx, es)).ShouldNot(HaveOccurred())
+
+		pullSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()},
+		}
+		Expect(cli.Create(ctx, pullSecret)).NotTo(HaveOccurred())
 
 		mockStatus = &status.MockStatus{}
 		mockStatus.On("Run").Return()
@@ -245,6 +253,30 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 			},
 		}
 		Expect(test.GetResource(cli, &dep)).To(BeNil())
+
+		// Expect operator role binding to be created
+		rb := rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{},
+		}
+		Expect(cli.Get(ctx, client.ObjectKey{
+			Name:      render.TigeraOperatorSecrets,
+			Namespace: common.CalicoNamespace,
+		}, &rb)).NotTo(HaveOccurred())
+		Expect(rb.OwnerReferences).To(HaveLen(1))
+		ownerRoleBinding := rb.OwnerReferences[0]
+		Expect(ownerRoleBinding.Kind).To(Equal("LogStorage"))
+
+		// Expect pull secrets to be created
+		pullSecrets := corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		}
+		Expect(cli.Get(ctx, client.ObjectKey{
+			Name:      "tigera-pull-secret",
+			Namespace: common.CalicoNamespace,
+		}, &pullSecrets)).NotTo(HaveOccurred())
+		Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+		pullSecret := pullSecrets.OwnerReferences[0]
+		Expect(pullSecret.Kind).To(Equal("LogStorage"))
 	})
 
 	It("should use images from ImageSet", func() {
@@ -339,6 +371,18 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 				},
 			}
 			Expect(test.GetResource(cli, &dep)).To(BeNil())
+
+			// Expect pull secrets to be created
+			pullSecrets := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			}
+			Expect(cli.Get(ctx, client.ObjectKey{
+				Name:      "tigera-pull-secret",
+				Namespace: common.CalicoNamespace,
+			}, &pullSecrets)).NotTo(HaveOccurred())
+			Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+			pullSecret := pullSecrets.OwnerReferences[0]
+			Expect(pullSecret.Kind).To(Equal("LogStorage"))
 		})
 	})
 
@@ -429,6 +473,29 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 				},
 			}
 			Expect(test.GetResource(cli, &dep)).To(BeNil())
+			// Expect operator role binding to be created
+			rb := rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			Expect(cli.Get(ctx, client.ObjectKey{
+				Name:      render.TigeraOperatorSecrets,
+				Namespace: tenantNS,
+			}, &rb)).NotTo(HaveOccurred())
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			ownerRoleBinding := rb.OwnerReferences[0]
+			Expect(ownerRoleBinding.Kind).To(Equal("Tenant"))
+
+			// Expect pull secrets to be created
+			pullSecrets := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			}
+			Expect(cli.Get(ctx, client.ObjectKey{
+				Name:      "tigera-pull-secret",
+				Namespace: tenantNS,
+			}, &pullSecrets)).NotTo(HaveOccurred())
+			Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+			pullSecret := pullSecrets.OwnerReferences[0]
+			Expect(pullSecret.Kind).To(Equal("Tenant"))
 		})
 	})
 })

--- a/pkg/controller/logstorage/linseed/linseed_controller_test.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -126,9 +126,15 @@ var _ = Describe("LogStorage Linseed controller", func() {
 				ControlPlaneReplicas: &replicas,
 				Variant:              operatorv1.TigeraSecureEnterprise,
 				Registry:             "some.registry.org/",
+				ImagePullSecrets: []corev1.LocalObjectReference{{
+					Name: "tigera-pull-secret",
+				}},
 			},
 		}
 		Expect(cli.Create(ctx, install)).ShouldNot(HaveOccurred())
+
+		pullSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}}
+		Expect(cli.Create(ctx, pullSecret)).NotTo(HaveOccurred())
 
 		// Create a basic LogStorage.
 		ls := &operatorv1.LogStorage{}
@@ -203,7 +209,7 @@ var _ = Describe("LogStorage Linseed controller", func() {
 			Expect(err.Error()).Should(ContainSubstring("CA secret"))
 		})
 
-		It("should reconcile resources for a standlone cluster", func() {
+		It("should reconcile resources for a standalone cluster", func() {
 			// Run the reconciler.
 			result, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -219,6 +225,30 @@ var _ = Describe("LogStorage Linseed controller", func() {
 				},
 			}
 			Expect(test.GetResource(cli, &linseedDp)).To(BeNil())
+
+			// Expect operator role binding to be created
+			rb := rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			Expect(cli.Get(ctx, client.ObjectKey{
+				Name:      render.TigeraOperatorSecrets,
+				Namespace: render.ElasticsearchNamespace,
+			}, &rb)).NotTo(HaveOccurred())
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			ownerRoleBinding := rb.OwnerReferences[0]
+			Expect(ownerRoleBinding.Kind).To(Equal("LogStorage"))
+
+			// Expect pull secrets to be created
+			pullSecrets := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			}
+			Expect(cli.Get(ctx, client.ObjectKey{
+				Name:      "tigera-pull-secret",
+				Namespace: render.ElasticsearchNamespace,
+			}, &pullSecrets)).NotTo(HaveOccurred())
+			Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+			pullSecret := pullSecrets.OwnerReferences[0]
+			Expect(pullSecret.Kind).To(Equal("LogStorage"))
 		})
 
 		It("should use images from ImageSet", func() {
@@ -401,7 +431,7 @@ var _ = Describe("LogStorage Linseed controller", func() {
 			mockStatus.AssertNotCalled(GinkgoT(), "OnCRFound")
 		})
 
-		It("should reconcile resources for a standlone cluster", func() {
+		It("should reconcile resources for a cluster", func() {
 			// Run the reconciler.
 			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: tenantNS}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -417,6 +447,29 @@ var _ = Describe("LogStorage Linseed controller", func() {
 				},
 			}
 			Expect(test.GetResource(cli, &linseedDp)).To(BeNil())
+			// Expect operator role binding to be created
+			rb := rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			Expect(cli.Get(ctx, client.ObjectKey{
+				Name:      render.TigeraOperatorSecrets,
+				Namespace: tenantNS,
+			}, &rb)).NotTo(HaveOccurred())
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			ownerRoleBinding := rb.OwnerReferences[0]
+			Expect(ownerRoleBinding.Kind).To(Equal("Tenant"))
+
+			// Expect pull secrets to be created
+			pullSecrets := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			}
+			Expect(cli.Get(ctx, client.ObjectKey{
+				Name:      "tigera-pull-secret",
+				Namespace: tenantNS,
+			}, &pullSecrets)).NotTo(HaveOccurred())
+			Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+			pullSecret := pullSecrets.OwnerReferences[0]
+			Expect(pullSecret.Kind).To(Equal("Tenant"))
 		})
 
 		It("should use images from ImageSet", func() {

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -602,7 +602,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	// Create a component handler to manage the rendered component.
-	componentHandler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
+	defaultHandler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
 	// Set replicas to 1 for management or managed clusters.
 	// TODO Remove after MCM tigera-manager HA deployment is supported.
@@ -693,6 +693,14 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
+	setup := render.NewSetup(&render.SetUpConfiguration{
+		OpenShift:       r.provider.IsOpenShift(),
+		Installation:    installation,
+		PullSecrets:     pullSecrets,
+		Namespace:       helper.InstallNamespace(),
+		PSS:             render.PSSRestricted,
+		CreateNamespace: !tenant.MultiTenant(),
+	})
 	components := []render.Component{
 		// Install manager components.
 		component,
@@ -716,8 +724,18 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		components = append(components, tunnelSecretPassthrough)
 	}
 
+	setupHandler := defaultHandler
+	if tenant.MultiTenant() {
+		// In standard installs, the Manager CR owns all the objects. For multi-tenant, pull secrets are owned by the Tenant instance.
+		setupHandler = utils.NewComponentHandler(log, r.client, r.scheme, tenant)
+	}
+	if err := setupHandler.CreateOrUpdateOrDelete(ctx, setup, r.status); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, logc)
+		return reconcile.Result{}, err
+	}
+
 	for _, component := range components {
-		if err := componentHandler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
+		if err := defaultHandler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, logc)
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -469,6 +470,9 @@ var _ = Describe("Manager controller tests", func() {
 					ControlPlaneReplicas: &replicas,
 					Variant:              operatorv1.TigeraSecureEnterprise,
 					Registry:             "some.registry.org/",
+					ImagePullSecrets: []corev1.LocalObjectReference{{
+						Name: "tigera-pull-secret",
+					}},
 				},
 				Status: operatorv1.InstallationStatus{
 					Variant: operatorv1.TigeraSecureEnterprise,
@@ -476,10 +480,15 @@ var _ = Describe("Manager controller tests", func() {
 						Registry: "some.registry.org/",
 						// The test is provider agnostic.
 						KubernetesProvider: operatorv1.ProviderNone,
+						ImagePullSecrets: []corev1.LocalObjectReference{{
+							Name: "tigera-pull-secret",
+						}},
 					},
 				},
 			}
 			Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+			pullSecrets := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}}
+			Expect(c.Create(ctx, pullSecrets)).NotTo(HaveOccurred())
 
 			Expect(c.Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: common.TigeraPrometheusNamespace},
@@ -556,6 +565,45 @@ var _ = Describe("Manager controller tests", func() {
 				// Mark that watches were successful.
 				r.licenseAPIReady.MarkAsReady()
 				r.tierWatchReady.MarkAsReady()
+			})
+
+			It("should reconcile manager namespace, role bindings and pull secrets", func() {
+				result, err := r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.RequeueAfter).To(Equal(0 * time.Second))
+
+				namespace := corev1.Namespace{
+					TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+				}
+				Expect(c.Get(ctx, client.ObjectKey{
+					Name: render.ManagerNamespace,
+				}, &namespace)).NotTo(HaveOccurred())
+				Expect(namespace.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("restricted"))
+				Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
+
+				// Expect operator rolebinding to be created
+				rb := rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{},
+				}
+				Expect(c.Get(ctx, client.ObjectKey{
+					Name:      render.TigeraOperatorSecrets,
+					Namespace: render.ManagerNamespace,
+				}, &rb)).NotTo(HaveOccurred())
+				Expect(rb.OwnerReferences).To(HaveLen(1))
+				ownerRoleBinding := rb.OwnerReferences[0]
+				Expect(ownerRoleBinding.Kind).To(Equal("Manager"))
+
+				// Expect pull secrets to be created
+				pullSecrets := corev1.Secret{
+					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				}
+				Expect(c.Get(ctx, client.ObjectKey{
+					Name:      "tigera-pull-secret",
+					Namespace: render.ManagerNamespace,
+				}, &pullSecrets)).NotTo(HaveOccurred())
+				Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+				pullSecret := pullSecrets.OwnerReferences[0]
+				Expect(pullSecret.Kind).To(Equal("Manager"))
 			})
 
 			Context("image reconciliation", func() {
@@ -667,7 +715,7 @@ var _ = Describe("Manager controller tests", func() {
 				})
 			})
 
-			Context("compliance reconciliation", func() {
+			Context("manager reconciliation", func() {
 				It("should degrade if license is not present", func() {
 					Expect(c.Delete(ctx, licenseKey)).NotTo(HaveOccurred())
 					mockStatus = &status.MockStatus{}
@@ -1428,6 +1476,39 @@ var _ = Describe("Manager controller tests", func() {
 				Expect(tenantARoutes.Data).ToNot(BeEmpty())
 
 				Expect(kerror.IsNotFound(test.GetResource(c, &tenantBRoutes))).Should(BeTrue())
+			})
+
+			It("should reconcile pull secrets and rolebindings", func() {
+				_, err := r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: tenantANamespace,
+					},
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Expect operator role binding to be created
+				rb := rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{},
+				}
+				Expect(c.Get(ctx, client.ObjectKey{
+					Name:      render.TigeraOperatorSecrets,
+					Namespace: tenantANamespace,
+				}, &rb)).NotTo(HaveOccurred())
+				Expect(rb.OwnerReferences).To(HaveLen(1))
+				ownerRoleBinding := rb.OwnerReferences[0]
+				Expect(ownerRoleBinding.Kind).To(Equal("Tenant"))
+
+				// Expect pull secrets to be created
+				pullSecrets := corev1.Secret{
+					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				}
+				Expect(c.Get(ctx, client.ObjectKey{
+					Name:      "tigera-pull-secret",
+					Namespace: tenantANamespace,
+				}, &pullSecrets)).NotTo(HaveOccurred())
+				Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+				pullSecret := pullSecrets.OwnerReferences[0]
+				Expect(pullSecret.Kind).To(Equal("Tenant"))
 			})
 		})
 	})

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -112,6 +112,9 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				Spec: operatorv1.InstallationSpec{
 					Variant:  operatorv1.TigeraSecureEnterprise,
 					Registry: "some.registry.org/",
+					ImagePullSecrets: []corev1.LocalObjectReference{{
+						Name: "tigera-pull-secret",
+					}},
 				},
 				Status: operatorv1.InstallationStatus{
 					Variant: operatorv1.TigeraSecureEnterprise,
@@ -137,6 +140,8 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 		Expect(c.Create(ctx, &operatorv1.LogCollector{
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
 		})).NotTo(HaveOccurred())
+		pullSecrets := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}}
+		Expect(c.Create(ctx, pullSecrets)).NotTo(HaveOccurred())
 
 		certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
@@ -162,6 +167,45 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 		r.licenseAPIReady.MarkAsReady()
 		r.tierWatchReady.MarkAsReady()
 		r.policyRecScopeWatchReady.MarkAsReady()
+	})
+
+	It("should reconcile namespace, role binding and pull secrts", func() {
+		result, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(0 * time.Second))
+
+		namespace := corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		}
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name: render.PolicyRecommendationNamespace,
+		}, &namespace)).NotTo(HaveOccurred())
+		Expect(namespace.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("restricted"))
+		Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
+
+		// Expect operator role binding to be created
+		rb := rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{},
+		}
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name:      render.TigeraOperatorSecrets,
+			Namespace: render.PolicyRecommendationNamespace,
+		}, &rb)).NotTo(HaveOccurred())
+		Expect(rb.OwnerReferences).To(HaveLen(1))
+		ownerRoleBinding := rb.OwnerReferences[0]
+		Expect(ownerRoleBinding.Kind).To(Equal("PolicyRecommendation"))
+
+		// Expect pull secrets to be created
+		pullSecrets := corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		}
+		Expect(c.Get(ctx, client.ObjectKey{
+			Name:      "tigera-pull-secret",
+			Namespace: render.PolicyRecommendationNamespace,
+		}, &pullSecrets)).NotTo(HaveOccurred())
+		Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+		pullSecret := pullSecrets.OwnerReferences[0]
+		Expect(pullSecret.Kind).To(Equal("PolicyRecommendation"))
 	})
 
 	Context("image reconciliation", func() {
@@ -447,6 +491,64 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				// Now reconcile tenant A's namespace and do not expect an error
 				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tenantANamespace}})
 				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("should reconcile pull secrets and role bindings", func() {
+				// Create the Tenant resources for tenant-a.
+				tenantA := &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default",
+						Namespace: tenantANamespace,
+					},
+					Spec: operatorv1.TenantSpec{ID: "tenant-a"},
+				}
+				Expect(c.Create(ctx, tenantA)).NotTo(HaveOccurred())
+				certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
+				Expect(c.Create(ctx, certificateManagerTenantA.CreateTrustedBundle().ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
+
+				linseedTLSTenantA, err := certificateManagerTenantA.GetOrCreateKeyPair(c, render.TigeraLinseedSecret, tenantANamespace, []string{render.TigeraLinseedSecret})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c.Create(ctx, linseedTLSTenantA.Secret(tenantANamespace))).NotTo(HaveOccurred())
+
+				Expect(c.Create(ctx, &operatorv1.PolicyRecommendation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tigera-secure",
+						Namespace: tenantANamespace,
+					},
+				})).NotTo(HaveOccurred())
+
+				_, err = r.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: tenantANamespace,
+					},
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Expect operator role binding to be created
+				rb := rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{},
+				}
+				Expect(c.Get(ctx, client.ObjectKey{
+					Name:      render.TigeraOperatorSecrets,
+					Namespace: tenantANamespace,
+				}, &rb)).NotTo(HaveOccurred())
+				Expect(rb.OwnerReferences).To(HaveLen(1))
+				ownerRoleBinding := rb.OwnerReferences[0]
+				Expect(ownerRoleBinding.Kind).To(Equal("Tenant"))
+
+				// Expect pull secrets to be created
+				pullSecrets := corev1.Secret{
+					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+				}
+				Expect(c.Get(ctx, client.ObjectKey{
+					Name:      "tigera-pull-secret",
+					Namespace: tenantANamespace,
+				}, &pullSecrets)).NotTo(HaveOccurred())
+				Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
+				pullSecret := pullSecrets.OwnerReferences[0]
+				Expect(pullSecret.Kind).To(Equal("Tenant"))
 			})
 		})
 	})

--- a/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_bgppeers.yaml
@@ -49,6 +49,17 @@ spec:
                   type: string
                 maxRestartTime:
                   type: string
+                nextHopMode:
+                  allOf:
+                    - enum:
+                        - Auto
+                        - Self
+                        - Keep
+                    - enum:
+                        - Auto
+                        - Self
+                        - Keep
+                  type: string
                 node:
                   type: string
                 nodeSelector:

--- a/pkg/render/compliance.go
+++ b/pkg/render/compliance.go
@@ -201,7 +201,6 @@ func (c *complianceComponent) Objects() ([]client.Object, []client.Object) {
 			c.complianceAccessAllowTigeraNetworkPolicy(),
 			networkpolicy.AllowTigeraDefaultDeny(c.cfg.Namespace),
 		)
-		complianceObjs = append(complianceObjs, secret.ToRuntimeObjects(secret.CopyToNamespace(c.cfg.Namespace, c.cfg.PullSecrets...)...)...)
 		complianceObjs = append(complianceObjs,
 			c.complianceControllerServiceAccount(),
 			c.complianceControllerRole(),

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -282,10 +282,7 @@ func (c *fluentdComponent) path(path string) string {
 
 func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 	var objs, toDelete []client.Object
-	objs = append(objs, CreateNamespace(LogCollectorNamespace, c.cfg.Installation.KubernetesProvider, PSSPrivileged, c.cfg.Installation.Azure))
 	objs = append(objs, c.allowTigeraPolicy())
-	objs = append(objs, CreateOperatorSecretsRoleBinding(LogCollectorNamespace))
-	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(LogCollectorNamespace, c.cfg.PullSecrets...)...)...)
 	objs = append(objs, c.metricsService())
 
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -105,7 +105,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 	It("should render with a default configuration", func() {
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -114,7 +113,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.PacketCaptureAPIRole, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.PacketCaptureAPIRoleBinding, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 		}
 
 		cfg.PacketCapture = &operatorv1.PacketCaptureAPI{
@@ -127,11 +125,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		component := render.Fluentd(cfg)
 		resources, _ := component.Objects()
 		rtest.ExpectResources(resources, expectedResources)
-
-		// Check the namespace.
-		ns := rtest.GetResource(resources, "tigera-fluentd", "", "", "v1", "Namespace").(*corev1.Namespace)
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("privileged"))
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 
 		ds := rtest.GetResource(resources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Volumes[0].VolumeSource.HostPath.Path).To(Equal("/var/log/calico"))
@@ -292,7 +285,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 	It("should render with a configuration for a managed cluster", func() {
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.LogCollectorNamespace}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}},
@@ -300,7 +292,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: render.LogCollectorNamespace}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdNodeName, Namespace: render.LogCollectorNamespace}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdNodeName, Namespace: render.LogCollectorNamespace}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 			&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: render.LogCollectorNamespace}},
 		}
 
@@ -318,11 +309,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		createResources, deleteResources := component.Objects()
 		rtest.ExpectResources(createResources, expectedResources)
 		Expect(deleteResources).To(BeEmpty())
-
-		// Check the namespace.
-		ns := rtest.GetResource(createResources, "tigera-fluentd", "", "", "v1", "Namespace").(*corev1.Namespace)
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("privileged"))
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 
 		ds := rtest.GetResource(createResources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Volumes[0].VolumeSource.HostPath.Path).To(Equal("/var/log/calico"))
@@ -395,7 +381,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 	It("should render with a configuration for a managed cluster with packet capture", func() {
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.LogCollectorNamespace}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}},
@@ -405,7 +390,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.PacketCaptureAPIRole, Namespace: render.LogCollectorNamespace}},
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.PacketCaptureAPIRoleBinding, Namespace: render.LogCollectorNamespace}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdNodeName, Namespace: render.LogCollectorNamespace}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 			&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: render.LogCollectorNamespace}},
 		}
 
@@ -430,11 +414,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		createResources, deleteResources := component.Objects()
 		rtest.ExpectResources(createResources, expectedResources)
 		Expect(deleteResources).To(BeEmpty())
-
-		// Check the namespace.
-		ns := rtest.GetResource(createResources, "tigera-fluentd", "", "", "v1", "Namespace").(*corev1.Namespace)
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("privileged"))
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 
 		ds := rtest.GetResource(createResources, "fluentd-node", "tigera-fluentd", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
 		Expect(ds.Spec.Template.Spec.Volumes[0].VolumeSource.HostPath.Path).To(Equal("/var/log/calico"))
@@ -542,14 +521,12 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 	It("should render for Windows nodes", func() {
 
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsServiceWindows, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd-windows"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd-windows"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node-windows", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node-windows", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 		}
 
 		cfg.OSType = rmeta.OSTypeWindows
@@ -636,7 +613,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "log-collector-s3-credentials", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
@@ -644,7 +620,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 		}
 
 		// Should render the correct resources.
@@ -691,14 +666,12 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 	It("should render with Syslog configuration", func() {
 
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 		}
 
 		var ps int32 = 180
@@ -857,7 +830,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "logcollector-splunk-credentials", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
@@ -865,7 +837,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 		}
 
 		// Should render the correct resources.
@@ -917,7 +888,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 		}
 
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-filters", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}},
@@ -925,7 +895,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 		}
 
 		// Should render the correct resources.
@@ -1194,7 +1163,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 
 			By("establishing the base case with no non-cluster hosts or forwarding options")
 			expectedResources := []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdMetricsService, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -1203,7 +1171,6 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.PacketCaptureAPIRole, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.PacketCaptureAPIRoleBinding, Namespace: render.LogCollectorNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: "tigera-fluentd"}, TypeMeta: metav1.TypeMeta{Kind: "DaemonSet", APIVersion: "apps/v1"}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 			}
 			cfg.PacketCapture = &operatorv1.PacketCaptureAPI{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1361,7 +1328,6 @@ func setupEKSCloudwatchLogConfig() *render.EksCloudwatchLogConfig {
 
 func getExpectedResourcesForEKS(isManagedcluster bool) []client.Object {
 	expectedResources := []client.Object{
-		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}},
 		&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.FluentdPolicyName, Namespace: render.LogCollectorNamespace},
 			TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 
@@ -1375,7 +1341,6 @@ func getExpectedResourcesForEKS(isManagedcluster bool) []client.Object {
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "eks-log-forwarder", Namespace: render.LogCollectorNamespace}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-eks-log-forwarder-secret", Namespace: render.LogCollectorNamespace}},
 		&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluentd-node", Namespace: render.LogCollectorNamespace}},
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.LogCollectorNamespace}},
 	}
 
 	if isManagedcluster {

--- a/pkg/render/logstorage/externalelasticsearch/externalelasticsearch.go
+++ b/pkg/render/logstorage/externalelasticsearch/externalelasticsearch.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
-	"github.com/tigera/operator/pkg/render/common/secret"
 )
 
 // ExternalElasticsearch is used when Elasticsearch doesn't exist in this cluster, but we still need to set up resources
@@ -51,14 +50,9 @@ func (e externalElasticsearch) ResolveImages(is *operatorv1.ImageSet) error {
 }
 
 func (e externalElasticsearch) Objects() (toCreate, toDelete []client.Object) {
-	toCreate = append(toCreate, render.CreateNamespace(render.ElasticsearchNamespace, e.installation.KubernetesProvider, render.PSSBaseline, e.installation.Azure))
-	toCreate = append(toCreate, render.CreateOperatorSecretsRoleBinding(render.ElasticsearchNamespace))
 	toCreate = append(toCreate, e.clusterConfig.ConfigMap())
 	toCreate = append(toCreate, e.oidcUserRole())
 	toCreate = append(toCreate, e.oidcUserRoleBinding())
-	if len(e.pullSecrets) > 0 {
-		toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(render.ElasticsearchNamespace, e.pullSecrets...)...)...)
-	}
 
 	if !e.multiTenant {
 		// We need to allow to es-kube-controllers to managed secrets in the management clusters

--- a/pkg/render/logstorage/externalelasticsearch/externalelasticsearch_test.go
+++ b/pkg/render/logstorage/externalelasticsearch/externalelasticsearch_test.go
@@ -49,16 +49,13 @@ var _ = Describe("External Elasticsearch rendering tests", func() {
 		It("should render all resources needed for External Elasticsearch", func() {
 
 			expectedResources := []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: relasticsearch.ClusterConfigConfigMapName, Namespace: common.OperatorNamespace()}, TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}},
 				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.EsManagerRole, Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.EsManagerRoleBinding, Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: render.ElasticsearchNamespace}},
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: render.ElasticsearchNamespace}},
 				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: common.OperatorNamespace()}},
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: common.OperatorNamespace()}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.ElasticsearchNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			}
 
 			component := ExternalElasticsearch(installation, clusterConfig, pullSecrets, false)

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -228,11 +228,6 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 	objs := []client.Object{}
 
 	if !c.cfg.Tenant.MultiTenant() {
-		// In multi-tenant environments, the namespace is pre-created. So, only create it if we're not in a multi-tenant environment.
-		objs = append(objs, CreateNamespace(c.cfg.Namespace, c.cfg.Installation.KubernetesProvider, PSSRestricted, c.cfg.Installation.Azure))
-
-		objs = append(objs, CreateOperatorSecretsRoleBinding(c.cfg.Namespace))
-
 		// For multi-tenant environments, the management cluster itself isn't shown in the UI so we only need to create these
 		// when there is no tenant.
 		objs = append(objs,
@@ -253,7 +248,6 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, c.multiTenantManagedClustersAccess()...)
 	}
 
-	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(c.cfg.Namespace, c.cfg.PullSecrets...)...)...)
 	objs = append(objs,
 		c.managerAllowTigeraNetworkPolicy(),
 		networkpolicy.AllowTigeraDefaultDeny(c.cfg.Namespace),

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -78,7 +78,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		// Should render the correct resources.
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.manager-access", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
@@ -93,7 +92,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			&v3.UISettingsGroup{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerUserSettings}, TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"}},
 			&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsLayerTigera}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
 			&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsViewDefault}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.ManagerNamespace}},
 		}
 		rtest.ExpectResources(resources, expectedResources)
 
@@ -199,11 +197,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			&corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			}))
-
-		// Check the namespace.
-		ns := rtest.GetResource(resources, "tigera-manager", "", "", "v1", "Namespace").(*corev1.Namespace)
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("restricted"))
-		Expect(ns.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 	})
 
 	It("should render toleration on GKE", func() {
@@ -526,7 +519,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		// Should render the correct resources.
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.manager-access", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
@@ -542,7 +534,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsLayerTigera}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
 			&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsViewDefault}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.VoltronLinseedPublicCert, Namespace: common.OperatorNamespace()}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.ManagerNamespace}},
 		}
 		rtest.ExpectResources(resources, expectedResources)
 
@@ -802,7 +793,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		})
 
 		expectedResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.manager-access", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-manager", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
@@ -817,7 +807,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			&v3.UISettingsGroup{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerUserSettings}, TypeMeta: metav1.TypeMeta{Kind: "UISettingsGroup", APIVersion: "projectcalico.org/v3"}},
 			&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsLayerTigera}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
 			&v3.UISettings{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterSettingsViewDefault}, TypeMeta: metav1.TypeMeta{Kind: "UISettings", APIVersion: "projectcalico.org/v3"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.ManagerNamespace}},
 		}
 		rtest.ExpectResources(resources, expectedResources)
 

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -122,9 +122,6 @@ func (pr *policyRecommendationComponent) Objects() ([]client.Object, []client.Ob
 	// Management and managed clusters need API access to the resources defined in the policy
 	// recommendation cluster role
 	objs = []client.Object{
-		CreateNamespace(pr.cfg.Namespace, pr.cfg.Installation.KubernetesProvider, PSSRestricted, pr.cfg.Installation.Azure),
-		CreateOperatorSecretsRoleBinding(pr.cfg.Namespace),
-
 		pr.serviceAccount(),
 		pr.clusterRole(),
 		pr.clusterRoleBinding(),
@@ -139,8 +136,6 @@ func (pr *policyRecommendationComponent) Objects() ([]client.Object, []client.Ob
 		// No further resources are needed for managed clusters
 		return objs, nil
 	}
-
-	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(pr.cfg.Namespace, pr.cfg.PullSecrets...)...)...)
 
 	// The deployment is created on management/standalone clusters only
 	objs = append(objs,

--- a/pkg/render/policyrecommendation_test.go
+++ b/pkg/render/policyrecommendation_test.go
@@ -93,7 +93,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 		resources, _ := component.Objects()
 
 		expectedCreateResources := []client.Object{
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation"}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation", Namespace: render.PolicyRecommendationNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -101,7 +100,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: render.PolicyRecommendationNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.tigera-policy-recommendation", Namespace: render.PolicyRecommendationNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation", Namespace: render.PolicyRecommendationNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.PolicyRecommendationNamespace}},
 		}
 
 		rtest.ExpectResources(resources, expectedCreateResources)
@@ -485,7 +483,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 			tenantAResources, _ := tenantAPolicyRec.Objects()
 
 			tenantAExpectedResources := []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -494,7 +491,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation-managed-cluster-access", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.tigera-policy-recommendation", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation", Namespace: tenantANamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: tenantANamespace}},
 			}
 
 			rtest.ExpectResources(tenantAResources, tenantAExpectedResources)
@@ -520,7 +516,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 			tenantBResources, _ := tenantBPolicyRec.Objects()
 
 			tenantBExpectedResources := []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
 				&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -529,7 +524,6 @@ var _ = Describe("Policy recommendation rendering tests", func() {
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation-managed-cluster-access", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.tigera-policy-recommendation", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "tigera-policy-recommendation", Namespace: tenantBNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
-				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: tenantBNamespace}},
 			}
 
 			rtest.ExpectResources(tenantBResources, tenantBExpectedResources)

--- a/pkg/render/setup.go
+++ b/pkg/render/setup.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	operatorv1 "github.com/tigera/operator/api/v1"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/secret"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type SetUpConfiguration struct {
+	OpenShift    bool
+	Installation *operatorv1.InstallationSpec
+	PullSecrets  []*corev1.Secret
+	Namespace    string
+	PSS          PodSecurityStandard
+
+	CreateNamespace bool
+}
+
+func NewSetup(cfg *SetUpConfiguration) Component {
+	return &SetUpComponent{cfg: cfg}
+}
+
+// SetUpComponent is an implementation of a Component that setup common resource between
+// controllers
+type SetUpComponent struct {
+	cfg *SetUpConfiguration
+}
+
+// ResolveImages should call components.GetReference for all images that the Component
+// needs, passing 'is' to the GetReference call and if there are any errors those
+// are returned. It is valid to pass nil for 'is' as GetReference accepts the value.
+// ResolveImages must be called before Objects is called for the component.
+func (p *SetUpComponent) ResolveImages(is *operatorv1.ImageSet) error {
+	return nil
+}
+
+// Objects returns the lists of objects in this component that should be created and/or deleted during
+// rendering.
+func (p *SetUpComponent) Objects() (objsToCreate []client.Object, objsToDelete []client.Object) {
+	if p.cfg.CreateNamespace {
+		objsToCreate = append(objsToCreate, CreateNamespace(p.cfg.Namespace, p.cfg.Installation.KubernetesProvider, p.cfg.PSS, p.cfg.Installation.Azure))
+	}
+
+	objsToCreate = append(objsToCreate, CreateOperatorSecretsRoleBinding(p.cfg.Namespace))
+	if len(p.cfg.PullSecrets) > 0 {
+		objsToCreate = append(objsToCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(p.cfg.Namespace, p.cfg.PullSecrets...)...)...)
+	}
+	return objsToCreate, objsToDelete
+}
+
+// Ready returns true if the component is ready to be created.
+func (p *SetUpComponent) Ready() bool {
+	return true
+}
+
+// SupportedOSType returns operating systems that is supported of the components returned by the Objects() function.
+// The "componentHandler" converts the returned OSTypes to a node selectors for the "kubernetes.io/os" label on client.Objects
+// that create pods. Return OSTypeAny means that no node selector should be set for the "kubernetes.io/os" label.
+func (p *SetUpComponent) SupportedOSType() rmeta.OSType {
+	return rmeta.OSTypeAny
+}


### PR DESCRIPTION
## Description

Pull secrets, namespaces and role bindings for operator secrets will be
created in the controller versus the rendered. A new setup component
will create the namespace (if specified), the rolebindings and pull
secrets. For MT setup, these objects will have the Tenant Owner.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
