### PR TITLE
[release-v1.39] Auto pick #4025: Fix security context for csr init container

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -274,6 +274,16 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		return reconcile.Result{}, err
 	}
 
+	// Since apiserver and queryserver may have different UID:GID at run-time, we need to produce this secret in separate volumes and with different permissions.
+	var qsTLSSecretCertificateManagementOnly certificatemanagement.KeyPairInterface
+	if installationSpec.CertificateManagement != nil {
+		qsTLSSecretCertificateManagementOnly, err = certificateManager.GetOrCreateKeyPair(r.client, "query-server-tls", common.OperatorNamespace(), dns.GetServiceDNSNames(render.APIServerServiceName, render.APIServerNamespace, r.clusterDomain))
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to get or create tls key pair", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+	}
+
 	certificateManager.AddToStatusManager(r.status, render.APIServerNamespace)
 
 	pullSecrets, err := utils.GetNetworkingPullSecrets(installationSpec, r.client)
@@ -437,6 +447,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		KeyValidatorConfig:          keyValidatorConfig,
 		KubernetesVersion:           r.kubernetesVersion,
 		CanCleanupOlderResources:    r.canCleanupLegacyNamespace(ctx, installationSpec.Variant, reqLogger),
+		QueryServerTLSKeyPairCertificateManagementOnly: qsTLSSecretCertificateManagementOnly,
 	}
 
 	var components []render.Component

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -275,9 +275,9 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	}
 
 	// Since apiserver and queryserver may have different UID:GID at run-time, we need to produce this secret in separate volumes and with different permissions.
-	var qsTLSSecretCertificateManagementOnly certificatemanagement.KeyPairInterface
+	var queryServerTLSSecretCertificateManagementOnly certificatemanagement.KeyPairInterface
 	if installationSpec.CertificateManagement != nil {
-		qsTLSSecretCertificateManagementOnly, err = certificateManager.GetOrCreateKeyPair(r.client, "query-server-tls", common.OperatorNamespace(), dns.GetServiceDNSNames(render.APIServerServiceName, render.APIServerNamespace, r.clusterDomain))
+		queryServerTLSSecretCertificateManagementOnly, err = certificateManager.GetOrCreateKeyPair(r.client, "query-server-tls", common.OperatorNamespace(), dns.GetServiceDNSNames(render.APIServerServiceName, render.APIServerNamespace, r.clusterDomain))
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to get or create tls key pair", err, reqLogger)
 			return reconcile.Result{}, err
@@ -447,7 +447,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		KeyValidatorConfig:          keyValidatorConfig,
 		KubernetesVersion:           r.kubernetesVersion,
 		CanCleanupOlderResources:    r.canCleanupLegacyNamespace(ctx, installationSpec.Variant, reqLogger),
-		QueryServerTLSKeyPairCertificateManagementOnly: qsTLSSecretCertificateManagementOnly,
+		QueryServerTLSKeyPairCertificateManagementOnly: queryServerTLSSecretCertificateManagementOnly,
 	}
 
 	var components []render.Component

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -197,7 +197,7 @@ var _ = Describe("apiserver controller tests", func() {
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentQueryServer.Image,
 					components.ComponentQueryServer.Version)))
