### PR TITLE
[v1.38] Use a host alias for calico/node to access Goldmane

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -347,6 +347,9 @@ func secondaryResources() []client.Object {
 		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoCNIPluginObjectName}},
 		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.KubeControllerRole}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: common.CalicoNamespace}},
+
+		// We care about the Goldmane Service for providing host aliases to calico/node.
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: goldmane.GoldmaneServiceName, Namespace: common.CalicoNamespace}},
 	}
 }
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1238,13 +1238,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	components := []render.Component{}
 
-	namespaceCfg := &render.NamespaceConfiguration{
-		Installation: &instance.Spec,
-		PullSecrets:  pullSecrets,
-	}
-	// Render namespaces for Calico.
-	components = append(components, render.Namespaces(namespaceCfg))
-
 	if newActiveCM != nil && !installationMarkedForDeletion {
 		log.Info("adding active configmap")
 		components = append(components, render.NewPassthrough(newActiveCM))
@@ -1387,6 +1380,19 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
+	// Create a component handler to create or update the rendered components.
+	handler := r.newComponentHandler(log, r.client, r.scheme, instance)
+
+	// Render namespaces first - this ensures that any other controllers blocked on namespace existence can proceed.
+	namespaceCfg := &render.NamespaceConfiguration{
+		Installation: &instance.Spec,
+		PullSecrets:  pullSecrets,
+	}
+	if err := handler.CreateOrUpdateOrDelete(ctx, render.Namespaces(namespaceCfg), nil); err != nil {
+		r.status.SetDegraded(operator.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	// Fetch any existing default BGPConfiguration object.
 	bgpConfiguration := &crdv1.BGPConfiguration{}
 	err = r.client.Get(ctx, types.NamespacedName{Name: "default"}, bgpConfiguration)
@@ -1414,6 +1420,12 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			if !apierrors.IsNotFound(err) {
 				r.status.SetDegraded(operator.ResourceReadError, "Unable to read Goldmane Service", err, reqLogger)
 				return reconcile.Result{}, err
+			} else {
+				// Service not found - Goldmane is probably still starting. Wait for it to appear. This helps prevent us from rolling out calico/node twice
+				// during initial installation - once when we first Reconcile and again when we detect the Goldmane Service, which triggers
+				// us adding host aliases to the calico/node DaemonSet.
+				r.status.SetDegraded(operator.ResourceNotFound, "Goldmane enabled, waiting for Service to receive an IP", nil, reqLogger)
+				return reconcile.Result{}, nil
 			}
 		} else {
 			goldmaneIP = goldmaneService.Spec.ClusterIP
@@ -1512,8 +1524,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	// Create a component handler to create or update the rendered components.
-	handler := r.newComponentHandler(log, r.client, r.scheme, instance)
 	for _, component := range components {
 		if err := handler.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
 			r.status.SetDegraded(operator.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -67,6 +67,8 @@ const (
 	CalicoNodeObjectName          = "calico-node"
 	CalicoCNIPluginObjectName     = "calico-cni-plugin"
 	BPFVolumeName                 = "bpffs"
+
+	goldmaneDomainName = "goldmane.calico-system.svc"
 )
 
 var (
@@ -967,7 +969,7 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 	if c.cfg.GoldmaneIP != "" {
 		hostAliases = []corev1.HostAlias{
 			{
-				Hostnames: []string{"goldmane.calico-system.svc"},
+				Hostnames: []string{goldmaneDomainName},
 				IP:        c.cfg.GoldmaneIP,
 			},
 		}
@@ -1470,7 +1472,7 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		nodeEnv = append(nodeEnv,
 			corev1.EnvVar{
 				Name:  "FELIX_FLOWLOGSGOLDMANESERVER",
-				Value: "goldmane.calico-system.svc:7443",
+				Value: fmt.Sprintf("%s:7443", goldmaneDomainName),
 			},
 			corev1.EnvVar{
 				Name:  "FELIX_FLOWLOGSFLUSHINTERVAL",

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -101,6 +101,9 @@ type NodeConfiguration struct {
 	ClusterDomain   string
 	Nameservers     []string
 
+	// Goldmane IP, to avoid DNS resolution using kube-dns.
+	GoldmaneIP string
+
 	// Optional fields.
 	LogCollector            *operatorv1.LogCollector
 	MigrateNamespaces       bool
@@ -960,6 +963,16 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 		annotations[bgpBindModeHashAnnotation] = rmeta.AnnotationHash(c.cfg.BindMode)
 	}
 
+	var hostAliases []corev1.HostAlias
+	if c.cfg.GoldmaneIP != "" {
+		hostAliases = []corev1.HostAlias{
+			{
+				Hostnames: []string{"goldmane.calico-system.svc"},
+				IP:        c.cfg.GoldmaneIP,
+			},
+		}
+	}
+
 	// Determine the name to use for the calico/node daemonset. For mixed-mode, we run the enterprise DaemonSet
 	// with its own name so as to not conflict.
 	ds := appsv1.DaemonSet{
@@ -977,10 +990,11 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 					Tolerations:                   rmeta.TolerateAll,
 					Affinity:                      affinity,
 					ImagePullSecrets:              c.cfg.Installation.ImagePullSecrets,
+					HostAliases:                   hostAliases,
 					ServiceAccountName:            CalicoNodeObjectName,
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 					HostNetwork:                   true,
-					DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
+					DNSPolicy:                     corev1.DNSDefault,
 					InitContainers:                initContainers,
 					Containers:                    []corev1.Container{nodeContainer},
 					Volumes:                       c.nodeVolumes(),
@@ -1450,8 +1464,9 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		{Name: "NO_DEFAULT_POOLS", Value: "true"},
 	}
 
-	// Only append goldmane variables if goldmane is running.
-	if c.cfg.GoldmaneRunning {
+	// Only append goldmane variables if goldmane is running and we have a valid IP address,
+	// as we rely on an explicitly configured host alias to resolve the goldmane service.
+	if c.cfg.GoldmaneRunning && c.cfg.GoldmaneIP != "" {
 		nodeEnv = append(nodeEnv,
 			corev1.EnvVar{
 				Name:  "FELIX_FLOWLOGSGOLDMANESERVER",


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v1.38**: tigera/operator#4104
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Use a host alias for Felix to talk to Goldmane, avoiding the need for Felix to use in-cluster DNS for any purpose.

Relying on kube-dns from within Felix is awkward, as kube-dns relies on Pod networking provided by Calico. 

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Use a host alias for Felix to resolve goldmane service address, avoiding dependency on kube-dns. 
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.