### PR TITLE
Support BYO certificates for non-cluster hosts

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1321,20 +1321,31 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to query NonClusterHost resource", err, reqLogger)
 			return reconcile.Result{}, err
-		} else if nonclusterhost != nil && r.typhaAutoscalerNonClusterHost == nil {
-			calicoClient, err := calicoclient.NewForConfig(r.config)
-			if err != nil {
-				r.status.SetDegraded(operatorv1.InvalidConfigurationError, "Failed to initialize Calico client", err, reqLogger)
-				return reconcile.Result{}, err
+		} else if nonclusterhost != nil {
+			// Attempt to retrieve the BYO node certificates for non-cluster hosts if they are present.
+			secret, err := utils.GetSecret(context.TODO(), r.client, render.NodeTLSSecretNameNonClusterHost, common.OperatorNamespace())
+			if err == nil && secret != nil {
+				data := secret.Data
+				if data != nil {
+					typhaNodeTLS.NodeNonClusterHostCommonName, typhaNodeTLS.NodeNonClusterHostURISAN = string(data[render.CommonName]), string(data[render.URISAN])
+				}
 			}
 
-			hepListWatch := cache.NewListWatchFromClient(calicoClient.ProjectcalicoV3().RESTClient(), "hostendpoints", corev1.NamespaceAll, fields.Everything())
-			hepIndexInformer := cache.NewSharedIndexInformer(hepListWatch, &v3.HostEndpoint{}, 0, cache.Indexers{})
-			go hepIndexInformer.Run(r.shutdownContext.Done())
+			if r.typhaAutoscalerNonClusterHost == nil {
+				calicoClient, err := calicoclient.NewForConfig(r.config)
+				if err != nil {
+					r.status.SetDegraded(operatorv1.InvalidConfigurationError, "Failed to initialize Calico client", err, reqLogger)
+					return reconcile.Result{}, err
+				}
 
-			typhaNonClusterHostWatch := cache.NewListWatchFromClient(r.clientset.AppsV1().RESTClient(), "deployments", "calico-system", fields.OneTermEqualSelector("metadata.name", "calico-typha"+render.TyphaNonClusterHostSuffix))
-			r.typhaAutoscalerNonClusterHost = newTyphaAutoscaler(r.clientset, hepIndexInformer, typhaNonClusterHostWatch, r.status, typhaAutoscalerOptionNonclusterHost(true))
-			r.typhaAutoscalerNonClusterHost.start(r.shutdownContext)
+				hepListWatch := cache.NewListWatchFromClient(calicoClient.ProjectcalicoV3().RESTClient(), "hostendpoints", corev1.NamespaceAll, fields.Everything())
+				hepIndexInformer := cache.NewSharedIndexInformer(hepListWatch, &v3.HostEndpoint{}, 0, cache.Indexers{})
+				go hepIndexInformer.Run(r.shutdownContext.Done())
+
+				typhaNonClusterHostWatch := cache.NewListWatchFromClient(r.clientset.AppsV1().RESTClient(), "deployments", "calico-system", fields.OneTermEqualSelector("metadata.name", "calico-typha"+render.TyphaNonClusterHostSuffix))
+				r.typhaAutoscalerNonClusterHost = newTyphaAutoscaler(r.clientset, hepIndexInformer, typhaNonClusterHostWatch, r.status, typhaAutoscalerOptionNonclusterHost(true))
+				r.typhaAutoscalerNonClusterHost.start(r.shutdownContext)
+			}
 		}
 	}
 

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -116,6 +116,8 @@ var _ = Describe("Testing core-controller installation", func() {
 	ready.MarkAsReady()
 
 	Context("mainline tests", func() {
+		var nodeIndexInformer cache.SharedIndexInformer
+
 		BeforeEach(func() {
 			// The schema contains all objects that should be known to the fake client when the test runs.
 			scheme = runtime.NewScheme()
@@ -165,7 +167,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// Create the indexer and informer used by the typhaAutoscaler
 			nlw := test.NewNodeListWatch(cs)
-			nodeIndexInformer := cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
+			nodeIndexInformer = cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
 
 			go nodeIndexInformer.Run(ctx.Done())
 			for nodeIndexInformer.HasSynced() {
@@ -235,6 +237,97 @@ var _ = Describe("Testing core-controller installation", func() {
 
 		AfterEach(func() {
 			cancel()
+		})
+
+		Context("non-cluster host tests", func() {
+			nonclusterhost := &operator.NonClusterHost{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}}
+
+			BeforeEach(func() {
+				By("Creating a NonClusterHost CR")
+				Expect(c.Create(ctx, nonclusterhost)).NotTo(HaveOccurred())
+
+				r.typhaAutoscalerNonClusterHost = newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus)
+				r.typhaAutoscalerNonClusterHost.start(ctx)
+			})
+
+			AfterEach(func() {
+				r.typhaAutoscalerNonClusterHost = nil
+				Expect(c.Delete(ctx, nonclusterhost)).NotTo(HaveOccurred())
+			})
+
+			It("should create a separate Typha deployment for non-cluster hosts", func() {
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).NotTo(HaveOccurred())
+
+				deploy := appsv1.Deployment{}
+				err = c.Get(ctx, types.NamespacedName{Name: "calico-typha-noncluster-host", Namespace: common.CalicoNamespace}, &deploy)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+				Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+					corev1.EnvVar{Name: "TYPHA_CLIENTCN", Value: "typha-client-noncluster-host"},
+				))
+			})
+
+			It("should use the common-name from node-certs-noncluster-host secret", func() {
+				secret := &corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{Name: "node-certs-noncluster-host", Namespace: common.OperatorNamespace()},
+					Data: map[string][]byte{
+						"tls.crt":     []byte("tls.crt"),
+						"tls.key":     []byte("tls.key"),
+						"common-name": []byte("custom-nch-cn"),
+					},
+				}
+				err := c.Create(ctx, secret)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() {
+					Expect(c.Delete(ctx, secret)).NotTo(HaveOccurred())
+				}()
+
+				_, err = r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).NotTo(HaveOccurred())
+
+				deploy := appsv1.Deployment{}
+				err = c.Get(ctx, types.NamespacedName{Name: "calico-typha-noncluster-host", Namespace: common.CalicoNamespace}, &deploy)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+				Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+					corev1.EnvVar{Name: "TYPHA_CLIENTCN", Value: "custom-nch-cn"},
+				))
+			})
+
+			It("should use the uri-san from node-certs-noncluster-host secret", func() {
+				secret := &corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{Name: "node-certs-noncluster-host", Namespace: common.OperatorNamespace()},
+					Data: map[string][]byte{
+						"tls.crt": []byte("tls.crt"),
+						"tls.key": []byte("tls.key"),
+						"uri-san": []byte("spiffe://custom-nch-uri-san"),
+					},
+				}
+				err := c.Create(ctx, secret)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() {
+					Expect(c.Delete(ctx, secret)).NotTo(HaveOccurred())
+				}()
+
+				_, err = r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).NotTo(HaveOccurred())
+
+				deploy := appsv1.Deployment{}
+				err = c.Get(ctx, types.NamespacedName{Name: "calico-typha-noncluster-host", Namespace: common.CalicoNamespace}, &deploy)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+				Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+					corev1.EnvVar{Name: "TYPHA_CLIENTURISAN", Value: "spiffe://custom-nch-uri-san"},
+				))
+			})
 		})
 
 		Context("with Goldmane installed", func() {
@@ -1064,6 +1157,7 @@ var _ = Describe("Testing core-controller installation", func() {
 					Expect(err.Error()).To(ContainSubstring("bpfNetworkBootstrap is enabled but linuxDataplane is not set to BPF"))
 				})
 			})