-			Expect(d.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(d.Spec.Template.Spec.InitContainers).To(HaveLen(2))
 			csrinit := test.GetContainer(d.Spec.Template.Spec.InitContainers, "calico-apiserver-certs-key-cert-provisioner")
 			Expect(csrinit).ToNot(BeNil())
 			Expect(csrinit.Image).To(Equal(

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -453,7 +453,7 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			Expect(keyPair.HashAnnotationValue()).To(Equal(""))
 
 			By("verifying the init container")
-			initContainer := keyPair.InitContainer(appNs)
+			initContainer := keyPair.InitContainer(appNs, nil)
 			imageSet, err := imageset.GetImageSet(context.Background(), cli, installation.Variant)
 			Expect(err).NotTo(HaveOccurred())
 			expectedImage, err := components.GetReference(

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -32,6 +32,7 @@ import (
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/api/pkg/lib/numorstring"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
@@ -132,6 +133,10 @@ type APIServerConfiguration struct {
 	KeyValidatorConfig          authentication.KeyValidatorConfig
 	KubernetesVersion           *common.VersionInfo
 	CanCleanupOlderResources    bool
+
+	// When certificate management is enabled, we need a separate init container to create a cert, running
+	// with the same permissions as query server.
+	QueryServerTLSKeyPairCertificateManagementOnly certificatemanagement.KeyPairInterface
 }
 
 type apiServerComponent struct {
@@ -985,16 +990,20 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 		deploymentStrategyType = appsv1.RecreateDeploymentStrategyType
 	}
 
-	var initContainers []corev1.Container
-	if c.cfg.TLSKeyPair.UseCertificateManagement() {
-		// Use the same CSR init container name for both OSS and Enterprise.
-		initContainer := c.cfg.TLSKeyPair.InitContainer(APIServerNamespace)
-		initContainer.Name = fmt.Sprintf("%s-%s", CalicoAPIServerTLSSecretName, certificatemanagement.CSRInitContainerName)
-		initContainers = append(initContainers, initContainer)
-	}
-
 	annotations := map[string]string{
 		c.cfg.TLSKeyPair.HashAnnotationKey(): c.cfg.TLSKeyPair.HashAnnotationValue(),
+	}
+
+	var initContainers []corev1.Container
+	if c.cfg.TLSKeyPair.UseCertificateManagement() {
+		initContainerAS := c.cfg.TLSKeyPair.InitContainer(APIServerNamespace, c.apiServerContainer().SecurityContext)
+		initContainerAS.Name = fmt.Sprintf("%s-%s", CalicoAPIServerTLSSecretName, certificatemanagement.CSRInitContainerName)
+
+		initContainerQS := c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.InitContainer(APIServerNamespace, c.queryServerContainer().SecurityContext)
+
+		annotations[c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.HashAnnotationKey()] = c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.HashAnnotationValue()
+
+		initContainers = append(initContainers, initContainerAS, initContainerQS)
 	}
 
 	containers := []corev1.Container{
@@ -1245,11 +1254,17 @@ func (c *apiServerComponent) startUpArgs() []string {
 func (c *apiServerComponent) queryServerContainer() corev1.Container {
 	queryServerTargetPort := getContainerPort(c.cfg, TigeraAPIServerQueryServerContainerName).ContainerPort
 
+	var tlsSecret certificatemanagement.KeyPairInterface
+	if c.cfg.QueryServerTLSKeyPairCertificateManagementOnly != nil {
+		tlsSecret = c.cfg.QueryServerTLSKeyPairCertificateManagementOnly
+	} else {
+		tlsSecret = c.cfg.TLSKeyPair
+	}
 	env := []corev1.EnvVar{
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 		{Name: "LISTEN_ADDR", Value: fmt.Sprintf(":%d", queryServerTargetPort)},
-		{Name: "TLS_CERT", Value: fmt.Sprintf("/%s/tls.crt", CalicoAPIServerTLSSecretName)},
-		{Name: "TLS_KEY", Value: fmt.Sprintf("/%s/tls.key", CalicoAPIServerTLSSecretName)},
+		{Name: "TLS_CERT", Value: fmt.Sprintf("/%s/tls.crt", tlsSecret.GetName())},
+		{Name: "TLS_KEY", Value: fmt.Sprintf("/%s/tls.key", tlsSecret.GetName())},
 	}
 	if c.cfg.TrustedBundle != nil {
 		env = append(env, corev1.EnvVar{Name: "TRUSTED_BUNDLE_PATH", Value: c.cfg.TrustedBundle.MountPath()})
@@ -1276,7 +1291,7 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 	}
 
 	volumeMounts := []corev1.VolumeMount{
-		c.cfg.TLSKeyPair.VolumeMount(c.SupportedOSType()),
+		tlsSecret.VolumeMount(c.SupportedOSType()),
 	}
 	if c.cfg.TrustedBundle != nil {
 		volumeMounts = append(volumeMounts, c.cfg.TrustedBundle.VolumeMounts(c.SupportedOSType())...)
@@ -1307,6 +1322,9 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 	volumes := []corev1.Volume{
 		c.cfg.TLSKeyPair.Volume(),
+	}
+	if c.cfg.QueryServerTLSKeyPairCertificateManagementOnly != nil {
+		volumes = append(volumes, c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.Volume())
 	}
 	hostPathType := corev1.HostPathDirectoryOrCreate
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -996,14 +996,14 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 
 	var initContainers []corev1.Container
 	if c.cfg.TLSKeyPair.UseCertificateManagement() {
-		initContainerAS := c.cfg.TLSKeyPair.InitContainer(APIServerNamespace, c.apiServerContainer().SecurityContext)
-		initContainerAS.Name = fmt.Sprintf("%s-%s", CalicoAPIServerTLSSecretName, certificatemanagement.CSRInitContainerName)
+		initContainerApiServer := c.cfg.TLSKeyPair.InitContainer(APIServerNamespace, c.apiServerContainer().SecurityContext)
+		initContainerApiServer.Name = fmt.Sprintf("%s-%s", CalicoAPIServerTLSSecretName, certificatemanagement.CSRInitContainerName)
 
-		initContainerQS := c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.InitContainer(APIServerNamespace, c.queryServerContainer().SecurityContext)
+		initContainerQueryServer := c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.InitContainer(APIServerNamespace, c.queryServerContainer().SecurityContext)
 
 		annotations[c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.HashAnnotationKey()] = c.cfg.QueryServerTLSKeyPairCertificateManagementOnly.HashAnnotationValue()
 
-		initContainers = append(initContainers, initContainerAS, initContainerQS)
+		initContainers = append(initContainers, initContainerApiServer, initContainerQueryServer)
 	}
 
 	containers := []corev1.Container{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -964,6 +964,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		certificateManager, err := certificatemanager.Create(cli, cfg.Installation, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
 		kp, err := certificateManager.GetOrCreateKeyPair(cli, render.CalicoAPIServerTLSSecretName, common.OperatorNamespace(), dnsNames)
+		Expect(err).NotTo(HaveOccurred())
 		qskp, err := certificateManager.GetOrCreateKeyPair(cli, render.CalicoAPIServerTLSSecretName, common.OperatorNamespace(), dnsNames)
 		cfg.TLSKeyPair = kp
 		cfg.QueryServerTLSKeyPairCertificateManagementOnly = qskp

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -221,8 +221,9 @@ func (c *dexComponent) clusterRoleBinding() client.Object {
 
 func (c *dexComponent) deployment() client.Object {
 	var initContainers []corev1.Container
+	sc := securitycontext.NewNonRootContext()
 	if c.cfg.TLSKeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(DexNamespace))
+		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(DexNamespace, sc))
 	}
 
 	annotations := c.cfg.DexConfig.RequiredAnnotations()
@@ -273,7 +274,7 @@ func (c *dexComponent) deployment() client.Object {
 							ImagePullPolicy: ImagePullPolicy(),
 							Env:             envVars,
 							LivenessProbe:   c.probe(),
-							SecurityContext: securitycontext.NewNonRootContext(),
+							SecurityContext: sc,
 
 							Command: []string{"/usr/bin/dex", "serve", "/etc/dex/baseCfg/config.yaml"},
 

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -547,7 +547,7 @@ func (c *fluentdComponent) daemonset() *appsv1.DaemonSet {
 	}
 	var initContainers []corev1.Container
 	if c.cfg.FluentdKeyPair != nil && c.cfg.FluentdKeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.FluentdKeyPair.InitContainer(LogCollectorNamespace))
+		initContainers = append(initContainers, c.cfg.FluentdKeyPair.InitContainer(LogCollectorNamespace, c.container().SecurityContext))
 	}
 
 	podTemplate := &corev1.PodTemplateSpec{

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -598,7 +598,7 @@ func (c *intrusionDetectionComponent) deploymentPodTemplate() *corev1.PodTemplat
 	}
 	var initContainers []corev1.Container
 	if c.cfg.IntrusionDetectionCertSecret != nil && c.cfg.IntrusionDetectionCertSecret.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.IntrusionDetectionCertSecret.InitContainer(c.cfg.Namespace))
+		initContainers = append(initContainers, c.cfg.IntrusionDetectionCertSecret.InitContainer(c.cfg.Namespace, intrusionDetectionContainer.SecurityContext))
 	}
 
 	containers := []corev1.Container{

--- a/pkg/render/intrusiondetection/dpi/dpi.go
+++ b/pkg/render/intrusiondetection/dpi/dpi.go
@@ -179,9 +179,10 @@ func (d *dpiComponent) SupportedOSType() meta.OSType {
 
 func (d *dpiComponent) dpiDaemonset() *appsv1.DaemonSet {
 	var terminationGracePeriod int64 = 0
+	container := d.dpiContainer()
 	var initContainers []corev1.Container
 	if d.cfg.TyphaNodeTLS.NodeSecret.UseCertificateManagement() {
-		initContainers = append(initContainers, d.cfg.TyphaNodeTLS.NodeSecret.InitContainer(DeepPacketInspectionNamespace))
+		initContainers = append(initContainers, d.cfg.TyphaNodeTLS.NodeSecret.InitContainer(DeepPacketInspectionNamespace, container.SecurityContext))
 	}
 	if d.dpiInitContainers() {
 		for _, initContainer := range d.cfg.IntrusionDetection.Spec.DeepPacketInspectionDaemonset.Spec.Template.Spec.InitContainers {
@@ -216,7 +217,7 @@ func (d *dpiComponent) dpiDaemonset() *appsv1.DaemonSet {
 			// Adjust DNS policy so we can access in-cluster services.
 			DNSPolicy:      corev1.DNSClusterFirstWithHostNet,
 			InitContainers: initContainers,
-			Containers:     []corev1.Container{d.dpiContainer()},
+			Containers:     []corev1.Container{container},
 			Volumes:        d.dpiVolumes(),
 		},
 	}

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -646,7 +646,7 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 
 	var initContainers []corev1.Container
 	if c.cfg.MetricsServerTLS != nil && c.cfg.MetricsServerTLS.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.MetricsServerTLS.InitContainer(c.cfg.Namespace))
+		initContainers = append(initContainers, c.cfg.MetricsServerTLS.InitContainer(c.cfg.Namespace, sc))
 	}
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -452,7 +452,7 @@ func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 				ReadOnly:  false,
 			},
 		}
-		csrInitContainerHTTP := es.cfg.ElasticsearchKeyPair.InitContainer(ElasticsearchNamespace)
+		csrInitContainerHTTP := es.cfg.ElasticsearchKeyPair.InitContainer(ElasticsearchNamespace, esContainer.SecurityContext)
 		csrInitContainerHTTP.Name = "key-cert-elastic"
 		csrInitContainerHTTP.VolumeMounts[0].Name = CSRVolumeNameHTTP
 		httpVolumemount := es.cfg.ElasticsearchKeyPair.VolumeMount(es.SupportedOSType())
@@ -468,7 +468,8 @@ func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 			"transport.tls.key",
 			"transport.tls.crt",
 			dns.GetServiceDNSNames(ElasticsearchServiceName, ElasticsearchNamespace, es.cfg.ClusterDomain),
-			ElasticsearchNamespace)
+			ElasticsearchNamespace,
+			esContainer.SecurityContext)
 		csrInitContainerTransport.Name = "key-cert-elastic-transport"
 
 		initContainers = append(

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -208,10 +208,10 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 			},
 		}},
 	}
-
+	sc := securitycontext.NewNonRootContext()
 	var initContainers []corev1.Container
 	if e.cfg.ESGatewayKeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, e.cfg.ESGatewayKeyPair.InitContainer(e.cfg.Namespace))
+		initContainers = append(initContainers, e.cfg.ESGatewayKeyPair.InitContainer(e.cfg.Namespace, sc))
 	}
 
 	volumes := []corev1.Volume{
@@ -262,7 +262,7 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 						},
 						InitialDelaySeconds: 10,
 					},
