### PR TITLE
Mount bpffs and cgroup fs for all dataplanes

### DIFF
--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -303,24 +303,6 @@ var _ = Describe("Node rendering tests", func() {
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_DEFAULT_SECURITY_GROUPS")})))
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_POD_SECURITY_GROUP")})))
 
-				expectedCNIEnv := []corev1.EnvVar{
-					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
-					{Name: "SLEEP", Value: "false"},
-					{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
-					{
-						Name: "CNI_NETWORK_CONFIG",
-						ValueFrom: &corev1.EnvVarSource{
-							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-								Key: "config",
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "cni-config",
-								},
-							},
-						},
-					},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env).To(ConsistOf(expectedCNIEnv))
-
 				// Verify volumes.
 				fileOrCreate := corev1.HostPathFileOrCreate
 				dirOrCreate := corev1.HostPathDirectoryOrCreate
@@ -374,12 +356,6 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
-
-				expectedCNIVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/host/opt/cni/bin", Name: "cni-bin-dir"},
-					{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 
 				// Verify tolerations.
 				Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(rmeta.TolerateAll))
@@ -475,9 +451,6 @@ var _ = Describe("Node rendering tests", func() {
 
 				rtest.ExpectEnv(ds.Spec.Template.Spec.Containers[0].Env, "NO_DEFAULT_POOLS", "true")
 
-				cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-				rtest.ExpectEnv(cniContainer.Env, "CNI_NET_DIR", "/etc/cni/net.d")
-
 				// Node image override results in correct image.
 				calicoNodeImage := fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
@@ -519,24 +492,6 @@ var _ = Describe("Node rendering tests", func() {
 				// Expect the SECURITY_GROUP env variables to not be set
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_DEFAULT_SECURITY_GROUPS")})))
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_POD_SECURITY_GROUP")})))
-
-				expectedCNIEnv := []corev1.EnvVar{
-					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
-					{Name: "SLEEP", Value: "false"},
-					{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
-					{
-						Name: "CNI_NETWORK_CONFIG",
-						ValueFrom: &corev1.EnvVarSource{
-							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-								Key: "config",
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "cni-config",
-								},
-							},
-						},
-					},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env).To(ConsistOf(expectedCNIEnv))
 
 				// Verify volumes.
 				fileOrCreate := corev1.HostPathFileOrCreate
@@ -591,12 +546,6 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
-
-				expectedCNIVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/host/opt/cni/bin", Name: "cni-bin-dir"},
-					{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 
 				// Verify tolerations.
 				Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(rmeta.TolerateAll))
@@ -977,12 +926,6 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
-
-				expectedCNIVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/host/opt/cni/bin", Name: "cni-bin-dir"},
-					{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 			})
 
 			It("should render all resources when using Calico CNI on EKS", func() {
@@ -1069,9 +1012,6 @@ var _ = Describe("Node rendering tests", func() {
 
 				rtest.ExpectEnv(ds.Spec.Template.Spec.Containers[0].Env, "NO_DEFAULT_POOLS", "true")
 
-				cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-				rtest.ExpectEnv(cniContainer.Env, "CNI_NET_DIR", "/etc/cni/net.d")
-
 				// Node image override results in correct image.
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)))
 
@@ -1112,24 +1052,6 @@ var _ = Describe("Node rendering tests", func() {
 				// Expect the SECURITY_GROUP env variables to not be set
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_DEFAULT_SECURITY_GROUPS")})))
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_POD_SECURITY_GROUP")})))
-
-				expectedCNIEnv := []corev1.EnvVar{
-					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
-					{Name: "SLEEP", Value: "false"},
-					{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
-					{
-						Name: "CNI_NETWORK_CONFIG",
-						ValueFrom: &corev1.EnvVarSource{
-							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-								Key: "config",
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "cni-config",
-								},
-							},
-						},
-					},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env).To(ConsistOf(expectedCNIEnv))
 
 				// Verify volumes.
 				fileOrCreate := corev1.HostPathFileOrCreate
@@ -1185,12 +1107,6 @@ var _ = Describe("Node rendering tests", func() {
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
-				expectedCNIVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/host/opt/cni/bin", Name: "cni-bin-dir"},
-					{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
-
 				// Verify tolerations.
 				Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(rmeta.TolerateAll))
 
@@ -1230,10 +1146,6 @@ var _ = Describe("Node rendering tests", func() {
 
 				// The pod template should have node critical priority
 				Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal(render.NodePriorityClassName))
-
-				// CNI install container should not be present.
-				//	cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-				//	Expect(cniContainer).To(BeNil())
 
 				verifyInitContainers(ds, amazonVPCInstalllation)
 				// Verify env
@@ -1506,9 +1418,6 @@ var _ = Describe("Node rendering tests", func() {
 
 				rtest.ExpectEnv(ds.Spec.Template.Spec.Containers[0].Env, "NO_DEFAULT_POOLS", "true")
 
-				cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-				rtest.ExpectEnv(cniContainer.Env, "CNI_NET_DIR", "/etc/cni/net.d")
-
 				// Node image override results in correct image.
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)))
 
@@ -1549,25 +1458,6 @@ var _ = Describe("Node rendering tests", func() {
 				// Expect the SECURITY_GROUP env variables to not be set
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_DEFAULT_SECURITY_GROUPS")})))
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).NotTo(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{"Name": Equal("TIGERA_POD_SECURITY_GROUP")})))
-
-				expectedCNIEnv := []corev1.EnvVar{
-					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
-					{Name: "SLEEP", Value: "false"},
-					{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
-					{
-						Name: "CNI_NETWORK_CONFIG",
-						ValueFrom: &corev1.EnvVarSource{
-							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-								Key: "config",
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "cni-config",
-								},
-							},
-						},
-					},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env).To(ConsistOf(expectedCNIEnv))
-
 				// Verify volumes.
 				fileOrCreate := corev1.HostPathFileOrCreate
 				dirOrCreate := corev1.HostPathDirectoryOrCreate
@@ -1621,12 +1511,6 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
-
-				expectedCNIVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/host/opt/cni/bin", Name: "cni-bin-dir"},
-					{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 
 				// Verify tolerations.
 				Expect(ds.Spec.Template.Spec.Tolerations).To(ConsistOf(rmeta.TolerateAll))
@@ -3068,9 +2952,6 @@ var _ = Describe("Node rendering tests", func() {
 
 				rtest.ExpectEnv(ds.Spec.Template.Spec.Containers[0].Env, "NO_DEFAULT_POOLS", "true")
 
-				cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-				rtest.ExpectEnv(cniContainer.Env, "CNI_NET_DIR", "/etc/cni/net.d")
-
 				// Node image override results in correct image.
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)))
 
@@ -3109,25 +2990,6 @@ var _ = Describe("Node rendering tests", func() {
 				}
 				expectedNodeEnv = configureExpectedNodeEnvIPVersions(expectedNodeEnv, defaultInstance, enableIPv4, enableIPv6)
 				Expect(ds.Spec.Template.Spec.Containers[0].Env).To(ConsistOf(expectedNodeEnv))
-
-				/*
-					expectedCNIEnv := []corev1.EnvVar{
-						{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
-						{Name: "SLEEP", Value: "false"},
-						{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
-						{
-							Name: "CNI_NETWORK_CONFIG",
-							ValueFrom: &corev1.EnvVarSource{
-								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-									Key: "config",
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "cni-config",
-									},
-								},
-							},
-						},
-					}
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env).To(ConsistOf(expectedCNIEnv))*/
 
 				// Verify readiness and liveness probes.
 				verifyProbesAndLifecycle(ds, false, false)

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -265,53 +265,7 @@ var _ = Describe("Node rendering tests", func() {
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					}))
 
-				validateInitContainers(ds, defaultInstance)
-				/*
-					// Validate correct number of init containers.
-					Expect(ds.Spec.Template.Spec.InitContainers).To(HaveLen(3))
-
-					// CNI container uses image override.
-					cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-					rtest.ExpectEnv(cniContainer.Env, "CNI_NET_DIR", "/etc/cni/net.d")
-					Expect(cniContainer.Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
-
-					ebpfBootstrap := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
-					Expect(ebpfBootstrap.Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)))
-
-					Expect(*cniContainer.SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
-					Expect(*cniContainer.SecurityContext.Privileged).To(BeTrue())
-					Expect(*cniContainer.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-					Expect(*cniContainer.SecurityContext.RunAsNonRoot).To(BeFalse())
-					Expect(*cniContainer.SecurityContext.RunAsUser).To(BeEquivalentTo(0))
-					Expect(cniContainer.SecurityContext.Capabilities).To(Equal(
-						&corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-					))
-					Expect(cniContainer.SecurityContext.SeccompProfile).To(Equal(
-						&corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						}))
-
-					// Verify the Flex volume container image.
-					flexvolContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver")
-					Expect(flexvolContainer.Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))
-
-					Expect(*flexvolContainer.SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
-					Expect(*flexvolContainer.SecurityContext.Privileged).To(BeTrue())
-					Expect(*flexvolContainer.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-					Expect(*flexvolContainer.SecurityContext.RunAsNonRoot).To(BeFalse())
-					Expect(*flexvolContainer.SecurityContext.RunAsUser).To(BeEquivalentTo(0))
-					Expect(flexvolContainer.SecurityContext.Capabilities).To(Equal(
-						&corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-					))
-					Expect(flexvolContainer.SecurityContext.SeccompProfile).To(Equal(
-						&corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						}))*/
-
+				verifyInitContainers(ds, defaultInstance)
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -528,37 +482,7 @@ var _ = Describe("Node rendering tests", func() {
 				calicoNodeImage := fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
 
-				validateInitContainers(ds, defaultInstance)
-				/*
-					// Validate correct number of init containers.
-					Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(3))
-
-					// CNI container uses image override.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
-
-					// Verify the Flex volume container image.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))
-
-					// Verify the ebpf-bootstrap image and command.
-					mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
-					Expect(mountBpffs.Image).To(Equal(calicoNodeImage))
-					Expect(mountBpffs.Command).To(Equal([]string{"calico-node", "-init"}))
-
-					Expect(*mountBpffs.SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
-					Expect(*mountBpffs.SecurityContext.Privileged).To(BeTrue())
-					Expect(*mountBpffs.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-					Expect(*mountBpffs.SecurityContext.RunAsNonRoot).To(BeFalse())
-					Expect(*mountBpffs.SecurityContext.RunAsUser).To(BeEquivalentTo(0))
-					Expect(mountBpffs.SecurityContext.Capabilities).To(Equal(
-						&corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
-					))
-					Expect(mountBpffs.SecurityContext.SeccompProfile).To(Equal(
-						&corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						}))*/
-
+				verifyInitContainers(ds, defaultInstance)
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -997,21 +921,7 @@ var _ = Describe("Node rendering tests", func() {
 				calicoNodeImage := fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
 
-				validateInitContainers(ds, defaultInstance)
-				/*
-					// Validate correct number of init containers.
-					Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(4))
-
-					// CNI container uses image override.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
-
-					// Verify the Flex volume container image.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))
-
-					// Verify the ebpf-bootstrap image and command.
-					mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
-					Expect(mountBpffs).NotTo(BeNil())*/
-
+				verifyInitContainers(ds, defaultInstance)
 				// Verify volumes.
 				fileOrCreate := corev1.HostPathFileOrCreate
 				dirOrCreate := corev1.HostPathDirectoryOrCreate
@@ -1165,17 +1075,7 @@ var _ = Describe("Node rendering tests", func() {
 				// Node image override results in correct image.
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)))
 
-				validateInitContainers(ds, defaultInstance)
-				/*
-					// Validate correct number of init containers.
-					Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(3))
-
-					// CNI container uses image override.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
-
-					// Verify the Flex volume container image.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))*/
-
+				verifyInitContainers(ds, defaultInstance)
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -1335,14 +1235,7 @@ var _ = Describe("Node rendering tests", func() {
 				//	cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
 				//	Expect(cniContainer).To(BeNil())
 
-				validateInitContainers(ds, amazonVPCInstalllation)
-				/*
-					// Validate correct number of init containers.
-					Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(1))
-
-					// Verify the Flex volume container image.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))*/
-
+				verifyInitContainers(ds, amazonVPCInstalllation)
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -1501,14 +1394,7 @@ var _ = Describe("Node rendering tests", func() {
 					// The pod template should have node critical priority
 					Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal(render.NodePriorityClassName))
 
-					validateInitContainers(ds, installation)
-					/*
-						// CNI install container should not be present.
-						cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-						Expect(cniContainer).To(BeNil())
-						// Validate correct number of init containers.
-						Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(1))*/
-
+					verifyInitContainers(ds, installation)
 					// Verify env
 					expectedEnvs = append(expectedEnvs,
 						corev1.EnvVar{Name: "CALICO_NETWORKING_BACKEND", Value: "none"},
@@ -1626,17 +1512,7 @@ var _ = Describe("Node rendering tests", func() {
 				// Node image override results in correct image.
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)))
 
-				validateInitContainers(ds, defaultInstance)
-				/*
-					// Validate correct number of init containers.
-					Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(2))
-
-					// CNI container uses image override.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
-
-					// Verify the Flex volume container image.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))*/
-
+				verifyInitContainers(ds, defaultInstance)
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -1789,17 +1665,7 @@ var _ = Describe("Node rendering tests", func() {
 				// The pod template should have node critical priority
 				Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal(render.NodePriorityClassName))
 
-				validateInitContainers(ds, cfg.Installation)
-				// CNI install container should not be present.
-				//cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-				//Expect(cniContainer).To(BeNil())
-
-				// Validate correct number of init containers.
-				//Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(1))
-
-				// Verify the Flex volume container image.
-				//Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))
-
+				verifyInitContainers(ds, cfg.Installation)
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -1952,9 +1818,7 @@ var _ = Describe("Node rendering tests", func() {
 				// The pod template should have node critical priority
 				Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal(render.NodePriorityClassName))
 
-				validateInitContainers(ds, defaultInstance)
-				//rtest.ExpectEnv(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env, "CNI_NET_DIR", "/var/run/multus/cni/net.d")
-
+				verifyInitContainers(ds, defaultInstance)
 				// Verify volumes. In particular, we want to make sure the flexvol-driver-host volume uses the right
 				// host path for flexvolume drivers.
 				fileOrCreate := corev1.HostPathFileOrCreate
@@ -2663,40 +2527,9 @@ var _ = Describe("Node rendering tests", func() {
 				// The pod template should have node critical priority
 				Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal(render.NodePriorityClassName))
 
-				validateInitContainers(ds, defaultInstance)
-				//cniContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni")
-				//rtest.ExpectEnv(cniContainer.Env, "CNI_NET_DIR", "/etc/cni/net.d")
-
-				// Validate correct number of init containers.
-				//Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(2))
-
-				/*
-					expectedCNIEnv := []corev1.EnvVar{
-						{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
-						{Name: "SLEEP", Value: "false"},
-						{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
-						{
-							Name: "CNI_NETWORK_CONFIG",
-							ValueFrom: &corev1.EnvVarSource{
-								ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-									Key: "config",
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "cni-config",
-									},
-								},
-							},
-						},
-					}
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Env).To(ConsistOf(expectedCNIEnv))*/
-
+				verifyInitContainers(ds, defaultInstance)
 				Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(
 					corev1.Volume{Name: "cni-net-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/etc/cni/net.d"}}}))
-
-				/*				expectedCNIVolumeMounts := []corev1.VolumeMount{
-									{MountPath: "/host/opt/cni/bin", Name: "cni-bin-dir"},
-									{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-								}
-								Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))*/
 			})
 
 			It("should render cni config with sysctl parameters", func() {
@@ -3241,17 +3074,7 @@ var _ = Describe("Node rendering tests", func() {
 				// Node image override results in correct image.
 				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)))
 
-				validateInitContainers(ds, defaultInstance)
-				/*
-					// Validate correct number of init containers.
-					Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(2))
-
-					// CNI container uses image override.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
-
-					// Verify the Flex volume container image.
-					Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("quay.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))*/
-
+				verifyInitContainers(ds, defaultInstance)
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
@@ -3446,13 +3269,7 @@ var _ = Describe("Node rendering tests", func() {
 				Expect(dep).ToNot(BeNil())
 				deploy, ok := dep.(*appsv1.DaemonSet)
 				Expect(ok).To(BeTrue())
-				validateInitContainers(deploy, cfg.Installation)
-				/*
-					Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(3))
-					Expect(deploy.Spec.Template.Spec.InitContainers[0].Name).To(Equal(fmt.Sprintf("%s-key-cert-provisioner", render.NodeTLSSecretName)))
-					Expect(deploy.Spec.Template.Spec.InitContainers[1].Name).To(Equal("flexvol-driver"))
-					Expect(deploy.Spec.Template.Spec.InitContainers[2].Name).To(Equal("install-cni"))
-					rtest.ExpectEnv(deploy.Spec.Template.Spec.InitContainers[0].Env, "SIGNER", "a.b/c")*/
+				verifyInitContainers(deploy, cfg.Installation)
 			})
 
 			It("should handle BGP layout", func() {
@@ -3507,10 +3324,7 @@ var _ = Describe("Node rendering tests", func() {
 
 				Expect(nodeDS.Spec.Template.Spec.Containers[0].Name).To(Equal("calico-node"))
 				Expect(nodeDS.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
-				validateInitContainers(nodeDS, cfg.Installation)
-				/*
-					Expect(nodeDS.Spec.Template.Spec.InitContainers[1].Name).To(Equal("install-cni"))
-					Expect(nodeDS.Spec.Template.Spec.InitContainers[1].Image).To(ContainSubstring("-fips"))*/
+				verifyInitContainers(nodeDS, cfg.Installation)
 			})
 
 			Context("With calico-node DaemonSet overrides", func() {
@@ -3768,7 +3582,7 @@ func configureExpectedNodeEnvIPVersions(expectedNodeEnv []corev1.EnvVar, default
 	return expectedNodeEnv
 }
 
-func validateInitContainers(ds *appsv1.DaemonSet, instance *operatorv1.InstallationSpec) {
+func verifyInitContainers(ds *appsv1.DaemonSet, instance *operatorv1.InstallationSpec) {
 	// Validate correct number of init containers.
 	numInitContainers := 3
 	isCalicoCNI := instance.CNI != nil && instance.CNI.Type == operatorv1.PluginCalico
@@ -3781,12 +3595,6 @@ func validateInitContainers(ds *appsv1.DaemonSet, instance *operatorv1.Installat
 	if instance.NonPrivileged != nil && *instance.NonPrivileged == nonPrivilegedEnabled {
 		numInitContainers++
 	}
-	/*
-		if instance.KubernetesProvider == operatorv1.ProviderEKS {
-			if instance.CNI != nil && instance.CNI.Type == operatorv1.PluginAmazonVPC {
-				numInitContainers = 2
-			}
-		}*/
 	if instance.CertificateManagement != nil {
 		numInitContainers++
 	}


### PR DESCRIPTION
## Description

This PR has the below changes
1. Render the calico-node daemonset with ebpf-bootstrap container for all dataplanes, as we need to mount the host's bpffs and cgroup, so that when we switch dataplane from eBPF, felix can cleanup the bpf state. This is done with the best effort flag, so that calico installs fine in platforms like Kind and K3s.
2. Restructuring the node render test

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Mount host's bpffs and cgroup in calico-node ds for all dataplanes.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
