### PR TITLE
Update semaphore os_agent from Ubuntu 20 to Ubuntu 22

### DIFF
--- a/.semaphore/clean_up.yml
+++ b/.semaphore/clean_up.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: f1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 
 blocks:
   - name: Clear Commit Caches

--- a/.semaphore/clear_cache.yml
+++ b/.semaphore/clear_cache.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: f1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 
 blocks:
   - name: Clear Entire Cache

--- a/.semaphore/push_images.yml
+++ b/.semaphore/push_images.yml
@@ -3,7 +3,7 @@ name: Operator CD
 agent:
   machine:
     type: f1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 global_job_config:
   secrets:
     - name: docker-hub

--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -8,7 +8,7 @@ execution_time_limit:
 agent:
   machine:
     type: f1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 
 global_job_config:
   secrets:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,7 +13,7 @@ auto_cancel:
 agent:
   machine:
     type: f1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 global_job_config:
   secrets:
   - name: docker-hub
@@ -138,7 +138,7 @@ blocks:
       agent:
         machine:
           type: f1-standard-2
-          os_image: ubuntu2004
+          os_image: ubuntu2204
       jobs:
         - name: Run FVs
           execution_time_limit:


### PR DESCRIPTION
## Description

Semaphore is retiring Ubuntu 20

So replace os_agent to Ubuntu 22

## Release Note

N/A

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

Sem change - no milestone label

f1 machines have an option to use Ubuntu 24 as well. Would you prefer Ubuntu 24 over Ubuntu 22? let me know
