### PR TITLE
[v1.36] Add deployment watches for Tigera API server

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -176,9 +176,18 @@ func add(c ctrlruntime.Controller, r *ReconcileAPIServer) error {
 		}
 	}
 
+	// Watch for changes to objects created by this controller.
+	if err = utils.AddDeploymentWatch(c, "tigera-apiserver", "tigera-system"); err != nil {
+		return fmt.Errorf("apiserver-controller failed to watch Deployment: %w", err)
+	}
+	if err = utils.AddDeploymentWatch(c, "calico-apiserver", "calico-apiserver"); err != nil {
+		return fmt.Errorf("apiserver-controller failed to watch Deployment: %w", err)
+	}
+
 	if err = imageset.AddImageSetWatch(c); err != nil {
 		return fmt.Errorf("apiserver-controller failed to watch ImageSet: %w", err)
 	}
+
 	// Watch for changes to TigeraStatus.
 	if err = utils.AddTigeraStatusWatch(c, ResourceName); err != nil {
 		return fmt.Errorf("apiserver-controller failed to watch apiserver Tigerastatus: %w", err)


### PR DESCRIPTION
## Description

This change backports the deployment watch changes from [1] to fix an issue where the deployment is modified but the Tigera Operator doesn't reconcile it to the expected version.

[1] https://github.com/tigera/operator/pull/4000/files#diff-12a0ea29f263b3a0f22ed87c7f0554e213df4d65bd2313d6b462a3921d6729c5R175-R182

Pick https://github.com/tigera/operator/pull/4288 into the v1.36 release branch.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Add missing deployment watches on the API Server controller.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
