### PR TITLE
[v1.39] Fix incorrect Guardian container name references

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -363,7 +363,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		var podProxies []*httpproxy.Config
 		for _, pod := range pods.Items {
 			for _, container := range pod.Spec.Containers {
-				if container.Name == render.GuardianDeploymentName {
+				if container.Name == render.GuardianContainerName {
 					var podProxyConfig *httpproxy.Config
 					var httpsProxy, noProxy string
 					for _, env := range container.Env {

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -761,7 +761,7 @@ func createPodWithProxy(ctx context.Context, c client.Client, config *test.Proxy
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{{
-				Name: render.GuardianDeploymentName,
+				Name: render.GuardianContainerName,
 				Env:  []v1.EnvVar{},
 			}},
 		},

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -389,7 +389,7 @@ func (c *GuardianComponent) deployment() *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        GuardianDeploymentName,
-					Namespace:   ManagerNamespace,
+					Namespace:   GuardianNamespace,
 					Annotations: c.annotations(),
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Fixed an issue that prevented the operator from detecting HTTP proxies set on the Guardian container.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
