### PR TITLE
[RS-2781] Enforce gateway licensing for l7-log-collector

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -142,6 +142,9 @@ components:
   l7-collector:
     image: tigera/l7-collector
     version: master
+  gateway-l7-collector:
+    image: tigera/gateway-l7-collector
+    version: master
   envoy:
     image: tigera/envoy
     version: master

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -233,6 +233,13 @@ var (
 		Registry: "{{ .Registry }}",
 	}
 {{- end }}
+{{ with index .Components "gateway-l7-collector" }}
+	ComponentGatewayL7Collector = Component{
+		Version:  "{{ .Version }}",
+		Image:    "{{ .Image }}",
+		Registry: "{{ .Registry }}",
+	}
+{{- end }}
 {{ with index .Components "envoy" }}
 	ComponentEnvoyProxy = Component{
 		Version:  "{{ .Version }}",
@@ -414,6 +421,7 @@ var (
 		ComponentPolicyRecommendation,
 		ComponentEgressGateway,
 		ComponentL7Collector,
+		ComponentGatewayL7Collector,
 		ComponentEnvoyProxy,
 		ComponentPrometheus,
 		ComponentTigeraPrometheusService,

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -203,6 +203,12 @@ var (
 		Registry: "",
 	}
 
+	ComponentGatewayL7Collector = Component{
+		Version:  "master",
+		Image:    "tigera/gateway-l7-collector",
+		Registry: "",
+	}
+
 	ComponentEnvoyProxy = Component{
 		Version:  "master",
 		Image:    "tigera/envoy",
@@ -361,6 +367,7 @@ var (
 		ComponentPolicyRecommendation,
 		ComponentEgressGateway,
 		ComponentL7Collector,
+		ComponentGatewayL7Collector,
 		ComponentEnvoyProxy,
 		ComponentPrometheus,
 		ComponentTigeraPrometheusService,

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -413,7 +413,7 @@ func (pr *gatewayAPIImplementationComponent) ResolveImages(is *operatorv1.ImageS
 		if err != nil {
 			return err
 		}
-		pr.L7LogCollectorImage, err = components.GetReference(components.ComponentL7Collector, reg, path, prefix, is)
+		pr.L7LogCollectorImage, err = components.GetReference(components.ComponentGatewayL7Collector, reg, path, prefix, is)
 		if err != nil {
 			return err
 		}

--- a/pkg/render/gateway_api.go
+++ b/pkg/render/gateway_api.go
@@ -753,10 +753,6 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 				Image: pr.L7LogCollectorImage,
 				Env: []corev1.EnvVar{
 					{
-						Name:  "ENABLE_LOG_TAIL",
-						Value: "true",
-					},
-					{
 						Name:  "FELIX_DIAL_TARGET",
 						Value: "/var/run/felix/nodeagent/socket",
 					},


### PR DESCRIPTION
## Description

This uses the new gateway l7 collector that uses the access logs and enforces licensing. It relates to https://github.com/tigera/calico-private/pull/9784. 

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