-					SecurityContext: securitycontext.NewNonRootContext(),
+					SecurityContext: sc,
 				},
 			},
 		},

--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -246,6 +246,7 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 			MountPath: "/mnt/dummy-location/",
 		},
 	}
+	sc := securitycontext.NewNonRootContext()
 	if k.cfg.Installation.CertificateManagement != nil {
 		config["elasticsearch.ssl.certificateAuthorities"] = []string{"/mnt/elastic-internal/http-certs/ca.crt"}
 		automountToken = true
@@ -258,7 +259,8 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 			corev1.TLSPrivateKeyKey,
 			corev1.TLSCertKey,
 			dns.GetServiceDNSNames(ServiceName, Namespace, k.cfg.ClusterDomain),
-			Namespace)
+			Namespace,
+			sc)
 
 		initContainers = append(initContainers, csrInitContainer)
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -349,7 +351,7 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 								},
 							},
 						},
-						SecurityContext: securitycontext.NewNonRootContext(),
+						SecurityContext: sc,
 						VolumeMounts:    volumeMounts,
 					}},
 					Volumes: volumes,

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -392,10 +392,10 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 			}
 		}
 	}
-
+	sc := securitycontext.NewNonRootContext()
 	var initContainers []corev1.Container
 	if l.cfg.KeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, l.cfg.KeyPair.InitContainer(l.namespace))
