### PR TITLE
[CORE-11756] Push `felixConfig.CgroupV2Path` to `ebpf-bootstrap` init container

### DIFF
--- a/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
+++ b/pkg/apis/crd.projectcalico.org/v1/felixconfig.go
@@ -223,6 +223,9 @@ type FelixConfigurationSpec struct {
 	HealthHost    *string `json:"healthHost,omitempty"`
 	HealthPort    *int    `json:"healthPort,omitempty"`
 
+	// CgroupV2Path overrides the default location where to find the cgroup hierarchy.
+	CgroupV2Path string `json:"cgroupV2Path,omitempty"`
+
 	// PrometheusMetricsEnabled enables the Prometheus metrics server in Felix if set to true. [Default: false]
 	PrometheusMetricsEnabled *bool `json:"prometheusMetricsEnabled,omitempty"`
 	// PrometheusMetricsHost is the host that the Prometheus metrics server should bind to. [Default: empty]

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1479,6 +1479,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		CanRemoveCNIFinalizer:         canRemoveCNI,
 		PrometheusServerTLS:           nodePrometheusTLS,
 		FelixHealthPort:               *felixConfiguration.Spec.HealthPort,
+		NodeCgroupV2Path:              felixConfiguration.Spec.CgroupV2Path,
 		BindMode:                      bgpConfiguration.Spec.BindMode,
 		FelixPrometheusMetricsEnabled: utils.IsFelixPrometheusMetricsEnabled(felixConfiguration),
 		FelixPrometheusMetricsPort:    felixPrometheusMetricsPort,

--- a/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/crds/calico/crd.projectcalico.org_felixconfigurations.yaml
@@ -428,6 +428,11 @@ spec:
                     - Disabled
                     - L2Only
                   type: string
+                cgroupV2Path:
+                  description:
+                    CgroupV2Path overrides the default location where to
+                    find the cgroup hierarchy.
+                  type: string
                 chainInsertMode:
                   description: |-
                     ChainInsertMode controls whether Felix hooks the kernel's top-level iptables chains by inserting a rule

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -138,6 +138,9 @@ type NodeConfiguration struct {
 	// and sets this.
 	FelixHealthPort int
 
+	// Node's CgroupV2Path override. The controller reads FelixConfiguration and sets this.
+	NodeCgroupV2Path string
+
 	// The bindMode read from the default BGPConfiguration. Used to trigger rolling updates
 	// should this value change.
 	BindMode string
@@ -1261,6 +1264,10 @@ func (c *nodeComponent) bpffsEnvvars() []corev1.EnvVar {
 	env = JoinServiceEndpoints(c.cfg.K8sEndpointSlice)
 	if env != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: "KUBERNETES_APISERVER_ENDPOINTS", Value: env})
+	}
+
+	if c.cfg.NodeCgroupV2Path != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: "CALICO_CGROUP_PATH", Value: c.cfg.NodeCgroupV2Path})
 	}
 
 	return envVars


### PR DESCRIPTION
## Description

- This pull request updates the node render to push `felixConfig.CgroupV2Path` to `ebpf-bootstrap` init container as an env var.
- This enhancement directly addresses [Issue #7892](https://github.com/projectcalico/calico/issues/7892), where Calico's eBPF dataplane fails to initialize on Talos Linux due to the default cgroupV2 mount location (`/run/calico/cgroup`) being non-writable.

**Related PRs**
 - This PR replaces #3235  
 - Calico OSS PR: [#11756](https://github.com/projectcalico/calico/pull/10877)

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
The operator now pushes the value of `felixConfig.CgroupV2Path` to the `ebpf-bootstrap` init container, improving compatibility with immutable OSes like Talos Linux.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
