### PR TITLE
feat(dex): Enable PKCE and silent token renewal for SPA

### DIFF
--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -289,17 +289,6 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, err
 	}
 
-	dexSecret := &corev1.Secret{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: render.DexObjectName, Namespace: common.OperatorNamespace()}, dexSecret); err != nil {
-		if errors.IsNotFound(err) {
-			// We need to render a new one.
-			dexSecret = render.CreateDexClientSecret()
-		} else {
-			r.status.SetDegraded(oprv1.ResourceReadError, "Failed to read tigera-operator/tigera-dex secret", err, reqLogger)
-			return reconcile.Result{}, err
-		}
-	}
-
 	pullSecrets, err := utils.GetNetworkingPullSecrets(install, r.client)
 	if err != nil {
 		r.status.SetDegraded(oprv1.ResourceReadError, "Error retrieving pull secrets", err, reqLogger)
@@ -381,7 +370,7 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	enableDex := utils.DexEnabled(authentication)
 
 	// DexConfig adds convenience methods around dex related objects in k8s and can be used to configure Dex.
-	dexCfg := render.NewDexConfig(install.CertificateManagement, authentication, dexSecret, idpSecret, r.clusterDomain)
+	dexCfg := render.NewDexConfig(install.CertificateManagement, authentication, idpSecret, r.clusterDomain)
 
 	// Create a component handler to manage the rendered component.
 	hlr := utils.NewComponentHandler(log, r.client, r.scheme, authentication)

--- a/pkg/controller/authentication/authentication_controller_test.go
+++ b/pkg/controller/authentication/authentication_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,17 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"golang.org/x/net/http/httpproxy"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
@@ -35,22 +46,11 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
+	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/test"
-	"golang.org/x/net/http/httpproxy"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("authentication controller tests", func() {

--- a/pkg/controller/logstorage/elastic/elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -444,8 +444,6 @@ var _ = Describe("LogStorage controller", func() {
 					},
 					Status: operatorv1.AuthenticationStatus{State: operatorv1.TigeraStatusReady},
 				})).ToNot(HaveOccurred())
-
-				Expect(cli.Create(ctx, render.CreateDexClientSecret())).ToNot(HaveOccurred())
 
 				Expect(cli.Create(ctx, &storagev1.StorageClass{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/crypto_utils.go
+++ b/pkg/render/crypto_utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,23 +17,7 @@ package render
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/tigera/operator/pkg/common"
-	calicrypto "github.com/tigera/operator/pkg/crypto"
 )
-
-func CreateDexClientSecret() *corev1.Secret {
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-dex",
-			Namespace: common.OperatorNamespace(),
-		},
-		Data: map[string][]byte{
-			ClientSecretSecretField: []byte(calicrypto.GeneratePassword(24)),
-		},
-	}
-}
 
 // CreateCertificateSecret is a convenience method for creating a secret that contains only a ca or cert to trust.
 func CreateCertificateSecret(caPem []byte, secretName string, namespace string) *corev1.Secret {

--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ const (
 	authenticationAnnotation = "hash.operator.tigera.io/tigera-dex-auth"
 	dexConfigMapAnnotation   = "hash.operator.tigera.io/tigera-dex-config"
 	dexIdpSecretAnnotation   = "hash.operator.tigera.io/tigera-idp-secret"
-	dexSecretAnnotation      = "hash.operator.tigera.io/tigera-dex-secret"
 
 	// Constants related to secrets.
 	serviceAccountSecretField    = "serviceAccountSecret"
@@ -64,7 +63,6 @@ const (
 	googleAdminEmailEnv = "ADMIN_EMAIL"
 	clientIDEnv         = "CLIENT_ID"
 	clientSecretEnv     = "CLIENT_SECRET"
-	dexSecretEnv        = "DEX_SECRET"
 	bindDNEnv           = "BIND_DN"
 	bindPWEnv           = "BIND_PW"
 
@@ -91,17 +89,16 @@ func NewDexKeyValidatorConfig(
 	authentication *oprv1.Authentication,
 	idpSecret *corev1.Secret,
 	clusterDomain string) authentication.KeyValidatorConfig {
-	return &DexKeyValidatorConfig{baseCfg(nil, authentication, nil, idpSecret, clusterDomain)}
+	return &DexKeyValidatorConfig{baseCfg(nil, authentication, idpSecret, clusterDomain)}
 }
 
 // Create a new DexConfig.
 func NewDexConfig(
 	certificateManagement *oprv1.CertificateManagement,
 	authentication *oprv1.Authentication,
-	dexSecret *corev1.Secret,
 	idpSecret *corev1.Secret,
 	clusterDomain string) DexConfig {
-	return &dexConfig{baseCfg(certificateManagement, authentication, dexSecret, idpSecret, clusterDomain)}
+	return &dexConfig{baseCfg(certificateManagement, authentication, idpSecret, clusterDomain)}
 }
 
 type DexKeyValidatorConfig struct {
@@ -124,7 +121,6 @@ type dexConfig struct {
 func baseCfg(
 	certificateManagement *oprv1.CertificateManagement,
 	authentication *oprv1.Authentication,
-	dexSecret *corev1.Secret,
 	idpSecret *corev1.Secret,
 	clusterDomain string) *dexBaseCfg {
 
@@ -151,7 +147,6 @@ func baseCfg(
 		certificateManagement: certificateManagement,
 		authentication:        authentication,
 		idpSecret:             idpSecret,
-		dexSecret:             dexSecret,
 		connectorType:         connType,
 		baseURL:               baseUrl,
 		clusterDomain:         clusterDomain,
@@ -163,7 +158,6 @@ type dexBaseCfg struct {
 	authentication        *oprv1.Authentication
 	tlsSecret             certificatemanagement.KeyPairInterface
 	idpSecret             *corev1.Secret
-	dexSecret             *corev1.Secret
 	baseURL               string
 	connectorType         string
 	clusterDomain         string
@@ -211,10 +205,6 @@ func (d *dexBaseCfg) UsernameClaim() string {
 	return claim
 }
 
-func (d *dexBaseCfg) ClientSecret() []byte {
-	return d.dexSecret.Data[ClientSecretSecretField]
-}
-
 func (d *dexBaseCfg) RequestedScopes() []string {
 	if d.authentication.Spec.OIDC != nil && d.authentication.Spec.OIDC.RequestedScopes != nil {
 		return d.authentication.Spec.OIDC.RequestedScopes
@@ -226,9 +216,6 @@ func (d *dexBaseCfg) RequiredSecrets(namespace string) []*corev1.Secret {
 	var secrets []*corev1.Secret
 	if d.tlsSecret != nil {
 		secrets = append(secrets, d.tlsSecret.Secret(namespace))
-	}
-	if d.dexSecret != nil {
-		secrets = append(secrets, secret.CopyToNamespace(namespace, d.dexSecret)...)
 	}
 	if d.idpSecret != nil {
 		secrets = append(secrets, secret.CopyToNamespace(namespace, d.idpSecret)...)
@@ -248,9 +235,6 @@ func (d *dexConfig) RequiredAnnotations() map[string]string {
 
 	if d.idpSecret != nil {
 		annotations[dexIdpSecretAnnotation] = rmeta.AnnotationHash(d.idpSecret.Data)
-	}
-	if d.dexSecret != nil {
-		annotations[dexSecretAnnotation] = rmeta.AnnotationHash(d.dexSecret.Data)
 	}
 	return annotations
 }
@@ -281,9 +265,7 @@ func (d *DexKeyValidatorConfig) RequiredEnv(prefix string) []corev1.EnvVar {
 
 // Append variables that are necessary for configuring dex.
 func (d *dexConfig) RequiredEnv(string) []corev1.EnvVar {
-	env := []corev1.EnvVar{
-		{Name: dexSecretEnv, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: d.dexSecret.Name}}}},
-	}
+	var env []corev1.EnvVar
 	if d.idpSecret != nil {
 		addIfPresent := func(fieldName, envName string) {
 			if _, found := d.idpSecret.Data[fieldName]; found {

--- a/pkg/render/dex_config_test.go
+++ b/pkg/render/dex_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,11 +71,10 @@ var _ = Describe("dex config tests", func() {
 			"serviceAccountSecret": []byte("my-secret2"),
 		},
 	}
-	dexSecret := render.CreateDexClientSecret()
 
 	Context("OIDC connector config options", func() {
 		It("should configure insecureSkipEmailVerified ", func() {
-			connector := render.NewDexConfig(nil, authentication, dexSecret, idpSecret, dns.DefaultClusterDomain).Connector()
+			connector := render.NewDexConfig(nil, authentication, idpSecret, dns.DefaultClusterDomain).Connector()
 			cfg := connector["config"].(map[string]interface{})
 			Expect(cfg["insecureSkipEmailVerified"]).To(Equal(true))
 		})
@@ -83,12 +82,12 @@ var _ = Describe("dex config tests", func() {
 
 	Context("Hashes should be consistent and not be affected by fields with pointers", func() {
 		It("should produce consistent hashes for dex config", func() {
-			hashes1 := render.NewDexConfig(nil, authentication, dexSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
-			hashes2 := render.NewDexConfig(nil, authentication.DeepCopy(), dexSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
-			hashes3 := render.NewDexConfig(nil, authenticationDiff, dexSecret, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
-			Expect(hashes1).To(HaveLen(3))
-			Expect(hashes2).To(HaveLen(3))
-			Expect(hashes3).To(HaveLen(3))
+			hashes1 := render.NewDexConfig(nil, authentication, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes2 := render.NewDexConfig(nil, authentication.DeepCopy(), idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			hashes3 := render.NewDexConfig(nil, authenticationDiff, idpSecret, dns.DefaultClusterDomain).RequiredAnnotations()
+			Expect(hashes1).To(HaveLen(2))
+			Expect(hashes2).To(HaveLen(2))
+			Expect(hashes3).To(HaveLen(2))
 			Expect(reflect.DeepEqual(hashes1, hashes2)).To(BeTrue())
 			Expect(reflect.DeepEqual(hashes1, hashes3)).To(BeFalse())
 		})
@@ -127,7 +126,7 @@ var _ = Describe("dex config tests", func() {
 	)
 
 	DescribeTable("Test DexConfig methods for various connectors ", func(auth *operatorv1.Authentication, expectedConnector map[string]interface{}, expectedVolumes []corev1.Volume, expectedEnv []corev1.EnvVar, secret *corev1.Secret) {
-		dexConfig := render.NewDexConfig(nil, auth, dexSecret, secret, dns.DefaultClusterDomain)
+		dexConfig := render.NewDexConfig(nil, auth, secret, dns.DefaultClusterDomain)
 		Expect(dexConfig.Connector()).To(BeEquivalentTo(expectedConnector))
 		annotations := dexConfig.RequiredAnnotations()
 
@@ -137,13 +136,11 @@ var _ = Describe("dex config tests", func() {
 		Expect(annotations).To(HaveKey("hash.operator.tigera.io/tigera-idp-secret"))
 		Expect(annotations["hash.operator.tigera.io/tigera-idp-secret"]).NotTo(BeEmpty())
 
-		Expect(annotations).To(HaveKey("hash.operator.tigera.io/tigera-dex-secret"))
-		Expect(annotations["hash.operator.tigera.io/tigera-dex-secret"]).NotTo(BeEmpty())
 		Expect(dexConfig.Issuer()).To(Equal(fmt.Sprintf("%s/dex", domain)))
 
 		Expect(dexConfig.RequiredVolumes()).To(ConsistOf(expectedVolumes))
 		Expect(dexConfig.RequiredEnv("")).To(Equal(expectedEnv))
-		Expect(dexConfig.RequiredSecrets("tigera-operator")).To(ConsistOf(dexSecret, secret))
+		Expect(dexConfig.RequiredSecrets("tigera-operator")).To(ConsistOf(secret))
 	},
 		Entry("Compare actual and expected OIDC config",
 			oidc, map[string]interface{}{
@@ -174,7 +171,6 @@ var _ = Describe("dex config tests", func() {
 					VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{DefaultMode: &defaultMode, SecretName: idpSecret.Name, Items: []corev1.KeyToPath{{Key: "serviceAccountSecret", Path: "google-groups.json"}}}},
 				},
 			}, []corev1.EnvVar{
-				{Name: "DEX_SECRET", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: dexSecret.Name}}}},
 				{Name: "CLIENT_ID", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.ClientIDSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: idpSecret.Name}}}},
 				{Name: "CLIENT_SECRET", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: idpSecret.Name}}}},
 				{Name: "ADMIN_EMAIL", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: "adminEmail", LocalObjectReference: corev1.LocalObjectReference{Name: idpSecret.Name}}}},
@@ -222,7 +218,6 @@ var _ = Describe("dex config tests", func() {
 					VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{DefaultMode: &defaultMode, SecretName: ldapSecret.Name, Items: []corev1.KeyToPath{{Key: render.RootCASecretField, Path: "idp.pem"}}}},
 				},
 			}, []corev1.EnvVar{
-				{Name: "DEX_SECRET", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: dexSecret.Name}}}},
 				{Name: "BIND_DN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.BindDNSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: ldapSecret.Name}}}},
 				{Name: "BIND_PW", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.BindPWSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: ldapSecret.Name}}}},
 			},
@@ -252,7 +247,6 @@ var _ = Describe("dex config tests", func() {
 					VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{DefaultMode: &defaultMode, SecretName: ocpSecret.Name, Items: []corev1.KeyToPath{{Key: render.RootCASecretField, Path: "idp.pem"}}}},
 				},
 			}, []corev1.EnvVar{
-				{Name: "DEX_SECRET", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: dexSecret.Name}}}},
 				{Name: "CLIENT_ID", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.ClientIDSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: ocpSecret.Name}}}},
 				{Name: "CLIENT_SECRET", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{Key: render.ClientSecretSecretField, LocalObjectReference: corev1.LocalObjectReference{Name: ocpSecret.Name}}}},
 			},
@@ -280,7 +274,7 @@ var _ = Describe("dex config tests", func() {
 			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 			Data:     secretData,
 		}
-		dexConfig := render.NewDexConfig(nil, google, dexSecret, secret, dns.DefaultClusterDomain)
+		dexConfig := render.NewDexConfig(nil, google, secret, dns.DefaultClusterDomain)
 		connector := dexConfig.Connector()["config"].(map[string]interface{})
 
 		email, emailFound := connector["adminEmail"]
@@ -319,7 +313,7 @@ var _ = Describe("dex config tests", func() {
 	DescribeTable("Test values for promptTypes ", func(in []operatorv1.PromptType, result string) {
 		auth := oidc.DeepCopy()
 		auth.Spec.OIDC.PromptTypes = in
-		dexConfig := render.NewDexConfig(nil, auth, dexSecret, idpSecret, dns.DefaultClusterDomain)
+		dexConfig := render.NewDexConfig(nil, auth, idpSecret, dns.DefaultClusterDomain)
 		config, ok := dexConfig.Connector()["config"].(map[string]interface{})
 		Expect(ok).To(BeTrue())
 		if result == "" {

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -67,7 +67,6 @@ var _ = Describe("dex rendering tests", func() {
 
 		var (
 			authentication *operatorv1.Authentication
-			dexSecret      *corev1.Secret
 			idpSecret      *corev1.Secret
 			pullSecrets    []*corev1.Secret
 			replicas       int32
@@ -164,7 +163,6 @@ var _ = Describe("dex rendering tests", func() {
 				},
 			}
 
-			dexSecret = render.CreateDexClientSecret()
 			idpSecret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      render.OIDCSecretName,
@@ -190,7 +188,7 @@ var _ = Describe("dex rendering tests", func() {
 
 			replicas = 2
 
-			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, dexSecret, idpSecret, clusterName)
+			dexCfg := render.NewDexConfig(installation.CertificateManagement, authentication, idpSecret, clusterName)
 			trustedCaBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -218,9 +216,7 @@ var _ = Describe("dex rendering tests", func() {
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: common.OperatorNamespace()}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretName, Namespace: common.OperatorNamespace()}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pullSecretName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.TigeraOperatorSecrets, Namespace: render.DexNamespace}},
@@ -286,7 +282,7 @@ var _ = Describe("dex rendering tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Web.Headers.ContentSecurityPolicy).To(Equal(""))
 			Expect(config.Web.Headers.XXSSProtection).To(Equal("1; mode=block"))
-			Expect(config.Web.Headers.XFrameOptions).To(Equal("DENY"))
+			Expect(config.Web.Headers.XFrameOptions).To(Equal("SAMEORIGIN"))
 			Expect(config.Web.Headers.StrictTransportSecurity).To(Equal("max-age=31536000; includeSubDomains"))
 			Expect(config.Web.Headers.XContentTypeOptions).To(Equal("nosniff"))
 		})
@@ -335,7 +331,7 @@ var _ = Describe("dex rendering tests", func() {
 
 		It("should render all resources for a certificate management", func() {
 			cfg.Installation.CertificateManagement = &operatorv1.CertificateManagement{}
-			cfg.DexConfig = render.NewDexConfig(cfg.Installation.CertificateManagement, authentication, dexSecret, idpSecret, clusterName)
+			cfg.DexConfig = render.NewDexConfig(cfg.Installation.CertificateManagement, authentication, idpSecret, clusterName)
 
 			component := render.Dex(cfg)
 			resources, _ := component.Objects()
@@ -350,9 +346,7 @@ var _ = Describe("dex rendering tests", func() {
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: common.OperatorNamespace()}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretName, Namespace: common.OperatorNamespace()}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.DexObjectName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: render.OIDCSecretName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pullSecretName, Namespace: render.DexNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-dex:csr-creator"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},


### PR DESCRIPTION
### feat(dex): Enable PKCE and silent token renewal for SPA

This change updates the Dex client configuration to support Single Page Applications (SPAs).

The Dex client is configured as public (`public: true`), which disables the use of a client secret and enables the more secure Proof Key for Code Exchange (PKCE) flow. This is the recommended standard for public
clients like browser-based applications.

Additionally, the 'X-Frame-Options' header is changed from 'DENY' to 'SAMEORIGIN'. This allows the SPA to use a hidden iframe to perform silent OIDC callbacks, enabling seamless token renewal without requiring a full-
page redirect.

Together, these changes improve security and user experience for the Calico Enterprise Manager when used as an SPA.

```release-note
This change updates the Dex client configuration to support Single Page Applications (SPAs) code flow with PKCE.
The 'X-Frame-Options' header was changed from 'DENY' to 'SAMEORIGIN'.
```