### PR TITLE
Configure nginx based on whether IPv6 is enabled

### DIFF
--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	_ "embed"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
@@ -53,6 +55,19 @@ const (
 	GoldmaneDeploymentName      = "goldmane"
 	GoldmaneServicePort         = 7443
 	GoldmaneNamespace           = common.CalicoNamespace
+
+	configMapName    = "whisker-nginx-config"
+	configVolumeName = "nginx-config"
+	configMountPath  = "/etc/nginx/conf.d"
+)
+
+var (
+	// Embed the nginx config files.
+	//go:embed nginx-v4.conf
+	NginxConfigV4 string
+
+	//go:embed nginx.conf
+	NginxConfigDual string
 )
 
 func Whisker(cfg *Configuration) render.Component {
@@ -114,6 +129,7 @@ func (c *Component) Objects() ([]client.Object, []client.Object) {
 
 	objs := []client.Object{
 		c.serviceAccount(),
+		c.nginxConfigMap(),
 		deployment,
 		c.whiskerService(),
 		c.networkPolicy(),
@@ -153,6 +169,13 @@ func (c *Component) whiskerContainer() corev1.Container {
 			{Name: "NOTIFICATIONS", Value: string(*c.cfg.Whisker.Spec.Notifications)},
 		},
 		SecurityContext: securitycontext.NewNonRootContext(),
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      configVolumeName,
+				MountPath: configMountPath,
+				ReadOnly:  true,
+			},
+		},
 	}
 }
 
@@ -197,7 +220,24 @@ func (c *Component) deployment() *appsv1.Deployment {
 	}
 
 	ctrs := []corev1.Container{c.whiskerContainer(), c.whiskerBackendContainer()}
-	volumes := []corev1.Volume{c.cfg.TrustedCertBundle.Volume(), c.cfg.WhiskerBackendKeyPair.Volume()}
+
+	volumes := []corev1.Volume{
+		// Add the trusted cert bundle volume to the pod.
+		c.cfg.TrustedCertBundle.Volume(),
+
+		// Add the whisker backend key pair volume to the pod.
+		c.cfg.WhiskerBackendKeyPair.Volume(),
+
+		// Volume for nginx config from config map.
+		{
+			Name: configVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+				},
+			},
+		},
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
@@ -248,6 +288,25 @@ func (c *Component) networkPolicy() *netv1.NetworkPolicy {
 			PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress, netv1.PolicyTypeEgress},
 			PodSelector: *selector.PodLabelSelector(WhiskerDeploymentName),
 			Egress:      append(egressRules, networkpolicy.K8sDNSEgressRules(c.cfg.OpenShift)...),
