### PR TITLE
[v1.38] fix: update Typha deployment annotations for non-cluster hosts

### DIFF
--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -464,6 +464,9 @@ func (c *typhaComponent) typhaDeployment() []client.Object {
 		// Create a separate deployment to handle non-cluster host requests.
 		deployNonClusterHost := deploy.DeepCopy()
 		deployNonClusterHost.Name += TyphaNonClusterHostSuffix
+		// Replace Typha secret annotation for NonClusterHost deployment.
+		delete(deployNonClusterHost.Spec.Template.Annotations, c.cfg.TLS.TyphaSecret.HashAnnotationKey())
+		deployNonClusterHost.Spec.Template.Annotations[c.cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationKey()] = c.cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationValue()
 		// Remove the affinity and use pod network
 		deployNonClusterHost.Spec.Template.Spec.Affinity = nil
 		deployNonClusterHost.Spec.Template.Spec.HostNetwork = false

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -184,6 +184,8 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(ok).To(BeTrue())
 		Expect(d).NotTo(BeNil())
 
+		Expect(d.Spec.Template.Annotations).NotTo(HaveKey(cfg.TLS.TyphaSecret.HashAnnotationKey()))
+		Expect(d.Spec.Template.Annotations).To(HaveKeyWithValue(cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationKey(), cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationValue()))
 		Expect(d.Spec.Template.Spec.Affinity).To(BeNil())
 		Expect(d.Spec.Template.Spec.HostNetwork).To(BeFalse())
 		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))


### PR DESCRIPTION
## Description

Pick https://github.com/tigera/operator/pull/4231 into the v1.38 release branch.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
