### PR TITLE
Fix PSS conflict in PolicyRecommendation controller (#4172)

### DIFF
--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -471,26 +471,8 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 		return reconcile.Result{}, err
 	}
 
-	setUp := render.NewSetup(&render.SetUpConfiguration{
-		OpenShift:       r.provider.IsOpenShift(),
-		Installation:    installation,
-		PullSecrets:     pullSecrets,
-		Namespace:       helper.InstallNamespace(),
-		PSS:             render.PSSRestricted,
-		CreateNamespace: !tenant.MultiTenant(),
-	})
-
 	// Prepend PolicyRecommendation before certificate creation
 	components = append([]render.Component{component}, components...)
-	setupHandler := defaultHandler
-	if tenant.MultiTenant() {
-		// In standard installs, the PolicyRecommendation CR owns all the objects. For multi-tenant, pull secrets are owned by the Tenant instance.
-		setupHandler = utils.NewComponentHandler(log, r.client, r.scheme, tenant)
-	}
-	if err := setupHandler.CreateOrUpdateOrDelete(ctx, setUp, r.status); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, logc)
-		return reconcile.Result{}, err
-	}
 
 	for _, cmp := range components {
 		if err := defaultHandler.CreateOrUpdateOrDelete(context.Background(), cmp, r.status); err != nil {

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -169,45 +169,6 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 		r.policyRecScopeWatchReady.MarkAsReady()
 	})
 
-	It("should reconcile namespace, role binding and pull secrts", func() {
-		result, err := r.Reconcile(ctx, reconcile.Request{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result.RequeueAfter).To(Equal(0 * time.Second))
-
-		namespace := corev1.Namespace{
-			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-		}
-		Expect(c.Get(ctx, client.ObjectKey{
-			Name: render.PolicyRecommendationNamespace,
-		}, &namespace)).NotTo(HaveOccurred())
-		Expect(namespace.Labels["pod-security.kubernetes.io/enforce"]).To(Equal("restricted"))
-		Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
-
-		// Expect operator role binding to be created
-		rb := rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{},
-		}
-		Expect(c.Get(ctx, client.ObjectKey{
-			Name:      render.TigeraOperatorSecrets,
-			Namespace: render.PolicyRecommendationNamespace,
-		}, &rb)).NotTo(HaveOccurred())
-		Expect(rb.OwnerReferences).To(HaveLen(1))
-		ownerRoleBinding := rb.OwnerReferences[0]
-		Expect(ownerRoleBinding.Kind).To(Equal("PolicyRecommendation"))
-
-		// Expect pull secrets to be created
-		pullSecrets := corev1.Secret{
-			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-		}
-		Expect(c.Get(ctx, client.ObjectKey{
-			Name:      "tigera-pull-secret",
-			Namespace: render.PolicyRecommendationNamespace,
-		}, &pullSecrets)).NotTo(HaveOccurred())
-		Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
-		pullSecret := pullSecrets.OwnerReferences[0]
-		Expect(pullSecret.Kind).To(Equal("PolicyRecommendation"))
-	})
-
 	Context("image reconciliation", func() {
 		It("should use builtin images", func() {
 			_, err := r.Reconcile(ctx, reconcile.Request{})
@@ -491,64 +452,6 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				// Now reconcile tenant A's namespace and do not expect an error
 				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tenantANamespace}})
 				Expect(err).ShouldNot(HaveOccurred())
-			})
-
-			It("should reconcile pull secrets and role bindings", func() {
-				// Create the Tenant resources for tenant-a.
-				tenantA := &operatorv1.Tenant{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "default",
-						Namespace: tenantANamespace,
-					},
-					Spec: operatorv1.TenantSpec{ID: "tenant-a"},
-				}
-				Expect(c.Create(ctx, tenantA)).NotTo(HaveOccurred())
-				certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
-				Expect(c.Create(ctx, certificateManagerTenantA.CreateTrustedBundle().ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
-
-				linseedTLSTenantA, err := certificateManagerTenantA.GetOrCreateKeyPair(c, render.TigeraLinseedSecret, tenantANamespace, []string{render.TigeraLinseedSecret})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(c.Create(ctx, linseedTLSTenantA.Secret(tenantANamespace))).NotTo(HaveOccurred())
-
-				Expect(c.Create(ctx, &operatorv1.PolicyRecommendation{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tigera-secure",
-						Namespace: tenantANamespace,
-					},
-				})).NotTo(HaveOccurred())
-
-				_, err = r.Reconcile(ctx, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: tenantANamespace,
-					},
-				})
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// Expect operator role binding to be created
-				rb := rbacv1.RoleBinding{
-					ObjectMeta: metav1.ObjectMeta{},
-				}
-				Expect(c.Get(ctx, client.ObjectKey{
-					Name:      render.TigeraOperatorSecrets,
-					Namespace: tenantANamespace,
-				}, &rb)).NotTo(HaveOccurred())
-				Expect(rb.OwnerReferences).To(HaveLen(1))
-				ownerRoleBinding := rb.OwnerReferences[0]
-				Expect(ownerRoleBinding.Kind).To(Equal("Tenant"))
-
-				// Expect pull secrets to be created
-				pullSecrets := corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-				}
-				Expect(c.Get(ctx, client.ObjectKey{
-					Name:      "tigera-pull-secret",
-					Namespace: tenantANamespace,
-				}, &pullSecrets)).NotTo(HaveOccurred())
-				Expect(pullSecrets.OwnerReferences).To(HaveLen(1))
-				pullSecret := pullSecrets.OwnerReferences[0]
-				Expect(pullSecret.Kind).To(Equal("Tenant"))
 			})
 		})
 	})


### PR DESCRIPTION
## Description

Cherry-pick #4172 onto `release-v1.40`

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Fix calico-system Namespace PSS Conflict where, under certain conditions, the calico-system would end up with a PSS value of `restricted` instead of `privileged`. This started happening on August 15, 2025 (so we may not have released an Enterprise version since).
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
