### PR TITLE
Update apiserver anti-affinity; remove old pods to prevent hostNetwork port conflicts

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -18,9 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
-
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -446,7 +443,6 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		MultiTenant:                 r.multiTenant,
 		KeyValidatorConfig:          keyValidatorConfig,
 		KubernetesVersion:           r.kubernetesVersion,
-		CanCleanupOlderResources:    r.canCleanupLegacyNamespace(ctx, installationSpec.Variant, reqLogger),
 		QueryServerTLSKeyPairCertificateManagementOnly: queryServerTLSSecretCertificateManagementOnly,
 	}
 
@@ -525,73 +521,4 @@ func (r *ReconcileAPIServer) maintainFinalizer(ctx context.Context, apiserver cl
 	// These objects require graceful termination before the CNI plugin is torn down.
 	apiServerDeployment := v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: render.APIServerNamespace}}
 	return utils.MaintainInstallationFinalizer(ctx, r.client, apiserver, render.APIServerFinalizer, &apiServerDeployment)
-}
-
-// canCleanupLegacyNamespace determines whether the legacy "tigera-system" namespace
-// (which previously hosted the API server) can be safely cleaned up.
-// It returns true only if:
-// - The new API server deployment in "calico-system" exists and is available.
-// - The old API server deployment in "tigera-system" is either removed or inactive.
-// - Both the APIServer custom resource and the TigeraStatus for 'apiserver' are in the Ready state
-func (r *ReconcileAPIServer) canCleanupLegacyNamespace(ctx context.Context, variant operatorv1.ProductVariant, logger logr.Logger) bool {
-
-	newNamespace := "calico-system"
-	oldNamespace := "tigera-system"
-	deploymentName := "calico-apiserver"
-
-	if variant == operatorv1.Calico {
-		oldNamespace = "calico-apiserver"
-	}
-
-	// Fetch the new API server deployment in calico-system
-	newDeploy := &appsv1.Deployment{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: newNamespace}, newDeploy); err != nil {
-		if errors.IsNotFound(err) {
-			logger.V(3).Info("New API server not found", "ns", newNamespace)
-		} else {
-			logger.Error(err, "Failed to get new API server", "ns", newNamespace)
-		}
-		return false
-	}
-	if newDeploy.Status.AvailableReplicas == 0 {
-		logger.V(3).Info("New API server has 0 replicas", "ns", newNamespace)
-		return false
-	}
-
-	// Fetch the old API server deployment in tigera-system
-	oldDeploy := &appsv1.Deployment{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: oldNamespace}, oldDeploy); err != nil {
-		if !errors.IsNotFound(err) {
-			logger.Error(err, "Failed to get old API server", "ns", oldNamespace)
-			return false
-		}
-	}
-	if oldDeploy.Status.AvailableReplicas > 0 {
-		logger.V(3).Info("Old API server still running", "ns", oldNamespace)
-		return false
-	}
-
-	// Ensure the new API server is functionally ready
-	if !utils.IsAPIServerReady(r.client, logger) {
-		logger.V(3).Info("APIServer CR is not ready")
-		return false
-	}
-
-	// Ensure TigeraStatus indicates readiness
-	ts := &operatorv1.TigeraStatus{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: ResourceName}, ts); err != nil {
-		if errors.IsNotFound(err) {
-			logger.V(3).Info("TigeraStatus not found")
-		} else {
-			logger.Error(err, "Failed to get TigeraStatus resource.")
-		}
-		return false
-	}
-	if !ts.Available() {
-		logger.V(3).Info("TigeraStatus for apiserver is not in Available status.")
-		return false
-	}
-
-	logger.Info("Safe to clean up old namespace for apiserver.")
-	return true
 }

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -19,12 +19,10 @@ import (
 	"fmt"
 	"time"
 
-	kerror "k8s.io/apimachinery/pkg/api/errors"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	kerror "k8s.io/apimachinery/pkg/api/errors"
 
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -799,126 +797,6 @@ var _ = Describe("apiserver controller tests", func() {
 				Expect(kerror.IsNotFound(err)).Should(BeTrue())
 			})
 
-		})
-	})
-
-	Context("check if older namespace can be cleaned up", func() {
-		BeforeEach(func() {
-			Expect(cli.Create(ctx, installation)).NotTo(HaveOccurred())
-		})
-
-		It("should return true when new deployment is ready, old one is gone, and TigeraStatus is healthy", func() {
-			err := cli.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = cli.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "tigera-system"},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 0},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = cli.Create(ctx, &operatorv1.TigeraStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: "apiserver"},
-				Status: operatorv1.TigeraStatusStatus{
-					Conditions: []operatorv1.TigeraStatusCondition{{Type: operatorv1.ComponentAvailable, Status: operatorv1.ConditionTrue}},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
-			_, err = r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
-			Expect(canCleanedUp).To(BeTrue())
-		})
-
-		It("should return false when new deployment is not ready", func() {
-			err := cli.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 0},
-			})
-			Expect(err).NotTo(HaveOccurred())
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
-			_, err = r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
-			Expect(canCleanedUp).To(BeFalse())
-		})
-
-		It("should return false when older deployment is still running", func() {
-			err := cli.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = cli.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "tigera-system"},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
-			})
-			Expect(err).NotTo(HaveOccurred())
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
-			_, err = r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
-			Expect(canCleanedUp).To(BeFalse())
-		})
-
-		It("should return false when TigeraStatus is not healthy", func() {
-			err := cli.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 1},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = cli.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "tigera-system"},
-				Status:     appsv1.DeploymentStatus{AvailableReplicas: 0},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = cli.Create(ctx, &operatorv1.TigeraStatus{
-				ObjectMeta: metav1.ObjectMeta{Name: "apiserver"},
-				Status: operatorv1.TigeraStatusStatus{
-					Conditions: []operatorv1.TigeraStatusCondition{{Type: operatorv1.ComponentAvailable, Status: operatorv1.ConditionFalse}},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-			r := ReconcileAPIServer{
-				client:              cli,
-				scheme:              scheme,
-				provider:            operatorv1.ProviderNone,
-				enterpriseCRDsExist: true,
-				status:              mockStatus,
-				tierWatchReady:      ready,
-			}
-			_, err = r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			canCleanedUp := r.canCleanupLegacyNamespace(ctx, installation.Spec.Variant, logf.Log.WithName("test"))
-			Expect(canCleanedUp).To(BeFalse())
 		})
 	})
 

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -132,7 +132,6 @@ type APIServerConfiguration struct {
 	MultiTenant                 bool
 	KeyValidatorConfig          authentication.KeyValidatorConfig
 	KubernetesVersion           *common.VersionInfo
-	CanCleanupOlderResources    bool
 
 	// When certificate management is enabled, we need a separate init container to create a cert, running
 	// with the same permissions as query server.
@@ -2222,24 +2221,19 @@ func (c *apiServerComponent) getDeprecatedResources() []client.Object {
 		})
 	}
 
