### PR TITLE
fix registry reference for calico/node-fips

### DIFF
--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -41,6 +41,7 @@ func GetReference(c Component, registry, imagePath, imagePrefix string, is *oper
 	if registry == "" || registry == UseDefault {
 		switch c {
 		case ComponentCalicoNode,
+			ComponentCalicoNodeFIPS,
 			ComponentCalicoNodeWindows,
 			ComponentCalicoCNI,
 			ComponentCalicoCNIFIPS,

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -101,7 +101,10 @@ spec:
                     BPFConntrackCleanupMode controls how BPF conntrack entries are cleaned up.  `Auto` will use a BPF program if supported,
                     falling back to userspace if not.  `Userspace` will always use the userspace cleanup code.  `BPFProgram` will
                     always use the BPF program (failing if not supported).
-                    [Default: Auto]
+
+                    /To be deprecated in future versions as conntrack map type changed to
+                    lru_hash and userspace cleanup is the only mode that is supported.
+                    [Default: Userspace]
                   enum:
                     - Auto
                     - Userspace
@@ -1052,6 +1055,11 @@ spec:
                     status reports. [Default: 90s]"
                   pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                   type: string
+                requireMTUFile:
+                  description: |-
+                    RequireMTUFile specifies whether mtu file is required to start the felix.
+                    Optional as to keep the same as previous behavior. [Default: false]
+                  type: boolean
                 routeRefreshInterval:
                   description: |-
                     RouteRefreshInterval is the period at which Felix re-checks the routes

--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -1038,6 +1038,16 @@ spec:
                     pending_policies field, offering a near-real-time view of policy changes across flows.
                     [Default: Continuous]
                   type: string
+                flowLogsPolicyScope:
+                  description: |-
+                    FlowLogsPolicyScope controls which policies are included in flow logs.
+                    AllPolicies - Processes both transit policies for the local node and
+                    endpoint policies derived from packet source/destination IPs. Provides comprehensive
+                    visibility into all policy evaluations but increases log volume.
+                    EndpointPolicies - Processes only policies for endpoints identified as the source
+                    or destination of the packet (whether workload or host endpoints).
+                    [Default: EndpointPolicies]
+                  type: string
                 flowLogsPositionFilePath:
                   description: |-
                     FlowLogsPositionFilePath is used specify the position of the external pipeline that reads flow logs. Default is /var/log/calico/flows.log.pos.


### PR DESCRIPTION
## Description

Currently the list of images from operator prints the calico node FIPS image using the `TigeraRegistry` instead of `CalicoRegistry`.  
This adds it to the list of images in the switch statement to return the right registry.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
fix digest of images to return correct registry for calico node FIPS image
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
