### PR TITLE
Wait for informer cache to be populated before starting Typha autoscaler in UT

### DIFF
--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 
 		n1.Spec.Unschedulable = true
 		_, err := c.CoreV1().Nodes().Update(ctx, n1, metav1.UpdateOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() error {
 			schedulableNodes, linuxNodes := ta.getNodeCounts()
@@ -127,11 +127,11 @@ var _ = Describe("Test typha autoscaler ", func() {
 			},
 		}
 		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		// Create a few nodes
-		_ = CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		_ = CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
 
 		// Create the autoscaler and run it
 		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
@@ -143,18 +143,18 @@ var _ = Describe("Test typha autoscaler ", func() {
 		// For three and four node clusters, we expect 2.
 		n3 := CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "linux"}, nil)
 		verifyTyphaReplicas(c, 2)
-		_ = CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "linux"}, nil)
 		verifyTyphaReplicas(c, 2)
 
 		// For > 4 nodes, we expect redundancy with 3 replicas.
-		_ = CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "linux"}, nil)
 		verifyTyphaReplicas(c, 3)
 
 		// Verify that making a node unschedulable updates replicas. Should bring us back
 		// down to 4 node scale.
 		n3.Spec.Unschedulable = true
 		_, err = c.CoreV1().Nodes().Update(ctx, n3, metav1.UpdateOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		verifyTyphaReplicas(c, 2)
 	})
 
@@ -174,7 +174,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 			},
 		}
 		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		// Create five nodes, one of which is not yet migrated
 		CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"}, nil)
@@ -182,6 +182,10 @@ var _ = Describe("Test typha autoscaler ", func() {
 		CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"}, nil)
 		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"}, nil)
 		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "pre-operator"}, nil)
+
+		Eventually(func() []any {
+			return nodeIndexInformer.GetStore().List()
+		}).Should(HaveLen(5))
 
 		// Create the autoscaler and run it
 		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
@@ -214,6 +218,10 @@ var _ = Describe("Test typha autoscaler ", func() {
 		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "linux"}, nil)
 		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "linux", "kubernetes.azure.com/cluster": "foo", "type": "virtual-kubelet"}, nil)
 
+		Eventually(func() []any {
+			return nodeIndexInformer.GetStore().List()
+		}).Should(HaveLen(5))
+
 		// Create the autoscaler and run it
 		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
 		ta.start(ctx)
@@ -239,16 +247,20 @@ var _ = Describe("Test typha autoscaler ", func() {
 			},
 		}
 		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		statusManager.On("SetDegraded", operator.ResourceScalingError, "Failed to autoscale typha - not enough linux nodes to schedule typha pods on, require 3 and have 2", mock.Anything, mock.Anything)
 
 		// Create a few nodes
-		_ = CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		_ = CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		_ = CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "windows"}, nil)
-		_ = CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "windows"}, nil)
-		_ = CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "windows"}, nil)
+		CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "windows"}, nil)
+		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "windows"}, nil)
+		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "windows"}, nil)
+
+		Eventually(func() []any {
+			return nodeIndexInformer.GetStore().List()
+		}).Should(HaveLen(5))
 
 		// Create the autoscaler and run it
 		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
@@ -264,7 +276,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 func verifyTyphaReplicas(c kubernetes.Interface, expectedReplicas int) {
 	EventuallyWithOffset(1, func() int32 {
 		typha, err := c.AppsV1().Deployments("calico-system").Get(context.Background(), "calico-typha", metav1.GetOptions{})
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		// Just return an invalid number that will never match an expected replica count.
 		if typha.Spec.Replicas == nil {
 			return -1

--- a/test/utils.go
+++ b/test/utils.go
@@ -23,30 +23,26 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stretchr/testify/mock"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/testing"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-
 	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/status"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // ExpectResourceCreated asserts that the given object is created,
@@ -202,9 +198,8 @@ func CreateNode(c kubernetes.Interface, name string, labels map[string]string, a
 		node.Annotations = annotations
 	}
 
-	var err error
-	node, err = c.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
-	gomega.Expect(err).To(gomega.BeNil())
+	node, err := c.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return node
 }
 


### PR DESCRIPTION
## Description

This change adds a wait for fake nodes to be populated in the shared index informer cache before start Typha autoscaler.

Speculative fix for a Typha autoscaler flake:

```
2026-01-06T14:40:31Z	ERROR	typha_autoscaler	Failed to autoscale typha	{"error": "not enough linux nodes to schedule typha pods on, require 1 and have 0"}
github.com/tigera/operator/pkg/controller/installation.(*typhaAutoscaler).start.func1
	/go/src/github.com/tigera/operator/pkg/controller/installation/typha_autoscaler.go:143
panic: 
	assert: mock: I don't know what to return because the method call was unexpected.
		Either do Mock.On("SetDegraded").Return(...) first, or remove the SetDegraded() call.
		This method was unexpected:
			SetDegraded(v1.TigeraStatusReason,string,<nil>,logr.Logger)
			0: "ResourceScalingError"
			1: "Failed to autoscale typha - not enough linux nodes to schedule typha pods on, require 1 and have 0"
			2: <nil>
			3: logr.Logger{sink:(*log.delegatingLogSink)(0xc0002f9c40), level:0}
```

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