-	// Delete the older namespace for OSS and EE.
-	// This supports upgrades from older OSS versions to newer EE versions, and vice versa.
-	// CanCleanupOlderResources ensure the newdeployment is up and running in calico-system in both variant.
-	if c.cfg.CanCleanupOlderResources {
-		renamedRscList = append(renamedRscList, &corev1.Namespace{
-			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "calico-apiserver",
-			},
-		})
+	renamedRscList = append(renamedRscList, &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "calico-apiserver",
+		},
+	})
 
-		renamedRscList = append(renamedRscList, &corev1.Namespace{
-			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "tigera-system",
-			},
-		})
-	}
+	renamedRscList = append(renamedRscList, &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tigera-system",
+		},
+	})
 
 	return renamedRscList
 }

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1054,7 +1054,7 @@ func (c *apiServerComponent) apiServerDeployment() *appsv1.Deployment {
 	}
 
 	if c.cfg.Installation.ControlPlaneReplicas != nil && *c.cfg.Installation.ControlPlaneReplicas > 1 {
-		d.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(APIServerName, APIServerNamespace)
+		d.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(APIServerName, []string{APIServerNamespace, "tigera-system", "calico-apiserver"})
 	}
 
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
@@ -2389,7 +2389,7 @@ func (c *apiServerComponent) deprecatedResources() []client.Object {
 		// Clean up legacy secrets in the tigera-operator namespace
 		&corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-			ObjectMeta: metav1.ObjectMeta{Name: "tigera-api-cert", Namespace: "tigera-operator"},
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-api-cert", Namespace: common.OperatorNamespace()},
 		},
 	}
 }

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -448,7 +448,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			}
 		}
 		Expect(deploy.Spec.Template.Spec.Containers).NotTo(BeNil())
