### PR TITLE
Use UBI9 base and pin to the latest calico/base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,9 @@ REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
 GO_BUILD_VER?=1.25.5-llvm18.1.8-k8s1.34.2
+CALICO_BASE_VER ?= ubi9-1765220429
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
+CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./api -name '*.go')
 SRC_FILES+=$(shell find ./internal/ -name '*.go')
@@ -290,7 +292,11 @@ image: build $(BUILD_IMAGE)
 
 $(BUILD_IMAGE): $(BUILD_IMAGE)-$(ARCH)
 $(BUILD_IMAGE)-$(ARCH): $(BINDIR)/operator-$(ARCH)
-	docker buildx build --load --platform=linux/$(ARCH) --pull -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg GIT_VERSION=$(GIT_VERSION) -f build/Dockerfile .
+	docker buildx build --load --platform=linux/$(ARCH) --pull \
+		--build-arg GIT_VERSION=$(GIT_VERSION) \
+		--build-arg CALICO_BASE=$(CALICO_BASE) \
+		-t $(BUILD_IMAGE):latest-$(ARCH) \
+		-f build/Dockerfile .
 ifeq ($(ARCH),amd64)
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(BUILD_IMAGE):latest
 endif

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10 AS ubi
+ARG CALICO_BASE
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS ubi
 
 FROM scratch AS source
 
@@ -21,13 +23,13 @@ ARG TARGETARCH
 COPY --from=ubi /etc/pki /etc/pki/
 COPY --from=ubi /usr/share/pki /usr/share/pki/
 # Used by the Helm library
-COPY --from=ubi /usr/lib64/libdl.so.2 /usr/lib64/libdl.so.2
+COPY --from=ubi /lib64/libdl.so.2 /lib64/libdl.so.2
 
 COPY LICENSE /licenses/LICENSE
 
 COPY build/_output/bin/operator-${TARGETARCH} /usr/bin/operator
 
-FROM calico/base
+FROM ${CALICO_BASE}
 
 ARG GIT_VERSION=unknown
 


### PR DESCRIPTION
## Description

This change updates the Tigera operator runtime base to UBI 9 and pins calico/base to the latest version. It also fixes the shared library path to /lib64, which is the canonical runtime location for shared libraries on RHEL systems.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Updated the Tigera Operator runtime base image to UBI 9.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
