### PR TITLE
cherry-pick#4004 Redirect Elasticsearch requests from managed cluster to Guardian instead of linseed endpoint

### DIFF
--- a/pkg/controller/logstorage/managedcluster/managed_cluster_controller_test.go
+++ b/pkg/controller/logstorage/managedcluster/managed_cluster_controller_test.go
@@ -18,13 +18,11 @@ import (
 	"context"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,9 +35,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
-	"github.com/tigera/operator/pkg/dns"
-	"github.com/tigera/operator/pkg/render"
-	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
 )
 
 func NewReconcilerWithShims(
@@ -104,25 +99,6 @@ var _ = Describe("LogStorageManagedCluster controller", func() {
 		Context("LogStorage is nil", func() {
 			BeforeEach(func() {
 				Expect(cli.Create(ctx, &operatorv1.ManagementClusterConnection{ObjectMeta: metav1.ObjectMeta{Name: utils.DefaultTSEEInstanceKey.Name}})).NotTo(HaveOccurred())
-			})
-
-			Context("ExternalService is correctly setup", func() {
-				DescribeTable("tests that the ExternalService is setup with the default service name", func(clusterDomain, expectedSvcName string) {
-					r, err := NewReconcilerWithShims(cli, scheme, operatorv1.ProviderNone, clusterDomain)
-					Expect(err).ShouldNot(HaveOccurred())
-					_, err = r.Reconcile(ctx, reconcile.Request{})
-					Expect(err).ShouldNot(HaveOccurred())
-					svc := &corev1.Service{}
-					Expect(
-						cli.Get(ctx, client.ObjectKey{Name: esgateway.ServiceName, Namespace: render.ElasticsearchNamespace}, svc),
-					).ShouldNot(HaveOccurred())
-
-					Expect(svc.Spec.ExternalName).Should(Equal(expectedSvcName))
-					Expect(svc.Spec.Type).Should(Equal(corev1.ServiceTypeExternalName))
-				},
-					Entry("default cluster domain", dns.DefaultClusterDomain, "guardian.calico-system.svc.cluster.local"),
-					Entry("custom cluster domain", "custom-domain.internal", "guardian.calico-system.svc.custom-domain.internal"),
-				)
 			})
 
 			Context("LogStorage exists", func() {

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -320,8 +320,10 @@ func (c *fluentdComponent) Objects() ([]client.Object, []client.Object) {
 		c.fluentdClusterRoleBinding(),
 	)
 	if c.cfg.ManagedCluster {
+		objs = append(objs, c.externalLinseedService())
 		objs = append(objs, c.externalLinseedRoleBinding())
 	} else {
+		toDelete = append(toDelete, c.externalLinseedService())
 		toDelete = append(toDelete, c.externalLinseedRoleBinding())
 	}
 
@@ -385,6 +387,21 @@ func (c *fluentdComponent) externalLinseedRoleBinding() *rbacv1.RoleBinding {
 				Name:      GuardianServiceAccountName,
 				Namespace: GuardianNamespace,
 			},
+		},
+	}
+}
+
+func (c *fluentdComponent) externalLinseedService() *corev1.Service {
+	// For managed clusters, we must create an external service for fluentd to forward the request to guardian.
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tigera-linseed",
+			Namespace: LogCollectorNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: fmt.Sprintf("%s.%s.svc.%s", GuardianServiceName, GuardianNamespace, c.cfg.ClusterDomain),
 		},
 	}
 }
@@ -664,7 +681,7 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		{Name: "LINSEED_ENABLED", Value: "true"},
 		// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
 		// namespace. For multi-tenant management clusters, this may vary.
-		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant))},
+		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant), c.cfg.ManagedCluster, true)},
 		{Name: "LINSEED_CA_PATH", Value: c.trustedBundlePath()},
 		{Name: "TLS_KEY_PATH", Value: c.keyPath()},
 		{Name: "TLS_CRT_PATH", Value: c.certPath()},