-		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", "calico-system")))
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", []string{"calico-system", "tigera-system", "calico-apiserver"})))
 	})
 
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
@@ -1019,7 +1019,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
-		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", "calico-system")))
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", []string{"calico-system", "tigera-system", "calico-apiserver"})))
 	})
 
 	Context("allow-tigera rendering", func() {
@@ -2068,7 +2068,7 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
-		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", "calico-system")))
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", []string{"calico-system", "tigera-system", "calico-apiserver"})))
 	})
 
 	It("should render with EKS provider without CNI.Type", func() {

--- a/pkg/render/common/podaffinity/pod_anti_affinity.go
+++ b/pkg/render/common/podaffinity/pod_anti_affinity.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ const (
 	K8sAppLabelName string = "k8s-app"
 )
 
-func NewPodAntiAffinity(name, namespace string) *corev1.Affinity {
+func NewPodAntiAffinity(name string, namespaces []string) *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
@@ -35,7 +35,7 @@ func NewPodAntiAffinity(name, namespace string) *corev1.Affinity {
 								K8sAppLabelName: name,
 							},
 						},
-						Namespaces:  []string{namespace},
+						Namespaces:  namespaces,
 						TopologyKey: "kubernetes.io/hostname",
 					},
 				},
@@ -47,7 +47,7 @@ func NewPodAntiAffinity(name, namespace string) *corev1.Affinity {
 								K8sAppLabelName: name,
 							},
 						},
