### PR TITLE
Add support for Tigera-Dex to integrate with CSI secret store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.20.2
 	sigs.k8s.io/gateway-api v1.2.1
 	sigs.k8s.io/kind v0.24.0 // Do not remove, not used by code but used by build
+	sigs.k8s.io/secrets-store-csi-driver v1.4.8
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -391,5 +391,7 @@ sigs.k8s.io/kind v0.24.0 h1:g4y4eu0qa+SCeKESLpESgMmVFBebL0BDa6f777OIWrg=
 sigs.k8s.io/kind v0.24.0/go.mod h1:t7ueEpzPYJvHA8aeLtI52rtFftNgUYUaCwvxjk7phfw=
 sigs.k8s.io/structured-merge-diff/v4 v4.5.0 h1:nbCitCK2hfnhyiKo6uf2HxUPTCodY6Qaf85SbDIaMBk=
 sigs.k8s.io/structured-merge-diff/v4 v4.5.0/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
+sigs.k8s.io/secrets-store-csi-driver v1.4.8 h1:YmL0lx9HMYqeZCnLyOZRMuGAZXmP/e42UGCCAnMKjgE=
+sigs.k8s.io/secrets-store-csi-driver v1.4.8/go.mod h1:IawZyjzh3xGt6hHdckJUf3ls04O0zG5H550PEZz/beo=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	aggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 	gateway "sigs.k8s.io/gateway-api/apis/v1"
+	csisecret "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 )
 
 // AddToSchemes may be used to add all resources defined in the project to a Scheme
@@ -53,4 +54,5 @@ func init() {
 	AddToSchemes = append(AddToSchemes, crdv1.SchemeBuilder.AddToScheme)
 	AddToSchemes = append(AddToSchemes, gateway.Install)
 	AddToSchemes = append(AddToSchemes, envoy.AddToScheme)
+	AddToSchemes = append(AddToSchemes, csisecret.AddToScheme)
 }

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -38,6 +38,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	csiv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	oprv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
@@ -86,6 +87,15 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 		{Name: render.DexPolicyName, Namespace: render.DexNamespace},
 		{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.DexNamespace},
 	})
+
+	var secretProviderClasses []client.Object
+	for _, namespace := range []string{render.DexNamespace, common.OperatorNamespace()} {
+		secretProviderClasses = append(secretProviderClasses, &csiv1.SecretProviderClass{
+			TypeMeta:   metav1.TypeMeta{Kind: "SecretProviderClass", APIVersion: "secrets-store.csi.x-k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretProviderClassName, Namespace: namespace},
+		})
+	}
+	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, nil, secretProviderClasses)
 
 	// Watch for changes to the dex namespace.
 	if err = c.WatchObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}}, &handler.EnqueueRequestForObject{}); err != nil {
@@ -283,9 +293,9 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	}
 
 	// Dex will be configured with the contents of this secret, such as clientID and clientSecret.
