### PR TITLE
[release-v1.38] Auto pick #4079: Added a guard in isRolloutCompleteWithBPFVolumes to check if

### DIFF
--- a/pkg/controller/installation/bpf.go
+++ b/pkg/controller/installation/bpf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,6 +63,12 @@ func bpfValidateAnnotations(fc *crdv1.FelixConfiguration) error {
 // the current scheduled pods also equals the number available.  When all these
 // checks are reconciled then FelixConfig can be patched as bpfEnabled: true.
 func isRolloutCompleteWithBPFVolumes(ds *appsv1.DaemonSet) bool {
+	if ds.Status.ObservedGeneration != ds.Generation {
+		// To avoid race condition: the k8s DaemonSet controller hasn't observed the
+		// latest Spec update yet, so the Status might still be outdated.
+		return false
+	}
+
 	for _, volume := range ds.Spec.Template.Spec.Volumes {
 		if volume.Name == render.BPFVolumeName {
 			//return ds.Status.CurrentNumberScheduled == ds.Status.UpdatedNumberScheduled && ds.Status.CurrentNumberScheduled == ds.Status.NumberAvailable


### PR DESCRIPTION
Cherry pick of tigera/operator/pull/4079 on release-v1.38.

#4079: Added a guard in isRolloutCompleteWithBPFVolumes to check if

# Original PR Body below

## Description

This PR fixes a race condition when checking if the `calico-node` DaemonSet has completed its rollout before enabling BPF.

Previously, when switching from Iptables to BPF, the `BPFEnabled` field and the `operator.tigera.io/bpfEnabled` annotation were sometimes set to `true` in the `FelixConfiguration` before the DaemonSet rollout finished.

This happened because `setBPFUpdatesOnFelixConfiguration` function ran **after** the DaemonSet `.Spec` was updated, but **before** the `.Status` was updated by the Kubernetes DaemonSet controller. As a result, `isRolloutCompleteWithBPFVolumes` returned a false positive, and BPF was enabled too early.

This PR updates the logic to ensure the rollout is actually complete before enabling BPF.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.