-						Namespaces:  []string{namespace},
+						Namespaces:  namespaces,
 						TopologyKey: "topology.kubernetes.io/zone",
 					},
 				},

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -294,7 +294,7 @@ func (c *dexComponent) deployment() client.Object {
 	}
 
 	if c.cfg.Installation.ControlPlaneReplicas != nil && *c.cfg.Installation.ControlPlaneReplicas > 1 {
-		d.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(DexObjectName, DexNamespace)
+		d.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(DexObjectName, []string{DexNamespace})
 	}
 
 	if c.cfg.Authentication != nil {

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -398,7 +398,7 @@ var _ = Describe("dex rendering tests", func() {
 			deploy, ok := rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
-			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-dex", "tigera-dex")))
+			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-dex", []string{"tigera-dex"})))
 		})
 
 		It("should render configuration with resource requests and limits", func() {

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -269,7 +269,7 @@ func (e *esGateway) esGatewayDeployment() *appsv1.Deployment {
 	}
 
 	if e.cfg.Installation.ControlPlaneReplicas != nil && *e.cfg.Installation.ControlPlaneReplicas > 1 {
-		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity(DeploymentName, e.cfg.Namespace)
+		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity(DeploymentName, []string{e.cfg.Namespace})
 	}
 
 	d := appsv1.Deployment{

--- a/pkg/render/logstorage/esgateway/esgateway_test.go
+++ b/pkg/render/logstorage/esgateway/esgateway_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -185,7 +185,7 @@ var _ = Describe("ES Gateway rendering tests", func() {
 			deploy, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
-			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, render.ElasticsearchNamespace)))
+			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, []string{render.ElasticsearchNamespace})))
 		})
 
 		It("should apply controlPlaneNodeSelector correctly", func() {

--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -361,7 +361,7 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 	}
 
 	if k.cfg.Installation.ControlPlaneReplicas != nil && *k.cfg.Installation.ControlPlaneReplicas > 1 {
-		kibana.Spec.PodTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity(CRName, Namespace)
+		kibana.Spec.PodTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity(CRName, []string{Namespace})
 	}
 
 	if k.cfg.LogStorage != nil {

--- a/pkg/render/logstorage/kibana/kibana_test.go
+++ b/pkg/render/logstorage/kibana/kibana_test.go
@@ -422,7 +422,7 @@ var _ = Describe("Kibana rendering tests", func() {
 				kibana, ok := rtest.GetResource(resources, "tigera-secure", "tigera-kibana", "kibana.k8s.elastic.co", "v1", "Kibana").(*kbv1.Kibana)
 				Expect(ok).To(BeTrue())
 				Expect(kibana.Spec.PodTemplate.Spec.Affinity).NotTo(BeNil())
-				Expect(kibana.Spec.PodTemplate.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-secure", "tigera-kibana")))
+				Expect(kibana.Spec.PodTemplate.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-secure", []string{"tigera-kibana"})))
 			})
 
 			It("should render the kibana pod template with resource requests and limits when set", func() {

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -469,7 +469,7 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 	}
 
 	if replicas != nil && *replicas > 1 {
-		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity(DeploymentName, l.namespace)
+		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity(DeploymentName, []string{l.namespace})
 	}
 
 	d := appsv1.Deployment{

--- a/pkg/render/logstorage/linseed/linseed_test.go
+++ b/pkg/render/logstorage/linseed/linseed_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Linseed rendering tests", func() {
 			deploy, ok := rtest.GetResource(resources, DeploymentName, render.ElasticsearchNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 			Expect(ok).To(BeTrue(), "Deployment not found")
 			Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
-			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, render.ElasticsearchNamespace)))
+			Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, []string{render.ElasticsearchNamespace})))
 		})
 
 		It("should apply controlPlaneNodeSelector correctly", func() {
@@ -612,7 +612,7 @@ var _ = Describe("Linseed rendering tests", func() {
 			resources, _ := component.Objects()
 			d := rtest.GetResource(resources, DeploymentName, cfg.Namespace, appsv1.GroupName, "v1", "Deployment").(*appsv1.Deployment)
 			Expect(d.Spec.Template.Spec.Affinity).NotTo(BeNil())
-			Expect(d.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, tenant.Namespace)))
+			Expect(d.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity(DeploymentName, []string{tenant.Namespace})))
 		})
 
 		It("should override resource request with the value from TenantSpec's linseedDeployment when available", func() {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -333,7 +333,7 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 	}
 
 	if c.cfg.Replicas != nil && *c.cfg.Replicas > 1 {
-		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity("tigera-manager", c.cfg.Namespace)
+		podTemplate.Spec.Affinity = podaffinity.NewPodAntiAffinity("tigera-manager", []string{c.cfg.Namespace})
 	}
 
 	d := &appsv1.Deployment{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -868,7 +868,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		deploy, ok := rtest.GetResource(resources, "tigera-manager", render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ok).To(BeTrue())
 		Expect(deploy.Spec.Template.Spec.Affinity).NotTo(BeNil())
-		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-manager", render.ManagerNamespace)))
+		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("tigera-manager", []string{render.ManagerNamespace})))
 	})
 
 	It("should override container's resource request with the value from Manager CR", func() {


### PR DESCRIPTION
## Description

Update apiserver anti-affinity to exclude new/legacy namespaces; clean up old pods to prevent hostNetwork port conflicts during upgrade


## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Not applicable
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
