### PR TITLE
[release-v1.39] Auto pick #4013: Render bpffs init container in iptables mode with

### DIFF
--- a/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/enterprise/crd.projectcalico.org_felixconfigurations.yaml
@@ -211,7 +211,7 @@ spec:
                     NoDelay - Felix does not introduce any delay to the packets. DNS rules may not have been programmed by the time
                     the first packet traverses the policy rules. Client applications need to handle reconnection attempts if initial
                     connection attempts fail. This may be problematic for some applications or for very low DNS TTLs.
-                    [Default: Inline]
+                    [Default: DelayDeniedPacket]
                   type: string
                 bpfDSROptoutCIDRs:
                   description: |-

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1209,11 +1209,15 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 		},
 	}
 
+	command := []string{CalicoNodeObjectName, "-init"}
+	if !c.cfg.Installation.BPFEnabled() {
+		command = append(command, "-skip-cgroup")
+	}
 	return corev1.Container{
 		Name:            "mount-bpffs",
 		Image:           c.nodeImage,
 		ImagePullPolicy: ImagePullPolicy(),
-		Command:         []string{CalicoNodeObjectName, "-init"},
+		Command:         command,
 		SecurityContext: securitycontext.NewRootContext(true),
 		VolumeMounts:    mounts,
 	}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -791,7 +791,7 @@ var _ = Describe("Node rendering tests", func() {
 				// Verify the mount-bpffs image and command.
 				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
 				Expect(mountBpffs.Image).To(Equal(ds.Spec.Template.Spec.Containers[0].Image))
-				Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init"}))
+				Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init", "-skip-cgroup"}))
 
 				Expect(*mountBpffs.SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
 				Expect(*mountBpffs.SecurityContext.Privileged).To(BeTrue())


### PR DESCRIPTION
Cherry pick of tigera/operator/pull/4013 on release-v1.39.

#4013: Render bpffs init container in iptables mode with

# Original PR Body below

## Description

skip cgroup when running bpffs init container in iptables mode, as we don't attach programs to cgroups in iptables mode.

Related calico PR: https://github.com/tigera/calico-private/pull/9249

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.