### PR TITLE
[release-v1.39] Auto pick #4161: Don't use * for impersonation resourceNames

### DIFF
--- a/api/v1/managementclusterconnection_types.go
+++ b/api/v1/managementclusterconnection_types.go
@@ -48,17 +48,20 @@ type ManagementClusterConnectionSpec struct {
 
 // Impersonation defines the rules for allowing impersonation.
 type Impersonation struct {
-	// Users is a list of users that can be impersonated.
+	// Users is a list of users that can be impersonated. An empty list infers all users can be impersonated, a null
+	// value means none.
 	// +optional
-	Users []string `json:"users,omitempty"`
+	Users []string `json:"users"`
 
-	// Groups is a list of group names that can be impersonated.
+	// Groups is a list of group names that can be impersonated. An empty list infers all groups can be impersonated,
+	//	// a null values means none.
 	// +optional
-	Groups []string `json:"groups,omitempty"`
+	Groups []string `json:"groups"`
 
-	// ServiceAccounts is a list of service account names that can be impersonated.
+	// ServiceAccounts is a list of service account names that can be impersonated. An empty list infers all service accounts can
+	// be impersonated, a null values means none.
 	// +optional
-	ServiceAccounts []string `json:"serviceAccounts,omitempty"`
+	ServiceAccounts []string `json:"serviceAccounts"`
 }
 
 type ManagementClusterTLS struct {

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -520,11 +520,10 @@ func fillDefaults(cr *operatorv1.ManagementClusterConnection, variant operatorv1
 		cr.Spec.TLS.CA = operatorv1.CATypeTigera
 	}
 	if variant == operatorv1.TigeraSecureEnterprise && cr.Spec.Impersonation == nil {
-		var wildcard = []string{"*"}
 		cr.Spec.Impersonation = &operatorv1.Impersonation{
-			Users:           wildcard,
-			Groups:          wildcard,
-			ServiceAccounts: wildcard,
+			Users:           []string{},
+			Groups:          []string{},
+			ServiceAccounts: []string{},
 		}
 	}
 }

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -751,7 +751,6 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 	})
 
 	val := []string{"some-value"}
