### PR TITLE
Bump ES&KB to v8.18.3

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: release-calient-v3.22-1
   eck-kibana:
-    version: 8.18.1
+    version: 8.18.3
   kibana:
     image: tigera/kibana
     version: release-calient-v3.22-1
   eck-elasticsearch:
-    version: 8.18.1
+    version: 8.18.3
   elasticsearch:
     image: tigera/elasticsearch
     version: release-calient-v3.22-1

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.18.1",
+		Version:  "8.18.3",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.18.1",
+		Version:  "8.18.3",
 		Registry: "",
 	}
 


### PR DESCRIPTION
```release-note

Bump elasticsearch and kibana to 8.18.3 to get security patches.

```