@@ -1046,7 +1063,7 @@ func (c *fluentdComponent) eksLogForwarderDeployment() *appsv1.Deployment {
 		{Name: "LINSEED_ENABLED", Value: "true"},
 		// Determine the namespace in which Linseed is running. For managed and standalone clusters, this is always the elasticsearch
 		// namespace. For multi-tenant management clusters, this may vary.
-		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant))},
+		{Name: "LINSEED_ENDPOINT", Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant), c.cfg.ManagedCluster, true)},
 		{Name: "LINSEED_CA_PATH", Value: c.trustedBundlePath()},
 		{Name: "TLS_CRT_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountCertificateFilePath()},
 		{Name: "TLS_KEY_PATH", Value: c.cfg.EKSLogForwarderKeyPair.VolumeMountKeyFilePath()},

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -636,7 +636,7 @@ func (c *intrusionDetectionComponent) webhooksControllerContainer() corev1.Conta
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "LINSEED_URL",
-			Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, ElasticsearchNamespace),
+			Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, ElasticsearchNamespace, c.cfg.ManagedCluster, false),
 		},
 		{
 			Name:  "LINSEED_CA",
@@ -684,7 +684,7 @@ func (c *intrusionDetectionComponent) intrusionDetectionControllerContainer() co
 		},
 		{
 			Name:  "LINSEED_URL",
-			Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant)),
+			Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, LinseedNamespace(c.cfg.Tenant), c.cfg.ManagedCluster, false),
 		},
 		{
 			Name:  "LINSEED_CA",

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1198,12 +1198,6 @@ func (m *managedClusterLogStorage) Objects() (objsToCreate []client.Object, objs
 	// to create token secrets in the managed cluster.
 	toCreate := []client.Object{}
 	roles, bindings := m.linseedExternalRolesAndBindings()
-	toCreate = append(toCreate,
-		CreateNamespace(ElasticsearchNamespace, m.cfg.Installation.KubernetesProvider, PSSPrivileged, m.cfg.Installation.Azure),
-		m.elasticsearchExternalService(),
-		m.linseedExternalService(),
-		CreateOperatorSecretsRoleBinding(ElasticsearchNamespace),
-	)
 
 	for _, r := range roles {
 		toCreate = append(toCreate, r)
@@ -1229,34 +1223,6 @@ func (m *managedClusterLogStorage) Ready() bool {
 
 func (m *managedClusterLogStorage) SupportedOSType() rmeta.OSType {
 	return rmeta.OSTypeLinux
-}
-
-func (m *managedClusterLogStorage) linseedExternalService() *corev1.Service {
-	return &corev1.Service{
-		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      LinseedServiceName,
-			Namespace: ElasticsearchNamespace,
-		},
-		Spec: corev1.ServiceSpec{
-			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: fmt.Sprintf("%s.%s.svc.%s", GuardianServiceName, GuardianNamespace, m.cfg.ClusterDomain),
-		},
-	}
-}
-
-func (m *managedClusterLogStorage) elasticsearchExternalService() *corev1.Service {
-	return &corev1.Service{
-		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ESGatewayServiceName,
-			Namespace: ElasticsearchNamespace,
-		},
-		Spec: corev1.ServiceSpec{
-			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: fmt.Sprintf("%s.%s.svc.%s", GuardianServiceName, GuardianNamespace, m.cfg.ClusterDomain),
-		},
-	}
 }
 
 // In managed clusters we need to provision roles and bindings for linseed to provide permissions
@@ -1393,6 +1359,27 @@ func (m *managedClusterLogStorage) deprecatedObjects() []client.Object {
 		&rbacv1.ClusterRoleBinding{
 			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed"},
+		},
+		// Remove legacy ExternalName service pointing to Guardian for linseed
+		&corev1.Service{
+			TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tigera-linseed",
+				Namespace: "tigera-elasticsearch",
+			},
+		},
+		// Remove legacy ExternalName service pointing to Guardian for elasticsearch
+		&corev1.Service{
+			TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tigera-secure-es-gateway-http",
+				Namespace: "tigera-elasticsearch",
+			},
+		},
+		// Remove elasticsearch namespace in the managed cluster.
+		&corev1.Namespace{
+			TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-elasticsearch"},
 		},
 	}
 }

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -584,18 +584,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 		Context("Initial creation", func() {
 			It("creates Managed cluster logstorage components", func() {
 				expectedCreateResources := []client.Object{
-					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchNamespace}},
-					&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.ESGatewayServiceName, Namespace: render.ElasticsearchNamespace},
-						Spec: corev1.ServiceSpec{
-							Type: corev1.ServiceTypeExternalName, ExternalName: fmt.Sprintf("%s.%s.svc.%s", render.GuardianServiceName, render.GuardianNamespace, dns.DefaultClusterDomain),
-						},
-					},
-					&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.LinseedServiceName, Namespace: render.ElasticsearchNamespace},
-						Spec: corev1.ServiceSpec{
-							Type:         corev1.ServiceTypeExternalName,
-							ExternalName: fmt.Sprintf("%s.%s.svc.%s", render.GuardianServiceName, render.GuardianNamespace, dns.DefaultClusterDomain),
-						},
-					},
 					&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-secrets"}},
 					&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-configmaps"}},
 					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: "calico-system"},
@@ -606,12 +594,14 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: "guardian", Namespace: "calico-system"}}},
 					&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: common.OperatorNamespace()}},
 					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoKubeControllerSecret, Namespace: common.OperatorNamespace()}},
-					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.ElasticsearchNamespace}},
 				}
 
 				expectedDeleteResources := []client.Object{
 					&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-namespaces"}},
 					&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed"}},
+					&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: "tigera-elasticsearch"}},
+					&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure-es-gateway-http", Namespace: "tigera-elasticsearch"}},
+					&corev1.Namespace{TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-elasticsearch"}},
 				}
 
 				component := render.NewManagedClusterLogStorage(cfg)

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -302,7 +302,7 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 		},
 		{
 			Name:  "LINSEED_URL",
-			Value: relasticsearch.LinseedEndpoint(pr.SupportedOSType(), pr.cfg.ClusterDomain, LinseedNamespace(pr.cfg.Tenant)),
+			Value: relasticsearch.LinseedEndpoint(pr.SupportedOSType(), pr.cfg.ClusterDomain, LinseedNamespace(pr.cfg.Tenant), pr.cfg.ManagedCluster, false),
 		},
 		{
 			Name:  "LINSEED_CA",


### PR DESCRIPTION
…ead of Linseed external svc

cherry-picked: https://github.com/tigera/operator/pull/4004

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
