### PR TITLE
Add a requeue when waiting for finalizer cleanup

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -78,6 +78,9 @@ var (
 	// most scenarios. Retries should be used sparingly, and only in extraordinary
 	// circumstances. Use this as a default when retries are needed.
 	StandardRetry = 30 * time.Second
+	// FinalizerRemovalRetry is the amount of time to wait before retrying a request
+	// when waiting for the removal of a finalizer from the Installation by a non-core controller.
+	FinalizerRemovalRetry = 10 * time.Second
 
 	// AllowedSysctlKeys controls the allowed Sysctl keys can be set in Tuning plugin
 	AllowedSysctlKeys = map[string]bool{
@@ -1033,22 +1036,24 @@ func RemoveInstallationFinalizer(i *operatorv1.Installation, finalizer string) {
 // We add a finalizer to the Installation when the mainResource has been installed, and only remove that finalizer when
 // the resource has been deleted and its secondary resources have stopped running. This allows for a graceful cleanup of any resources
 // prior to the CNI plugin being removed.
+// The bool return value indicates if the finalizer is Set
 func MaintainInstallationFinalizer(
 	ctx context.Context,
 	c client.Client,
 	mainResource client.Object,
 	finalizer string,
 	secondaryResources ...client.Object,
-) error {
+) (bool, error) {
+	finalizerSet := false
 	// Get the Installation.
 	installation := &operatorv1.Installation{}
 	if err := c.Get(ctx, DefaultInstanceKey, installation); err != nil {
 		if errors.IsNotFound(err) {
 			log.V(1).Info("Installation config not found")
-			return nil
+			return finalizerSet, nil
 		}
 		log.Error(err, "An error occurred when querying the Installation resource")
-		return err
+		return finalizerSet, err
 	}
 	patchFrom := client.MergeFrom(installation.DeepCopy())
 
@@ -1056,12 +1061,14 @@ func MaintainInstallationFinalizer(
 	if mainResource != nil {
 		// Add a finalizer indicating that the mainResource is still available.
 		SetInstallationFinalizer(installation, finalizer)
+		finalizerSet = true
 	} else {
 		// Remove the finalizer. We can skip this check if the finalizer is already not present.
 		if !stringsutil.StringInSlice(finalizer, installation.GetFinalizers()) {
 			log.V(2).Info("Finalizer not present, skipping removal", "finalizer", finalizer)
-			return nil
+			return finalizerSet, nil
 		}
+		finalizerSet = true
 
 		// Check if the namespaced secondaryResources are still present.
 		// Keep track of all the secondary resources that the main resource creates.
@@ -1069,30 +1076,31 @@ func MaintainInstallationFinalizer(
 		for _, secondaryResource := range secondaryResources {
 			err := c.Get(ctx, types.NamespacedName{Namespace: secondaryResource.GetNamespace(), Name: secondaryResource.GetName()}, secondaryResource)
 			if err != nil && !errors.IsNotFound(err) {
-				return err
+				return finalizerSet, err
 			} else if errors.IsNotFound(err) {
 				log.Info("Object no longer exists.", "object", secondaryResource)
 			} else {
 				log.Info("Object is still present, waiting for termination", "object", secondaryResource)
-				return nil
+				return finalizerSet, nil
 			}
 
 			// If the secondary resource itself is gone, ensure there are no Pods left over from this resource.
 			terminated, err := AllPodsTerminated(ctx, c, secondaryResource)
 			if err != nil {
-				return err
+				return finalizerSet, err
 			}
 			if !terminated {
 				log.Info("Pods for object are still present, waiting for termination", "object", secondaryResource)
-				return nil
+				return finalizerSet, nil
 			}
 		}
 		log.Info("All objects no longer exist. Removing finalizer", "finalizer", finalizer)
 		RemoveInstallationFinalizer(installation, finalizer)
+		finalizerSet = false
 	}
 
 	// Update the installation with any finalizer changes.
-	return c.Patch(ctx, installation, patchFrom)
+	return finalizerSet, c.Patch(ctx, installation, patchFrom)
 }
 
 func AllPodsTerminated(ctx context.Context, c client.Client, obj client.Object) (bool, error) {

--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -159,7 +159,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	} else if whiskerCR == nil {
 		r.status.OnCRNotFound()
-		return reconcile.Result{}, r.maintainFinalizer(ctx, nil)
+		f, err := r.maintainFinalizer(ctx, nil)
+		// If the finalizer is still set, then requeue so we aren't dependent on the periodic reconcile to check and remove the finalizer
+		if f {
+			return reconcile.Result{RequeueAfter: utils.FinalizerRemovalRetry}, nil
+		} else {
+			return reconcile.Result{}, err
+		}
 	}
 	r.status.OnCRFound()
 	// SetMetaData in the TigeraStatus such as observedGenerations.
@@ -223,7 +229,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if err := r.maintainFinalizer(ctx, whiskerCR); err != nil {
+	if _, err := r.maintainFinalizer(ctx, whiskerCR); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error setting finalizer on Installation", err, reqLogger)
 		return reconcile.Result{}, err
 	}
@@ -284,7 +290,8 @@ func updateWhiskerWithDefaults(instance *operatorv1.Whisker) {
 	}
 }
 
-func (r *Reconciler) maintainFinalizer(ctx context.Context, whiskerCr client.Object) error {
+// The bool return value indicates if the finalizer is Set
+func (r *Reconciler) maintainFinalizer(ctx context.Context, whiskerCr client.Object) (bool, error) {
 	// These objects require graceful termination before the CNI plugin is torn down.
 	whiskerDeployment := &v1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: common.CalicoNamespace, Name: whisker.WhiskerDeploymentName}}
 	return utils.MaintainInstallationFinalizer(ctx, r.cli, whiskerCr, render.WhiskerFinalizer, whiskerDeployment)

--- a/test/gatewayapi_test.go
+++ b/test/gatewayapi_test.go
@@ -483,7 +483,7 @@ func cleanupGatewayResources(c client.Client) {
 		}
 		err := GetResource(c, ns)
 		if err == nil {
-			return fmt.Errorf("Calico namespace still exists")
+			return fmt.Errorf("tigera-gateway namespace still exists")
 		}
 		if !kerror.IsNotFound(err) {
 			return err


### PR DESCRIPTION
## Description

Waiting for finalizer cleanup had nothing that would trigger a controller to run again since the controllers were only waiting on pods to be deleted, and in general our controllers are not watching pods. So this added to requeue a reconcile when the CR has been deleted but the finalizer for the controller still is set so that a controller will more quickly detect when the pods are finally deleted.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
