### PR TITLE
[EV-6086] Bump ECK Elasticsearch and Kibana versions to 8.18.8

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: release-calient-v3.22
   eck-kibana:
-    version: 8.18.4
+    version: 8.18.8
   kibana:
     image: tigera/kibana
     version: release-calient-v3.22
   eck-elasticsearch:
-    version: 8.18.4
+    version: 8.18.8
   elasticsearch:
     image: tigera/elasticsearch
     version: release-calient-v3.22

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.18.4",
+		Version:  "8.18.8",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.18.4",
+		Version:  "8.18.8",
 		Registry: "",
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

```release-note
Updates the versions of the ECK Kibana and ECK Elasticsearch components to fix CVEs in Calico Enterprise v3.22 EP2.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
