### PR TITLE
[RS-2546] Update operator to deploy waf-http-filter in Enterprise

### DIFF
--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -404,6 +404,7 @@ var (
 		ComponentFluentdWindows,
 		ComponentGuardian,
 		ComponentIntrusionDetectionController,
+		ComponentWAFHTTPFilter,
 		ComponentSecurityEventWebhooksProcessor,
 		ComponentKibana,
 		ComponentManager,

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -164,7 +164,7 @@ var (
 	}
 {{- end }}
 {{ with index .Components "waf-http-filter" }}
-	ComponentWafHTTPFilter = Component{
+	ComponentWAFHTTPFilter = Component{
 		Version:  "{{ .Version }}",
 		Image:    "{{ .Image }}",
 		Registry: "{{ .Registry }}",

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -143,7 +143,7 @@ var (
 		Registry: "",
 	}
 
-	ComponentWafHTTPFilter = Component{
+	ComponentWAFHTTPFilter = Component{
 		Version:  "master",
 		Image:    "tigera/waf-http-filter",
 		Registry: "",

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -351,6 +351,7 @@ var (
 		ComponentFluentdWindows,
 		ComponentGuardian,
 		ComponentIntrusionDetectionController,
+		ComponentWafHTTPFilter,
 		ComponentSecurityEventWebhooksProcessor,
 		ComponentKibana,
 		ComponentManager,

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -351,7 +351,7 @@ var (
 		ComponentFluentdWindows,
 		ComponentGuardian,
 		ComponentIntrusionDetectionController,
-		ComponentWafHTTPFilter,
+		ComponentWAFHTTPFilter,
 		ComponentSecurityEventWebhooksProcessor,
 		ComponentKibana,
 		ComponentManager,

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -712,9 +712,12 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 				MountPath: "/var/run/waf-http-filter",
 			}
 			hasSocketVolumeMount := false
-			for _, volumeMount := range envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts {
+			for i, volumeMount := range envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts {
 				if volumeMount.Name == socketVolumeMount.Name {
 					hasSocketVolumeMount = true
+					if volumeMount.MountPath != socketVolumeMount.MountPath {
+						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts[i] = socketVolumeMount
+					}
 				}
 			}
 			if !hasSocketVolumeMount {
@@ -739,12 +742,19 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 			}
 			hasLogsVolume := false
 			hasSocketVolume := false
-			for _, volume := range envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes {
+			for i, volume := range envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes {
 				if volume.Name == logsVolume.Name {
 					hasLogsVolume = true
+					// Handle update
+					if volume.VolumeSource.HostPath.Path != logsVolume.VolumeSource.HostPath.Path || volume.VolumeSource.HostPath.Type != logsVolume.VolumeSource.HostPath.Type {
+						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes[i] = logsVolume
+					}
 				}
 				if volume.Name == socketVolume.Name {
 					hasSocketVolume = true
+					if volume.VolumeSource.EmptyDir != socketVolume.VolumeSource.EmptyDir {
+						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes[i] = socketVolume
+					}
 				}
 			}
 			if !hasLogsVolume {

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -409,7 +409,7 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 		CreateNamespace(
 			resources.namespace.Name,
 			pr.cfg.Installation.KubernetesProvider,
-			PSSPrivileged,
+			PSSPrivileged, // Needed for HostPath volume to write logs to
 			pr.cfg.Installation.Azure,
 		),
 	}

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -371,7 +371,7 @@ func (pr *gatewayAPIImplementationComponent) ResolveImages(is *operatorv1.ImageS
 		if err != nil {
 			return err
 		}
-		pr.wafHTTPFilterImage, err = components.GetReference(components.ComponentWafHTTPFilter, reg, path, prefix, is)
+		pr.wafHTTPFilterImage, err = components.GetReference(components.ComponentWAFHTTPFilter, reg, path, prefix, is)
 		if err != nil {
 			return err
 		}

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -481,8 +481,9 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 	// "ShutdownManager" and "RateLimit" images.)
 	envoyGatewayConfig.Provider.Kubernetes.RateLimitDeployment.Pod.ImagePullSecrets = secret.GetReferenceList(pr.cfg.PullSecrets)
 
-	// Enable backend APIs.
+	// Enable extension APIs.
 	envoyGatewayConfig.ExtensionAPIs.EnableBackend = true
+	envoyGatewayConfig.ExtensionAPIs.EnableEnvoyPatchPolicy = true
 
 	// Rebuild the ConfigMap with those changes.
 	envoyGatewayConfigMap := resources.envoyGatewayConfigMap.DeepCopyObject().(*corev1.ConfigMap)

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -25,9 +25,11 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/ptr"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -341,6 +343,7 @@ type gatewayAPIImplementationComponent struct {
 	envoyGatewayImage   string
 	envoyProxyImage     string
 	envoyRatelimitImage string
+	wafHTTPFilterImage  string
 }
 
 func GatewayAPIImplementationComponent(cfg *GatewayAPIImplementationConfig) Component {
@@ -365,6 +368,10 @@ func (pr *gatewayAPIImplementationComponent) ResolveImages(is *operatorv1.ImageS
 			return err
 		}
 		pr.envoyRatelimitImage, err = components.GetReference(components.ComponentGatewayAPIEnvoyRatelimit, reg, path, prefix, is)
+		if err != nil {
+			return err
+		}
+		pr.wafHTTPFilterImage, err = components.GetReference(components.ComponentWafHTTPFilter, reg, path, prefix, is)
 		if err != nil {
 			return err
 		}
@@ -632,6 +639,9 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 			envoyProxy.Spec.Provider.Kubernetes.EnvoyDaemonSet.Container = &envoyapi.KubernetesContainerSpec{}
 		}
 		envoyProxy.Spec.Provider.Kubernetes.EnvoyDaemonSet.Container.Image = &pr.envoyProxyImage
+
+		// The WAF HTTP filter is not supported when the envoy proxy is deployed as a DaemonSet
+		// as there is no support for init containers in a DaemonSet.
 	} else {
 		// Deployment as a Deployment.
 		if envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment == nil {
@@ -645,6 +655,71 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 			envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container = &envoyapi.KubernetesContainerSpec{}
 		}
 		envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.Image = &pr.envoyProxyImage
+
+		if pr.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
+			// Update the envoy proxy deployment to include the WAF HTTP filter
+
+			// Update Pod volumes
+			if envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes == nil {
+				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes = []corev1.Volume{
+					{
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/var/log/calico",
+								Type: ptr.ToPtr[corev1.HostPathType](corev1.HostPathDirectoryOrCreate),
+							},
+						},
+						Name: "var-log-calico",
+					},
+					{
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+						Name: "waf-http-filter",
+					},
+				}
+			}
+
+			// Add the init container to the deployment
+			if envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers == nil {
+				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers = []corev1.Container{
+					corev1.Container{
+						Name:  "waf-http-filter",
+						Image: pr.wafHTTPFilterImage,
+						Args: []string{
+							"-logFileDirectory",
+							"/var/log/calico/waf",
+							"-logFileName",
+							"waf.log",
+							"-socketPath",
+							"/var/run/waf-http-filter/extproc.sock",
+						},
+						RestartPolicy: ptr.ToPtr[corev1.ContainerRestartPolicy](corev1.ContainerRestartPolicyAlways),
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "waf-http-filter",
+								MountPath: "/var/run/waf-http-filter",
+							},
+							{
+								Name:      "var-log-calico",
+								MountPath: "/var/log/calico",
+							},
+						},
+						SecurityContext: securitycontext.NewRootContext(true),
+					},
+				}
+			}
+
+			if envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts == nil {
+				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts = []corev1.VolumeMount{
+					{
+						Name:      "waf-http-filter",
+						MountPath: "/var/run/waf-http-filter",
+					},
+				}
+			}
+
+		}
 	}
 
 	// Apply overrides.

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -402,7 +402,7 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 		CreateNamespace(
 			resources.namespace.Name,
 			pr.cfg.Installation.KubernetesProvider,
-			PSSBaseline,
+			PSSPrivileged,
 			pr.cfg.Installation.Azure,
 		),
 	}


### PR DESCRIPTION
## Description

This PR updates the operator to deploy waf-http-filter in Enterprise when enabling the Gateway API.

This will setup the required waf-http-filter sidecar container in the envoy-proxy deployment, but envoy won't be configured to use it by default. To do so, the user will need to create a separate EnvoyExtensionPolicy to enable the filter and protect the traffic with WAF.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note


<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Deploy the WAF HTTP Filter alongside the Envoy Proxy when running in Calico Enterprise.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
