### PR TITLE
Annotate guardian with cluster version info

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -70,7 +70,8 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 
 	// Create the reconciler
 	tierWatchReady := &utils.ReadyFlag{}
-	reconciler := newReconciler(mgr.GetClient(), mgr.GetScheme(), statusManager, opts.DetectedProvider, tierWatchReady, opts)
+	clusterInfoWatchReady := &utils.ReadyFlag{}
+	reconciler := newReconciler(mgr.GetClient(), mgr.GetScheme(), statusManager, opts.DetectedProvider, tierWatchReady, clusterInfoWatchReady, opts)
 
 	// Create a new controller
 	c, err := ctrlruntime.NewController(controllerName, mgr, controller.Options{Reconciler: reconciler})
@@ -82,6 +83,10 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		// Watch for changes to License and Tier, as their status is used as input to determine whether network policy should be reconciled by this controller.
 		go utils.WaitToAddLicenseKeyWatch(c, opts.K8sClientset, log, nil)
 		go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, opts.K8sClientset, log, tierWatchReady)
+
+		// Watch for changes to ClusterInformation, as Guardian needs to restart the tunnel
+		// if the cluster's CNX version changes.
+		go utils.WaitToAddClusterInformationWatch(c, opts.K8sClientset, log, clusterInfoWatchReady)
 
 		go utils.WaitToAddNetworkPolicyWatches(c, opts.K8sClientset, log, []types.NamespacedName{
 			{Name: render.GuardianPolicyName, Namespace: render.GuardianNamespace},
@@ -159,15 +164,17 @@ func newReconciler(
 	statusMgr status.StatusManager,
 	p operatorv1.Provider,
 	tierWatchReady *utils.ReadyFlag,
+	clusterInfoWatchReady *utils.ReadyFlag,
 	opts options.AddOptions,
 ) *ReconcileConnection {
 	c := &ReconcileConnection{
-		cli:            cli,
-		scheme:         schema,
-		provider:       p,
-		status:         statusMgr,
-		clusterDomain:  opts.ClusterDomain,
-		tierWatchReady: tierWatchReady,
+		cli:                   cli,
+		scheme:                schema,
+		provider:              p,
+		status:                statusMgr,
+		clusterDomain:         opts.ClusterDomain,
+		tierWatchReady:        tierWatchReady,
+		clusterInfoWatchReady: clusterInfoWatchReady,
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -184,6 +191,7 @@ type ReconcileConnection struct {
 	status                     status.StatusManager
 	clusterDomain              string
 	tierWatchReady             *utils.ReadyFlag
+	clusterInfoWatchReady      *utils.ReadyFlag
 	resolvedPodProxies         []*httpproxy.Config
 	lastAvailabilityTransition metav1.Time
 }
@@ -242,6 +250,12 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 			r.status.SetDegraded(operatorv1.ResourceValidationError, "", err, reqLogger)
 			return reconcile.Result{}, err
 		}
+	}
+
+	// Validate that the cluster information watch is ready.
+	if !r.clusterInfoWatchReady.IsReady() {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for clusterInfoWatchReady watch to be established", err, reqLogger)
+		return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 	}
 
 	if err := utils.ApplyDefaults(ctx, r.cli, managementClusterConnection); err != nil {
@@ -376,6 +390,18 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 	}
 	r.lastAvailabilityTransition = currentAvailabilityTransition
 
+	var managedClusterVersion string
+	clusterInformation, err := utils.FetchClusterInformation(ctx, r.cli)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying clusterInformation", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+	if variant == operatorv1.TigeraSecureEnterprise {
+		managedClusterVersion = clusterInformation.Spec.CNXVersion
+	} else {
+		managedClusterVersion = clusterInformation.Spec.CalicoVersion
+	}
+
 	var includeEgressNetworkPolicy bool
 	if variant == operatorv1.TigeraSecureEnterprise {
 		// Validate that the tier watch is ready before querying the tier to ensure we utilize the cache.
@@ -408,6 +434,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		// License becomes available. Therefore, if we fail to query the Tier, we exclude NetworkPolicy from reconciliation
 		// and tolerate errors arising from the Tier not being created.
 		includeEgressNetworkPolicy = tierAvailable && licenseActive
+
 	}
 
 	ch := utils.NewComponentHandler(log, r.cli, r.scheme, managementClusterConnection)
@@ -422,6 +449,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		TrustedCertBundle:           trustedBundle,
 		ManagementClusterConnection: managementClusterConnection,
 		GuardianClientKeyPair:       guardianKeyPair,
+		Version:                     managedClusterVersion,
 	}
 
 	certComponent := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -91,7 +91,7 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	}
 
 	// Watch for changes to ClusterInformation, as Guardian needs to restart the tunnel
-	// if the cluster's CNX version changes.
+	// if the cluster's version changes.
 	go utils.WaitToAddClusterInformationWatch(c, opts.K8sClientset, log, clusterInfoWatchReady)
 
 	for _, secretName := range []string{

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -84,15 +84,15 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		go utils.WaitToAddLicenseKeyWatch(c, opts.K8sClientset, log, nil)
 		go utils.WaitToAddTierWatch(networkpolicy.TigeraComponentTierName, c, opts.K8sClientset, log, tierWatchReady)
 
-		// Watch for changes to ClusterInformation, as Guardian needs to restart the tunnel
-		// if the cluster's CNX version changes.
-		go utils.WaitToAddClusterInformationWatch(c, opts.K8sClientset, log, clusterInfoWatchReady)
-
 		go utils.WaitToAddNetworkPolicyWatches(c, opts.K8sClientset, log, []types.NamespacedName{
 			{Name: render.GuardianPolicyName, Namespace: render.GuardianNamespace},
 			{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.GuardianNamespace},
 		})
 	}
