### PR TITLE
GatewayAPI controller: reconcile periodically

### DIFF
--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -57,13 +57,20 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	err = c.WatchObject(&operatorv1.GatewayAPI{}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.V(5).Info("Failed to create GatewayAPI watch", "err", err)
-		return fmt.Errorf("gatewayapi-controller failed to watch primary resource: %v", err)
+		return fmt.Errorf("gatewayapi-controller failed to watch primary resource: %w", err)
 	}
 
 	if err = utils.AddInstallationWatch(c); err != nil {
 		log.V(5).Info("Failed to create network watch", "err", err)
-		return fmt.Errorf("gatewayapi-controller failed to watch Tigera network resource: %v", err)
+		return fmt.Errorf("gatewayapi-controller failed to watch Tigera network resource: %w", err)
 	}
+
+	// Perform periodic reconciliation. This acts as a backstop to catch reconcile issues,
+	// and also makes sure we spot when things change that might not trigger a reconciliation.
+	if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("gatewayapi-controller failed to create periodic reconcile watch: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
It's standard for controllers to do this, and we somehow missed it for the Gateway API controller.

This was tentatively observed in https://tigera.atlassian.net/browse/RS-2498 and then confirmed as a problem during v3.22ep1 test cycles: https://tigera.atlassian.net/browse/RS-2673

(cherry-pick of #4047 )