-	idpSecret, err := utils.GetIDPSecret(ctx, r.client, authentication)
+	secretProviderClass, idpSecret, err := utils.GetSecretOrProviderClass(ctx, r.client, authentication)
 	if err != nil {
-		r.status.SetDegraded(oprv1.ResourceValidationError, "Invalid or missing identity provider secret", err, reqLogger)
+		r.status.SetDegraded(oprv1.ResourceValidationError, "Invalid or missing IDP secret or IDP secret provider", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
@@ -370,7 +380,7 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	enableDex := utils.DexEnabled(authentication)
 
 	// DexConfig adds convenience methods around dex related objects in k8s and can be used to configure Dex.
-	dexCfg := render.NewDexConfig(install.CertificateManagement, authentication, idpSecret, r.clusterDomain)
+	dexCfg := render.NewDexConfig(install.CertificateManagement, authentication, idpSecret, secretProviderClass, r.clusterDomain)
 
 	// Create a component handler to manage the rendered component.
 	hlr := utils.NewComponentHandler(log, r.client, r.scheme, authentication)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -24,6 +24,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
+	csiv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	"github.com/go-logr/logr"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
@@ -133,6 +135,18 @@ func AddSecretsWatch(c ctrlruntime.Controller, name, namespace string) error {
 func AddSecretsWatchWithHandler(c ctrlruntime.Controller, name, namespace string, h handler.EventHandler) error {
 	s := &corev1.Secret{
 		TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "V1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	return AddNamespacedWatch(c, s, h)
+}
+
+func AddSecretProviderClassWatch(c ctrlruntime.Controller, name, namespace string) error {
+	return AddSecretProviderClassWatchWithHandler(c, name, namespace, &handler.EnqueueRequestForObject{})
+}
+
+func AddSecretProviderClassWatchWithHandler(c ctrlruntime.Controller, name, namespace string, h handler.EventHandler) error {
+	s := &csiv1.SecretProviderClass{
+		TypeMeta:   metav1.TypeMeta{Kind: "SecretProviderClass", APIVersion: "secrets-store.csi.x-k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 	}
 	return AddNamespacedWatch(c, s, h)
@@ -680,8 +694,8 @@ type resourceWatchContext struct {
 	logger    logr.Logger
 }
 
-// WaitToAddResourceWatch will check if projectcalico.org APIs are available and if so, it will add a watch for resource
-// The completion of this operation will be signaled on a ready channel
+// WaitToAddResourceWatch will check if the required CRD APIs are available and if so, it will add a watch for the
+// resource. The completion of this operation will be signaled on a ready channel
 func WaitToAddResourceWatch(controller ctrlruntime.Controller, c kubernetes.Interface, log logr.Logger, flag *ReadyFlag, objs []client.Object) {
 	// Track resources left to watch and establish their watch context.
 	resourcesToWatch := map[client.Object]resourceWatchContext{}
@@ -706,7 +720,8 @@ func WaitToAddResourceWatch(controller ctrlruntime.Controller, c kubernetes.Inte
 		for obj := range resourcesToWatch {
 			objLog := resourcesToWatch[obj].logger
 			predicateFn := resourcesToWatch[obj].predicate
-			if ok, err := isCalicoResourceReady(c, obj.GetObjectKind().GroupVersionKind().Kind); err != nil {
+			gvk := obj.GetObjectKind().GroupVersionKind()
+			if ok, err := isResourceReady(c, gvk); err != nil {
 				msg := "Failed to check if resource is ready - will retry"
 				if errors.IsNotFound(err) {
 					objLog.WithValues("Error", err).V(2).Info(msg)
@@ -732,17 +747,27 @@ func WaitToAddResourceWatch(controller ctrlruntime.Controller, c kubernetes.Inte
 	}
 }
 
-// isCalicoResourceReady checks if the specified resourceKind is available.
-// the resourceKind must be of the calico resource group.
-func isCalicoResourceReady(client kubernetes.Interface, resourceKind string) (bool, error) {
+// isResourceReady checks if the specified resource is available.
+func isResourceReady(client kubernetes.Interface, gvk schema.GroupVersionKind) (bool, error) {
+	gv := gvk.GroupVersion()
+	if gv.Empty() {
+		// Default to the Calico group and version if not specified so existing callers that only
+		// provide the Kind continue to function.
+		var err error
+		gv, err = schema.ParseGroupVersion(v3.GroupVersionCurrent)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	// Only get the resources for the groupVersion we care about so that we are resilient to other
 	// apiservices being down.
-	res, err := client.Discovery().ServerResourcesForGroupVersion(v3.GroupVersionCurrent)
+	res, err := client.Discovery().ServerResourcesForGroupVersion(gv.String())
 	if err != nil {
 		return false, err
 	}
 	for _, r := range res.APIResources {
-		if resourceKind == r.Kind {
+		if gvk.Kind == r.Kind {
 			return true, nil
 		}
 	}

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -35,6 +35,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,7 +116,8 @@ var _ = Describe("Tigera License polling test", func() {
 				Kind: "LicenseKey",
 			}},
 		})
-		Expect(isCalicoResourceReady(client, v3.KindLicenseKey)).To(BeTrue())
+		gvk := schema.GroupVersionKind{Kind: v3.KindLicenseKey}
+		Expect(isResourceReady(client, gvk)).To(BeTrue())
 		discovery.AssertExpectations(GinkgoT())
 	})
 
@@ -125,7 +127,8 @@ var _ = Describe("Tigera License polling test", func() {
 				Kind: "Deployment",
 			}},
 		})
-		Expect(isCalicoResourceReady(client, v3.KindLicenseKey)).To(BeFalse())
+		gvk := schema.GroupVersionKind{Kind: v3.KindLicenseKey}
+		Expect(isResourceReady(client, gvk)).To(BeFalse())
 		discovery.AssertExpectations(GinkgoT())
 	})
 })

--- a/pkg/render/common/authentication/tigera/key_validator_config/key_validator_config.go
+++ b/pkg/render/common/authentication/tigera/key_validator_config/key_validator_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/common/authentication/types.go
+++ b/pkg/render/common/authentication/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/render/common/secret/secrets.go
+++ b/pkg/render/common/secret/secrets.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"fmt"
 	"time"
+
+	csisecret "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	"github.com/openshift/library-go/pkg/crypto"
 
@@ -115,6 +117,31 @@ func CopyToNamespace(ns string, oSecrets ...*corev1.Secret) []*corev1.Secret {
 
 // ToRuntimeObjects converts the given list of secrets to a list of client.Objects
 func ToRuntimeObjects(secrets ...*corev1.Secret) []client.Object {
+	var objs []client.Object
+	for _, secret := range secrets {
+		if secret == nil {
+			continue
+		}
+		objs = append(objs, secret)
+	}
+	return objs
+}
+
+// CopySecretProviderClassToNamespace returns a new list of SecretProviderClassToNamespace generated from the ones given but with the namespace changed to the
+// given one.
+func CopySecretProviderClassToNamespace(ns string, oSecrets ...*csisecret.SecretProviderClass) []*csisecret.SecretProviderClass {
+	var secrets []*csisecret.SecretProviderClass
+	for _, s := range oSecrets {
+		x := s.DeepCopy()
+		x.ObjectMeta = metav1.ObjectMeta{Name: s.Name, Namespace: ns}
+
+		secrets = append(secrets, x)
+	}
+	return secrets
+}
+
+// ToSecretProviderClassRuntimeObjects converts the given list of SecretProviderClass to a list of client.Objects
+func ToSecretProviderClassRuntimeObjects(secrets ...*csisecret.SecretProviderClass) []client.Object {
 	var objs []client.Object
 	for _, secret := range secrets {
 		if secret == nil {

--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 
+	csisecret "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+
 	oprv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/render/common/authentication"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -48,6 +50,7 @@ const (
 	serviceAccountFilePathField  = "serviceAccountFilePath"
 	RootCASecretField            = "rootCA"
 	OIDCSecretName               = "tigera-oidc-credentials"
+	OIDCSecretProviderClassName  = "tigera-oidc-credentials"
 	OpenshiftSecretName          = "tigera-openshift-credentials"
 	LDAPSecretName               = "tigera-ldap-credentials"
 	serviceAccountSecretLocation = "/etc/dex/secrets/google-groups.json"
@@ -76,20 +79,39 @@ const (
 
 // DexConfig is a config for DexIdP itself.
 type DexConfig interface {
+	// Connector returns the dex connector configuration block.
 	Connector() map[string]interface{}
+	// RedirectURIs returns the list of redirect URIs for the dex static client.
 	RedirectURIs() []string
-	// RequiredVolumeMounts returns volume mounts that the KeyValidatorConfig implementation requires.
+	// Issuer returns the issuer URL for dex.
+	Issuer() string
+	// RequiredEnv returns env variables required by the dex deployment.
+	RequiredEnv(prefix string) []corev1.EnvVar
+	// RequiredAnnotations returns pod annotations required by the dex deployment.
+	RequiredAnnotations() map[string]string
+	// RequiredSecrets returns secrets required by the dex deployment in the given namespace.
+	RequiredSecrets(namespace string) []*corev1.Secret
+	// RequiredVolumeMounts returns volume mounts required by the dex deployment.
 	RequiredVolumeMounts() []corev1.VolumeMount
-	// RequiredVolumes returns volumes that the KeyValidatorConfig implementation requires.
+	// RequiredVolumes returns volumes required by the dex deployment.
 	RequiredVolumes() []corev1.Volume
-	authentication.KeyValidatorConfig
+	// RequiredSecretProviderClass returns SecretProviderClass objects required by the dex deployment.
+	RequiredSecretProviderClass(namespace string) []*csisecret.SecretProviderClass
 }
 
 func NewDexKeyValidatorConfig(
 	authentication *oprv1.Authentication,
-	idpSecret *corev1.Secret,
 	clusterDomain string) authentication.KeyValidatorConfig {
-	return &DexKeyValidatorConfig{baseCfg(nil, authentication, idpSecret, clusterDomain)}
+	// Compute baseURL similar to baseCfg but without creating dexBaseCfg.
+	baseUrl := authentication.Spec.ManagerDomain
+	if !strings.HasPrefix(baseUrl, "http://") && !strings.HasPrefix(baseUrl, "https://") {
+		baseUrl = fmt.Sprintf("https://%s", baseUrl)
+	}
+	return &DexKeyValidatorConfig{
+		authentication: authentication,
+		baseURL:        baseUrl,
+		clusterDomain:  clusterDomain,
+	}
 }
 
 // Create a new DexConfig.
@@ -97,13 +119,36 @@ func NewDexConfig(
 	certificateManagement *oprv1.CertificateManagement,
 	authentication *oprv1.Authentication,
 	idpSecret *corev1.Secret,
+	secretProviderClass *csisecret.SecretProviderClass,
 	clusterDomain string) DexConfig {
-	return &dexConfig{baseCfg(certificateManagement, authentication, idpSecret, clusterDomain)}
+	return &dexConfig{
+		dexBaseCfg:          baseCfg(certificateManagement, authentication, idpSecret, clusterDomain),
+		secretProviderClass: secretProviderClass,
+	}
 }
 
 type DexKeyValidatorConfig struct {
-	*dexBaseCfg
+	authentication *oprv1.Authentication
+	baseURL        string
+	clusterDomain  string
+	tlsSecret      certificatemanagement.KeyPairInterface
 }
+
+func (d *DexKeyValidatorConfig) BaseURL() string { return d.baseURL }
+
+func (d *DexKeyValidatorConfig) Issuer() string { return fmt.Sprintf("%s/dex", d.baseURL) }
+
+func (d *DexKeyValidatorConfig) ClientID() string { return DexClientId }
+
+func (d *DexKeyValidatorConfig) UsernameClaim() string {
+	claim := defaultUsernameClaim
+	if d.authentication != nil && d.authentication.Spec.OIDC != nil && d.authentication.Spec.OIDC.UsernameClaim != "" {
+		claim = d.authentication.Spec.OIDC.UsernameClaim
+	}
+	return claim
+}
+
+func (d *DexKeyValidatorConfig) RequiredConfigMaps(string) []*corev1.ConfigMap { return nil }
 
 func (d *DexKeyValidatorConfig) RequiredVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{}
@@ -114,6 +159,7 @@ func (d *DexKeyValidatorConfig) RequiredVolumes() []corev1.Volume {
 }
 
 type dexConfig struct {
+	secretProviderClass *csisecret.SecretProviderClass
 	*dexBaseCfg
 }
 
@@ -223,6 +269,14 @@ func (d *dexBaseCfg) RequiredSecrets(namespace string) []*corev1.Secret {
 	return secrets
 }
 
+func (d *dexConfig) RequiredSecretProviderClass(namespace string) []*csisecret.SecretProviderClass {
+	var secrets []*csisecret.SecretProviderClass
+	if d.secretProviderClass != nil {
+		secrets = append(secrets, secret.CopySecretProviderClassToNamespace(namespace, d.secretProviderClass)...)
+	}
+	return secrets
+}
+
 // RequiredAnnotations returns the annotations that are relevant for a Dex deployment.
 func (d *dexConfig) RequiredAnnotations() map[string]string {
 	var annotations = map[string]string{
@@ -237,6 +291,14 @@ func (d *dexConfig) RequiredAnnotations() map[string]string {
 		annotations[dexIdpSecretAnnotation] = rmeta.AnnotationHash(d.idpSecret.Data)
 	}
 	return annotations
+}
+
+func (d *DexKeyValidatorConfig) RequiredSecrets(namespace string) []*corev1.Secret {
+	var secrets []*corev1.Secret
+	if d.tlsSecret != nil {
+		secrets = append(secrets, d.tlsSecret.Secret(namespace))
+	}
+	return secrets
 }
 
 // RequiredAnnotations returns the annotations that are relevant for a validator config.
@@ -309,6 +371,24 @@ func (d *dexConfig) RequiredVolumes() []corev1.Volume {
 			},
 		)
 	}
+
+	if d.secretProviderClass != nil {
+		isReadOnly := true
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: "secrets-store",
+				VolumeSource: corev1.VolumeSource{
+					CSI: &corev1.CSIVolumeSource{
+						Driver:   "secrets-store.csi.k8s.io",
+						ReadOnly: &isReadOnly,
+						VolumeAttributes: map[string]string{
+							"secretProviderClass": d.secretProviderClass.Name,
+						},
+					},
+				},
+			},
+		)
+	}
 	return volumes
 }
 
@@ -321,17 +401,25 @@ func (d *dexConfig) RequiredVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 	}
-	if d.idpSecret.Data[serviceAccountSecretField] != nil {
+	if d.idpSecret != nil && d.idpSecret.Data[serviceAccountSecretField] != nil {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "secrets",
 			MountPath: "/etc/dex/secrets",
 			ReadOnly:  true,
 		})
 	}
-	if d.idpSecret.Data[RootCASecretField] != nil {
+	if d.idpSecret != nil && d.idpSecret.Data[RootCASecretField] != nil {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "secrets",
 			MountPath: "/etc/ssl/certs/",
+			ReadOnly:  true,
+		})
+	}
+
+	if d.secretProviderClass != nil {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "secrets-store",
+			MountPath: "/mnt/secrets-store",
 			ReadOnly:  true,
 		})
 	}
@@ -394,7 +482,7 @@ func (d *dexConfig) Connector() map[string]interface{} {
 			"redirectURI":  fmt.Sprintf("%s/dex/callback", d.BaseURL()),
 			"scopes":       d.RequestedScopes(),
 		}
-		if d.idpSecret.Data[serviceAccountSecretField] != nil && d.idpSecret.Data[adminEmailSecretField] != nil {
+		if d.idpSecret != nil && d.idpSecret.Data[serviceAccountSecretField] != nil && d.idpSecret.Data[adminEmailSecretField] != nil {
 			config[serviceAccountFilePathField] = serviceAccountSecretLocation
 			config[adminEmailSecretField] = fmt.Sprintf("$%s", googleAdminEmailEnv)
 		}

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	csisecret "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
@@ -188,7 +189,7 @@ var _ = Describe("dex rendering tests", func() {
 
 			replicas = 2
 
-			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, idpSecret, clusterName)
+			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, idpSecret, nil, clusterName)
 			trustedCaBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -288,7 +289,7 @@ var _ = Describe("dex rendering tests", func() {
 		})
 
 		DescribeTable("should render the cluster name properly in the validator", func(clusterDomain string) {
-			validatorConfig := render.NewDexKeyValidatorConfig(authentication, idpSecret, clusterDomain)
+			validatorConfig := render.NewDexKeyValidatorConfig(authentication, clusterDomain)
 			validatorEnv := validatorConfig.RequiredEnv("")
 
 			expectedUrl := fmt.Sprintf("https://tigera-dex.tigera-dex.svc.%s:5556", clusterDomain)
@@ -298,6 +299,92 @@ var _ = Describe("dex rendering tests", func() {
 			Entry("default cluster domain", dns.DefaultClusterDomain),
 			Entry("custom cluster domain", "custom.internal"),
 		)
+
+		Context("when SecretProviderClass is provided", func() {
+			var secretProviderClass *csisecret.SecretProviderClass
+
+			BeforeEach(func() {
+				secretProviderClass = &csisecret.SecretProviderClass{
+					TypeMeta:   metav1.TypeMeta{Kind: "SecretProviderClass", APIVersion: "secrets-store.csi.x-k8s.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretName, Namespace: common.OperatorNamespace()},
+				}
+				cfg.DexConfig = render.NewDexConfig(cfg.Installation.CertificateManagement, authentication, nil, secretProviderClass, clusterName)
+				cfg.Authentication = authentication
+			})
+
+			It("should render resources using SecretProviderClass", func() {
+				component := render.Dex(cfg)
+				resources, _ := component.Objects()
+
+				expectedResources := []client.Object{
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}, TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}},
+					&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: render.DexPolicyName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
+					&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkpolicy.TigeraComponentDefaultDenyPolicyName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
+					&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
+					&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
+					&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
+					&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
+					&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+					&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}},
+					&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pullSecretName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
+					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.DexNamespace}},
+					&csisecret.SecretProviderClass{ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "SecretProviderClass", APIVersion: "secrets-store.csi.x-k8s.io/v1"}},
+				}
+
+				rtest.ExpectResources(resources, expectedResources)
+
+				Expect(rtest.GetResource(resources, render.OIDCSecretName, common.OperatorNamespace(), "", "v1", "Secret")).To(BeNil())
+				Expect(rtest.GetResource(resources, render.OIDCSecretName, render.DexNamespace, "", "v1", "Secret")).To(BeNil())
+
+				d := rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+				Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+				Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "WATCH_DIR", Value: "/mnt/secrets-store"}))
+
+				Expect(d.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: "secrets-store", MountPath: "/mnt/secrets-store", ReadOnly: true}))
+				var secretsStoreVol *corev1.Volume
+				for i := range d.Spec.Template.Spec.Volumes {
+					if d.Spec.Template.Spec.Volumes[i].Name == "secrets-store" {
+						secretsStoreVol = &d.Spec.Template.Spec.Volumes[i]
+						break
+					}
+				}
+				Expect(secretsStoreVol).NotTo(BeNil())
+				Expect(secretsStoreVol.CSI).NotTo(BeNil())
+				Expect(secretsStoreVol.CSI.Driver).To(Equal("secrets-store.csi.k8s.io"))
+				Expect(secretsStoreVol.CSI.VolumeAttributes).To(HaveKeyWithValue("secretProviderClass", render.OIDCSecretName))
+			})
+		})
+
+		It("should switch from Kubernetes Secret to SecretProviderClass", func() {
+			cfg.Authentication = authentication
+
+			// Initial render with Kubernetes Secret.
+			component := render.Dex(cfg)
+			resources, _ := component.Objects()
+
+			Expect(rtest.GetResource(resources, render.OIDCSecretName, render.DexNamespace, "", "v1", "Secret")).NotTo(BeNil())
+			Expect(rtest.GetResource(resources, render.OIDCSecretName, render.DexNamespace, "secrets-store.csi.x-k8s.io", "v1", "SecretProviderClass")).To(BeNil())
+
+			d := rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(d.Spec.Template.Annotations).To(HaveKey("hash.operator.tigera.io/tigera-idp-secret"))
+
+			// Update configuration to use SecretProviderClass.
+			spc := &csisecret.SecretProviderClass{
+				TypeMeta:   metav1.TypeMeta{Kind: "SecretProviderClass", APIVersion: "secrets-store.csi.x-k8s.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretName, Namespace: common.OperatorNamespace()},
+			}
+			cfg.DexConfig = render.NewDexConfig(cfg.Installation.CertificateManagement, authentication, nil, spc, clusterName)
+
+			component = render.Dex(cfg)
+			resources, _ = component.Objects()
+
+			Expect(rtest.GetResource(resources, render.OIDCSecretName, render.DexNamespace, "", "v1", "Secret")).To(BeNil())
+			Expect(rtest.GetResource(resources, render.OIDCSecretName, render.DexNamespace, "secrets-store.csi.x-k8s.io", "v1", "SecretProviderClass")).NotTo(BeNil())
+
+			d = rtest.GetResource(resources, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+			Expect(d.Spec.Template.Annotations).NotTo(HaveKey("hash.operator.tigera.io/tigera-idp-secret"))
+			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "WATCH_DIR", Value: "/mnt/secrets-store"}))
+		})
 
 		It("should apply tolerations", func() {
 			t := corev1.Toleration{
@@ -331,7 +418,7 @@ var _ = Describe("dex rendering tests", func() {
 
 		It("should render all resources for a certificate management", func() {
 			cfg.Installation.CertificateManagement = &operatorv1.CertificateManagement{}
-			cfg.DexConfig = render.NewDexConfig(cfg.Installation.CertificateManagement, authentication, idpSecret, clusterName)
+			cfg.DexConfig = render.NewDexConfig(cfg.Installation.CertificateManagement, authentication, idpSecret, nil, clusterName)
 
 			component := render.Dex(cfg)
 			resources, _ := component.Objects()

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1529,7 +1529,7 @@ func renderObjects(roc renderConfig) []client.Object {
 			},
 		}
 
-		dexCfg = render.NewDexKeyValidatorConfig(authentication, nil, dns.DefaultClusterDomain)
+		dexCfg = render.NewDexKeyValidatorConfig(authentication, dns.DefaultClusterDomain)
 	}
 
 	var tunnelSecret certificatemanagement.KeyPairInterface

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -665,9 +665,7 @@ var _ = Describe("monitor rendering tests", func() {
 			},
 		}
 
-		dexCfg := render.NewDexKeyValidatorConfig(authentication,
-			nil,
-			dns.DefaultClusterDomain)
+		dexCfg := render.NewDexKeyValidatorConfig(authentication, dns.DefaultClusterDomain)
 		cfg.KeyValidatorConfig = dexCfg
 		cfg.ServerTLSSecret = prometheusKeyPair
 		component := monitor.Monitor(cfg)

--- a/pkg/render/packet_capture_api_test.go
+++ b/pkg/render/packet_capture_api_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -410,7 +410,7 @@ var _ = Describe("Rendering tests for PacketCapture API component", func() {
 			},
 		}
 
-		dexCfg := render.NewDexKeyValidatorConfig(authentication, nil, dns.DefaultClusterDomain)
+		dexCfg := render.NewDexKeyValidatorConfig(authentication, dns.DefaultClusterDomain)
 		resources := renderPacketCapture(defaultInstallation, dexCfg)
 
 		checkPacketCaptureResources(resources, false, true)


### PR DESCRIPTION
This pull request introduces support for Kubernetes `SecretProviderClass` resources from the `secrets-store-csi-driver`, enabling the operator to use external secrets for authentication (e.g., OIDC) in addition to traditional Kubernetes Secrets. The changes update the authentication controller logic, utilities, and rendering components to detect, watch, and handle `SecretProviderClass` resources, ensuring seamless integration and prioritization when both secret types are present.

**Authentication and Secret Management Enhancements:**

* Added support for `SecretProviderClass` resources from the `secrets-store-csi-driver`, including dependency updates in `go.mod` and imports throughout the codebase.
* Modified authentication controller logic to detect and watch for `SecretProviderClass` resources, and prioritize their usage over standard Kubernetes Secrets when both are present.
* Added utility functions for copying and converting `SecretProviderClass` resources, and updated Dex rendering to handle these resources.

**Controller and Utility Improvements:**

* Enhanced resource watch logic to support CRDs beyond Calico, generalizing readiness checks and updating related tests.
* Added helper functions to watch `SecretProviderClass` resources in the controller utilities.
* `DexKeyValidatorConfig` was refactored to eliminate its dependency on `dexBaseCfg`, achieving a standalone structure with necessary methods implemented.
* The `DexConfig` interface was refactored to remove its dependency on `KeyValidatorConfig`, ensuring it only contains methods specific to Dex functionality.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Added support for Kubernetes SecretProviderClass resources from the secrets-store-csi-driver into the authentication flow, allowing for identity provider (IdP) secrets to be sourced via CSI drivers in addition to standard Kubernetes Secrets.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
