### PR TITLE
 Ci-1925 fix(apiserver): Add missing permission permission

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -706,7 +706,14 @@ func (c *apiServerComponent) authClusterRole() client.Object {
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 			ResourceNames: []string{securitycontextconstraints.Privileged},
-		})
+		},
+			// Starting with OCP 4.20, these permissions are required at startup when it sets up watches.
+			rbacv1.PolicyRule{
+				APIGroups: []string{"config.openshift.io"},
+				Resources: []string{"infrastructures"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		)
 	}
 
 	return &rbacv1.ClusterRole{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -466,6 +466,11 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Verbs:         []string{"use"},
 			ResourceNames: []string{"privileged"},
 		}))
+		Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"config.openshift.io"},
+			Resources: []string{"infrastructures"},
+			Verbs:     []string{"get", "list", "watch"},
+		}))
 	})
 
 	It("should render an API server with custom configuration", func() {


### PR DESCRIPTION
fix(apiserver): Add missing permission permission

On OCP 4.20, the apiserver would show error:
 "time="2026-01-15T15:29:01Z" level=error msg="Failed to watch" error="failed to list config.openshift.io/v1, Resource=infrastructures: infrastructures.config.openshift.io is forbidden: User \"system:serviceaccount:calico-system:calico-apiserver\" cannot list resource \"infrastructures\" in API group \"config.openshift.io\" at the cluster scope" klog-logger=calico-apiserver reflector="pkg/mod/k8s.io/client-go@v0.33.6/tools/cache/reflector.go:285" type="config.openshift.io/v1, Resource=infrastructures""

```release-note
Added a required permission for setting up watches in the calico-apiserver on OCP 4.20
```