### PR TITLE
Ci 1787 1.36

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -782,6 +782,12 @@ func (es *elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentV
 		"cluster.max_shards_per_node": 10000,
 		// Disable geoip downloader. This removes an error from the startup logs, because our network policy blocks it.
 		"ingest.geoip.downloader.enabled": false,
+		// (Dynamic, time unit value) How often index lifecycle management checks for indices that meet policy criteria.
+		// Defaults to 10m.
+		// In the case that a user is creating many shards with their setup, it can happen that ILM operations need more
+		// time to complete than the default interval setting. We increase the interval such that we will not encounter
+		// a build-up of ILM requests.
+		"indices.lifecycle.poll_interval": "60m",
 	}
 
 	if es.cfg.Installation.CertificateManagement != nil {

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -248,6 +248,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					"node.ingest":                     "true",
 					"cluster.max_shards_per_node":     10000,
 					"ingest.geoip.downloader.enabled": false,
+					"indices.lifecycle.poll_interval": "60m",
 				}))
 			})
 
@@ -361,11 +362,12 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					{Name: "elastic-internal-transport-certificates", MountPath: certificatemanagement.CSRCMountPath},
 				}, false)
 				Expect(resultES.Spec.NodeSets[0].Config).To(Equal(&v1.Config{Data: map[string]interface{}{
-					"node.data":                       "true",
-					"node.ingest":                     "true",
-					"node.master":                     "true",
-					"cluster.max_shards_per_node":     10000,
-					"ingest.geoip.downloader.enabled": false,
+					"node.data":                                       "true",
+					"node.ingest":                                     "true",
+					"node.master":                                     "true",
+					"cluster.max_shards_per_node":                     10000,
+					"ingest.geoip.downloader.enabled":                 false,
+					"indices.lifecycle.poll_interval":                 "60m",
 					"xpack.security.http.ssl.certificate_authorities": []string{"/usr/share/elasticsearch/config/http-certs/ca.crt"},
 					"xpack.security.transport.ssl.key":                "/usr/share/elasticsearch/config/transport-certs/transport.tls.key",
 					"xpack.security.transport.ssl.certificate":        "/usr/share/elasticsearch/config/transport-certs/transport.tls.crt",
@@ -985,6 +987,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.ingest":                     "true",
 						"cluster.max_shards_per_node":     10000,
 						"ingest.geoip.downloader.enabled": false,
+						"indices.lifecycle.poll_interval": "60m",
 						"node.attr.zone":                  "us-west-2a",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
@@ -1006,6 +1009,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.ingest":                     "true",
 						"cluster.max_shards_per_node":     10000,
 						"ingest.geoip.downloader.enabled": false,
+						"indices.lifecycle.poll_interval": "60m",
 						"node.attr.zone":                  "us-west-2b",
 						"cluster.routing.allocation.awareness.attributes": "zone",
 					}))
@@ -1078,6 +1082,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.ingest":                     "true",
 						"cluster.max_shards_per_node":     10000,
 						"ingest.geoip.downloader.enabled": false,
+						"indices.lifecycle.poll_interval": "60m",
 						"node.attr.zone":                  "us-west-2a",
 						"node.attr.rack":                  "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",
@@ -1109,6 +1114,7 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						"node.ingest":                     "true",
 						"cluster.max_shards_per_node":     10000,
 						"ingest.geoip.downloader.enabled": false,
+						"indices.lifecycle.poll_interval": "60m",
 						"node.attr.zone":                  "us-west-2b",
 						"node.attr.rack":                  "rack1",
 						"cluster.routing.allocation.awareness.attributes": "zone,rack",


### PR DESCRIPTION
Cherry pick of #3996 on release-v1.36.

#3998: Increase the lifecycle.poll_interval for Elasticsearch

# Original branch name

rene-dekker:CI-1787

# Original PR Body below

```
$ curl -ks  -u"elastic:$token" https://127.0.0.1:9200/_cluster/settings?include_defaults | jq | grep life -A 3
      "lifecycle": {
        "history_index_enabled": "true",
        "poll_interval": "60m",
        "step": {
```

```release-note
Increase the lifecycle.poll_interval for Elasticsearch. In a case where a cluster has many indices, the default setting can cause ES performance issues.
```