### PR TITLE
Gateway API: allow for OpenShift 4.19 CRD lockdown

### DIFF
--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -57,7 +57,6 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 	r := &ReconcileGatewayAPI{
 		client:              mgr.GetClient(),
 		scheme:              mgr.GetScheme(),
-		provider:            opts.DetectedProvider,
 		enterpriseCRDsExist: opts.EnterpriseCRDExists,
 		status:              status.New(mgr.GetClient(), "gatewayapi", opts.KubernetesVersion),
 		clusterDomain:       opts.ClusterDomain,
@@ -135,7 +134,6 @@ var _ reconcile.Reconciler = &ReconcileGatewayAPI{}
 type ReconcileGatewayAPI struct {
 	client              client.Client
 	scheme              *runtime.Scheme
-	provider            operatorv1.Provider
 	enterpriseCRDsExist bool
 	status              status.StatusManager
 	clusterDomain       string
@@ -192,12 +190,22 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	// so that the CRDs are left in place even if the GatewayAPI CR is removed again.  This is
 	// in case the customer uses a second (or more) implementation of the Gateway API in
 	// addition to the one that we are providing here.
-	crdComponent := render.NewPassthrough(render.GatewayAPICRDs(log)...)
+	//
+	// OpenShift 4.19+ pre-installs some of the Gateway CRDs, but not all of them, and has a
+	// webhook that prevents us from installing the ones that OpenShift is missing.  To work
+	// with this we distinguish between "essential" and "optional" CRDs.  The "essential" set
+	// must be a subset of those that OpenShift installs and/or allows to be installed, and must
+	// also suffice for all of the Gateway-related feature that we consider important as part of
+	// Calico; and this controller will report an error and degraded status if any of those do
+	// not already exist and cannot be installed.  The "optional" set is everything else that we
+	// would ideally install, to provide more options to our users; but this controller will
+	// only warn if any of those cannot be installed (and do not already exist).
+	essentialCRDs, optionalCRDs := render.GatewayAPICRDs(installation.KubernetesProvider)
 	handler := r.newComponentHandler(log, r.client, r.scheme, nil)
 	if gatewayAPI.Spec.CRDManagement == nil || *gatewayAPI.Spec.CRDManagement == operatorv1.CRDManagementPreferExisting {
 		handler.SetCreateOnly()
 	}
-	err = handler.CreateOrUpdateOrDelete(ctx, crdComponent, nil)
+	err = handler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(essentialCRDs...), nil)
 	if gatewayAPI.Spec.CRDManagement == nil && (err == nil || errors.IsAlreadyExists(err)) {
 		// The GatewayAPI CR does not yet have a specified value for its CRDManagement
 		// field, and we can now infer a reasonable value.
@@ -233,8 +241,12 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 		}
 	}
 	if err != nil && !errors.IsAlreadyExists(err) {
-		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error rendering GatewayAPI CRDs", err, log)
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error rendering essential GatewayAPI CRDs", err, log)
 		return reconcile.Result{}, err
+	}
+	err = handler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(optionalCRDs...), nil)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		reqLogger.Info("Could not render all optional GatewayAPI CRDs", "err", err)
 	}
 
 	pullSecrets, err := utils.GetNetworkingPullSecrets(installation, r.client)

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	envoyapi "github.com/envoyproxy/gateway/api/v1alpha1"
-	"github.com/go-logr/logr"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
@@ -336,17 +335,31 @@ func GatewayAPIResourcesGetter() func() *gatewayAPIResources {
 
 var GatewayAPIResources = GatewayAPIResourcesGetter()
 
-func GatewayAPICRDs(log logr.Logger) []client.Object {
+func GatewayAPICRDs(provider operatorv1.Provider) ([]client.Object, []client.Object) {
 	resources := GatewayAPIResources()
-	gatewayAPICRDs := make([]client.Object, 0, len(resources.k8sCRDs)+len(resources.envoyCRDs))
+	essentialCRDs := make([]client.Object, 0, len(resources.k8sCRDs)+len(resources.envoyCRDs))
+	optionalCRDs := make([]client.Object, 0, len(resources.k8sCRDs)+len(resources.envoyCRDs))
 	for _, crd := range resources.k8sCRDs {
-		gatewayAPICRDs = append(gatewayAPICRDs, crd.DeepCopyObject().(client.Object))
+		if provider.IsOpenShift() {
+			// OpenShift 4.19+ restricts the Gateway CRDs that we can install, so report
+			// that only some of them are essential.
+			switch strings.TrimSuffix(crd.Name, ".gateway.networking.k8s.io") {
+			case "gatewayclasses", "gateways", "httproutes", "referencegrants":
+				essentialCRDs = append(essentialCRDs, crd.DeepCopyObject().(client.Object))
+			default:
+				optionalCRDs = append(optionalCRDs, crd.DeepCopyObject().(client.Object))
+			}
+		} else {
+			// Other platforms do not restrict Gateway CRDs, so report them all as
+			// essential.
+			essentialCRDs = append(essentialCRDs, crd.DeepCopyObject().(client.Object))
+		}
 	}
 	for _, crd := range resources.envoyCRDs {
-		gatewayAPICRDs = append(gatewayAPICRDs, crd.DeepCopyObject().(client.Object))
+		essentialCRDs = append(essentialCRDs, crd.DeepCopyObject().(client.Object))
 	}
 
-	return gatewayAPICRDs
+	return essentialCRDs, optionalCRDs
 }
 
 type GatewayAPIImplementationConfig struct {


### PR DESCRIPTION
OpenShift 4.19+ pre-installs some of the Gateway CRDs, but not all of them, and has a webhook that prevents us from installing the ones that OpenShift is missing.  To work with this we distinguish between "essential" and "optional" CRDs.  The "essential" set must be a subset of those that OpenShift installs and/or allows to be installed, and must also suffice for all of the Gateway-related feature that we consider important as part of Calico; and this controller will report an error and degraded status if any of those do not already exist and cannot be installed.  The "optional" set is everything else that we would ideally install, to provide more options to our users; but this controller will only warn if any of those cannot be installed (and do not already exist).

Fixes https://tigera.atlassian.net/browse/RS-2689
Fixes https://tigera.atlassian.net/browse/RS-2690

## Release Note

```release-note
Accommodate OpenShift 4.19, which only provides some of the Gateway API CRDs itself and prevents our operator from installing the others.  It means that our Gateway API support is less rich on OpenShift 4.19 than on other platforms, but that is better than not working at all.
```