### PR TITLE
[release-v1.38] Auto pick #4123: Extract service account name from serviceaccount token

### DIFF
--- a/pkg/common/operator_serviceaccount.go
+++ b/pkg/common/operator_serviceaccount.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021,2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,16 @@
 package common
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cloudflare/cfssl/log"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 var serviceAccount = ""
@@ -40,13 +47,63 @@ func OperatorServiceAccount() string {
 func getServiceAccount() string {
 	v, ok := os.LookupEnv("OPERATOR_SERVICEACCOUNT")
 	if ok {
+		log.Infof("Detected operator service account %q from environment variable", v)
 		return v
 	}
-	body, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	if err != nil {
-		log.Info("Failed to read serviceaccount/namespace file")
-	} else {
-		return string(body)
+
+	sa := serviceAccountFromToken()
+	if sa != "" {
+		log.Infof("Detected operator service account %q from token review", sa)
+		return sa
 	}
+	log.Infof("Falling back to default operator service account 'tigera-operator'")
 	return "tigera-operator"
+}
+
+func serviceAccountFromToken() string {
+	// Parse the JWT token to get the service account name.
+	token, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		log.Infof("Failed to read serviceaccount token file: %s", err)
+		return ""
+	}
+	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		log.Errorf("Failed to read namespace file: %v", err)
+		return ""
+	}
+	prefix := fmt.Sprintf("system:serviceaccount:%s:", string(ns))
+
+	// Send a TokenReview to the Kubernetes API to validate and parse the token.
+	tokenReview := authv1.TokenReview{
+		Spec: authv1.TokenReviewSpec{
+			Token: string(token),
+		},
+	}
+
+	// Create a Kubernetes client.
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Errorf("Failed to create in-cluster config: %s", err)
+		return ""
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Errorf("Failed to create Kubernetes client: %s", err)
+		return ""
+	}
+	tr, err := cs.AuthenticationV1().TokenReviews().Create(context.Background(), &tokenReview, metav1.CreateOptions{})
+	if err != nil {
+		log.Errorf("Failed to create TokenReview: %s", err)
+		return ""
+	}
+	if !tr.Status.Authenticated {
+		log.Errorf("Failed to authenticate serviceaccount token")
+		return ""
+	}
+	if tr.Status.User.Username == "" || !strings.HasPrefix(tr.Status.User.Username, prefix) {
+		log.Errorf("Failed to get serviceaccount username from token review")
+		return ""
+	}
+	return strings.TrimPrefix(tr.Status.User.Username, prefix)
 }


### PR DESCRIPTION
Cherry pick of #4123 on release-v1.38.

#4123: Extract service account name from serviceaccount token

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/10906


## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Properly provide secrets RBAC when operator is running in an alternative namespace.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.