### PR TITLE
fix(logging): Don't make logs before the logger is initialized

### DIFF
--- a/pkg/common/operator_serviceaccount.go
+++ b/pkg/common/operator_serviceaccount.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/cloudflare/cfssl/log"
 	authv1 "k8s.io/api/authentication/v1"
@@ -29,9 +30,8 @@ import (
 
 var serviceAccount = ""
 
-func init() {
-	serviceAccount = getServiceAccount()
-}
+// once ensures that serviceAccount is initialized only once.
+var once sync.Once
 
 // OperatorServiceAccount returns the ServiceAccount name the operator is running in.
 // The value returned is based on the following priority (these are evaluated at startup):
@@ -41,6 +41,9 @@ func init() {
 //	then the contents is returned.
 //	The default "tigera-operator" is returned.
 func OperatorServiceAccount() string {
+	once.Do(func() {
+		serviceAccount = getServiceAccount()
+	})
 	return serviceAccount
 }
 

--- a/pkg/common/operator_serviceaccount_test.go
+++ b/pkg/common/operator_serviceaccount_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,9 +22,11 @@ import (
 )
 
 var _ = Describe("Operator ServiceAccount name tests", func() {
-	It("should read service account name from the environment variable", func() {
+	It("should read service account name from the environment variable once", func() {
 		Expect(os.Setenv("OPERATOR_SERVICEACCOUNT", "tigera-operator-env-var")).NotTo(HaveOccurred())
-		Expect(getServiceAccount()).To(Equal("tigera-operator-env-var"))
+		Expect(OperatorServiceAccount()).To(Equal("tigera-operator-env-var"))
 		Expect(os.Unsetenv("OPERATOR_SERVICEACCOUNT")).NotTo(HaveOccurred())
+		Expect(os.Setenv("OPERATOR_SERVICEACCOUNT", "other-value")).NotTo(HaveOccurred())
+		Expect(OperatorServiceAccount()).To(Equal("tigera-operator-env-var"))
 	})
 })


### PR DESCRIPTION
Before this fix the init() of operator_serviceaccount.go would happen before the logger is initialized, leading to messages such as:
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
 Detected at:
 	>  goroutine 1 [running, locked to thread]:
 	>  runtime/debug.Stack()
 	...
```
This fix uses sync.Once to ensure the string is initialized once, but lazily loads it, rather than at startup time.

```release-note
Fixes an issue where the logger was not initialized before log statements were produced.
```