### PR TITLE
[CORE-11751] Enable BPF dataplane auto-install by default for kube-proxy clusters

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -220,8 +220,8 @@ type InstallationSpec struct {
 type BPFNetworkBootstrapType string
 
 const (
-	BPFNetworkAutoEnabled  BPFNetworkBootstrapType = "Enabled"
-	BPFNetworkAutoDisabled BPFNetworkBootstrapType = "Disabled"
+	BPFNetworkBootstrapEnabled  BPFNetworkBootstrapType = "Enabled"
+	BPFNetworkBootstrapDisabled BPFNetworkBootstrapType = "Disabled"
 )
 
 // KubeProxyManagementType specifies whether kube-proxy management is enabled.
@@ -1000,7 +1000,7 @@ func (installation *InstallationSpec) BPFNetworkBootstrapEnabled() bool {
 	return installation != nil &&
 		installation.CalicoNetwork != nil &&
 		installation.CalicoNetwork.BPFNetworkBootstrap != nil &&
-		*installation.CalicoNetwork.BPFNetworkBootstrap == BPFNetworkAutoEnabled
+		*installation.CalicoNetwork.BPFNetworkBootstrap == BPFNetworkBootstrapEnabled
 }
 
 func (installation *InstallationSpec) KubeProxyManagementEnabled() bool {

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -82,7 +82,7 @@ type InstallationSpec struct {
 	// If the specified value is not empty, the Operator will still attempt auto-detection, but
 	// will additionally compare the auto-detected value to the specified value to confirm they match.
 	// +optional
-	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;RKE2;TKG;
+	// +kubebuilder:validation:Enum="";EKS;GKE;AKS;OpenShift;DockerEnterprise;RKE2;TKG;Kind;
 	KubernetesProvider Provider `json:"kubernetesProvider,omitempty"`
 
 	// CNI specifies the CNI that will be used by this installation.
@@ -386,7 +386,7 @@ type ComponentResource struct {
 }
 
 // Provider represents a particular provider or flavor of Kubernetes. Valid options
-// are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
+// are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG, Kind.
 type Provider string
 
 var (
@@ -398,6 +398,7 @@ var (
 	ProviderOpenShift Provider = "OpenShift"
 	ProviderDockerEE  Provider = "DockerEnterprise"
 	ProviderTKG       Provider = "TKG"
+	ProviderKind      Provider = "Kind"
 )
 
 func (p Provider) IsNone() bool {
@@ -430,6 +431,10 @@ func (p Provider) IsRKE2() bool {
 
 func (p Provider) IsTKG() bool {
 	return p == ProviderTKG
+}
+
+func (p Provider) IsKind() bool {
+	return p == ProviderKind
 }
 
 // ProductVariant represents the variant of the product.

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -404,7 +404,7 @@ func autoDetectDefaultBPF(ctx context.Context, client client.Client, instance *o
 		return false
 	}
 
-	// linuxDataplane, bpfNetworkingBootstrap, and kubeProxyManagement shouldn't be set, or should be set to their default values.
+	// linuxDataplane, bpfNetworkingBootstrap, and kubeProxyManagement should either be unset or set to their auto-detected target values.
 	calicoNetwork := instance.Spec.CalicoNetwork
 	if calicoNetwork != nil &&
 		((calicoNetwork.LinuxDataplane != nil && *calicoNetwork.LinuxDataplane != operator.LinuxDataplaneBPF) ||

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -419,15 +419,18 @@ func autoDetectDefaultBPF(ctx context.Context, client client.Client, instance *o
 		return false
 	}
 
+	// At the time of this implementation, we don't support BPF on KinD clusters.
+	if isKind, err := utils.IsKindCluster(ctx, client); err != nil || isKind {
+		return false
+	}
+
 	// Check if the cluster has the required resources.
-	_, err := utils.CheckBPFClusterResourcesReq(ctx, client)
-	if err != nil {
+	if _, err := utils.CheckBPFClusterResourcesReq(ctx, client); err != nil {
 		return false
 	}
 
 	// Check if it can retrieve kube-proxy DaemonSet and validate it's not managed.
-	_, err = utils.GetManageableKubeProxy(ctx, client)
-	if err != nil {
+	if _, err := utils.GetManageableKubeProxy(ctx, client); err != nil {
 		return false
 	}
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -396,6 +396,45 @@ func getActivePools(ctx context.Context, client client.Client) (*crdv1.IPPoolLis
 	return &filtered, nil
 }
 
+// autoDetectDefaultBPF checks whether the Operator can default to the BPF dataplane and install it automatically without user intervention.
+func autoDetectDefaultBPF(ctx context.Context, client client.Client, instance *operator.Installation) bool {
+	// Check if it's a new installation. `instance.Status.Computed` is set at the end of a successful reconcile. Thus, if it's
+	// nil, it's likely a new installation.
+	if instance == nil || instance.Status.Computed != nil {
+		return false
+	}
+
+	// linuxDataplane, bpfNetworkingBootstrap, and kubeProxyManagement shouldn't be set, or should be set to their default values.
+	calicoNetwork := instance.Spec.CalicoNetwork
+	if calicoNetwork != nil &&
+		((calicoNetwork.LinuxDataplane != nil && *calicoNetwork.LinuxDataplane != operator.LinuxDataplaneBPF) ||
+			(calicoNetwork.BPFNetworkBootstrap != nil && *calicoNetwork.BPFNetworkBootstrap != operator.BPFNetworkBootstrapEnabled) ||
+			(calicoNetwork.KubeProxyManagement != nil && *calicoNetwork.KubeProxyManagement != operator.KubeProxyManagementEnabled)) {
+		return false
+	}
+
+	// At the time of this implementation, we're avoiding managed platforms (EKS, GKE, AKS, OpenShift) as they often come with complex networking
+	// setups, automation layers, or restrictions that could lead to unintended behavior when applying BPF configurations automatically.
+	if !instance.Spec.KubernetesProvider.IsNone() {
+		return false
+	}
+
+	// Check if the cluster has the required resources.
+	_, err := utils.CheckBPFClusterResourcesReq(ctx, client)
+	if err != nil {
+		return false
+	}
+
+	// Check if it can retrieve kube-proxy DaemonSet and validate it's not managed.
+	_, err = utils.GetManageableKubeProxy(ctx, client)
+	if err != nil {
+		return false
+	}
+
+	log.V(1).Info("Defaulting dataplane to BPF, since the cluster meets the requirements.")
+	return true
+}
+
 // updateInstallationWithDefaults returns the default installation instance with defaults populated.
 func updateInstallationWithDefaults(ctx context.Context, client client.Client, instance *operator.Installation, provider operator.Provider) error {
 	// Determine the provider in use by combining any auto-detected value with any value
@@ -420,7 +459,14 @@ func updateInstallationWithDefaults(ctx context.Context, client client.Client, i
 		return fmt.Errorf("unable to list IPPools: %s", err.Error())
 	}
 
-	err = MergeAndFillDefaults(instance, awsNode, currentPools)
+	defaultBpfDataplane := autoDetectDefaultBPF(ctx, client, instance)
+
+	params := &fillDefaultsParams{
+		currentPools:        currentPools,
+		defaultBpfDataplane: &defaultBpfDataplane,
+	}
+
+	err = MergeAndFillDefaults(instance, awsNode, params)
 	if err != nil {
 		return err
 	}
@@ -429,18 +475,23 @@ func updateInstallationWithDefaults(ctx context.Context, client client.Client, i
 
 // MergeAndFillDefaults merges in configuration from the Kubernetes provider, if applicable, and then
 // populates defaults in the Installation instance.
-func MergeAndFillDefaults(i *operator.Installation, awsNode *appsv1.DaemonSet, currentPools *crdv1.IPPoolList) error {
+func MergeAndFillDefaults(i *operator.Installation, awsNode *appsv1.DaemonSet, params *fillDefaultsParams) error {
 	if awsNode != nil {
 		if err := updateInstallationForAWSNode(i, awsNode); err != nil {
 			return fmt.Errorf("could not resolve AWS node configuration: %s", err.Error())
 		}
 	}
 
-	return fillDefaults(i, currentPools)
+	return fillDefaults(i, params)
+}
+
+type fillDefaultsParams struct {
+	currentPools        *crdv1.IPPoolList
+	defaultBpfDataplane *bool
 }
 
 // fillDefaults populates the default values onto an Installation object.
-func fillDefaults(instance *operator.Installation, currentPools *crdv1.IPPoolList) error {
+func fillDefaults(instance *operator.Installation, params *fillDefaultsParams) error {
 	if len(instance.Spec.Variant) == 0 {
 		// Default to installing Calico.
 		instance.Spec.Variant = operator.Calico
@@ -522,6 +573,17 @@ func fillDefaults(instance *operator.Installation, currentPools *crdv1.IPPoolLis
 		instance.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{}
 	}
 
+	// defaultBpfDataplane == true indicates that this is a new installation, and that automatic BPF installation can be set by default.
+	if params != nil && params.defaultBpfDataplane != nil && *params.defaultBpfDataplane {
+		// Set defaults for auto-installing BPF dataplane.
+		dpBPF := operator.LinuxDataplaneBPF
+		instance.Spec.CalicoNetwork.LinuxDataplane = &dpBPF
+		bpfNetworkEnabled := operator.BPFNetworkBootstrapEnabled
+		instance.Spec.CalicoNetwork.BPFNetworkBootstrap = &bpfNetworkEnabled
+		kpEnabled := operator.KubeProxyManagementEnabled
+		instance.Spec.CalicoNetwork.KubeProxyManagement = &kpEnabled
+	}
+
 	// Default dataplane is iptables.
 	if instance.Spec.CalicoNetwork.LinuxDataplane == nil {
 		dpIptables := operator.LinuxDataplaneIptables
@@ -579,8 +641,8 @@ func fillDefaults(instance *operator.Installation, currentPools *crdv1.IPPoolLis
 		// BPF dataplane requires IP autodetection even if we're not using Calico IPAM.
 		needIPv4Autodetection = true
 	}
-	if currentPools != nil {
-		for _, pool := range currentPools.Items {
+	if params != nil && params.currentPools != nil {
+		for _, pool := range params.currentPools.Items {
 			ip, _, err := net.ParseCIDR(pool.Spec.CIDR)
 			if err != nil {
 				return fmt.Errorf("failed to parse CIDR %s: %s", pool.Spec.CIDR, err)
@@ -1484,7 +1546,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		FelixPrometheusMetricsPort:    felixPrometheusMetricsPort,
 	}
 	// Check if BPFNetworkBootstrap is Enabled and its requirements are met.
-	bpfBootstrapReq, err := utils.BPFBootstrapRequirements(r.client, ctx, &instance.Spec)
+	bpfBootstrapReq, err := utils.BPFBootstrapRequirements(ctx, r.client, &instance.Spec)
 	if err != nil {
 		r.status.SetDegraded(operator.ResourceValidationError, "bpfNetworkBootstrap is Enabled but the requirements are not met", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -572,7 +572,7 @@ var _ = Describe("Testing core-controller installation", func() {
 					VXLANMode:    crdv1.VXLANModeAlways,
 				},
 			})
-			Expect(MergeAndFillDefaults(installation, nil, &fillDefaultsParams{currentPools: &currentPools})).To(BeNil())
+			Expect(fillDefaults(installation, &currentPools)).To(BeNil())
 			Expect(installation.Spec.CalicoNetwork.NodeAddressAutodetectionV4.SkipInterface).Should(Equal("^br-.*"))
 			Expect(installation.Spec.CalicoNetwork.NodeAddressAutodetectionV6).Should(BeNil())
 		})
@@ -585,7 +585,7 @@ var _ = Describe("Testing core-controller installation", func() {
 					KubernetesProvider: provider,
 				},
 			}
-			Expect(MergeAndFillDefaults(installation, nil, nil)).To(BeNil())
+			Expect(fillDefaults(installation, nil)).To(BeNil())
 			if expected {
 				Expect(installation.Spec.TyphaAffinity).ToNot(BeNil())
 				Expect(installation.Spec.TyphaAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).Should(Equal(result))

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -26,6 +26,7 @@ import (
 	operator "github.com/tigera/operator/api/v1"
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/ptr"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -45,7 +46,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		}
 
 		instance := &operator.Installation{}
-		err := fillDefaults(instance, &currentPools)
+		err := fillDefaults(instance, &fillDefaultsParams{currentPools: &currentPools})
 		Expect(err).NotTo(HaveOccurred())
 
 		// The resulting resource should pass validation.
@@ -86,7 +87,7 @@ var _ = Describe("Defaulting logic tests", func() {
 
 		instance := &operator.Installation{}
 		instance.Spec.Variant = operator.TigeraSecureEnterprise
-		err := fillDefaults(instance, &currentPools)
+		err := fillDefaults(instance, &fillDefaultsParams{currentPools: &currentPools})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
@@ -95,6 +96,8 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(instance.Spec.CalicoNetwork).NotTo(BeNil())
 		Expect(instance.Spec.CalicoNetwork.LinuxDataplane).ToNot(BeNil())
 		Expect(*instance.Spec.CalicoNetwork.LinuxDataplane).To(Equal(operator.LinuxDataplaneIptables))
+		Expect(instance.Spec.CalicoNetwork.BPFNetworkBootstrap).To(BeNil())
+		Expect(instance.Spec.CalicoNetwork.KubeProxyManagement).To(BeNil())
 		Expect(instance.Spec.CalicoNetwork.WindowsDataplane).ToNot(BeNil())
 		Expect(*instance.Spec.CalicoNetwork.WindowsDataplane).To(Equal(operator.WindowsDataplaneDisabled))
 		Expect(*instance.Spec.CalicoNetwork.BGP).To(Equal(operator.BGPEnabled))
@@ -307,6 +310,16 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 	})
 
+	It("should default to BPF auto install", func() {
+		instance := &operator.Installation{}
+		err := fillDefaults(instance, &fillDefaultsParams{defaultBpfDataplane: ptr.BoolToPtr(true)})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(*instance.Spec.CalicoNetwork.LinuxDataplane).To(Equal(operator.LinuxDataplaneBPF))
+		Expect(*instance.Spec.CalicoNetwork.BPFNetworkBootstrap).To(Equal(operator.BPFNetworkBootstrapEnabled))
+		Expect(*instance.Spec.CalicoNetwork.KubeProxyManagement).To(Equal(operator.KubeProxyManagementEnabled))
+		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
+	})
+
 	It("should default BGP to enabled for Calico CNI", func() {
 		instance := &operator.Installation{
 			Spec: operator.InstallationSpec{
@@ -387,7 +400,7 @@ var _ = Describe("Defaulting logic tests", func() {
 				},
 			},
 		}
-		err := fillDefaults(instance, &currentPools)
+		err := fillDefaults(instance, &fillDefaultsParams{currentPools: &currentPools})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
 	})
@@ -649,7 +662,8 @@ var _ = Describe("Defaulting logic tests", func() {
 	table.DescribeTable("should handle various pool configurations",
 		func(currentPools []crdv1.IPPool) {
 			instance := &operator.Installation{}
-			Expect(fillDefaults(instance, &crdv1.IPPoolList{Items: currentPools})).NotTo(HaveOccurred())
+			pools := &crdv1.IPPoolList{Items: currentPools}
+			Expect(fillDefaults(instance, &fillDefaultsParams{currentPools: pools})).NotTo(HaveOccurred())
 
 			// The resulting instance should be valid.
 			Expect(validateCustomResource(instance)).NotTo(HaveOccurred())

--- a/pkg/controller/kubeproxy/controller.go
+++ b/pkg/controller/kubeproxy/controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strconv"
 
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -133,17 +132,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Mark resource found so we can report problems via tigerastatus
 	r.status.OnCRFound()
 
-	// Try to retrieve the kube-proxy DaemonSet.
-	kubeProxyDS := &appsv1.DaemonSet{}
-	err = r.cli.Get(ctx, utils.KubeProxyInstanceKey, kubeProxyDS)
+	// Try to retrieve a manageable kube-proxy DaemonSet.
+	kubeProxyDS, err := utils.GetManageableKubeProxy(ctx, r.cli)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get kube-proxy: %w", err)
-	}
-
-	// Validate that the kube-proxy DaemonSet is not managed by an external tool.
-	err = validateDaemonSetManaged(kubeProxyDS)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceValidationError, "failed to validate kube-proxy DaemonSet", err, reqLogger)
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "failed to retrieve a valid kube-proxy DaemonSet", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
@@ -197,27 +189,4 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	r.status.ReadyToMonitor()
 	r.status.ClearDegraded()
 	return reconcile.Result{}, nil
-}
-
-// validateDaemonSetManaged checks whether the DaemonSet is managed by an external tool,
-// based on common labels or annotations typically added by automation.
-func validateDaemonSetManaged(ds *appsv1.DaemonSet) error {
-	if len(ds.Labels) == 0 && len(ds.Annotations) == 0 {
-		return nil
-	}
-
-	// Kubernetes well-known labels
-	if _, ok := ds.Labels["app.kubernetes.io/managed-by"]; ok {
-		return fmt.Errorf("DaemonSet is likely managed by: %s", ds.Labels["app.kubernetes.io/managed-by"])
-	}
-	if _, ok := ds.Labels["addonmanager.kubernetes.io/mode"]; ok {
-		return fmt.Errorf("DaemonSet is likely managed by another source due to the label 'addonmanager.kubernetes.io/mode: %s'", ds.Labels["addonmanager.kubernetes.io/mode"])
-	}
-
-	// Check for GitOps tools
-	if _, ok := ds.Annotations["argocd.argoproj.io/tracking-id"]; ok {
-		return fmt.Errorf("DaemonSet is likely managed by another source due to the label 'argocd.argoproj.io/tracking-id: %s'", ds.Annotations["argocd.argoproj.io/tracking-id"])
-	}
-
-	return nil
 }

--- a/pkg/controller/kubeproxy/kubeproxy_controller_test.go
+++ b/pkg/controller/kubeproxy/kubeproxy_controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("kube-proxy controller tests", func() {
 				ds := kubeProxyDS()
 				ds.Labels = labels
 				ds.Annotations = annotations
-				err := utils.ValidateDaemonSetManaged(ds)
+				err := utils.ValidateDaemonSetUnmanaged(ds)
 				Expect(err == nil).Should(Equal(shouldSucceed))
 			},
 			table.Entry("managed by argocd",

--- a/pkg/controller/kubeproxy/kubeproxy_controller_test.go
+++ b/pkg/controller/kubeproxy/kubeproxy_controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("kube-proxy controller tests", func() {
 				ds := kubeProxyDS()
 				ds.Labels = labels
 				ds.Annotations = annotations
-				err := validateDaemonSetManaged(ds)
+				err := utils.ValidateDaemonSetManaged(ds)
 				Expect(err == nil).Should(Equal(shouldSucceed))
 			},
 			table.Entry("managed by argocd",

--- a/pkg/controller/utils/bpf.go
+++ b/pkg/controller/utils/bpf.go
@@ -34,25 +34,30 @@ type BPFBootstrap struct {
 // BPFBootstrapRequirements checks whether the BPF auto-bootstrap requirements are met.
 // If so, it retrieves the kube-proxy DaemonSet, the Kubernetes service, and its EndpointSlices, returning them in a BPFBootstrap struct.
 // If it's not possible to retrieve any of these resources, it returns an error.
-func BPFBootstrapRequirements(c client.Client, ctx context.Context, install *operator.InstallationSpec) (*BPFBootstrap, error) {
+func BPFBootstrapRequirements(ctx context.Context, c client.Client, install *operator.InstallationSpec) (*BPFBootstrap, error) {
 	// If BPFNetworkBootstrap is not Enabled, skip further processing.
 	if !install.BPFNetworkBootstrapEnabled() {
 		return nil, nil
 	}
 
-	// 1. If BPFNetworkBootstrap is enabled, linuxDataplane must be BPF.
+	// If BPFNetworkBootstrap is enabled, linuxDataplane must be BPF.
 	if !install.BPFEnabled() {
 		return nil, fmt.Errorf("bpfNetworkBootstrap is enabled but linuxDataplane is not set to BPF")
 	}
 
-	// 2. kubernetes service endpoint shouldn't be defined by kubernetes-service-endpoints ConfigMap.
+	return CheckBPFClusterResourcesReq(ctx, c)
+}
+
+// CheckBPFClusterResourcesReq checks whether the cluster has/hasn't the required resources for BPF auto-bootstrap.
+func CheckBPFClusterResourcesReq(ctx context.Context, c client.Client) (*BPFBootstrap, error) {
+	// 1. kubernetes service endpoint shouldn't be defined by kubernetes-service-endpoints ConfigMap.
 	_, err := GetK8sServiceEndPoint(c)
 	if err == nil {
 		return nil, fmt.Errorf("kubernetes service endpoint is defined by the kubernetes-service-endpoints ConfigMap.")
 	}
 
 	bpfBootstrapReq := &BPFBootstrap{}
-	// 3. Try to retrieve kubernetes service.
+	// 2. Try to retrieve kubernetes service.
 	service := &corev1.Service{}
 	err = c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "kubernetes"}, service)
 	if err != nil {
@@ -60,7 +65,7 @@ func BPFBootstrapRequirements(c client.Client, ctx context.Context, install *ope
 	}
 	bpfBootstrapReq.K8sService = service
 
-	// 4. Try to retrieve kubernetes service endpoint slices. If the cluster is dual-stack, there should be at least one EndpointSlice for each address type.
+	// 3. Try to retrieve kubernetes service endpoint slices. If the cluster is dual-stack, there should be at least one EndpointSlice for each address type.
 	endpointSlice := &discoveryv1.EndpointSliceList{}
 	err = c.List(ctx, endpointSlice, client.InNamespace("default"), client.MatchingLabels{"kubernetes.io/service-name": "kubernetes"})
 	if err != nil || len(endpointSlice.Items) == 0 {

--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -154,5 +154,19 @@ var _ = Describe("provider discovery", func() {
 		p, e := AutoDiscoverProvider(context.Background(), c)
 		Expect(e).To(BeNil())
 		Expect(p).To(Equal(operatorv1.ProviderRKE2))
+	})
+
+	It("should detect KinD if a Node has ProviderID prefixed with kind://", func() {
+		c := fake.NewSimpleClientset(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kind-worker",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "kind://docker/kind/kind-worker",
+			},
+		})
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderKind))
 	})
 })

--- a/pkg/controller/utils/kubeproxy.go
+++ b/pkg/controller/utils/kubeproxy.go
@@ -26,9 +26,9 @@ var (
 	KubeProxyInstanceKey = client.ObjectKey{Name: "kube-proxy", Namespace: "kube-system"}
 )
 
-// ValidateDaemonSetManaged checks whether the DaemonSet is managed by an external tool,
+// ValidateDaemonSetUnmanaged checks whether the DaemonSet is managed by an external tool,
 // based on common labels or annotations typically added by automation.
-func ValidateDaemonSetManaged(ds *appsv1.DaemonSet) error {
+func ValidateDaemonSetUnmanaged(ds *appsv1.DaemonSet) error {
 	if len(ds.Labels) == 0 && len(ds.Annotations) == 0 {
 		return nil
 	}
@@ -56,7 +56,7 @@ func GetManageableKubeProxy(ctx context.Context, c client.Client) (*appsv1.Daemo
 		return nil, fmt.Errorf("failed to get kube-proxy: %w", err)
 	}
 
-	err = ValidateDaemonSetManaged(kubeProxyDS)
+	err = ValidateDaemonSetUnmanaged(kubeProxyDS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/utils/kubeproxy.go
+++ b/pkg/controller/utils/kubeproxy.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	KubeProxyInstanceKey = client.ObjectKey{Name: "kube-proxy", Namespace: "kube-system"}
+)
+
+// ValidateDaemonSetManaged checks whether the DaemonSet is managed by an external tool,
+// based on common labels or annotations typically added by automation.
+func ValidateDaemonSetManaged(ds *appsv1.DaemonSet) error {
+	if len(ds.Labels) == 0 && len(ds.Annotations) == 0 {
+		return nil
+	}
+
+	// Kubernetes well-known labels
+	if _, ok := ds.Labels["app.kubernetes.io/managed-by"]; ok {
+		return fmt.Errorf("DaemonSet is likely managed by: %s", ds.Labels["app.kubernetes.io/managed-by"])
+	}
+	if _, ok := ds.Labels["addonmanager.kubernetes.io/mode"]; ok {
+		return fmt.Errorf("DaemonSet is likely managed by another source due to the label 'addonmanager.kubernetes.io/mode: %s'", ds.Labels["addonmanager.kubernetes.io/mode"])
+	}
+
+	// Check for GitOps tools
+	if _, ok := ds.Annotations["argocd.argoproj.io/tracking-id"]; ok {
+		return fmt.Errorf("DaemonSet is likely managed by another source due to the label 'argocd.argoproj.io/tracking-id: %s'", ds.Annotations["argocd.argoproj.io/tracking-id"])
+	}
+
+	return nil
+}
+
+func GetManageableKubeProxy(ctx context.Context, c client.Client) (*appsv1.DaemonSet, error) {
+	kubeProxyDS := &appsv1.DaemonSet{}
+	err := c.Get(ctx, KubeProxyInstanceKey, kubeProxyDS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kube-proxy: %w", err)
+	}
+
+	err = ValidateDaemonSetManaged(kubeProxyDS)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeProxyDS, nil
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -68,7 +68,6 @@ var (
 	DefaultInstanceKey     = client.ObjectKey{Name: "default"}
 	DefaultTSEEInstanceKey = client.ObjectKey{Name: "tigera-secure"}
 	OverlayInstanceKey     = client.ObjectKey{Name: "overlay"}
-	KubeProxyInstanceKey   = client.ObjectKey{Name: "kube-proxy", Namespace: "kube-system"}
 
 	PeriodicReconcileTime = 5 * time.Minute
 

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -6900,6 +6900,7 @@ spec:
                     - DockerEnterprise
                     - RKE2
                     - TKG
+                    - Kind
                   type: string
                 logging:
                   description: Logging Configuration for Components
@@ -15857,6 +15858,7 @@ spec:
                         - DockerEnterprise
                         - RKE2
                         - TKG
+                        - Kind
                       type: string
                     logging:
                       description: Logging Configuration for Components

--- a/test/gatewayapi_test.go
+++ b/test/gatewayapi_test.go
@@ -61,7 +61,7 @@ var _ = Describe("GatewayAPI tests", func() {
 			Client: c,
 			Scheme: mgr.GetScheme(),
 		}).SetupWithManager(mgr, options.AddOptions{
-			DetectedProvider:    operator.ProviderNone,
+			DetectedProvider:    operator.ProviderKind,
 			EnterpriseCRDExists: EnterpriseCRDsExist,
 			ManageCRDs:          ManageCRDsDisable,
 			ShutdownContext:     shutdownContext,

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -377,7 +377,7 @@ func setupManager(manageCRDs bool, multiTenant bool, enterpriseCRDsExist bool) (
 	// Setup all Controllers
 	ctx, cancel := context.WithCancel(context.TODO())
 	err := controller.AddToManager(mgr, options.AddOptions{
-		DetectedProvider:    operator.ProviderNone,
+		DetectedProvider:    operator.ProviderKind,
 		EnterpriseCRDExists: enterpriseCRDsExist,
 		ManageCRDs:          manageCRDs,
 		ShutdownContext:     ctx,


### PR DESCRIPTION
## Description

This PR enables BPF dataplane auto-install by default for clusters using kube-proxy, advancing Calico's transition toward eBPF as the default dataplane. It follows the initial implementation of BPF auto-install and focuses on providing a seamless, low-friction experience for users deploying Calico in BPF mode.
- **Kind clusters as auto-detected providers:** Implemented a new logic to detect KinD clusters and changed the FVs to consider this new provider, as we use KinD to run them.
- **Auto-detection:** New logic to detect clusters where BPF dataplane can be enabled by default.
- **Default configuration:** For targeted clusters, install Calico with the eBPF dataplane, without requiring any user configuration or manual intervention.
- **Refactors:**
  - Wrapped the logic for detecting whether BPF networking can be bootstrapped, so it can be reused in the new auto-detection flow.
  - Wrapped the logic for determining whether the Operator can manage kube-proxy, also for reuse in the new auto-detection flow.
  - Removed the MergeAndFillDefaults function and incorporated its logic directly into updateInstallationWithDefaults.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
- eBPF dataplane is now enabled by default for clusters using kube-proxy. Calico auto-detects eligible clusters and installs with eBPF mode without user configuration.
- Kind was added as a new option for `KubernetesProvider` in Installation CRD.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