-	star := []string{"*"}
 	DescribeTable("should render impersonation permissions correctly", func(impersonation *operatorv1.Impersonation, expectedUser, expectedGroup, expectedSA []string) {
 		By("ensuring a tigerastatus exists")
 		ts := &operatorv1.TigeraStatus{
@@ -795,8 +794,9 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		Expect(groups).To(Equal(expectedGroup))
 		Expect(sas).To(Equal(expectedSA))
 	},
-		Entry("no impersonation configured", nil, star, star, star),
+		Entry("no impersonation configured", nil, nil, nil, nil),
 		Entry("all set", &operatorv1.Impersonation{Users: val, Groups: val, ServiceAccounts: val}, val, val, val),
+		Entry("all set to empty", &operatorv1.Impersonation{Users: []string{}, Groups: []string{}, ServiceAccounts: []string{}}, nil, nil, nil),
 		Entry("user set", &operatorv1.Impersonation{Users: val}, val, nil, nil),
 		Entry("groups set", &operatorv1.Impersonation{Groups: val}, nil, val, nil),
 		Entry("service accounts set", &operatorv1.Impersonation{ServiceAccounts: val}, nil, nil, val),

--- a/pkg/crds/operator/operator.tigera.io_managementclusterconnections.yaml
+++ b/pkg/crds/operator/operator.tigera.io_managementclusterconnections.yaml
@@ -236,19 +236,24 @@ spec:
                     guardian will lose its default permissions to impersonate groups.
                   properties:
                     groups:
-                      description: Groups is a list of group names that can be impersonated.
+                      description:
+                        "Groups is a list of group names that can be impersonated.
+                        An empty list infers all groups can be impersonated,\n\t// a
+                        null values means none."
                       items:
                         type: string
                       type: array
                     serviceAccounts:
-                      description:
-                        ServiceAccounts is a list of service account names
-                        that can be impersonated.
+                      description: |-
+                        ServiceAccounts is a list of service account names that can be impersonated. An empty list infers all service accounts can
+                        be impersonated, a null values means none.
                       items:
                         type: string
                       type: array
                     users:
-                      description: Users is a list of users that can be impersonated.
+                      description: |-
+                        Users is a list of users that can be impersonated. An empty list infers all users can be impersonated, a null
+                        value means none.
                       items:
                         type: string
                       type: array

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -242,8 +242,7 @@ func (c *GuardianComponent) clusterRole() *rbacv1.ClusterRole {
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		impersonation := c.cfg.ManagementClusterConnection.Spec.Impersonation
 		if impersonation != nil {
-
-			if len(impersonation.Users) > 0 {
+			if impersonation.Users != nil {
 				policyRules = append(policyRules,
 					rbacv1.PolicyRule{
 						APIGroups:     []string{""},
@@ -252,7 +251,7 @@ func (c *GuardianComponent) clusterRole() *rbacv1.ClusterRole {
 						Verbs:         []string{"impersonate"},
 					})
 			}
-			if len(impersonation.Groups) > 0 {
+			if impersonation.Groups != nil {
 				policyRules = append(policyRules,
 					rbacv1.PolicyRule{
 						APIGroups:     []string{""},
@@ -261,7 +260,7 @@ func (c *GuardianComponent) clusterRole() *rbacv1.ClusterRole {
 						Verbs:         []string{"impersonate"},
 					})
 			}
-			if len(impersonation.ServiceAccounts) > 0 {
+			if impersonation.ServiceAccounts != nil {
 				policyRules = append(policyRules,
 					rbacv1.PolicyRule{
 						APIGroups:     []string{""},

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -175,6 +175,125 @@ var _ = Describe("Rendering tests", func() {
 				Effect:   corev1.TaintEffectNoSchedule,
 			}))
 		})
+
+		It("should render guardian with unlimited impersonation", func() {
+			cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{
+				Spec: operatorv1.ManagementClusterConnectionSpec{
+					Impersonation: &operatorv1.Impersonation{
+						Users:           []string{},
+						Groups:          []string{},
+						ServiceAccounts: []string{},
+					},
+				},
+			}
+
+			g := render.Guardian(cfg)
+			resources, _ := g.Objects()
+			Expect(resources).ToNot(BeNil())
+
+			clusterRole, ok := rtest.GetResource(resources, render.GuardianClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(ok).To(BeTrue())
+
+			foundUserImp, foundGroupImp, foundSaImp := false, false, false
+			for _, rule := range clusterRole.Rules {
+				if rule.Verbs[0] == "impersonate" {
+					if rule.Resources[0] == "users" {
+						Expect(rule.ResourceNames).To(Equal([]string{}))
+						foundUserImp = true
+					}
+					if rule.Resources[0] == "groups" {
+						Expect(rule.ResourceNames).To(Equal([]string{}))
+						foundGroupImp = true
+					}
+					if rule.Resources[0] == "serviceaccounts" {
+						Expect(rule.ResourceNames).To(Equal([]string{}))
+						foundSaImp = true
+					}
+				}
+			}
+
+			Expect(foundUserImp).To(BeTrue())
+			Expect(foundGroupImp).To(BeTrue())
+			Expect(foundSaImp).To(BeTrue())
+		})
+
+		It("should render guardian with specific impersonation", func() {
+			cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{
+				Spec: operatorv1.ManagementClusterConnectionSpec{
+					Impersonation: &operatorv1.Impersonation{
+						Users:           []string{"foo"},
+						Groups:          []string{"bar"},
+						ServiceAccounts: []string{"zaz"},
+					},
+				},
+			}
+
+			g := render.Guardian(cfg)
+			resources, _ := g.Objects()
+			Expect(resources).ToNot(BeNil())
+
+			clusterRole, ok := rtest.GetResource(resources, render.GuardianClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(ok).To(BeTrue())
+
+			foundUserImp, foundGroupImp, foundSaImp := false, false, false
+			for _, rule := range clusterRole.Rules {
+				if rule.Verbs[0] == "impersonate" {
+					if rule.Resources[0] == "users" {
+						Expect(rule.ResourceNames).To(Equal([]string{"foo"}))
+						foundUserImp = true
+					}
+					if rule.Resources[0] == "groups" {
+						Expect(rule.ResourceNames).To(Equal([]string{"bar"}))
+						foundGroupImp = true
+					}
+					if rule.Resources[0] == "serviceaccounts" {
+						Expect(rule.ResourceNames).To(Equal([]string{"zaz"}))
+						foundSaImp = true
+					}
+				}
+			}
+
+			Expect(foundUserImp).To(BeTrue())
+			Expect(foundGroupImp).To(BeTrue())
+			Expect(foundSaImp).To(BeTrue())
+		})
+
+		It("should render guardian with specific no sa permissions but with user and group", func() {
+			cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{
+				Spec: operatorv1.ManagementClusterConnectionSpec{
+					Impersonation: &operatorv1.Impersonation{
+						Users:  []string{},
+						Groups: []string{},
+					},
+				},
+			}
+
+			g := render.Guardian(cfg)
+			resources, _ := g.Objects()
+			Expect(resources).ToNot(BeNil())
+
+			clusterRole, ok := rtest.GetResource(resources, render.GuardianClusterRoleName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(ok).To(BeTrue())
+
+			foundUserImp, foundGroupImp, foundSaImp := false, false, false
+			for _, rule := range clusterRole.Rules {
+				if rule.Verbs[0] == "impersonate" {
+					if rule.Resources[0] == "users" {
+						foundUserImp = true
+					}
+					if rule.Resources[0] == "groups" {
+						foundGroupImp = true
+					}
+					if rule.Resources[0] == "serviceaccounts" {
+						foundSaImp = true
+					}
+				}
+			}
+
+			Expect(foundUserImp).To(BeTrue())
+			Expect(foundGroupImp).To(BeTrue())
+			Expect(foundSaImp).To(BeFalse())
+		})
 	})
 
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
@@ -290,7 +409,6 @@ var _ = Describe("guardian", func() {
 			rtest.ExpectEnv(container.Env, "GUARDIAN_VOLTRON_CA_TYPE", "Public")
 		})
 		It("should render guardian with resource requests and limits when configured", func() {
-
 			guardianResources := corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					"cpu":     resource.MustParse("2"),


### PR DESCRIPTION
Cherry pick of #4161 on release-v1.39.

#4161: Don't use * for impersonation resourceNames

# Original PR Body below

Resource names don't accept *, * would signifiy a resource named star. If we come accross * in the CR config then leave the impersonation resourceName list empty (that signifies all resource names).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.