### PR TITLE
[release-v1.38] Auto pick #4034: Bump go-build to 1.24.5-llvm18.1.8-k8s1.32.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.24.4-llvm18.1.8-k8s1.32.5
+GO_BUILD_VER?=1.24.5-llvm18.1.8-k8s1.32.6
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./api -name '*.go')

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.21.0-2.0
   eck-kibana:
-    version: 8.18.1
+    version: 8.18.3
   kibana:
     image: tigera/kibana
     version: v3.21.0-2.0
   eck-elasticsearch:
-    version: 8.18.1
+    version: 8.18.3
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.21.0-2.0

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.18.1",
+		Version:  "8.18.3",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.18.1",
+		Version:  "8.18.3",
 		Registry: "",
 	}
 


### PR DESCRIPTION
Cherry pick of #4034 on release-v1.38.

#4034: Bump go-build to 1.24.5-llvm18.1.8-k8s1.32.6

# Original branch name

rene-dekker:CI-1787

# Original PR Body below

```release-note
Bump go-build to 1.24.5-llvm18.1.8-k8s1.32.6
Bump elasticsearch and kibana to 8.18.3 to get security patches.
```