### PR TITLE
Fix panic when setting BPF and CalicoNetwork is nil

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -438,6 +438,10 @@ func checkAndApplyBPFDefaults(ctx context.Context, client client.Client, instanc
 
 	// defaultBpfDataplane == true indicates that this is a new installation, and that automatic BPF installation can be set by default.
 	if defaultBpfDataplane {
+		if instance.Spec.CalicoNetwork == nil {
+			instance.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{}
+		}
+
 		dpBPF := operator.LinuxDataplaneBPF
 		instance.Spec.CalicoNetwork.LinuxDataplane = &dpBPF
 		bpfNetworkEnabled := operator.BPFNetworkBootstrapEnabled

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1002,7 +1002,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			})
 		})
 
-		Context("with LinuxDataplane=BPF and BPFNetworkBootstrap=Enabled", func() {
+		Context("streamline BPF installation", func() {
 			createResource := func(obj client.Object) {
 				Expect(c.Create(ctx, obj)).NotTo(HaveOccurred())
 			}
@@ -1038,6 +1038,15 @@ var _ = Describe("Testing core-controller installation", func() {
 							{Addresses: []string{"5.6.7.8", "5.6.7.9", "5.6.7.10"}},
 						},
 						Ports: []discoveryv1.EndpointPort{{Port: ptr.Int32ToPtr(6443)}},
+					})
+			}
+			createKubeProxy := func() {
+				createResource(
+					&appsv1.DaemonSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      utils.KubeProxyInstanceKey.Name,
+							Namespace: utils.KubeProxyInstanceKey.Namespace,
+						},
 					})
 			}
 
@@ -1210,16 +1219,6 @@ var _ = Describe("Testing core-controller installation", func() {
 				kubeProxyManagementDisabled := operator.KubeProxyManagementDisabled
 				kubeProxyManagementEnabled := operator.KubeProxyManagementEnabled
 
-				createKubeProxy := func() {
-					createResource(
-						&appsv1.DaemonSet{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      utils.KubeProxyInstanceKey.Name,
-								Namespace: utils.KubeProxyInstanceKey.Namespace,
-							},
-						})
-				}
-
 				table.DescribeTable("auto-detect cluster status to defaulting BPF",
 					func(funcs []func(), installation *operator.Installation, shouldDefaulted bool) {
 						for _, f := range funcs {
@@ -1267,6 +1266,25 @@ var _ = Describe("Testing core-controller installation", func() {
 					table.Entry("missing kube-proxy daemonset",
 						[]func(){createK8sService, createEndpointSlice}, &operator.Installation{}, false,
 					),
+				)
+			})
+			When("reconciling without custom configuration", func() {
+				table.DescribeTable("reconciles correctly for different variants",
+					func(variant operator.ProductVariant) {
+						mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+						createKubeProxy()
+						createK8sService()
+						createEndpointSlice()
+
+						cr.Spec.Variant = variant
+						Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+
+						By("r.Reconcile()")
+						_, err := r.Reconcile(ctx, reconcile.Request{})
+						Expect(err).ShouldNot(HaveOccurred())
+					},
+					table.Entry("variant is TigeraSecureEnterprise", operator.TigeraSecureEnterprise),
+					table.Entry("variant is Calico", operator.Calico),
 				)
 			})
 		})


### PR DESCRIPTION
## Description

This pull request fixes a panic that occurs when enabling BPF mode and the `CalicoNetwork` configuration is nil.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
