### PR TITLE
deps(CVE-v3.20): Bump ES and KBN version to 7.17.29

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.20.5
   eck-kibana:
-    version: 7.17.28
+    version: 7.17.29
   kibana:
     image: tigera/kibana
     version: v3.20.5
   eck-elasticsearch:
-    version: 7.17.28
+    version: 7.17.29
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.20.5

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "7.17.28",
+		Version:  "7.17.29",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "7.17.28",
+		Version:  "7.17.29",
 		Registry: "",
 	}
 


### PR DESCRIPTION
## Description

Bump ES and KBN version to 7.17.29

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Bump ES and KBN version to 7.17.29
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
