### PR TITLE
[v1.39] [CORE-11648]: Added localASNumber field to the bgppeer crd

### DIFF
--- a/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_bgppeers.yaml
@@ -55,6 +55,9 @@ spec:
                   Note: that this field is deprecated. Users should use the NextHopMode field to control
                   the next hop attribute for a BGP peer.
                 type: boolean
+              localASNumber:
+                format: int32
+                type: integer
               localWorkloadSelector:
                 description: |-
                   Selector for the local workload that the node should peer with. When this is set, the peerSelector and peerIP fields must be empty,


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v1.39**: tigera/operator#4059
## Description

Added `localASNumber` field to the `bgppeer` crd 
Changes generated based on localASNumber calico PR
https://github.com/projectcalico/calico/pull/10600

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.