### PR TITLE
Add dashboard sidecar for Enterprise

### DIFF
--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -620,13 +620,19 @@ var _ = Describe("Manager controller tests", func() {
 						},
 					}
 					Expect(test.GetResource(c, &d)).To(BeNil())
-					Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
+					Expect(d.Spec.Template.Spec.Containers).To(HaveLen(4))
 					mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
 					Expect(mgr).ToNot(BeNil())
 					Expect(mgr.Image).To(Equal(
 						fmt.Sprintf("some.registry.org/%s:%s",
 							components.ComponentManager.Image,
 							components.ComponentManager.Version)))
+					dashboard := test.GetContainer(d.Spec.Template.Spec.Containers, render.DashboardAPIName)
+					Expect(dashboard).ToNot(BeNil())
+					Expect(dashboard.Image).To(Equal(
+						fmt.Sprintf("some.registry.org/%s:%s",
+							components.ComponentUIAPIs.Image,
+							components.ComponentUIAPIs.Version)))
 					uiAPIContainer := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-ui-apis")
 					Expect(uiAPIContainer).ToNot(BeNil())
 					Expect(uiAPIContainer.Image).To(Equal(
@@ -664,14 +670,20 @@ var _ = Describe("Manager controller tests", func() {
 						},
 					}
 					Expect(test.GetResource(c, &d)).To(BeNil())
-					Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
-					mgr := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-manager")
+					Expect(d.Spec.Template.Spec.Containers).To(HaveLen(4))
+					mgr := test.GetContainer(d.Spec.Template.Spec.Containers, render.ManagerName)
 					Expect(mgr).ToNot(BeNil())
 					Expect(mgr.Image).To(Equal(
 						fmt.Sprintf("some.registry.org/%s@%s",
 							components.ComponentManager.Image,
 							"sha256:managerhash")))
-					uiAPIContainer := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-ui-apis")
+					dashboard := test.GetContainer(d.Spec.Template.Spec.Containers, render.DashboardAPIName)
+					Expect(dashboard).ToNot(BeNil())
+					Expect(dashboard.Image).To(Equal(
+						fmt.Sprintf("some.registry.org/%s@%s",
+							components.ComponentUIAPIs.Image,
+							"sha256:uiapihash")))
+					uiAPIContainer := test.GetContainer(d.Spec.Template.Spec.Containers, render.UIAPIsName)
 					Expect(uiAPIContainer).ToNot(BeNil())
 					Expect(uiAPIContainer.Image).To(Equal(
 						fmt.Sprintf("some.registry.org/%s@%s",
@@ -1128,8 +1140,8 @@ var _ = Describe("Manager controller tests", func() {
 						},
 					}
 					Expect(test.GetResource(c, &d)).To(BeNil())
-					Expect(d.Spec.Template.Spec.Containers).To(HaveLen(3))
-					voltron := test.GetContainer(d.Spec.Template.Spec.Containers, "tigera-voltron")
+					Expect(d.Spec.Template.Spec.Containers).To(HaveLen(4))
+					voltron := test.GetContainer(d.Spec.Template.Spec.Containers, render.VoltronName)
 					Expect(voltron).NotTo(BeNil())
 					Expect(voltron.Env).To(ContainElement(corev1.EnvVar{Name: "VOLTRON_ENABLE_NONCLUSTER_HOST", Value: "true"}))
 				})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -89,10 +89,15 @@ const (
 
 // ManagementClusterConnection configuration constants
 const (
+	ManagerName              = "tigera-manager"
+	UIAPIsName               = "tigera-ui-apis"
 	VoltronName              = "tigera-voltron"
 	VoltronTunnelSecretName  = "tigera-management-cluster-connection"
 	defaultVoltronPort       = "9443"
 	defaultTunnelVoltronPort = "9449"
+	DashboardAPIPort         = "8444"
+	DashboardAPIHealthPort   = "8090"
+	DashboardAPIName         = "tigera-dashboard-api"
 )
 
 // Manager returns a component for rendering namespaced manager resources.
@@ -300,7 +305,7 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 
 	managerPodContainers := []corev1.Container{c.managerUIAPIsContainer(), c.voltronContainer()}
 	if c.cfg.Tenant == nil {
-		managerPodContainers = append(managerPodContainers, c.managerContainer())
+		managerPodContainers = append(managerPodContainers, c.dashboardContainer(), c.managerContainer())
 	}
 	annotations := c.tlsAnnotations
 	if c.cfg.VoltronRouteConfig != nil {
@@ -434,6 +439,7 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 		{Name: "CNX_PROMETHEUS_API_URL", Value: fmt.Sprintf("/api/v1/namespaces/%s/services/calico-node-prometheus:9090/proxy/api/v1", common.TigeraPrometheusNamespace)},
 		{Name: "CNX_COMPLIANCE_REPORTS_API_URL", Value: "/compliance/reports"},
 		{Name: "CNX_QUERY_API_URL", Value: "/api/v1/namespaces/calico-system/services/https:calico-api:8080/proxy"},
+		{Name: "DASHBOARD_API_URL", Value: "/dashboards"},
 		{Name: "CNX_ELASTICSEARCH_API_URL", Value: "/tigera-elasticsearch"},
 		{Name: "CNX_ELASTICSEARCH_KIBANA_URL", Value: fmt.Sprintf("/%s", KibanaBasePath)},
 		{Name: "CNX_ENABLE_ERROR_TRACKING", Value: "false"},
@@ -451,7 +457,7 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 // managerContainer returns the manager container.
 func (c *managerComponent) managerContainer() corev1.Container {
 	return corev1.Container{
-		Name:            "tigera-manager",
+		Name:            ManagerName,
 		Image:           c.managerImage,
 		ImagePullPolicy: ImagePullPolicy(),
 		Env:             c.managerEnvVars(),
@@ -600,6 +606,63 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 	}
 }
 
+// dashboardContainer returns the dashboard sidecar container that only gets created in Enterprise (where tenancy is
+// not enabled).
+func (c *managerComponent) dashboardContainer() corev1.Container {
+	var keyPath, certPath string
+	if c.cfg.InternalTLSKeyPair != nil {
+		keyPath, certPath = c.cfg.InternalTLSKeyPair.VolumeMountKeyFilePath(), c.cfg.InternalTLSKeyPair.VolumeMountCertificateFilePath()
+	}
+
+	env := []corev1.EnvVar{
+		{Name: "LISTEN_ADDR", Value: fmt.Sprintf("127.0.0.1:%s", DashboardAPIPort)},
+		{Name: "LOG_LEVEL", Value: "Info"},
+		{Name: "LINSEED_URL", Value: fmt.Sprintf("https://tigera-linseed.%s.svc.%s", ElasticsearchNamespace, c.cfg.ClusterDomain)},
+		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
+		{Name: "LINSEED_CLIENT_CERT", Value: certPath},
+		{Name: "MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: fmt.Sprintf("https://tigera-manager.%s.svc:%s", c.cfg.Namespace, defaultVoltronPort)},
+		{Name: "HEALTH_PORT", Value: DashboardAPIHealthPort},
+	}
+
+	mounts := append(
+		c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType()),
+		c.cfg.InternalTLSKeyPair.VolumeMount(c.SupportedOSType()),
+	)
+
+	return corev1.Container{
+		Name:            DashboardAPIName,
+		Image:           c.uiAPIsImage,
+		ImagePullPolicy: ImagePullPolicy(),
+		Command:         []string{"/usr/bin/dashboard-api"},
+		Env:             env,
+		VolumeMounts:    mounts,
+		SecurityContext: securitycontext.NewNonRootContext(),
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/usr/bin/dashboard-api", "-ready"},
+				},
+			},
+			FailureThreshold:    3,
+			PeriodSeconds:       30,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      5,
+			InitialDelaySeconds: 5,
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/usr/bin/dashboard-api", "-ready"},
+				},
+			},
+			FailureThreshold: 3,
+			PeriodSeconds:    30,
+			SuccessThreshold: 1,
+			TimeoutSeconds:   5,
+		},
+	}
+}
+
 // managerUIAPIsContainer returns the ES proxy container
 func (c *managerComponent) managerUIAPIsContainer() corev1.Container {
 	var keyPath, certPath string
@@ -654,7 +717,7 @@ func (c *managerComponent) managerUIAPIsContainer() corev1.Container {
 	}
 
 	return corev1.Container{
-		Name:            "tigera-ui-apis",
+		Name:            UIAPIsName,
 		Image:           c.uiAPIsImage,
 		ImagePullPolicy: ImagePullPolicy(),
 		LivenessProbe:   c.managerUIAPIsProbe(),
@@ -850,6 +913,12 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				},
 				Verbs: []string{"list"},
 			},
