### PR TITLE
[release-v1.36] Auto pick #4137: feat(dex): Enable PKCE and silent token renewal for SPA

### DIFF
--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -352,9 +352,11 @@ func (c *dexComponent) configMap() *corev1.ConfigMap {
 			"allowedOrigins":          []string{"*"},
 			"discoveryAllowedOrigins": []string{"*"},
 			"headers": map[string]string{
-				"X-Content-Type-Options":    "nosniff",
-				"X-XSS-Protection":          "1; mode=block",
-				"X-Frame-Options":           "DENY",
+				"X-Content-Type-Options": "nosniff",
+				"X-XSS-Protection":       "1; mode=block",
+				// Since Dex is running on the same domain as the manager, this will allow an iFrame
+				// to make a silent-callback to refresh access tokens.
+				"X-Frame-Options":           "SAMEORIGIN",
 				"Strict-Transport-Security": "max-age=31536000; includeSubDomains",
 			},
 		},
@@ -369,6 +371,9 @@ func (c *dexComponent) configMap() *corev1.ConfigMap {
 				"redirectURIs": c.cfg.DexConfig.RedirectURIs(),
 				"name":         "Calico Enterprise Manager",
 				"secretEnv":    dexSecretEnv,
+				// When public is true, it enables the code PKCE flow as opposed to a client_secret,
+				// which is not secure for SPA.
+				"public": true,
 			},
 		},
 		"expiry": map[string]string{


### PR DESCRIPTION
Cherry pick of #4137 on release-v1.36.

#4137: feat(dex): Enable PKCE and silent token renewal for SPA

# Original branch name

rene-dekker:ci-1806

# Original PR Body below

### feat(dex): Enable PKCE and silent token renewal for SPA

This change updates the Dex client configuration to support Single Page Applications (SPAs).

The Dex client is configured as public (`public: true`), which disables the use of a client secret and enables the more secure Proof Key for Code Exchange (PKCE) flow. This is the recommended standard for public
clients like browser-based applications.

Additionally, the 'X-Frame-Options' header is changed from 'DENY' to 'SAMEORIGIN'. This allows the SPA to use a hidden iframe to perform silent OIDC callbacks, enabling seamless token renewal without requiring a full-
page redirect.

Together, these changes improve security and user experience for the Calico Enterprise Manager when used as an SPA.

```release-note
This change updates the Dex client configuration to support Single Page Applications (SPAs) code flow with PKCE.
The 'X-Frame-Options' header was changed from 'DENY' to 'SAMEORIGIN'.
```