### PR TITLE
fix: remove nit about registry and imagepath

### DIFF
--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -140,19 +140,6 @@ func GetComponents(versionsPath string) (Release, error) {
 			component.ImagePath = imageParts[0]
 			component.Image = imageParts[1]
 		}
-
-		// ensure that imagePath and registry end with a '/' if they are set
-		// this is to avoid errors when constructing full image paths
-		// by concatenating registry + imagePath + image
-		if component.ImagePath != "" && !strings.HasSuffix(component.ImagePath, "/") {
-			return cv, fmt.Errorf("component '%s' has an imagePath that does not end with a '/'. "+
-				"Update the imagePath field to end with a '/'", key)
-		}
-		if component.Registry != "" && !strings.HasSuffix(component.Registry, "/") {
-			return cv, fmt.Errorf("component '%s' has a registry that does not end with a '/'. "+
-				"Update the registry field to end with a '/'", key)
-		}
-
 		cv.Components[key] = component
 	}
 

--- a/pkg/components/images_test.go
+++ b/pkg/components/images_test.go
@@ -86,6 +86,20 @@ var _ = Describe("test GetReference", func() {
 		)
 	})
 
+	Context("registry override not ending with slash", func() {
+		DescribeTable("should render",
+			func(c Component, imagePath string) {
+				Expect(GetReference(c, "quay.io", "", "", nil)).To(Equal(fmt.Sprintf("quay.io/%s%s:%s", imagePath, c.Image, c.Version)))
+			},
+			Entry("a calico image correctly", ComponentCalicoNode, CalicoImagePath),
+			Entry("a tigera image correctly", ComponentTigeraNode, TigeraImagePath),
+			Entry("an ECK image correctly", ComponentElasticsearchOperator, TigeraImagePath),
+			Entry("an operator init image correctly", ComponentOperatorInit, OperatorImagePath),
+			Entry("a CSR init image correctly", ComponentCalicoCSRInitContainer, CalicoImagePath),
+			Entry("a CSR init image correctly", ComponentTigeraCSRInitContainer, TigeraImagePath),
+		)
+	})
+
 	Context("image prefix override", func() {
 		DescribeTable("should render",
 			func(c Component, image string) {
@@ -101,6 +115,20 @@ var _ = Describe("test GetReference", func() {
 	})
 
 	Context("imagepath override", func() {
+		DescribeTable("should render",
+			func(c Component, registry string) {
+				Expect(GetReference(c, "", "userpath/", "", nil)).To(Equal(fmt.Sprintf("%suserpath/%s:%s", registry, c.Image, c.Version)))
+			},
+			Entry("a calico image correctly", ComponentCalicoNode, CalicoRegistry),
+			Entry("a tigera image correctly", ComponentTigeraNode, TigeraRegistry),
+			Entry("an ECK image correctly", ComponentElasticsearchOperator, TigeraRegistry),
+			Entry("an operator init image correctly", ComponentOperatorInit, OperatorRegistry),
+			Entry("a CSR init image correctly", ComponentCalicoCSRInitContainer, CalicoRegistry),
+			Entry("a CSR init image correctly", ComponentTigeraCSRInitContainer, TigeraRegistry),
+		)
+	})
+
+	Context("imagepath override not ending in slash", func() {
 		DescribeTable("should render",
 			func(c Component, registry string) {
 				Expect(GetReference(c, "", "userpath", "", nil)).To(Equal(fmt.Sprintf("%suserpath/%s:%s", registry, c.Image, c.Version)))

--- a/pkg/components/references.go
+++ b/pkg/components/references.go
@@ -16,7 +16,7 @@ package components
 
 import (
 	"fmt"
-	"strings"
+	"path"
 
 	operator "github.com/tigera/operator/api/v1"
 )
@@ -88,10 +88,6 @@ func GetReference(c Component, registry, imagePath, imagePrefix string, is *oper
 		if c.Registry != "" {
 			registry = c.Registry
 		}
-	} else if !strings.HasSuffix(registry, "/") {
-		// If the registry is explicitly set, make sure it ends with a slash so that the
-		// image can be appended correctly below.
-		registry = fmt.Sprintf("%s/", registry)
 	}
 
 	// If a user supplies an imaagePrefix, prepend it to the image name.
@@ -109,19 +105,15 @@ func GetReference(c Component, registry, imagePath, imagePrefix string, is *oper
 		if c.imagePath != "" {
 			imagePath = c.imagePath
 		}
-	} else if !strings.HasSuffix(imagePath, "/") {
-		// If the imagePath is explicitly set, make sure it ends with a slash so that the
-		// image can be appended correctly below.
-		imagePath = fmt.Sprintf("%s/", imagePath)
 	}
 
 	if is == nil {
-		return fmt.Sprintf("%s%s%s:%s", registry, imagePath, imageName, c.Version), nil
+		return fmt.Sprintf("%s:%s", path.Join(registry, imagePath, imageName), c.Version), nil
 	}
 
 	for _, img := range is.Spec.Images {
-		if img.Image == fmt.Sprintf("%s%s", defaultImagePath, c.Image) {
-			return fmt.Sprintf("%s%s%s@%s", registry, imagePath, imageName, img.Digest), nil
+		if img.Image == path.Join(defaultImagePath, c.Image) {
+			return fmt.Sprintf("%s@%s", path.Join(registry, imagePath, imageName), img.Digest), nil
 		}
 	}
 


### PR DESCRIPTION
## Description

Validation added in #4213 is a bit nitpicky since this can simply use `path.Join` when combining the registry, imagePath and image.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
