### PR TITLE
Fix ApplicationLayer watch of MutatingWebhookConfiguration to properl…

### DIFF
--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -118,7 +118,7 @@ func add(mgr manager.Manager, c ctrlruntime.Controller) error {
 	}
 
 	// Watch mutatingwebhookconfiguration responsible for sidecar injetion
-	err = c.WatchObject(&admregv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: common.SidecarMutatingWebhookConfigName}},
+	err = utils.AddClusterWatch(c, &admregv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: common.SidecarMutatingWebhookConfigName}},
 		&handler.EnqueueRequestForObject{})
 	if err != nil {
 		return fmt.Errorf("applicationlayer-controller failed to watch sidecar MutatingWebhookConfiguration resource: %w", err)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -265,6 +265,15 @@ func AddNamespacedWatch(c ctrlruntime.Controller, obj client.Object, h handler.E
 	return c.WatchObject(obj, h, pred)
 }
 
+// AddClusterWatch creates a watch on the given Cluster scoped object. If a name is provided, then it will
+// use predicates to only return matching objects. If it is not, then all events of the provided kind
+// will be generated. Updates that do not modify the object's generation (e.g., status and metadata) will be ignored.
+// If a namespace is set on the obj passed in, the namespace will be set to the empty string.
+func AddClusterWatch(c ctrlruntime.Controller, obj client.Object, h handler.EventHandler) error {
+	obj.SetNamespace("")
+	return AddNamespacedWatch(c, obj, h)
+}
+
 func IsAPIServerReady(client client.Client, l logr.Logger) bool {
 	instance, msg, err := GetAPIServer(context.Background(), client)
 	if err != nil {


### PR DESCRIPTION
…y focus

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
ApplicationLayer controller now properly sets up the watch on the MutatingWebhookConfiguration so it will only reconcile on the specified named resource.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
