### PR TITLE
Fix Windows resource configuration names

### DIFF
--- a/api/v1/calico_node_windows_types.go
+++ b/api/v1/calico_node_windows_types.go
@@ -23,13 +23,14 @@ import (
 // CalicoNodeWindowsDaemonSetContainer is a calico-node-windows DaemonSet container.
 type CalicoNodeWindowsDaemonSetContainer struct {
 	// Name is an enum which identifies the calico-node-windows DaemonSet container by name.
-	// Supported values are: calico-node-windows
-	// +kubebuilder:validation:Enum=calico-node-windows
+	// Supported values are: node, felix, confd
+	// calico-node-windows is allowed because it was previously allowed.
+	// +kubebuilder:validation:Enum=calico-node-windows;node;felix;confd
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.
-	// If specified, this overrides the named calico-node-windows DaemonSet container's resources.
-	// If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources.
+	// If specified, this overrides the named DaemonSet container's resources.
+	// If omitted, the DaemonSet will use its default value for this container's resources.
 	// If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
 	// +optional
 	Resources *v1.ResourceRequirements `json:"resources,omitempty"`

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -397,7 +397,7 @@ const (
 // The ComponentResource struct associates a ResourceRequirements with a component by name
 type ComponentResource struct {
 	// ComponentName is an enum which identifies the component
-	// +kubebuilder:validation:Enum=Node;Typha;KubeControllers
+	// +kubebuilder:validation:Enum=Node;Typha;KubeControllers;NodeWindows;FelixWindows;ConfdWindows
 	ComponentName ComponentName `json:"componentName"`
 
 	// ResourceRequirements allows customization of limits and requests for compute resources such as cpu and memory.

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -3932,15 +3932,19 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the calico-node-windows DaemonSet container by name.
-                                          Supported values are: calico-node-windows
+                                          Supported values are: node, felix, confd
+                                          calico-node-windows is allowed because it was previously allowed.
                                         enum:
                                           - calico-node-windows
+                                          - node
+                                          - felix
+                                          - confd
                                         type: string
                                       resources:
                                         description: |-
                                           Resources allows customization of limits and requests for compute resources such as cpu and memory.
-                                          If specified, this overrides the named calico-node-windows DaemonSet container's resources.
-                                          If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources.
+                                          If specified, this overrides the named DaemonSet container's resources.
+                                          If omitted, the DaemonSet will use its default value for this container's resources.
                                           If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
                                         properties:
                                           claims:
@@ -5472,6 +5476,9 @@ spec:
                           - Node
                           - Typha
                           - KubeControllers
+                          - NodeWindows
+                          - FelixWindows
+                          - ConfdWindows
                         type: string
                       resourceRequirements:
                         description:
@@ -12787,15 +12794,19 @@ spec:
                                           name:
                                             description: |-
                                               Name is an enum which identifies the calico-node-windows DaemonSet container by name.
-                                              Supported values are: calico-node-windows
+                                              Supported values are: node, felix, confd
+                                              calico-node-windows is allowed because it was previously allowed.
                                             enum:
                                               - calico-node-windows
+                                              - node
+                                              - felix
+                                              - confd
                                             type: string
                                           resources:
                                             description: |-
                                               Resources allows customization of limits and requests for compute resources such as cpu and memory.
-                                              If specified, this overrides the named calico-node-windows DaemonSet container's resources.
-                                              If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources.
+                                              If specified, this overrides the named DaemonSet container's resources.
+                                              If omitted, the DaemonSet will use its default value for this container's resources.
                                               If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
                                             properties:
                                               claims:
@@ -14352,6 +14363,9 @@ spec:
                               - Node
                               - Typha
                               - KubeControllers
+                              - NodeWindows
+                              - FelixWindows
+                              - ConfdWindows
                             type: string
                           resourceRequirements:
                             description:


### PR DESCRIPTION
## Description

#4362 found that it is not possible currently to configure requests/limits for the CalicoWindowsDaemonSet. This PR aims to fix that.

Fixes #4362

## Release Note

```release-note
Fixes configuration of Calico Windows Daemonset Requests and Limits. 
```

## For PR author


## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
