### PR TITLE
fix(networkpolicy): Add a missing allow rule from IDC to Voltron when…

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -1037,6 +1037,13 @@ func (c *intrusionDetectionComponent) intrusionDetectionControllerAllowTigeraPol
 			Protocol:    &networkpolicy.TCPProtocol,
 			Destination: helper.LinseedEntityRule(),
 		})
+		if c.cfg.ManagementCluster {
+			egressRules = append(egressRules, v3.Rule{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: helper.ManagerEntityRule(),
+			})
+		}
 	}
 	egressRules = append(egressRules, []v3.Rule{
 		{


### PR DESCRIPTION
Without this change, the traffic would get passed to the next tier where it may be denied.