### PR TITLE
Include prometheus and alertmanager status in monitor status

### DIFF
--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2025 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,10 +68,14 @@ var _ = Describe("Monitor controller tests", func() {
 		Expect(apis.AddToScheme(scheme)).NotTo(HaveOccurred())
 		Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
 		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(monitoringv1.AddToScheme(scheme)).NotTo(HaveOccurred())
 
 		// Create a client that will have a crud interface of k8s objects.
 		ctx = context.Background()
-		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).
+			WithStatusSubresource(&monitoringv1.Prometheus{}).
+			WithStatusSubresource(&monitoringv1.Alertmanager{}).
+			Build()
 
 		// Create an object we can use throughout the test to do the monitor reconcile loops.
 		mockStatus = &status.MockStatus{}
@@ -85,6 +89,7 @@ var _ = Describe("Monitor controller tests", func() {
 		mockStatus.On("ReadyToMonitor")
 		mockStatus.On("RemoveDeployments", mock.Anything)
 		mockStatus.On("RemoveCertificateSigningRequests", common.TigeraPrometheusNamespace)
+		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 		mockStatus.On("SetMetaData", mock.Anything).Return()
 
 		// Create an object we can use throughout the test to do the monitor reconcile loops.
@@ -133,6 +138,133 @@ var _ = Describe("Monitor controller tests", func() {
 		// Mark that watches were successful.
 		r.prometheusReady.MarkAsReady()
 		r.tierWatchReady.MarkAsReady()
+	})
+
+	Context("prometheus resources", func() {
+		BeforeEach(func() {
+			// Add the Prometheus and Alertmanager instances
+			prom := &monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      monitor.CalicoNodePrometheus,
+					Namespace: common.TigeraPrometheusNamespace,
+				},
+			}
+			Expect(cli.Create(ctx, prom)).To(BeNil())
+
+			prom.Status = monitoringv1.PrometheusStatus{
+				Conditions: []monitoringv1.Condition{
+					{
+						Type:   monitoringv1.Available,
+						Status: monitoringv1.ConditionTrue,
+					},
+					{
+						Type:   monitoringv1.Reconciled,
+						Status: monitoringv1.ConditionTrue,
+					},
+				},
+			}
+			Expect(cli.Status().Update(ctx, prom)).To(Succeed())
+
+			alertManager := &monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      monitor.CalicoNodeAlertmanager,
+					Namespace: common.TigeraPrometheusNamespace,
+				},
+			}
+			Expect(cli.Create(ctx, alertManager)).To(BeNil())
+
+			alertManager.Status = monitoringv1.AlertmanagerStatus{
+				Conditions: []monitoringv1.Condition{
+					{
+						Type:   monitoringv1.Available,
+						Status: monitoringv1.ConditionTrue,
+					},
+					{
+						Type:   monitoringv1.Reconciled,
+						Status: monitoringv1.ConditionTrue,
+					},
+				},
+			}
+			Expect(cli.Status().Update(ctx, alertManager)).To(Succeed())
+		})
+
+		It("should be ready if the prometheus statefulset is ready", func() {
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			mockStatus.AssertNotCalled(GinkgoT(), "SetDegraded",
+				operatorv1.ResourceNotReady,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			)
+		})
+
+		It("should be ready if the alertmanager statefulset is ready", func() {
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			mockStatus.AssertNotCalled(GinkgoT(), "SetDegraded",
+				operatorv1.ResourceNotReady,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			)
+		})
+
+		It("should degrade if the prometheus statefulset isn't ready", func() {
+			prom := &monitoringv1.Prometheus{}
+			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodePrometheus, Namespace: common.TigeraPrometheusNamespace}, prom)).NotTo(HaveOccurred())
+
+			prom.Status.Conditions = []monitoringv1.Condition{
+				{
+					Type:   monitoringv1.Available,
+					Status: monitoringv1.ConditionFalse,
+				},
+				{
+					Type:   monitoringv1.Reconciled,
+					Status: monitoringv1.ConditionTrue,
+				},
+			}
+			Expect(cli.Status().Update(ctx, prom)).To(Succeed())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			mockStatus.AssertCalled(GinkgoT(), "SetDegraded",
+				operatorv1.ResourceNotReady,
+				"Prometheus component is not available",
+				mock.Anything,
+				mock.Anything,
+			)
+		})
+
+		It("should degrade if the alertmanager statefulset isn't ready", func() {
+			alertManager := &monitoringv1.Alertmanager{}
+			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeAlertmanager, Namespace: common.TigeraPrometheusNamespace}, alertManager)).NotTo(HaveOccurred())
+
+			alertManager.Status.Conditions = []monitoringv1.Condition{
+				{
+					Type:   monitoringv1.Available,
+					Status: monitoringv1.ConditionFalse,
+				},
+				{
+					Type:   monitoringv1.Reconciled,
+					Status: monitoringv1.ConditionTrue,
+				},
+			}
+			Expect(cli.Status().Update(ctx, alertManager)).To(Succeed())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			mockStatus.AssertCalled(GinkgoT(), "SetDegraded",
+				operatorv1.ResourceNotReady,
+				"Alertmanager component is not available",
+				mock.Anything,
+				mock.Anything,
+			)
+		})
 	})
 
 	Context("controller reconciliation", func() {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -25,6 +25,7 @@ import (
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	csiv1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	"github.com/go-logr/logr"
@@ -58,6 +59,7 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/logstorage/eck"
+	"github.com/tigera/operator/pkg/render/monitor"
 )
 
 const (
@@ -857,6 +859,30 @@ func GetElasticsearch(ctx context.Context, c client.Client) (*esv1.Elasticsearch
 		return nil, err
 	}
 	return &es, nil
+}
+
+func GetAlertmanager(ctx context.Context, c client.Client) (*monitoringv1.Alertmanager, error) {
+	a := monitoringv1.Alertmanager{}
+	err := c.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeAlertmanager, Namespace: common.TigeraPrometheusNamespace}, &a)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &a, nil
+}
+
+func GetPrometheus(ctx context.Context, c client.Client) (*monitoringv1.Prometheus, error) {
+	p := monitoringv1.Prometheus{}
+	err := c.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodePrometheus, Namespace: common.TigeraPrometheusNamespace}, &p)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &p, nil
 }
 
 // AddKubeProxyWatch creates a watch on the kube-proxy DaemonSet.


### PR DESCRIPTION
## Description

* Include prometheus and alertmanager status in monitor status

The monitor should be unavailable if there is a prometheus or alertmanager instance that is unavailable. This handles the case where the prometheus install failed, and the statefulsets haven't been created yet.

* monitor: Only check prometheus / alertmanager Available status

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Fixed a readiness check for prometheus and alertmanager deployments.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
