### PR TITLE
Allow tigera-manager cluster role to get serviceaccounts

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -881,8 +881,17 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				Verbs: []string{"list"},
 			},
 			{
+				// Get:  required by Voltron to validate non-cluster host service accounts
+				//       when handling proxied requests for the Kubernetes API server.
+				// List: required by Voltron when performing impersonation for components
+				//       such as Compliance.
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
+				Resources: []string{"serviceaccounts"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "nodes", "events", "services", "pods"},
 				Verbs:     []string{"list"},
 			},
 			{

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -356,7 +356,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
+				Resources: []string{"serviceaccounts"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "nodes", "events", "services", "pods"},
 				Verbs:     []string{"list"},
 			},
 			{
@@ -656,7 +661,12 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"serviceaccounts", "namespaces", "nodes", "events", "services", "pods"},
+				Resources: []string{"serviceaccounts"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "nodes", "events", "services", "pods"},
 				Verbs:     []string{"list"},
 			},
 			{


### PR DESCRIPTION
## Description

This change updates the `tigera-manager-role` cluster role to `get` serviceaccounts in addition to `list`. This is needed for non-cluster host agents to get a single service account.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