+		initContainers = append(initContainers, l.cfg.KeyPair.InitContainer(l.namespace, sc))
 	}
 
 	annotations := l.cfg.TrustedBundle.HashAnnotations()
@@ -418,7 +418,7 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 		volumes = append(volumes, l.cfg.TokenKeyPair.Volume())
 		volumeMounts = append(volumeMounts, l.cfg.TokenKeyPair.VolumeMount(l.SupportedOSType()))
 		if l.cfg.TokenKeyPair.UseCertificateManagement() {
-			initContainers = append(initContainers, l.cfg.TokenKeyPair.InitContainer(l.namespace))
+			initContainers = append(initContainers, l.cfg.TokenKeyPair.InitContainer(l.namespace, sc))
 		}
 		annotations[l.cfg.TokenKeyPair.HashAnnotationKey()] = l.cfg.TokenKeyPair.HashAnnotationValue()
 	}
@@ -446,7 +446,7 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 					ImagePullPolicy: render.ImagePullPolicy(),
 					Env:             envVars,
 					VolumeMounts:    volumeMounts,
-					SecurityContext: securitycontext.NewNonRootContext(),
+					SecurityContext: sc,
 					ReadinessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							Exec: &corev1.ExecAction{

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -293,15 +293,15 @@ func (c *managerComponent) Ready() bool {
 func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 	var initContainers []corev1.Container
 	if c.cfg.TLSKeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(c.cfg.Namespace))
+		initContainers = append(initContainers, c.cfg.TLSKeyPair.InitContainer(c.cfg.Namespace, securitycontext.NewNonRootContext()))
 	}
 
 	// Containers for the manager pod.
 	if c.cfg.InternalTLSKeyPair != nil && c.cfg.InternalTLSKeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.InternalTLSKeyPair.InitContainer(ManagerNamespace))