+
+	// Watch for changes to ClusterInformation, as Guardian needs to restart the tunnel
+	// if the cluster's CNX version changes.
+	go utils.WaitToAddClusterInformationWatch(c, opts.K8sClientset, log, clusterInfoWatchReady)
 
 	for _, secretName := range []string{
 		render.PacketCaptureServerCert,

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -97,7 +97,10 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		Expect(c.Create(ctx, &operatorv1.Monitor{
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
 		}))
-		r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready)
+
+		Expect(c.Create(ctx, &v3.ClusterInformation{ObjectMeta: metav1.ObjectMeta{Name: "default"}})).NotTo(HaveOccurred())
+
+		r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready, ready)
 		dpl = &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -214,7 +217,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 
 	Context("image reconciliation", func() {
 		It("should use builtin images", func() {
-			r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready)
+			r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready, ready)
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -246,7 +249,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				},
 			})).ToNot(HaveOccurred())
 
-			r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready)
+			r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready, ready)
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -282,7 +285,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 			}
 			Expect(c.Create(ctx, licenseKey)).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, &v3.Tier{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera"}})).NotTo(HaveOccurred())
-			r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready)
+			r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, ready, ready)
 		})
 
 		Context("IP-based management cluster address", func() {
@@ -314,7 +317,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				mockStatus.On("OnCRFound").Return()
 				mockStatus.On("SetMetaData", mock.Anything).Return()
 
-				r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, notReady)
+				r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, notReady, ready)
 				test.ExpectWaitForTierWatch(ctx, r, mockStatus)
 
 				policies := v3.NetworkPolicyList{}
@@ -359,7 +362,7 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 				mockStatus.On("OnCRFound").Return()
 				mockStatus.On("SetMetaData", mock.Anything).Return()
 
-				r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, notReady)
+				r = clusterconnection.NewReconcilerWithShims(c, clientScheme, mockStatus, operatorv1.ProviderNone, notReady, ready)
 				test.ExpectWaitForTierWatch(ctx, r, mockStatus)
 
 				policies := v3.NetworkPolicyList{}

--- a/pkg/controller/clusterconnection/shim_test.go
+++ b/pkg/controller/clusterconnection/shim_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,10 +36,11 @@ func NewReconcilerWithShims(
 	status status.StatusManager,
 	provider operatorv1.Provider,
 	tierWatchReady *utils.ReadyFlag,
+	clusterInfoWatchReady *utils.ReadyFlag,
 ) reconcile.Reconciler {
 	opts := options.AddOptions{
 		ShutdownContext: context.Background(),
 	}
 
-	return newReconciler(cli, schema, status, provider, tierWatchReady, opts)
+	return newReconciler(cli, schema, status, provider, tierWatchReady, clusterInfoWatchReady, opts)
 }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -225,6 +225,10 @@ func WaitToAddLicenseKeyWatch(controller ctrlruntime.Controller, c kubernetes.In
 	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{&v3.LicenseKey{TypeMeta: metav1.TypeMeta{Kind: v3.KindLicenseKey}}})
 }
 
+func WaitToAddClusterInformationWatch(controller ctrlruntime.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {
+	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{&v3.ClusterInformation{TypeMeta: metav1.TypeMeta{Kind: v3.KindClusterInformation}}})
+}
+
 func WaitToAddPolicyRecommendationScopeWatch(controller ctrlruntime.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag) {
 	WaitToAddResourceWatch(controller, c, log, flag, []client.Object{&v3.PolicyRecommendationScope{TypeMeta: metav1.TypeMeta{Kind: v3.KindPolicyRecommendationScope}}})
 }
@@ -309,6 +313,13 @@ func GetLogCollector(ctx context.Context, cli client.Client) (*operatorv1.LogCol
 // It will return an error if the license is not installed/cannot be read
 func FetchLicenseKey(ctx context.Context, cli client.Client) (v3.LicenseKey, error) {
 	instance := &v3.LicenseKey{}
+	err := cli.Get(ctx, DefaultInstanceKey, instance)
+	return *instance, err
+}
+
+// FetchClusterInformation fetches and returns the clusterinformation.
+func FetchClusterInformation(ctx context.Context, cli client.Client) (v3.ClusterInformation, error) {
+	instance := &v3.ClusterInformation{}
 	err := cli.Get(ctx, DefaultInstanceKey, instance)
 	return *instance, err
 }

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -113,6 +113,10 @@ type GuardianConfiguration struct {
 	PodProxies []*httpproxy.Config
 
 	GuardianClientKeyPair certificatemanagement.KeyPairInterface
+
+	// Version stores the version of the cluster, as reported by the ClusterInformation object. It is used to restart
+	// guardian when the version changes, which triggers the management cluster to re-check for version skew.
+	Version string
 }
 
 type GuardianComponent struct {
@@ -454,6 +458,10 @@ func (c *GuardianComponent) volumeMounts() []corev1.VolumeMount {
 func (c *GuardianComponent) annotations() map[string]string {
 	annotations := c.cfg.TrustedCertBundle.HashAnnotations()
 	annotations["hash.operator.tigera.io/tigera-managed-cluster-connection"] = rmeta.AnnotationHash(c.cfg.TunnelSecret.Data)
+
+	if len(c.cfg.Version) != 0 {
+		annotations["hash.operator.tigera.io/version"] = c.cfg.Version
+	}
 	return annotations
 }
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Operator now annotates Guardian pods with cluster version information
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
