### PR TITLE
Fix OIDC PKCE flow + Google connector

### DIFF
--- a/pkg/render/dex_config.go
+++ b/pkg/render/dex_config.go
@@ -255,7 +255,15 @@ func (d *dexBaseCfg) RequestedScopes() []string {
 	if d.authentication.Spec.OIDC != nil && d.authentication.Spec.OIDC.RequestedScopes != nil {
 		return d.authentication.Spec.OIDC.RequestedScopes
 	}
-	return []string{"openid", "email", "profile"}
+	return []string{
+		// openid: Standard OIDC scope, always required.
+		"openid",
+		// email: This is the one that requests the `email` and `email_verified` claims. It is the most commonly used username claim.
+		"email",
+		// profile: Gets user metadata claims like name, picture, etc.
+		"profile",
+		// offline_access: This claim is necessary for the PKCE flow in order to refresh access_tokens.
+		"offline_access"}
 }
 
 func (d *dexBaseCfg) RequiredSecrets(namespace string) []*corev1.Secret {

--- a/pkg/render/dex_config_test.go
+++ b/pkg/render/dex_config_test.go
@@ -152,7 +152,7 @@ var _ = Describe("dex config tests", func() {
 					"clientID":                  "$CLIENT_ID",
 					"clientSecret":              "$CLIENT_SECRET",
 					"redirectURI":               "https://example.com/dex/callback",
-					"scopes":                    []string{"openid", "email", "profile"},
+					"scopes":                    []string{"openid", "email", "profile", "offline_access"},
 					"userNameKey":               "email",
 					"userIDKey":                 "email",
 					"claimMapping":              map[string]string{"groups": "group"},

--- a/pkg/render/dex_config_test.go
+++ b/pkg/render/dex_config_test.go
@@ -265,7 +265,7 @@ var _ = Describe("dex config tests", func() {
 		Entry("Compare actual and expected Openshift config", ocp),
 	)
 
-	DescribeTable("Test dex connector for Google ", func(secretData map[string][]byte, expectPresent bool) {
+	DescribeTable("Test dex connector for Google ", func(secretData map[string][]byte, expectPresent bool, emailVerification operatorv1.EmailVerificationType) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      render.OIDCSecretName,
@@ -274,11 +274,17 @@ var _ = Describe("dex config tests", func() {
 			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 			Data:     secretData,
 		}
+		google.Spec.OIDC.EmailVerification = &emailVerification
 		dexConfig := render.NewDexConfig(nil, google, secret, nil, dns.DefaultClusterDomain)
 		connector := dexConfig.Connector()["config"].(map[string]interface{})
 
 		email, emailFound := connector["adminEmail"]
 		saPath, saFound := connector["serviceAccountFilePath"]
+		if emailVerification == operatorv1.EmailVerificationTypeSkip {
+			Expect(connector["insecureSkipEmailVerified"]).To(Equal(true))
+		} else {
+			Expect(connector["insecureSkipEmailVerified"]).To(Equal(false))
+		}
 		if expectPresent {
 			Expect(email).To(Equal(email))
 			Expect(emailFound).To(BeTrue())
@@ -294,21 +300,34 @@ var _ = Describe("dex config tests", func() {
 			"clientID":             []byte("a.b.com"),
 			"clientSecret":         []byte("my-secret"),
 			"serviceAccountSecret": []byte("my-secret2"),
-		}, true),
+		}, true, nil),
 		Entry("Compare actual and expected OIDC config", map[string][]byte{
 			"clientID":     []byte("a.b.com"),
 			"clientSecret": []byte("my-secret"),
-		}, false),
+		}, false, nil),
 		Entry("Compare actual and expected OIDC config", map[string][]byte{
 			"clientID":             []byte("a.b.com"),
 			"clientSecret":         []byte("my-secret"),
 			"serviceAccountSecret": []byte("my-secret2"),
-		}, false),
+		}, false, nil),
 		Entry("Compare actual and expected OIDC config", map[string][]byte{
 			"adminEmail":   []byte(email),
 			"clientID":     []byte("a.b.com"),
 			"clientSecret": []byte("my-secret"),
-		}, false))
+		}, false, nil),
+		Entry("Check that EmailVerificationTypeSkip is properly propagated", map[string][]byte{
+			"adminEmail":           []byte(email),
+			"clientID":             []byte("a.b.com"),
+			"clientSecret":         []byte("my-secret"),
+			"serviceAccountSecret": []byte("my-secret2"),
+		}, true, operatorv1.EmailVerificationTypeSkip),
+		Entry("Check that EmailVerificationTypeVerify is properly propagated", map[string][]byte{
+			"adminEmail":           []byte(email),
+			"clientID":             []byte("a.b.com"),
+			"clientSecret":         []byte("my-secret"),
+			"serviceAccountSecret": []byte("my-secret2"),
+		}, true, operatorv1.EmailVerificationTypeVerify),
+	)
 
 	DescribeTable("Test values for promptTypes ", func(in []operatorv1.PromptType, result string) {
 		auth := oidc.DeepCopy()


### PR DESCRIPTION
 This PR includes two fixes:

### fix!: add missing offline_access claim to requestedScopes when not defined by user 

Although documented in our api as a default value when requestedScopes is not provided, the code no longer defaulted this value since PR #1065. Likely, this has to do with the fact that only recently we started using this claim when we switched from the implicit flow to the code flow for our UI.

BREAKING CHANGE: fixed the defaulting behaviour for Authentication.Spec.OIDC.requestedScopes such that it now includes offline_access as documented in the API.

### fix: fix email unverified issue when obtaining dex token

In recent times, the Google flow no longer results in email_verified claim being true by default. We now propagate the insecureSkipEmailVerify setting also for the google connector.