+		initContainers = append(initContainers, c.cfg.InternalTLSKeyPair.InitContainer(ManagerNamespace, securitycontext.NewNonRootContext()))
 	}
 	if c.cfg.VoltronLinseedKeyPair != nil && c.cfg.VoltronLinseedKeyPair.UseCertificateManagement() {
-		initContainers = append(initContainers, c.cfg.VoltronLinseedKeyPair.InitContainer(ManagerNamespace))
+		initContainers = append(initContainers, c.cfg.VoltronLinseedKeyPair.InitContainer(ManagerNamespace, securitycontext.NewNonRootContext()))
 	}
 
 	managerPodContainers := []corev1.Container{c.managerUIAPIsContainer(), c.voltronContainer()}

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -471,12 +471,13 @@ func (mc *monitorComponent) alertmanagerService() *corev1.Service {
 }
 
 func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
+	sc := securitycontext.NewNonRootContext()
 	var initContainers []corev1.Container
 	if mc.cfg.ServerTLSSecret.UseCertificateManagement() {
-		initContainers = append(initContainers, mc.cfg.ServerTLSSecret.InitContainer(common.TigeraPrometheusNamespace))
+		initContainers = append(initContainers, mc.cfg.ServerTLSSecret.InitContainer(common.TigeraPrometheusNamespace, sc))
 	}
 	if mc.cfg.ClientTLSSecret.UseCertificateManagement() {
-		initContainers = append(initContainers, mc.cfg.ClientTLSSecret.InitContainer(common.TigeraPrometheusNamespace))
+		initContainers = append(initContainers, mc.cfg.ClientTLSSecret.InitContainer(common.TigeraPrometheusNamespace, sc))
 	}
 	env := []corev1.EnvVar{
 		{
@@ -577,7 +578,7 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 								},
 							},
 						},
