### PR TITLE
[CORE-11605] Rename init container `mount-bpffs` to `ebpf-bootstrap`

### DIFF
--- a/api/v1/calico_node_types.go
+++ b/api/v1/calico_node_types.go
@@ -38,8 +38,8 @@ type CalicoNodeDaemonSetContainer struct {
 // CalicoNodeDaemonSetInitContainer is a calico-node DaemonSet init container.
 type CalicoNodeDaemonSetInitContainer struct {
 	// Name is an enum which identifies the calico-node DaemonSet init container by name.
-	// Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
-	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-prometheus-server-tls-key-cert-provisioner
+	// Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;mount-bpffs;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-prometheus-server-tls-key-cert-provisioner
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/api/v1/calico_node_types.go
+++ b/api/v1/calico_node_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,8 +38,8 @@ type CalicoNodeDaemonSetContainer struct {
 // CalicoNodeDaemonSetInitContainer is a calico-node DaemonSet init container.
 type CalicoNodeDaemonSetInitContainer struct {
 	// Name is an enum which identifies the calico-node DaemonSet init container by name.
-	// Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
-	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;mount-bpffs;node-certs-key-cert-provisioner;calico-node-prometheus-server-tls-key-cert-provisioner
+	// Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-prometheus-server-tls-key-cert-provisioner
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/api/v1/calico_node_types.go
+++ b/api/v1/calico_node_types.go
@@ -38,8 +38,8 @@ type CalicoNodeDaemonSetContainer struct {
 // CalicoNodeDaemonSetInitContainer is a calico-node DaemonSet init container.
 type CalicoNodeDaemonSetInitContainer struct {
 	// Name is an enum which identifies the calico-node DaemonSet init container by name.
-	// Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
-	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;mount-bpffs;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-prometheus-server-tls-key-cert-provisioner
+	// Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner, mount-bpffs (deprecated, replaced by ebpf-bootstrap)
+	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-prometheus-server-tls-key-cert-provisioner;mount-bpffs
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/api/v1/calico_node_windows_types.go
+++ b/api/v1/calico_node_windows_types.go
@@ -38,8 +38,8 @@ type CalicoNodeWindowsDaemonSetContainer struct {
 // CalicoNodeWindowsDaemonSetInitContainer is a calico-node-windows DaemonSet init container.
 type CalicoNodeWindowsDaemonSetInitContainer struct {
 	// Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-	// Supported values are: install-cni;hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
-	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-windows-prometheus-server-tls-key-cert-provisioner
+	// Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;mount-bpffs;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-windows-prometheus-server-tls-key-cert-provisioner
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/api/v1/calico_node_windows_types.go
+++ b/api/v1/calico_node_windows_types.go
@@ -38,8 +38,8 @@ type CalicoNodeWindowsDaemonSetContainer struct {
 // CalicoNodeWindowsDaemonSetInitContainer is a calico-node-windows DaemonSet init container.
 type CalicoNodeWindowsDaemonSetInitContainer struct {
 	// Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-	// Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
-	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;mount-bpffs;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-windows-prometheus-server-tls-key-cert-provisioner
+	// Supported values are: install-cni;hostpath-init, flexvol-driver, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;node-certs-key-cert-provisioner;calico-node-windows-prometheus-server-tls-key-cert-provisioner
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/api/v1/calico_node_windows_types.go
+++ b/api/v1/calico_node_windows_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,8 +38,8 @@ type CalicoNodeWindowsDaemonSetContainer struct {
 // CalicoNodeWindowsDaemonSetInitContainer is a calico-node-windows DaemonSet init container.
 type CalicoNodeWindowsDaemonSetInitContainer struct {
 	// Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-	// Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
-	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;mount-bpffs;node-certs-key-cert-provisioner;calico-node-windows-prometheus-server-tls-key-cert-provisioner
+	// Supported values are: install-cni;hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+	// +kubebuilder:validation:Enum=install-cni;hostpath-init;flexvol-driver;ebpf-bootstrap;node-certs-key-cert-provisioner;calico-node-windows-prometheus-server-tls-key-cert-provisioner
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				fmt.Sprintf("some.registry.org/%s:%s",
 					components.ComponentTigeraCSRInitContainer.Image,
 					components.ComponentTigeraCSRInitContainer.Version)))
-			bpfInit := test.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
+			bpfInit := test.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
 			Expect(bpfInit).ToNot(BeNil())
 			Expect(bpfInit.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s:%s",
@@ -426,7 +426,7 @@ var _ = Describe("Testing core-controller installation", func() {
 					components.ComponentTigeraCSRInitContainer.Image,
 					"sha256:calicocsrinithash")))
 
-			bpfInit := test.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
+			bpfInit := test.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
 			Expect(bpfInit).ToNot(BeNil())
 			Expect(bpfInit.Image).To(Equal(
 				fmt.Sprintf("some.registry.org/%s@%s",

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -358,9 +358,8 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 	// Verify the CalicoNodeWindowsDaemonSet overrides, if specified, is valid.
 	if ds := instance.Spec.CalicoNodeWindowsDaemonSet; ds != nil {
 		err := validation.ValidateReplicatedPodResourceOverrides(ds, node.ValidateCalicoNodeWindowsDaemonSetContainer, node.ValidateCalicoNodeWindowsDaemonSetInitContainer)
-		err2 := validateExclusiveInitContainers(rcc.GetInitContainers(ds))
-		if err != nil || err2 != nil {
-			return fmt.Errorf("Installation spec.CalicoNodeWindowsDaemonSet is not valid: %w", errors.Join(err, err2))
+		if err != nil {
+			return fmt.Errorf("Installation spec.CalicoNodeWindowsDaemonSet is not valid: %w", err)
 		}
 	}
 

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -350,7 +350,7 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 	if ds := instance.Spec.CalicoNodeDaemonSet; ds != nil {
 		err := validation.ValidateReplicatedPodResourceOverrides(ds, node.ValidateCalicoNodeDaemonSetContainer, node.ValidateCalicoNodeDaemonSetInitContainer)
 		err2 := validateExclusiveInitContainers(rcc.GetInitContainers(ds))
-		if err != nil {
+		if err != nil || err2 != nil {
 			return fmt.Errorf("Installation spec.CalicoNodeDaemonSet is not valid: %w", errors.Join(err, err2))
 		}
 	}
@@ -359,7 +359,7 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 	if ds := instance.Spec.CalicoNodeWindowsDaemonSet; ds != nil {
 		err := validation.ValidateReplicatedPodResourceOverrides(ds, node.ValidateCalicoNodeWindowsDaemonSetContainer, node.ValidateCalicoNodeWindowsDaemonSetInitContainer)
 		err2 := validateExclusiveInitContainers(rcc.GetInitContainers(ds))
-		if err != nil {
+		if err != nil || err2 != nil {
 			return fmt.Errorf("Installation spec.CalicoNodeWindowsDaemonSet is not valid: %w", errors.Join(err, err2))
 		}
 	}

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -872,6 +872,35 @@ var _ = Describe("Installation validation tests", func() {
 			}
 			err = validateCustomResource(instance)
 			Expect(err).To(HaveOccurred())
+
+			instance.Spec.CalicoNodeDaemonSet = &operator.CalicoNodeDaemonSet{
+				Spec: &operator.CalicoNodeDaemonSetSpec{
+					Template: &operator.CalicoNodeDaemonSetPodTemplateSpec{
+						Spec: &operator.CalicoNodeDaemonSetPodSpec{
+							InitContainers: []operator.CalicoNodeDaemonSetInitContainer{
+								{
+									Name: "mount-bpffs",
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceCPU: resource.MustParse("100m"),
+										},
+									},
+								},
+								{
+									Name: "ebpf-bootstrap",
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceMemory: resource.MustParse("100Mi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err = validateCustomResource(instance)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -901,6 +930,35 @@ var _ = Describe("Installation validation tests", func() {
 			instance.Spec.CalicoNodeWindowsDaemonSet = &operator.CalicoNodeWindowsDaemonSet{
 				Spec: &operator.CalicoNodeWindowsDaemonSetSpec{
 					MinReadySeconds: &invalidMinReadySeconds,
+				},
+			}
+			err = validateCustomResource(instance)
+			Expect(err).To(HaveOccurred())
+
+			instance.Spec.CalicoNodeDaemonSet = &operator.CalicoNodeDaemonSet{
+				Spec: &operator.CalicoNodeDaemonSetSpec{
+					Template: &operator.CalicoNodeDaemonSetPodTemplateSpec{
+						Spec: &operator.CalicoNodeDaemonSetPodSpec{
+							InitContainers: []operator.CalicoNodeDaemonSetInitContainer{
+								{
+									Name: "mount-bpffs",
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceCPU: resource.MustParse("100m"),
+										},
+									},
+								},
+								{
+									Name: "ebpf-bootstrap",
+									Resources: &v1.ResourceRequirements{
+										Requests: v1.ResourceList{
+											v1.ResourceMemory: resource.MustParse("100Mi"),
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			}
 			err = validateCustomResource(instance)

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -934,35 +934,6 @@ var _ = Describe("Installation validation tests", func() {
 			}
 			err = validateCustomResource(instance)
 			Expect(err).To(HaveOccurred())
-
-			instance.Spec.CalicoNodeDaemonSet = &operator.CalicoNodeDaemonSet{
-				Spec: &operator.CalicoNodeDaemonSetSpec{
-					Template: &operator.CalicoNodeDaemonSetPodTemplateSpec{
-						Spec: &operator.CalicoNodeDaemonSetPodSpec{
-							InitContainers: []operator.CalicoNodeDaemonSetInitContainer{
-								{
-									Name: "mount-bpffs",
-									Resources: &v1.ResourceRequirements{
-										Requests: v1.ResourceList{
-											v1.ResourceCPU: resource.MustParse("100m"),
-										},
-									},
-								},
-								{
-									Name: "ebpf-bootstrap",
-									Resources: &v1.ResourceRequirements{
-										Requests: v1.ResourceList{
-											v1.ResourceMemory: resource.MustParse("100Mi"),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			err = validateCustomResource(instance)
-			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -2667,12 +2667,12 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node DaemonSet init container by name.
-                                          Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+                                          Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
                                         enum:
                                           - install-cni
                                           - hostpath-init
                                           - flexvol-driver
-                                          - mount-bpffs
+                                          - ebpf-bootstrap
                                           - node-certs-key-cert-provisioner
                                           - calico-node-prometheus-server-tls-key-cert-provisioner
                                         type: string
@@ -3955,12 +3955,12 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-                                          Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+                                          Supported values are: install-cni;hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                         enum:
                                           - install-cni
                                           - hostpath-init
                                           - flexvol-driver
-                                          - mount-bpffs
+                                          - ebpf-bootstrap
                                           - node-certs-key-cert-provisioner
                                           - calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                         type: string
@@ -11464,12 +11464,12 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node DaemonSet init container by name.
-                                              Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+                                              Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
                                             enum:
                                               - install-cni
                                               - hostpath-init
                                               - flexvol-driver
-                                              - mount-bpffs
+                                              - ebpf-bootstrap
                                               - node-certs-key-cert-provisioner
                                               - calico-node-prometheus-server-tls-key-cert-provisioner
                                             type: string
@@ -12775,12 +12775,12 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-                                              Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+                                              Supported values are: install-cni;hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                             enum:
                                               - install-cni
                                               - hostpath-init
                                               - flexvol-driver
-                                              - mount-bpffs
+                                              - ebpf-bootstrap
                                               - node-certs-key-cert-provisioner
                                               - calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                             type: string

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -3956,13 +3956,11 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-                                          Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+                                          Supported values are: install-cni;hostpath-init, flexvol-driver, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                         enum:
                                           - install-cni
                                           - hostpath-init
                                           - flexvol-driver
-                                          - mount-bpffs
-                                          - ebpf-bootstrap
                                           - node-certs-key-cert-provisioner
                                           - calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                         type: string
@@ -12778,13 +12776,11 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-                                              Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+                                              Supported values are: install-cni;hostpath-init, flexvol-driver, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                             enum:
                                               - install-cni
                                               - hostpath-init
                                               - flexvol-driver
-                                              - mount-bpffs
-                                              - ebpf-bootstrap
                                               - node-certs-key-cert-provisioner
                                               - calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                             type: string

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -2667,15 +2667,15 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node DaemonSet init container by name.
-                                          Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+                                          Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner, mount-bpffs (deprecated, replaced by ebpf-bootstrap)
                                         enum:
                                           - install-cni
                                           - hostpath-init
                                           - flexvol-driver
-                                          - mount-bpffs
                                           - ebpf-bootstrap
                                           - node-certs-key-cert-provisioner
                                           - calico-node-prometheus-server-tls-key-cert-provisioner
+                                          - mount-bpffs
                                         type: string
                                       resources:
                                         description: |-
@@ -11464,15 +11464,15 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node DaemonSet init container by name.
-                                              Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+                                              Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner, mount-bpffs (deprecated, replaced by ebpf-bootstrap)
                                             enum:
                                               - install-cni
                                               - hostpath-init
                                               - flexvol-driver
-                                              - mount-bpffs
                                               - ebpf-bootstrap
                                               - node-certs-key-cert-provisioner
                                               - calico-node-prometheus-server-tls-key-cert-provisioner
+                                              - mount-bpffs
                                             type: string
                                           resources:
                                             description: |-

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -2667,11 +2667,12 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node DaemonSet init container by name.
-                                          Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+                                          Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
                                         enum:
                                           - install-cni
                                           - hostpath-init
                                           - flexvol-driver
+                                          - mount-bpffs
                                           - ebpf-bootstrap
                                           - node-certs-key-cert-provisioner
                                           - calico-node-prometheus-server-tls-key-cert-provisioner
@@ -3955,11 +3956,12 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-                                          Supported values are: install-cni;hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+                                          Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                         enum:
                                           - install-cni
                                           - hostpath-init
                                           - flexvol-driver
+                                          - mount-bpffs
                                           - ebpf-bootstrap
                                           - node-certs-key-cert-provisioner
                                           - calico-node-windows-prometheus-server-tls-key-cert-provisioner
@@ -11464,11 +11466,12 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node DaemonSet init container by name.
-                                              Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
+                                              Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner
                                             enum:
                                               - install-cni
                                               - hostpath-init
                                               - flexvol-driver
+                                              - mount-bpffs
                                               - ebpf-bootstrap
                                               - node-certs-key-cert-provisioner
                                               - calico-node-prometheus-server-tls-key-cert-provisioner
@@ -12775,11 +12778,12 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node-windows DaemonSet init container by name.
-                                              Supported values are: install-cni;hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
+                                              Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs (legacy value, replaced by ebpf-bootstrap), ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner
                                             enum:
                                               - install-cni
                                               - hostpath-init
                                               - flexvol-driver
+                                              - mount-bpffs
                                               - ebpf-bootstrap
                                               - node-certs-key-cert-provisioner
                                               - calico-node-windows-prometheus-server-tls-key-cert-provisioner

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1014,9 +1014,9 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 
 	if overrides := c.cfg.Installation.CalicoNodeDaemonSet; overrides != nil {
 		// If the overrides specify the legacy mount-bpffs init container, then we rename it to the new value: ebpf-bootstrap.
-		for _, ic := range rcomp.GetInitContainers(overrides) {
-			if ic.Name == "mount-bpffs" {
-				ic.Name = "ebpf-bootstrap"
+		for index := range rcomp.GetInitContainers(overrides) {
+			if overrides.Spec.Template.Spec.InitContainers[index].Name == "mount-bpffs" {
+				overrides.Spec.Template.Spec.InitContainers[index].Name = "ebpf-bootstrap"
 			}
 		}
 		rcomp.ApplyDaemonSetOverrides(&ds, overrides)

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1214,7 +1214,7 @@ func (c *nodeComponent) bpffsInitContainer() corev1.Container {
 		command = append(command, "-skip-cgroup")
 	}
 	return corev1.Container{
-		Name:            "mount-bpffs",
+		Name:            "ebpf-bootstrap",
 		Image:           c.nodeImage,
 		ImagePullPolicy: ImagePullPolicy(),
 		Command:         command,

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -527,8 +527,8 @@ var _ = Describe("Node rendering tests", func() {
 				// Verify the Flex volume container image.
 				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))
 
-				// Verify the mount-bpffs image and command.
-				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
+				// Verify the ebpf-bootstrap image and command.
+				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
 				Expect(mountBpffs.Image).To(Equal(calicoNodeImage))
 				Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init"}))
 
@@ -788,8 +788,8 @@ var _ = Describe("Node rendering tests", func() {
 				// Verify the Flex volume container image.
 				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("%s%s:%s", components.TigeraRegistry, components.ComponentTigeraFlexVolume.Image, components.ComponentTigeraFlexVolume.Version)))
 
-				// Verify the mount-bpffs image and command.
-				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
+				// Verify the ebpf-bootstrap image and command.
+				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
 				Expect(mountBpffs.Image).To(Equal(ds.Spec.Template.Spec.Containers[0].Image))
 				Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init", "-skip-cgroup"}))
 
@@ -996,8 +996,8 @@ var _ = Describe("Node rendering tests", func() {
 				// Verify the Flex volume container image.
 				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))
 
-				// Verify the mount-bpffs image and command.
-				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
+				// Verify the ebpf-bootstrap image and command.
+				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
 				Expect(mountBpffs).To(BeNil())
 
 				// Verify volumes.

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -884,9 +884,9 @@ func (c *windowsComponent) windowsDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1
 
 	if overrides := c.cfg.Installation.CalicoNodeWindowsDaemonSet; overrides != nil {
 		// If the overrides specify the legacy mount-bpffs init container, then we rename it to the new value: ebpf-bootstrap.
-		for _, ic := range rcomp.GetInitContainers(overrides) {
-			if ic.Name == "mount-bpffs" {
-				ic.Name = "ebpf-bootstrap"
+		for index := range rcomp.GetInitContainers(overrides) {
+			if overrides.Spec.Template.Spec.InitContainers[index].Name == "mount-bpffs" {
+				overrides.Spec.Template.Spec.InitContainers[index].Name = "ebpf-bootstrap"
 			}
 		}
 		rcomp.ApplyDaemonSetOverrides(&ds, overrides)

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -883,12 +883,6 @@ func (c *windowsComponent) windowsDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1
 	setNodeCriticalPod(&(ds.Spec.Template))
 
 	if overrides := c.cfg.Installation.CalicoNodeWindowsDaemonSet; overrides != nil {
-		// If the overrides specify the legacy mount-bpffs init container, then we rename it to the new value: ebpf-bootstrap.
-		for index := range rcomp.GetInitContainers(overrides) {
-			if overrides.Spec.Template.Spec.InitContainers[index].Name == "mount-bpffs" {
-				overrides.Spec.Template.Spec.InitContainers[index].Name = "ebpf-bootstrap"
-			}
-		}
 		rcomp.ApplyDaemonSetOverrides(&ds, overrides)
 	}
 

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -883,6 +883,12 @@ func (c *windowsComponent) windowsDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1
 	setNodeCriticalPod(&(ds.Spec.Template))
 
 	if overrides := c.cfg.Installation.CalicoNodeWindowsDaemonSet; overrides != nil {
+		// If the overrides specify the legacy mount-bpffs init container, then we rename it to the new value: ebpf-bootstrap.
+		for _, ic := range rcomp.GetInitContainers(overrides) {
+			if ic.Name == "mount-bpffs" {
+				ic.Name = "ebpf-bootstrap"
+			}
+		}
 		rcomp.ApplyDaemonSetOverrides(&ds, overrides)
 	}
 


### PR DESCRIPTION
## Description

The init container `mount-bpffs` has been renamed to `ebpf-bootstrap` to better reflect its purpose, as it will handle more than just mounting the BPF filesystem. 
 - The old name is still supported in the `CalicoNodeDaemonSet` CRD to maintain backward compatibility.
 -  A validation check has been added to prevent both `mount-bpffs` and `ebpf-bootstrap` from being specified at the same time.

**Note:**
The `mount-bpffs` value was removed from the `CalicoNodeWindowsDaemonSet` CRD. Since eBPF is not supported on Windows and this init container was not created by the Operator, it's more appropriate to remove it entirely rather than keep the old, the new, or even both values.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
The init container `mount-bpffs` is now named `ebpf-bootstrap` to reflect its broader responsibilities. No impact on functionality.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
