### PR TITLE
[v1.40] fix: allow deletion of CSRs for non-cluster hosts

### DIFF
--- a/pkg/render/nonclusterhost/nonclusterhost.go
+++ b/pkg/render/nonclusterhost/nonclusterhost.go
@@ -199,7 +199,7 @@ func (c *nonClusterHostComponent) clusterRole() *rbacv1.ClusterRole {
 		{
 			APIGroups: []string{"certificates.k8s.io"},
 			Resources: []string{"certificatesigningrequests"},
-			Verbs:     []string{"create", "list", "watch"},
+			Verbs:     []string{"create", "delete", "list", "watch"},
 		},
 		{
 			APIGroups:     []string{"certificates.tigera.io"},

--- a/pkg/render/nonclusterhost/nonclusterhost_test.go
+++ b/pkg/render/nonclusterhost/nonclusterhost_test.go
@@ -150,7 +150,7 @@ var _ = Describe("NonClusterHost rendering tests", func() {
 			rbacv1.PolicyRule{
 				APIGroups: []string{"certificates.k8s.io"},
 				Resources: []string{"certificatesigningrequests"},
-				Verbs:     []string{"create", "list", "watch"},
+				Verbs:     []string{"create", "delete", "list", "watch"},
 			},
 			rbacv1.PolicyRule{
 				APIGroups:     []string{"certificates.tigera.io"},


### PR DESCRIPTION
## Description

Pick https://github.com/tigera/operator/pull/4236 into the v1.40 release branch.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Allow non-cluster hosts to remove failed CSRs before generating new requests.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