-						SecurityContext: securitycontext.NewNonRootContext(),
+						SecurityContext: sc,
 					},
 				},
 				Image:            &mc.prometheusImage,

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -234,6 +234,11 @@ func (pc *packetCaptureApiComponent) deployment() *appsv1.Deployment {
 	if pc.cfg.Installation.KubernetesProvider.IsGKE() {
 		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
+	container := pc.container()
+	var initContainers []corev1.Container
+	if pc.cfg.ServerCertSecret.UseCertificateManagement() {
+		initContainers = append(initContainers, pc.cfg.ServerCertSecret.InitContainer(PacketCaptureNamespace, container.SecurityContext))
+	}
 	d := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -256,8 +261,8 @@ func (pc *packetCaptureApiComponent) deployment() *appsv1.Deployment {
 					ServiceAccountName: PacketCaptureServiceAccountName,
 					Tolerations:        tolerations,
 					ImagePullSecrets:   secret.GetReferenceList(pc.cfg.PullSecrets),
-					InitContainers:     pc.initContainers(),
-					Containers:         []corev1.Container{pc.container()},
+					InitContainers:     initContainers,
+					Containers:         []corev1.Container{container},
 					Volumes:            pc.volumes(),
 				},
 			},
@@ -271,14 +276,6 @@ func (pc *packetCaptureApiComponent) deployment() *appsv1.Deployment {
 	}
 
 	return d
-}
-
-func (pc *packetCaptureApiComponent) initContainers() []corev1.Container {
-	var initContainers []corev1.Container
-	if pc.cfg.ServerCertSecret.UseCertificateManagement() {
-		initContainers = append(initContainers, pc.cfg.ServerCertSecret.InitContainer(PacketCaptureNamespace))
-	}
-	return initContainers
 }
 
 func (pc *packetCaptureApiComponent) container() corev1.Container {

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -27,10 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/ptr"
-
 	rcomponents "github.com/tigera/operator/pkg/render/common/components"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -359,7 +359,7 @@ func (pr *policyRecommendationComponent) deployment() *appsv1.Deployment {
 	}
 	var initContainers []corev1.Container
 	if pr.cfg.PolicyRecommendationCertSecret != nil && pr.cfg.PolicyRecommendationCertSecret.UseCertificateManagement() {
-		initContainers = append(initContainers, pr.cfg.PolicyRecommendationCertSecret.InitContainer(PolicyRecommendationNamespace))
+		initContainers = append(initContainers, pr.cfg.PolicyRecommendationCertSecret.InitContainer(PolicyRecommendationNamespace, controllerContainer.SecurityContext))
 	}
 
 	tolerations := pr.cfg.Installation.ControlPlaneTolerations

--- a/pkg/tls/certificatemanagement/csr.go
+++ b/pkg/tls/certificatemanagement/csr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,14 +19,13 @@ import (
 	"fmt"
 	"strings"
 
-	operatorv1 "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/components"
-	"github.com/tigera/operator/pkg/render/common/securitycontext"
-
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 )
 
 const (
@@ -46,7 +45,8 @@ func CreateCSRInitContainer(
 	keyName string,
 	certName string,
 	dnsNames []string,
-	appNameLabel string) corev1.Container {
+	appNameLabel string,
+	securityContext *corev1.SecurityContext) corev1.Container {
 	return corev1.Container{
 		Name:  CSRInitContainerName,
 		Image: image,
@@ -85,7 +85,7 @@ func CreateCSRInitContainer(
 				},
 			}},
 		},
-		SecurityContext: securitycontext.NewNonRootContext(),
+		SecurityContext: securityContext,
 		Resources:       components.GetCSRContainerDefaultResources(),
 	}
 }

