### PR TITLE
Add DATAPLANE env var to dikastes in l7-log-collector

### DIFF
--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -347,6 +347,12 @@ func (c *component) containers() []corev1.Container {
 			commandArgs = append(commandArgs, "--per-host-alp-enabled")
 		}
 
+		// Determine dataplane mode for dikastes
+		dataplane := "iptables"
+		if c.config.Installation.IsNftables() {
+			dataplane = "nftables"
+		}
+
 		dikastes := corev1.Container{
 			Name:            DikastesContainerName,
 			Image:           c.config.dikastesImage,
@@ -355,6 +361,7 @@ func (c *component) containers() []corev1.Container {
 			Env: []corev1.EnvVar{
 				{Name: "LOG_LEVEL", Value: "Info"},
 				{Name: "DIKASTES_SUBSCRIPTION_TYPE", Value: "per-host-policies"},
+				{Name: "DATAPLANE", Value: dataplane},
 			},
 			VolumeMounts:    volMounts,
 			SecurityContext: securitycontext.NewRootContext(true),


### PR DESCRIPTION
## Description

Bug fix: The dikastes container in l7-log-collector daemonset was missing the DATAPLANE env var, causing it to default to iptables regardless of Installation spec.

This change adds the DATAPLANE env var to dikastes, using the same logic as l7-admission-controller and egress-gateway.

**Testing:**
- Unit tests updated and passing
- Manual verification on nftables cluster confirmed dikastes receives correct DATAPLANE value

**Components affected:** applicationlayer render

## Release Note

```release-note
Fix l7-log-collector dikastes container missing DATAPLANE environment variable
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`