### PR TITLE
Revert #4214 - Include prometheus and alertmanager status in monitor status

### DIFF
--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -22,7 +22,6 @@ import (
 
 	crdv1 "github.com/tigera/operator/pkg/apis/crd.projectcalico.org/v1"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -355,48 +354,6 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	} else {
 		includeV3NetworkPolicy = true
-	}
-
-	p, err := utils.GetPrometheus(ctx, r.client)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred trying to retrieve the Prometheus status", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	if p != nil {
-		available := monitoringv1.ConditionFalse
-
-		for _, cond := range p.Status.Conditions {
-			if cond.Type == monitoringv1.Available {
-				available = cond.Status
-			}
-		}
-
-		if available != monitoringv1.ConditionTrue {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, "Prometheus component is not available", err, reqLogger)
-			return reconcile.Result{}, err
-		}
-	}
-
-	am, err := utils.GetAlertmanager(ctx, r.client)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred trying to retrieve the Alertmanager status", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	if am != nil {
-		available := monitoringv1.ConditionFalse
-
-		for _, cond := range am.Status.Conditions {
-			if cond.Type == monitoringv1.Available {
-				available = cond.Status
-			}
-		}
-
-		if available != monitoringv1.ConditionTrue {
-			r.status.SetDegraded(operatorv1.ResourceNotReady, "Alertmanager component is not available", err, reqLogger)
-			return reconcile.Result{}, err
-		}
 	}
 
 	// Create a component handler to manage the rendered component.

--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,6 @@ var _ = Describe("Monitor controller tests", func() {
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 		Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
 		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
-		Expect(monitoringv1.AddToScheme(scheme)).NotTo(HaveOccurred())
 
 		// Create a client that will have a crud interface of k8s objects.
 		ctx = context.Background()
@@ -86,7 +85,6 @@ var _ = Describe("Monitor controller tests", func() {
 		mockStatus.On("ReadyToMonitor")
 		mockStatus.On("RemoveDeployments", mock.Anything)
 		mockStatus.On("RemoveCertificateSigningRequests", common.TigeraPrometheusNamespace)
-		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 		mockStatus.On("SetMetaData", mock.Anything).Return()
 
 		// Create an object we can use throughout the test to do the monitor reconcile loops.
@@ -135,107 +133,6 @@ var _ = Describe("Monitor controller tests", func() {
 		// Mark that watches were successful.
 		r.prometheusReady.MarkAsReady()
 		r.tierWatchReady.MarkAsReady()
-	})
-
-	Context("prometheus resources", func() {
-		BeforeEach(func() {
-			// Add the Prometheus and Alertmanager instances
-			prom := &monitoringv1.Prometheus{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      monitor.CalicoNodePrometheus,
-					Namespace: common.TigeraPrometheusNamespace,
-				},
-				Status: monitoringv1.PrometheusStatus{
-					Conditions: []monitoringv1.Condition{
-						{
-							Type:   monitoringv1.Available,
-							Status: monitoringv1.ConditionTrue,
-						},
-						{
-							Type:   monitoringv1.Reconciled,
-							Status: monitoringv1.ConditionTrue,
-						},
-					},
-				},
-			}
-			Expect(cli.Create(ctx, prom)).To(BeNil())
-
-			alertManager := &monitoringv1.Alertmanager{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      monitor.CalicoNodeAlertmanager,
-					Namespace: common.TigeraPrometheusNamespace,
-				},
-				Status: monitoringv1.AlertmanagerStatus{
-					Conditions: []monitoringv1.Condition{
-						{
-							Type:   monitoringv1.Available,
-							Status: monitoringv1.ConditionTrue,
-						},
-						{
-							Type:   monitoringv1.Reconciled,
-							Status: monitoringv1.ConditionTrue,
-						},
-					},
-				},
-			}
-			Expect(cli.Create(ctx, alertManager)).To(BeNil())
-		})
-
-		It("should degrade if the prometheus statefulset isn't ready", func() {
-			prom := &monitoringv1.Prometheus{}
-			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodePrometheus, Namespace: common.TigeraPrometheusNamespace}, prom)).NotTo(HaveOccurred())
-
-			patch := client.MergeFrom(prom.DeepCopy())
-			prom.Status.Conditions = []monitoringv1.Condition{
-				{
-					Type:   monitoringv1.Available,
-					Status: monitoringv1.ConditionFalse,
-				},
-				{
-					Type:   monitoringv1.Reconciled,
-					Status: monitoringv1.ConditionTrue,
-				},
-			}
-			Expect(cli.Patch(ctx, prom, patch)).To(Succeed())
-
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			mockStatus.AssertCalled(GinkgoT(), "SetDegraded",
-				operatorv1.ResourceNotReady,
-				"Prometheus component is not available",
-				mock.Anything,
-				mock.Anything,
-			)
-		})
-
-		It("should degrade if the alertmanager statefulset isn't ready", func() {
-			alertManager := &monitoringv1.Alertmanager{}
-			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeAlertmanager, Namespace: common.TigeraPrometheusNamespace}, alertManager)).NotTo(HaveOccurred())
-
-			patch := client.MergeFrom(alertManager.DeepCopy())
-			alertManager.Status.Conditions = []monitoringv1.Condition{
-				{
-					Type:   monitoringv1.Available,
-					Status: monitoringv1.ConditionFalse,
-				},
-				{
-					Type:   monitoringv1.Reconciled,
-					Status: monitoringv1.ConditionTrue,
-				},
-			}
-			Expect(cli.Patch(ctx, alertManager, patch)).To(Succeed())
-
-			_, err := r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			mockStatus.AssertCalled(GinkgoT(), "SetDegraded",
-				operatorv1.ResourceNotReady,
-				"Alertmanager component is not available",
-				mock.Anything,
-				mock.Anything,
-			)
-		})
 	})
 
 	Context("controller reconciliation", func() {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -24,7 +24,6 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	csiv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	"github.com/go-logr/logr"
@@ -58,7 +57,6 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/logstorage/eck"
-	"github.com/tigera/operator/pkg/render/monitor"
 )
 
 const (
@@ -858,30 +856,6 @@ func GetElasticsearch(ctx context.Context, c client.Client) (*esv1.Elasticsearch
 		return nil, err
 	}
 	return &es, nil
-}
-
-func GetAlertmanager(ctx context.Context, c client.Client) (*monitoringv1.Alertmanager, error) {
-	a := monitoringv1.Alertmanager{}
-	err := c.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeAlertmanager, Namespace: common.TigeraPrometheusNamespace}, &a)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return &a, nil
-}
-
-func GetPrometheus(ctx context.Context, c client.Client) (*monitoringv1.Prometheus, error) {
-	p := monitoringv1.Prometheus{}
-	err := c.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodePrometheus, Namespace: common.TigeraPrometheusNamespace}, &p)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return &p, nil
 }
 
 // AddKubeProxyWatch creates a watch on the kube-proxy DaemonSet.


### PR DESCRIPTION
This reverts commit 6e55cb7d7ef08d0ad0e0a0fe48cec1d945da1da9.

## Description

There was a deadlock condition when the pull secrets existed, but were empty. Reverting this, and a proper fix will be done later.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