+			// Allow Enterprise Custom Dashboards to access managed clusters
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"managedclusters"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
@@ -908,17 +977,21 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				Verbs: []string{"get", "create"},
 			},
 			{
-				// Add access to Linseed APIs.
+				// Add access to Linseed APIs. Those multi-cluster variants are for Linseed to query across multiple
+				// clusters for Enterprise Custom Dashboards.
 				APIGroups: []string{"linseed.tigera.io"},
 				Resources: []string{
 					"flows",
 					"flowlogs",
+					"flowlogs-multi-cluster",
 					"bgplogs",
 					"auditlogs",
 					"dnsflows",
 					"dnslogs",
+					"dnslogs-multi-cluster",
 					"l7flows",
 					"l7logs",
+					"l7logs-multi-cluster",
 					"events",
 					"processes",
 				},


### PR DESCRIPTION
## Description

Added support for embedding a dashboard query API sidecar in the manager deployment when running the enterprise variant, wiring in a `TLSTerminatedRoute` and local forwarding to `8444`

Introduced a dedicated container configuration with required environment variables, readiness/liveness probes, and mounts for Linseed credentials and certificates

Broadened manager RBAC to include `managedclusters` access, and multi-cluster log permissions for Linseed APIs

Relaxed Voltron route builder to allow `TLSTerminatedRoute` entries without a CA bundle, enabling plain HTTP destinations

## Release Note
```release-note
The operator is now responsible for installing custom dashboard in the Enterprise environment.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
