### PR TITLE
[CORE-11648]: Added localASNumber field to the bgppeer crd

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
@@ -35,6 +35,9 @@ spec:
                   type: array
                 keepOriginalNextHop:
                   type: boolean
+                localASNumber:
+                  format: int32
+                  type: integer
                 localWorkloadSelector:
                   type: string
                 maxRestartTime:


### PR DESCRIPTION
## Description

Added `localASNumber` field to the `bgppeer` crd 
Changes generated based on localASNumber calico PR
https://github.com/projectcalico/calico/pull/10600

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
