### PR TITLE
[release-v1.40] Auto pick #4198: Ensure dns names ending with a "." aren't added to

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -73,10 +73,15 @@ func IsDomainName(name string) bool {
 // - <svc_name>.<ns>.svc
 // - <svc_name>.<ns>.svc.<cluster-domain>
 func GetServiceDNSNames(name, namespace, clusterDomain string) []string {
-	return []string{
+	domains := []string{
 		name,
 		fmt.Sprintf("%s.%s", name, namespace),
 		fmt.Sprintf("%s.%s.svc", name, namespace),
-		fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain),
 	}
+
+	// If the cluster domain isn't set, this becomes an invalid DNS name since it would end in a dot. So only add it if it's set.
+	if clusterDomain != "" {
+		domains = append(domains, fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain))
+	}
+	return domains
 }


### PR DESCRIPTION
Cherry pick of #4198 on release-v1.40.

#4198: Ensure dns names ending with a "." aren't added to

# Original PR Body below

## Description

If the clusterDomain isn't set then we add domain names ending with a ".", which are invalid. Golangs crypto library just started enforcing valid dns names, and our fv tests are failing because we don't have a cluster name set and it results in entries like "calico-api.calico-system.svc." (notice the end dot!!) being set in the certificate.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

[TSLA-10307]


[TSLA-10296]: https://tigera.atlassian.net/browse/TSLA-10296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TSLA-10307]: https://tigera.atlassian.net/browse/TSLA-10307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