### PR TITLE
fix(istio): add NativeNftables field to GlobalConfig

### DIFF
--- a/pkg/render/istio/config.go
+++ b/pkg/render/istio/config.go
@@ -22,6 +22,7 @@ type GlobalConfig struct {
 	Proxy                  *ProxyConfig     `json:"proxy,omitempty"`
 	ProxyInit              *ProxyInitConfig `json:"proxy_init,omitempty"`
 	Platform               string           `json:"platform,omitempty"`
+	NativeNftables         *bool            `json:"nativeNftables,omitempty"`
 }
 
 type ProxyConfig struct {

--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -29,6 +29,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/ptr"
 	"github.com/tigera/operator/pkg/render"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -109,6 +110,7 @@ func Istio(cfg *Configuration) (*IstioComponentCRDs, *IstioComponent, error) {
 		IstioCNIOpts: IstioCNIOpts{
 			Global: &GlobalConfig{
 				IstioNamespace: IstioNamespace,
+				NativeNftables: ptr.BoolToPtr(true),
 			},
 			Ambient: &AmbientConfig{
 				Enabled:                    true,


### PR DESCRIPTION
## Description

set to true by default because we currently don't have iptables-legacy

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