+		},
+	}
+}
+
+func (c *Component) nginxConfigMap() *corev1.ConfigMap {
+	// Determine which config to use based on supported IP families.
+	config := NginxConfigV4
+	if c.cfg.Installation.CalicoNetwork != nil && c.cfg.Installation.CalicoNetwork.NodeAddressAutodetectionV6 != nil {
+		config = NginxConfigDual
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: WhiskerNamespace,
+		},
+		Data: map[string]string{
+			"default.conf": config,
 		},
 	}
 }

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -39,13 +39,14 @@ import (
 var (
 	defaultTLSKeyPair        = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
 	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
+	numExpectedObjects       = 5
 )
 
 var _ = Describe("ComponentRendering", func() {
-	DescribeTable("Creation and deletion counts", func(cfg *whisker.Configuration, creatObjs, delObjs int) {
+	DescribeTable("Creation and deletion counts", func(cfg *whisker.Configuration, createObjs, delObjs int) {
 		component := whisker.Whisker(cfg)
 		objsToCreate, objsToDelete := component.Objects()
-		Expect(objsToCreate).To(HaveLen(creatObjs))
+		Expect(objsToCreate).To(HaveLen(createObjs))
 		Expect(objsToDelete).To(HaveLen(delObjs))
 	},
 		Entry("Should return objects to create when variant is Calico",
@@ -58,7 +59,7 @@ var _ = Describe("ComponentRendering", func() {
 				WhiskerBackendKeyPair: defaultTLSKeyPair,
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.ToPtr(operatorv1.Enabled)}},
 			},
-			4, 0,
+			numExpectedObjects, 0,
 		),
 		Entry("Should return objects to delete when variant is not Calico",
 			&whisker.Configuration{
@@ -70,7 +71,7 @@ var _ = Describe("ComponentRendering", func() {
 				WhiskerBackendKeyPair: defaultTLSKeyPair,
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.ToPtr(operatorv1.Enabled)}},
 			},
-			0, 4,
+			0, numExpectedObjects,
 		),
 	)
 
@@ -127,6 +128,13 @@ var _ = Describe("ComponentRendering", func() {
 										{Name: "NOTIFICATIONS", Value: "Enabled"},
 									},
 									SecurityContext: securitycontext.NewNonRootContext(),
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "nginx-config",
+											MountPath: "/etc/nginx/conf.d",
+											ReadOnly:  true,
+										},
+									},
 								},
 								{
 									Name:            whisker.WhiskerBackendContainerName,
@@ -148,6 +156,14 @@ var _ = Describe("ComponentRendering", func() {
 							Volumes: []corev1.Volume{
 								defaultTrustedCertBundle.Volume(),
 								defaultTLSKeyPair.Volume(),
+								{
+									Name: "nginx-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: "whisker-nginx-config"},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -155,6 +171,61 @@ var _ = Describe("ComponentRendering", func() {
 			},
 		),
 	)
+
+	It("should generate an IPv4-only NGINX configuration", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.ToPtr(operatorv1.Enabled)}},
+			ClusterID:             "test-cluster-id",
+			CalicoVersion:         "test-calico-version",
+			ClusterType:           "test-cluster-type",
+			ClusterDomain:         "cluster.domain",
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		config, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, "whisker-nginx-config", whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		actual, ok := config.Data["default.conf"]
+		Expect(ok).To(BeTrue(), "expected default.conf to be present in config map")
+		Expect(actual).To(Equal(whisker.NginxConfigV4))
+	})
+
+	It("should generate a dual-stack NGINX configuration", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+				CalicoNetwork: &operatorv1.CalicoNetworkSpec{
+					NodeAddressAutodetectionV6: &operatorv1.NodeAddressAutodetection{
+						FirstFound: ptr.ToPtr(true),
+					},
+				},
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.ToPtr(operatorv1.Enabled)}},
+			ClusterID:             "test-cluster-id",
+			CalicoVersion:         "test-calico-version",
+			ClusterType:           "test-cluster-type",
+			ClusterDomain:         "cluster.domain",
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		config, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, "whisker-nginx-config", whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		actual, ok := config.Data["default.conf"]
+		Expect(ok).To(BeTrue(), "expected default.conf to be present in config map")
+		Expect(actual).To(Equal(whisker.NginxConfigDual))
+	})
 
 	It("Should apply overrides", func() {
 		affinity := &corev1.Affinity{

--- a/pkg/render/whisker/nginx-v4.conf
+++ b/pkg/render/whisker/nginx-v4.conf
@@ -1,0 +1,55 @@
+# Nginx configuration for Whisker on systems that do not support Ipv6.
+server {
+    # Listen on all.
+    listen 0.0.0.0:8081;
+
+    server_tokens off;
+
+    add_header X-Frame-Options sameorigin;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # no-cache to revalidate resources before using cache, to pick up possibled updated changes
+    # from this nginx server serving the react-app
+    add_header Cache-Control "private, no-cache, must-revalidate" always;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # nginx.start.sh will convert environment variables into a config file located in /etc/config/config.json when running the container.
+    # This file is located here because the nginx.start.sh script does not have permissions to write to the main html directory and we don't want to give it permissions to write there.
+    location /config/config.json {
+        root /etc;
+        default_type application/json;
+    }
+
+    location /whisker-backend/ {
+        rewrite ^/whisker-backend/(.*)$ /$1 break;
+        proxy_pass http://localhost:3002;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_cache off;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        # Timeout settings: effectively disable timeouts, we don't want to proxy interfering with the server or client
+        # functionality (especially for streaming APIs).
+        proxy_read_timeout 1d;
+        proxy_send_timeout 1d;
+        proxy_connect_timeout 1d;
+        send_timeout 1d;
+        keepalive_timeout 1d;
+    }
+
+    error_page 404 =200 /index.html;
+    location = /40x.html {
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page 500 502 503 504  /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}

--- a/pkg/render/whisker/nginx.conf
+++ b/pkg/render/whisker/nginx.conf
@@ -1,0 +1,56 @@
+# Nginx configuration for Whisker on systems that support IPv6.
+server {
+    # Listen on all.
+    listen 0.0.0.0:8081;
+    listen [::]:8081 ipv6only=on;
+
+    server_tokens off;
+
+    add_header X-Frame-Options sameorigin;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # no-cache to revalidate resources before using cache, to pick up possibled updated changes
+    # from this nginx server serving the react-app
+    add_header Cache-Control "private, no-cache, must-revalidate" always;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # nginx.start.sh will convert environment variables into a config file located in /etc/config/config.json when running the container.
+    # This file is located here because the nginx.start.sh script does not have permissions to write to the main html directory and we don't want to give it permissions to write there.
+    location /config/config.json {
+        root /etc;
+        default_type application/json;
+    }
+
+    location /whisker-backend/ {
+        rewrite ^/whisker-backend/(.*)$ /$1 break;
+        proxy_pass http://localhost:3002;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_cache off;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        # Timeout settings: effectively disable timeouts, we don't want to proxy interfering with the server or client
+        # functionality (especially for streaming APIs).
+        proxy_read_timeout 1d;
+        proxy_send_timeout 1d;
+        proxy_connect_timeout 1d;
+        send_timeout 1d;
+        keepalive_timeout 1d;
+    }
+
+    error_page 404 =200 /index.html;
+    location = /40x.html {
+    }
+
+    # redirect server error pages to the static page /50x.html
+    error_page 500 502 503 504  /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}

--- a/test/whisker_test.go
+++ b/test/whisker_test.go
@@ -17,6 +17,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -121,7 +122,7 @@ var _ = Describe("Tests for Whisker installation", func() {
 		operatorDone = createInstallation(c, mgr, shutdownContext, nil)
 		verifyCalicoHasDeployed(c)
 
-		By("Creating a CRD resource not named default")
+		By("Creating a Whisker and Goldmane resource")
 		whiskerCR := &operator.Whisker{
 			TypeMeta:   metav1.TypeMeta{Kind: "Whisker", APIVersion: "operator.tigera.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: "default"},
@@ -149,20 +150,11 @@ var _ = Describe("Tests for Whisker installation", func() {
 		Eventually(func() error {
 			Expect(GetResource(c, install)).To(BeNil())
 			fmt.Println("Finalizers: ", install.ObjectMeta.Finalizers)
-			if containsFinalizer(install.ObjectMeta.Finalizers, render.WhiskerFinalizer) ||
-				containsFinalizer(install.ObjectMeta.Finalizers, render.GoldmaneFinalizer) {
+			if slices.Contains(install.ObjectMeta.Finalizers, render.WhiskerFinalizer) ||
+				slices.Contains(install.ObjectMeta.Finalizers, render.GoldmaneFinalizer) {
 				return fmt.Errorf("expected finalizers to be removed, but found: %v", install.ObjectMeta.Finalizers)
 			}
 			return nil
 		}, 1*time.Minute, 1*time.Second).Should(BeNil())
 	})
 })
-
-func containsFinalizer(finalizers []string, finalizer string) bool {
-	for _, f := range finalizers {
-		if f == finalizer {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes https://github.com/projectcalico/calico/issues/10956

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Fix that Whisker would not function on nodes with IPv6 support disabled.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.