### PR TITLE
[RS-2546] Update operator to deploy waf-http-filter in Enterprise

### DIFF
--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -351,6 +351,7 @@ var (
 		ComponentFluentdWindows,
 		ComponentGuardian,
 		ComponentIntrusionDetectionController,
+		ComponentWafHTTPFilter,
 		ComponentSecurityEventWebhooksProcessor,
 		ComponentKibana,
 		ComponentManager,

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -481,8 +481,9 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 	// "ShutdownManager" and "RateLimit" images.)
 	envoyGatewayConfig.Provider.Kubernetes.RateLimitDeployment.Pod.ImagePullSecrets = secret.GetReferenceList(pr.cfg.PullSecrets)
 
-	// Enable backend APIs.
+	// Enable extension APIs.
 	envoyGatewayConfig.ExtensionAPIs.EnableBackend = true
+	envoyGatewayConfig.ExtensionAPIs.EnableEnvoyPatchPolicy = true
 
 	// Rebuild the ConfigMap with those changes.
 	envoyGatewayConfigMap := resources.envoyGatewayConfigMap.DeepCopyObject().(*corev1.ConfigMap)

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -402,7 +402,7 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 		CreateNamespace(
 			resources.namespace.Name,
 			pr.cfg.Installation.KubernetesProvider,
-			PSSBaseline,
+			PSSPrivileged,
 			pr.cfg.Installation.Azure,
 		),
 	}


### PR DESCRIPTION
## Description

This PR updates the operator to deploy `waf-http-filter` in Enterprise when enabling the Gateway API. 

This will setup the required `waf-http-filter` sidecar container in the envoy-proxy deployment, but envoy won't be configured to use it by default. To do so, the user will need to create a separate `EnvoyExtensionPolicy` to enable the filter and protect the traffic with WAF. 

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
