### PR TITLE
[v1.41] fix(tunnel-secret): Two owners for one resource

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -310,7 +310,6 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	}
 
 	// Query enterprise-only data.
-	var tunnelCAKeyPair certificatemanagement.KeyPairInterface
 	var trustedBundle certificatemanagement.TrustedBundle
 	var applicationLayer *operatorv1.ApplicationLayer
 	var managementCluster *operatorv1.ManagementCluster
@@ -350,23 +349,17 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			return reconcile.Result{}, err
 		}
 
-		// This block depends on the Manager controller having defaulted the ManagementCluster CR and having created the tunnel CA secret.
-		// If these conditions are not met, this controller does not degrade as the Manager controller needs API server to be ready to accomplish the above.
+		// Management cluster only: check if the tunnel CA secret has been created. The apiserver mounts this secret so
+		// it can sign certificates for managed clusters. If the managementCluster has not been defaulted then we should
+		// not degrade. This is because the manager_controller exits the reconcile loop if the apiserver is not available.
 		if managementCluster != nil && managementCluster.Spec.TLS != nil && !r.multiTenant {
-			// The secret that contains the CA x509 certificate to create client certificates for the managed cluster
-			// is created by the Manager controller in tigera-operator namespace. We will read this secret and make
-			// sure it is available in the same namespace as the API server (calico-system)
-			// This secret is only created for a management cluster in a multi-cluster setup for a single tenant.
-			// Other cluster types do not require this secret. (Standalone configuration do not need it and multi-tenant
-			// configuration create secrets inside the tenant namespaces)
 			tunnelSecretName := managementCluster.Spec.TLS.SecretName
-			tunnelCASecret, err := utils.GetSecret(ctx, r.client, tunnelSecretName, common.OperatorNamespace())
+			// The manager_controller should have written this secret. We know this since spec.TLS has been defaulted.
+			// If the secret does not exist, we degrade this controller.
+			_, err := utils.GetSecret(ctx, r.client, tunnelSecretName, common.OperatorNamespace())
 			if err != nil {
 				r.status.SetDegraded(operatorv1.ResourceReadError, "Unable to fetch the tunnel secret", err, reqLogger)
 				return reconcile.Result{}, err
-			}
-			if tunnelCASecret != nil {
-				tunnelCAKeyPair = certificatemanagement.NewKeyPair(tunnelCASecret, nil, "")
 			}
 		}
 
@@ -488,7 +481,6 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			ServiceAccounts: []string{render.APIServerServiceAccountName},
 			KeyPairOptions: []rcertificatemanagement.KeyPairOption{
 				rcertificatemanagement.NewKeyPairOption(tlsSecret, true, true),
-				rcertificatemanagement.NewKeyPairOption(tunnelCAKeyPair, false, true),
 			},
 			TrustedBundle: trustedBundle,
 		}),

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -693,20 +693,6 @@ var _ = Describe("apiserver controller tests", func() {
 				// Reconcile the API server
 				_, err = r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
-
-				clusterConnectionInAppNs := corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.VoltronTunnelSecretName,
-						Namespace: "calico-system",
-					},
-				}
-
-				// Ensure that the tunnel secret was copied in calico-system namespace
-				err = test.GetResource(cli, &clusterConnectionInAppNs)
-				Expect(kerror.IsNotFound(err)).Should(BeFalse())
-				Expect(clusterConnectionInAppNs.Data).Should(HaveKeyWithValue("tls.crt", []byte("certvalue")))
-				Expect(clusterConnectionInAppNs.Data).Should(HaveKeyWithValue("tls.key", []byte("keyvalue")))
 			})
 
 			It("Should reconcile multi-cluster setup for a management cluster for a single tenant", func() {
@@ -742,20 +728,9 @@ var _ = Describe("apiserver controller tests", func() {
 						Namespace: "calico-system",
 					},
 				}
-				clusterConnectionInAppNs := corev1.Secret{
-					TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      render.VoltronTunnelSecretName,
-						Namespace: "calico-system",
-					},
-				}
 
 				// Ensure a deployment was created for the API server
 				err = test.GetResource(cli, &deployment)
-				Expect(kerror.IsNotFound(err)).Should(BeFalse())
-
-				// Ensure that the tunnel secret was copied in calico-system namespace
-				err = test.GetResource(cli, &clusterConnectionInAppNs)
 				Expect(kerror.IsNotFound(err)).Should(BeFalse())
 			})
 


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v1.41**: tigera/operator#4358
```
Every 2.0s: kubectl get secret calico-management-cluster-connection -o yaml -n calico-system                                                                                                                                      
...
metadata:
  creationTimestamp: "2026-01-13T23:59:25Z"
  name: calico-management-cluster-connection
  namespace: calico-system
  ownerReferences:
  - apiVersion: operator.tigera.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: APIServer
    name: tigera-secure
    uid: 88bcd287-6671-437b-9ef1-228659e66904
  resourceVersion: "182749"
  uid: ea542965-a729-4e32-945e-48614ac19ab0
type: Opaque

...

kind: Secret
metadata:
  creationTimestamp: "2026-01-13T23:59:25Z"
  name: calico-management-cluster-connection
  namespace: calico-system
  ownerReferences:
  - apiVersion: operator.tigera.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Manager
    name: tigera-secure
    uid: 313ddf8c-1d7f-4abd-99ce-c826b154d88a
  resourceVersion: "185440"
  uid: ea542965-a729-4e32-945e-48614ac19ab0
...
```

The primary controller responsible for this secret is the manager_controller, so we removed the creation logic from the apiserver_controller.

```release-note
Fixed an issue caused by manager_controller and apiserver_controller both writing the calico-management-cluster-connection secret to calico-system causing constant reconciliations.
```