+
 			When("the LinuxDataplane is BPF", func() {
 				BeforeEach(func() {
 					By("Setting the dataplane to BPF and Enabling network bootstrap")

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -92,6 +92,9 @@ type TyphaNodeTLS struct {
 	NodeSecret                certificatemanagement.KeyPairInterface
 	NodeCommonName            string
 	NodeURISAN                string
+
+	NodeNonClusterHostCommonName string
+	NodeNonClusterHostURISAN     string
 }
 
 // NodeConfiguration is the public API used to provide information to the render code to

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -171,11 +171,17 @@ var _ = Describe("Typha rendering tests", func() {
 			&corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			}))
+	})
 
-		// Validate the non-cluster host typha deployment
-		dResource = rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment")
+	It("should render a separate Typha deployment for non-cluster hosts", func() {
+		component := render.Typha(&cfg)
+		resources, _ := component.Objects()
+
+		dResource := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment")
 		Expect(dResource).ToNot(BeNil())
-		d = dResource.(*appsv1.Deployment)
+		d, ok := dResource.(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(d).NotTo(BeNil())
 
 		Expect(d.Spec.Template.Spec.Affinity).To(BeNil())
 		Expect(d.Spec.Template.Spec.HostNetwork).To(BeFalse())
@@ -188,6 +194,40 @@ var _ = Describe("Typha rendering tests", func() {
 		))
 		Expect(d.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Host).To(BeEmpty())
 		Expect(d.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Host).To(BeEmpty())
+	})
+
+	It("should use custom client common name when specified for non-cluster host Typha deployment", func() {
+		cfg.TLS.NodeNonClusterHostCommonName = "custom-nch-cn"
+		component := render.Typha(&cfg)
+		resources, _ := component.Objects()
+
+		dResource := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment")
+		Expect(dResource).ToNot(BeNil())
+		d, ok := dResource.(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(d).NotTo(BeNil())
+
+		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+			corev1.EnvVar{Name: "TYPHA_CLIENTCN", Value: "custom-nch-cn"},
+		))
+	})
+
+	It("should use custom client uri-san when specified for non-cluster host Typha deployment", func() {
+		cfg.TLS.NodeNonClusterHostURISAN = "spiffe://custom-nch-uri-san"
+		component := render.Typha(&cfg)
+		resources, _ := component.Objects()
+
+		dResource := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment")
+		Expect(dResource).ToNot(BeNil())
+		d, ok := dResource.(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		Expect(d).NotTo(BeNil())
+
+		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+			corev1.EnvVar{Name: "TYPHA_CLIENTURISAN", Value: "spiffe://custom-nch-uri-san"},
+		))
 	})
 
 	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
@@ -439,6 +479,7 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(deploy.Spec.Template.Spec.InitContainers[0].Name).To(Equal(fmt.Sprintf("%s-key-cert-provisioner", render.TyphaTLSSecretName)))
 		rtest.ExpectEnv(deploy.Spec.Template.Spec.InitContainers[0].Env, "SIGNER", "a.b/c")
 	})
+
 	It("should not enable prometheus metrics if TyphaMetricsPort is nil", func() {
 		installation.Variant = operatorv1.TigeraSecureEnterprise
 		installation.TyphaMetricsPort = nil


### PR DESCRIPTION
## Description

This change enables non-cluster hosts to use custom signed certificaes for Node and Typha, following the same setup process in [1]. Secret names are changed to non-cluster host specific names to avoid conflicts with in-cluster setup.

[1] https://docs.tigera.io/calico-enterprise/latest/operations/comms/typha-node-tls

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
