### PR TITLE
fix: gateway-l7-collector tag has excess prefix

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -145,7 +145,7 @@ components:
     image: l7-collector
     version: master
   gateway-l7-collector:
-    image: tigera/gateway-l7-collector
+    image: gateway-l7-collector
     version: master
   envoy:
     image: envoy


### PR DESCRIPTION
## Description

`gateway-l7-collector` should match the rest of the tag formats. strangely, `make gen-versions` yields nothing. looks like `enterprise.go` already has the correct value for `image` for some reason?

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
