### PR TITLE
Increase the lifecycle.poll_interval for Elasticsearch

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -743,6 +743,12 @@ func (es *elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentV
 		"cluster.max_shards_per_node": 10000,
 		// Disable geoip downloader. This removes an error from the startup logs, because our network policy blocks it.
 		"ingest.geoip.downloader.enabled": false,
+		// (Dynamic, time unit value) How often index lifecycle management checks for indices that meet policy criteria.
+		// Defaults to 10m.
+		// In the case that a user is creating many shards with their setup, it can happen that ILM operations need more
+		// time to complete than the default interval setting. We increase the interval such that we will not encounter
+		// a build-up of ILM requests.
+		"indices.lifecycle.poll_interval": "60m",
 	}
 
 	if es.cfg.Installation.CertificateManagement != nil {

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"node.roles":                      []string{"data", "ingest", "master", "remote_cluster_client"},
 					"cluster.max_shards_per_node":     10000,
 					"ingest.geoip.downloader.enabled": false,
+					"indices.lifecycle.poll_interval": "60m",
 				}))
 			})
 
@@ -381,6 +382,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					},
 					"cluster.max_shards_per_node":                     10000,
 					"ingest.geoip.downloader.enabled":                 false,
+					"indices.lifecycle.poll_interval":                 "60m",
 					"xpack.security.http.ssl.certificate_authorities": []string{"/usr/share/elasticsearch/config/http-certs/ca.crt"},
 					"xpack.security.transport.ssl.key":                "/usr/share/elasticsearch/config/transport-certs/transport.tls.key",
 					"xpack.security.transport.ssl.certificate":        "/usr/share/elasticsearch/config/transport-certs/transport.tls.crt",
@@ -1016,6 +1018,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.roles":                                      []string{"data", "ingest", "master", "remote_cluster_client"},
 						"cluster.max_shards_per_node":                     10000,
 						"ingest.geoip.downloader.enabled":                 false,
+						"indices.lifecycle.poll_interval":                 "60m",
 						"node.attr.zone":                                  "us-west-2a",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
@@ -1035,6 +1038,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.roles":                                      []string{"data", "ingest", "master", "remote_cluster_client"},
 						"cluster.max_shards_per_node":                     10000,
 						"ingest.geoip.downloader.enabled":                 false,
+						"indices.lifecycle.poll_interval":                 "60m",
 						"node.attr.zone":                                  "us-west-2b",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
@@ -1105,6 +1109,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.roles":                                      []string{"data", "ingest", "master", "remote_cluster_client"},
 						"cluster.max_shards_per_node":                     10000,
 						"ingest.geoip.downloader.enabled":                 false,
+						"indices.lifecycle.poll_interval":                 "60m",
 						"node.attr.zone":                                  "us-west-2a",
 						"node.attr.rack":                                  "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",
@@ -1134,6 +1139,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.roles":                                      []string{"data", "ingest", "master", "remote_cluster_client"},
 						"cluster.max_shards_per_node":                     10000,
 						"ingest.geoip.downloader.enabled":                 false,
+						"indices.lifecycle.poll_interval":                 "60m",
 						"node.attr.zone":                                  "us-west-2b",
 						"node.attr.rack":                                  "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",


### PR DESCRIPTION
```
$ curl -ks  -u"elastic:$token" https://127.0.0.1:9200/_cluster/settings?include_defaults | jq | grep life -A 3
      "lifecycle": {
        "history_index_enabled": "true",
        "poll_interval": "60m",
        "step": {
```

```release-note
Increase the lifecycle.poll_interval for Elasticsearch. In a case where a cluster has many indices, the default setting can cause ES performance issues.
```