--- a/pkg/tls/certificatemanagement/interface.go
+++ b/pkg/tls/certificatemanagement/interface.go
@@ -51,7 +51,7 @@ type KeyPairInterface interface {
 	UseCertificateManagement() bool
 	// BYO returns true if this KeyPair was provided by the user. If BYO is true, UseCertificateManagement is false.
 	BYO() bool
-	InitContainer(namespace string) corev1.Container
+	InitContainer(namespace string, securityContext *corev1.SecurityContext) corev1.Container
 	VolumeMount(osType meta.OSType) corev1.VolumeMount
 	VolumeMountKeyFilePath() string
 	VolumeMountCertificateFilePath() string

--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,10 +20,11 @@ import (
 	"errors"
 	"fmt"
 
-	operatorv1 "github.com/tigera/operator/api/v1"
-	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 )
 
 var ErrInvalidCertNoPEMData = errors.New("cert has no PEM data")
@@ -130,7 +131,7 @@ func (k *KeyPair) VolumeMount(osType rmeta.OSType) corev1.VolumeMount {
 }
 
 // InitContainer contains an init container for making a CSR. is only applicable when certificate management is enabled.
-func (k *KeyPair) InitContainer(namespace string) corev1.Container {
+func (k *KeyPair) InitContainer(namespace string, securityContext *corev1.SecurityContext) corev1.Container {
 	initContainer := CreateCSRInitContainer(
 		k.CertificateManagement,
 		k.Name,
@@ -140,7 +141,8 @@ func (k *KeyPair) InitContainer(namespace string) corev1.Container {
 		corev1.TLSPrivateKeyKey,
 		corev1.TLSCertKey,
 		k.DNSNames,
-		namespace)
+		namespace,
+		securityContext)
 	initContainer.Name = fmt.Sprintf("%s-%s", k.GetName(), initContainer.Name)
 	return initContainer
 }


### PR DESCRIPTION
Cherry pick of #4025 on release-v1.39.

#4025: Fix security context for csr init container

# Original branch name

rene-dekker:CI-1787

# Original PR Body below

Fix security context for csr init container

The CSR init container should have the same scc as the container using the private key, cert and ca files that are created. Otherwise, permission errors will prevent the main container from starting.

I'm not sure exactly why it surfaces only now, but basically queryserver and apiserver do not run with the same scc. For this particular instance, we create two csr containers, even as they need the same dns names on their certs. This is the best solution, since other solutions would require either to give queryserver the same scc as apiserver, or to set wider file permissions on the cert files.

```release-note
Fix security contexts for init containers when certificate management is enabled, so the certificates have the right permissions set on them.
```

Works in cluster. Without it, most components won't come up.
```
NAME                          AVAILABLE   PROGRESSING   DEGRADED   SINCE
apiserver                     True        False         False      4h35m
authentication                True        False         False      4h37m
calico                        True        False         False      8h
intrusion-detection           True        False         False      7m59s
ippools                       True        False         False      8h
log-collector                 True        False         False      4h49m
log-storage                   True        False         False      4h55m
log-storage-access            True        False         False      5m39s
log-storage-dashboards        True        False         False      6m39s
log-storage-elastic           True        False         False      6m34s
log-storage-esmetrics         True        False         False      5m24s
log-storage-kubecontrollers   True        False         False      7m34s
log-storage-secrets           True        False         False      4h55m
manager                       True        False         False      4h37m
monitor                       True        False         False      4h38m
policy-recommendation         True        False         False      4h53m
tiers                         True        False         False      4h54m
```