### PR TITLE
Don't use * for impersonation resourceNames

### DIFF
--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -237,18 +237,28 @@ func (c *GuardianComponent) serviceAccount() *corev1.ServiceAccount {
 	}
 }
 
+func formatImpersonationResourceNames(resourceNames []string) []string {
+	for _, resourceName := range resourceNames {
+		// If the resource name is "*", then we need to return an empty list as * signifies all resources.
+		if resourceName == "*" {
+			return []string{}
+		}
+	}
+
+	return resourceNames
+}
+
 func (c *GuardianComponent) clusterRole() *rbacv1.ClusterRole {
 	var policyRules []rbacv1.PolicyRule
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		impersonation := c.cfg.ManagementClusterConnection.Spec.Impersonation
 		if impersonation != nil {
-
 			if len(impersonation.Users) > 0 {
 				policyRules = append(policyRules,
 					rbacv1.PolicyRule{
 						APIGroups:     []string{""},
 						Resources:     []string{"users"},
-						ResourceNames: impersonation.Users,
+						ResourceNames: formatImpersonationResourceNames(impersonation.Users),
 						Verbs:         []string{"impersonate"},
 					})
 			}
@@ -257,7 +267,7 @@ func (c *GuardianComponent) clusterRole() *rbacv1.ClusterRole {
 					rbacv1.PolicyRule{
 						APIGroups:     []string{""},
 						Resources:     []string{"groups"},
-						ResourceNames: impersonation.Groups,
+						ResourceNames: formatImpersonationResourceNames(impersonation.Groups),
 						Verbs:         []string{"impersonate"},
 					})
 			}
@@ -266,7 +276,7 @@ func (c *GuardianComponent) clusterRole() *rbacv1.ClusterRole {
 					rbacv1.PolicyRule{
 						APIGroups:     []string{""},
 						Resources:     []string{"serviceaccounts"},
-						ResourceNames: impersonation.ServiceAccounts,
+						ResourceNames: formatImpersonationResourceNames(impersonation.ServiceAccounts),
 						Verbs:         []string{"impersonate"},
 					})
 			}

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -175,6 +175,88 @@ var _ = Describe("Rendering tests", func() {
 				Effect:   corev1.TaintEffectNoSchedule,
 			}))
 		})
+
+		It("should render guardian with unlimited impersonation", func() {
+			cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{
+				Spec: operatorv1.ManagementClusterConnectionSpec{
+					Impersonation: &operatorv1.Impersonation{
+						Users:           []string{"*"},
+						Groups:          []string{"*"},
+						ServiceAccounts: []string{"*"},
+					},
+				},
+			}
+
+			g := render.Guardian(cfg)
+			resources, _ := g.Objects()
+			Expect(resources).ToNot(BeNil())
+
+			clusterRole, ok := rtest.GetResource(resources, render.GuardianClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(ok).To(BeTrue())
+
+			foundUserImp, foundGroupImp, foundSaImp := false, false, false
+			for _, rule := range clusterRole.Rules {
+				if rule.Verbs[0] == "impersonate" {
+					if rule.Resources[0] == "users" {
+						Expect(rule.ResourceNames).To(Equal([]string{}))
+						foundUserImp = true
+					}
+					if rule.Resources[0] == "groups" {
+						Expect(rule.ResourceNames).To(Equal([]string{}))
+						foundGroupImp = true
+					}
+					if rule.Resources[0] == "serviceaccounts" {
+						Expect(rule.ResourceNames).To(Equal([]string{}))
+						foundSaImp = true
+					}
+				}
+			}
+
+			Expect(foundUserImp).To(BeTrue())
+			Expect(foundGroupImp).To(BeTrue())
+			Expect(foundSaImp).To(BeTrue())
+		})
+
+		It("should render guardian with specific impersonation", func() {
+			cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{
+				Spec: operatorv1.ManagementClusterConnectionSpec{
+					Impersonation: &operatorv1.Impersonation{
+						Users:           []string{"foo"},
+						Groups:          []string{"bar"},
+						ServiceAccounts: []string{"zaz"},
+					},
+				},
+			}
+
+			g := render.Guardian(cfg)
+			resources, _ := g.Objects()
+			Expect(resources).ToNot(BeNil())
+
+			clusterRole, ok := rtest.GetResource(resources, render.GuardianClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(ok).To(BeTrue())
+
+			foundUserImp, foundGroupImp, foundSaImp := false, false, false
+			for _, rule := range clusterRole.Rules {
+				if rule.Verbs[0] == "impersonate" {
+					if rule.Resources[0] == "users" {
+						Expect(rule.ResourceNames).To(Equal([]string{"foo"}))
+						foundUserImp = true
+					}
+					if rule.Resources[0] == "groups" {
+						Expect(rule.ResourceNames).To(Equal([]string{"bar"}))
+						foundGroupImp = true
+					}
+					if rule.Resources[0] == "serviceaccounts" {
+						Expect(rule.ResourceNames).To(Equal([]string{"zaz"}))
+						foundSaImp = true
+					}
+				}
+			}
+
+			Expect(foundUserImp).To(BeTrue())
+			Expect(foundGroupImp).To(BeTrue())
+			Expect(foundSaImp).To(BeTrue())
+		})
 	})
 
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
@@ -290,7 +372,6 @@ var _ = Describe("guardian", func() {
 			rtest.ExpectEnv(container.Env, "GUARDIAN_VOLTRON_CA_TYPE", "Public")
 		})
 		It("should render guardian with resource requests and limits when configured", func() {
-
 			guardianResources := corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					"cpu":     resource.MustParse("2"),


### PR DESCRIPTION
Resource names don't accept *, * would signifiy a resource named star. If we come accross * in the CR config then leave the impersonation resourceName list empty (that signifies all resource names).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
