### PR TITLE
Bugfix: Provision EnvoyProxy with the gateway class name

### DIFF
--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -333,7 +333,7 @@ type GatewayAPIImplementationConfig struct {
 	PullSecrets           []*corev1.Secret
 	CustomEnvoyGateway    *envoyapi.EnvoyGateway
 	CustomEnvoyProxies    map[string]*envoyapi.EnvoyProxy
-	CurrentGatewayClasses map[string]string // Map from GatewayClass name to EnvoyProxy name.
+	CurrentGatewayClasses set.Set[string]
 }
 
 type gatewayAPIImplementationComponent struct {
@@ -529,9 +529,6 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 
 	objs = append(objs, certgenJob)
 
-	currentGCNames := set.New[string]()
-	currentEPNames := set.New[string]()
-
 	// Provision GatewayClasses.
 	for i := range pr.cfg.GatewayAPI.Spec.GatewayClasses {
 		className := pr.cfg.GatewayAPI.Spec.GatewayClasses[i].Name
@@ -539,17 +536,20 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 		// The EnvoyProxy config.
 		proxyConfig := pr.envoyProxyConfig(className, pr.cfg.CustomEnvoyProxies[className], &(pr.cfg.GatewayAPI.Spec.GatewayClasses[i]))
 		objs = append(objs, proxyConfig)
-		currentEPNames.Insert(className)
 
 		// The GatewayClass using that EnvoyProxy config.
 		objs = append(objs, pr.gatewayClass(className, envoyGatewayConfig.Gateway.ControllerName, proxyConfig))
-		currentGCNames.Insert(className)
+
+		if pr.cfg.CurrentGatewayClasses.Has(className) {
+			pr.cfg.CurrentGatewayClasses.Delete(className)
+		}
 	}
 
 	objsToDelete := []client.Object(nil)
-	for gcName, epName := range pr.cfg.CurrentGatewayClasses {
-		if !currentGCNames.Has(gcName) {
-			objsToDelete = append(objsToDelete, &gapi.GatewayClass{
+	for _, gcName := range pr.cfg.CurrentGatewayClasses.UnsortedList() {
+		log.V(1).Info("Will delete GatewayClass and EnvoyProxy", "name", gcName)
+		objsToDelete = append(objsToDelete,
+			&gapi.GatewayClass{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "GatewayClass",
 					APIVersion: "gateway.networking.k8s.io/v1",
@@ -557,26 +557,25 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 				ObjectMeta: metav1.ObjectMeta{
 					Name: gcName,
 				},
-			})
-		}
-		if !currentEPNames.Has(epName) {
-			objsToDelete = append(objsToDelete, &envoyapi.EnvoyProxy{
+			},
+			&envoyapi.EnvoyProxy{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "EnvoyProxy",
 					APIVersion: "gateway.envoyproxy.io/v1alpha1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      epName,
+					Name:      gcName,
 					Namespace: "tigera-gateway",
 				},
-			})
-		}
+			},
+		)
 	}
 
+	log.V(1).Info("GatewayAPI rendering", "num_current", len(objs), "num_delete", len(objsToDelete))
 	return objs, objsToDelete
 }
 
-func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(defaultName string, envoyProxy *envoyapi.EnvoyProxy, classSpec *operatorv1.GatewayClassSpec) *envoyapi.EnvoyProxy {
+func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, envoyProxy *envoyapi.EnvoyProxy, classSpec *operatorv1.GatewayClassSpec) *envoyapi.EnvoyProxy {
 	// Ensure the minimal structure that we need for basic correctness and for the following
 	// customizations.  Note, we always create the running EnvoyProxy in our own namespace, even
 	// if it's based on a custom resource from another namespace.
@@ -600,9 +599,7 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(defaultName string
 	if envoyProxy.APIVersion == "" {
 		envoyProxy.APIVersion = "gateway.envoyproxy.io/v1alpha1"
 	}
-	if envoyProxy.ObjectMeta.Name == "" {
-		envoyProxy.ObjectMeta.Name = defaultName
-	}
+	envoyProxy.ObjectMeta.Name = className
 	envoyProxy.ObjectMeta.Namespace = "tigera-gateway"
 	if envoyProxy.Spec.Provider == nil {
 		envoyProxy.Spec.Provider = &envoyapi.EnvoyProxyProvider{}

--- a/test/gatewayapi_test.go
+++ b/test/gatewayapi_test.go
@@ -292,7 +292,7 @@ var _ = Describe("GatewayAPI tests", func() {
 
 		getEPLoggingLevels := func() (map[envoyapi.ProxyLogComponent]envoyapi.LogLevel, error) {
 			var ep envoyapi.EnvoyProxy
-			err = c.Get(shutdownContext, types.NamespacedName{Namespace: "tigera-gateway", Name: "custom-ep"}, &ep)
+			err = c.Get(shutdownContext, types.NamespacedName{Namespace: "tigera-gateway", Name: "custom-gc"}, &ep)
 			if err != nil {
 				return nil, err
 			}
@@ -311,6 +311,7 @@ var _ = Describe("GatewayAPI tests", func() {
 
 		By("Checking that EnvoyProxy in tigera-gateway namespace gets the additional level")
 		Eventually(getEPLoggingLevels, "10s").Should(HaveKeyWithValue(envoyapi.LogComponentConnection, envoyapi.LogLevelDebug))
+		Consistently(getEPLoggingLevels, "60s", "10s").Should(HaveKeyWithValue(envoyapi.LogComponentConnection, envoyapi.LogLevelDebug))
 	})
 
 	It("watches the custom EnvoyGateway ConfigMap", func() {


### PR DESCRIPTION
There was a bug in the logic of cleaning up unwanted GatewayClasses and EnvoyProxies: if a custom EnvoyProxy had a name different from that of the GatewayClass using it, the renderer would accidentally delete the EnvoyProxy again from the tigera-gateway namespace, almost immediately after provisioning it, making the GatewayClass inoperable.

As part of this fix, we now create EnvoyProxies in the tigera-gateway namespace with the same name as that of the GatewayClass.  In other words:

    custom EnvoyProxy exists with <user-name> in <user-namespace>

    GatewayClasses[*].Name = <custom-class-name>
    GatewayClasses[*].EnvoyProxyRef = {<user-name>, <user-namespace>}

    =>

    EnvoyProxy provisioned with <custom-class-name> in tigera-gateway
    GatewayClass provisioned with <custom-class-name> in tigera-gateway

whereas previously the penultimate line would have been

    EnvoyProxy provisioned with <user-name> in tigera-gateway

My previous thinking was "if the user has chosen a name, let's respect that." My thinking now is:

1. That leads to bugs like the one here.

2. If we respect `<user-name>`, it's possible that `<user-name>` for the EnvoyProxy of a GatewayClass with EnvoyProxyRef will clash with `<custom-class-name>` for another GatewayClass without EnvoyProxyRef.  Let's just use `<custom-class-name>` in all cases.