### PR TITLE
Update nodeSet naming

### DIFF
--- a/pkg/controller/logstorage/elastic/elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/ptr"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/stretchr/testify/mock"
@@ -773,6 +774,20 @@ var _ = Describe("LogStorage controller", func() {
 							Name:      render.ElasticsearchName,
 							Namespace: render.ElasticsearchNamespace,
 						},
+						Spec: esv1.ElasticsearchSpec{
+							NodeSets: []esv1.NodeSet{
+								{
+									Name: "default",
+									VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+										{
+											Spec: corev1.PersistentVolumeClaimSpec{
+												StorageClassName: ptr.ToPtr("tigera-elasticsearch"),
+											},
+										},
+									},
+								},
+							},
+						},
 						Status: esv1.ElasticsearchStatus{
 							Phase: esv1.ElasticsearchReadyPhase,
 						},
@@ -894,6 +909,20 @@ var _ = Describe("LogStorage controller", func() {
 								Name:      render.ElasticsearchName,
 								Namespace: render.ElasticsearchNamespace,
 							},
+							Spec: esv1.ElasticsearchSpec{
+								NodeSets: []esv1.NodeSet{
+									{
+										Name: "default",
+										VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+											{
+												Spec: corev1.PersistentVolumeClaimSpec{
+													StorageClassName: ptr.ToPtr("tigera-elasticsearch"),
+												},
+											},
+										},
+									},
+								},
+							},
 							Status: esv1.ElasticsearchStatus{
 								Phase: esv1.ElasticsearchReadyPhase,
 							},
@@ -945,6 +974,20 @@ var _ = Describe("LogStorage controller", func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      render.ElasticsearchName,
 							Namespace: render.ElasticsearchNamespace,
+						},
+						Spec: esv1.ElasticsearchSpec{
+							NodeSets: []esv1.NodeSet{
+								{
+									Name: "default",
+									VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+										{
+											Spec: corev1.PersistentVolumeClaimSpec{
+												StorageClassName: ptr.ToPtr("tigera-elasticsearch"),
+											},
+										},
+									},
+								},
+							},
 						},
 					}
 					Expect(test.GetResource(cli, &escfg)).To(BeNil())
@@ -1311,7 +1354,26 @@ func setUpLogStorageComponents(cli client.Client, ctx context.Context, storageCl
 			KubernetesProvider:   operatorv1.ProviderNone,
 			Registry:             "testregistry.com/",
 		},
-		Elasticsearch:        &esv1.Elasticsearch{ObjectMeta: metav1.ObjectMeta{Name: render.ElasticsearchName, Namespace: render.ElasticsearchNamespace}},
+		Elasticsearch: &esv1.Elasticsearch{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      render.ElasticsearchName,
+				Namespace: render.ElasticsearchNamespace,
+			},
+			Spec: esv1.ElasticsearchSpec{
+				NodeSets: []esv1.NodeSet{
+					{
+						Name: "default",
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									StorageClassName: ptr.ToPtr("tigera-elasticsearch"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		ClusterConfig:        relasticsearch.NewClusterConfig("cluster", 1, 1, 1),
 		ElasticsearchKeyPair: esKeyPair,
 		TrustedBundle:        trustedBundle,

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -796,15 +796,16 @@ func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim, currentES *esv1.Elast
 	if currentES == nil {
 		nameMustBeGenerated = true
 	} else {
+		// Check if the existing PVC template matches our LogStorage CR. If it does not, we need to force a rename.
+		// We assume that the VolumeClaimTemplate is the same across all NodeSets (this is how we configure it).
 		currentPVCTemplate := currentES.Spec.NodeSets[0].VolumeClaimTemplates[0]
-
 		storageClassNamesMatch := *pvcTemplate.Spec.StorageClassName == *currentPVCTemplate.Spec.StorageClassName
 		resourceRequirementsMatch := reflect.DeepEqual(currentPVCTemplate.Spec.Resources, pvcTemplate.Spec.Resources)
-
 		if !storageClassNamesMatch || !resourceRequirementsMatch {
 			nameMustBeGenerated = true
 		}
 
+		// Capture the existing name. If there are multiple NodeSets, there will be a suffix, so we strip it.
 		splitExistingName := strings.Split(currentES.Spec.NodeSets[0].Name, "-")[0]
 		existingName = &splitExistingName
 	}

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -781,7 +781,7 @@ func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim, currentES *esv1.Elast
 		panic("ElasticSearch CR has no NodeSets")
 	}
 	if currentES != nil && len(currentES.Spec.NodeSets[0].VolumeClaimTemplates) != 1 {
-		panic(fmt.Sprintf("ElasticSearch CR has %d VolumeClaimTemplates in it's NodeSets, expected 1", len(currentES.Spec.NodeSets[0].VolumeClaimTemplates)))
+		panic(fmt.Sprintf("ElasticSearch CR has %d VolumeClaimTemplates in its NodeSets, expected 1", len(currentES.Spec.NodeSets[0].VolumeClaimTemplates)))
 	}
 	if currentES != nil && currentES.Spec.NodeSets[0].VolumeClaimTemplates[0].Spec.StorageClassName == nil {
 		panic("ElasticSearch CR's VolumeClaimTemplate has no StorageClassName")

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -15,15 +15,14 @@
 package render
 
 import (
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"hash/fnv"
+	"reflect"
 	"strings"
 
 	cmnv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	"gopkg.in/inf.v0"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -244,7 +243,7 @@ func (es *elasticsearchComponent) Objects() ([]client.Object, []client.Object) {
 	toCreate = append(toCreate, es.elasticsearchServiceAccount())
 	toCreate = append(toCreate, es.cfg.ClusterConfig.ConfigMap())
 
-	toCreate = append(toCreate, es.elasticsearchCluster())
+	toCreate = append(toCreate, es.elasticsearchCluster(es.cfg.Elasticsearch))
 
 	if es.cfg.Installation.KubernetesProvider.IsOpenShift() {
 		toCreate = append(toCreate, es.elasticsearchClusterRole(), es.elasticsearchClusterRoleBinding())
@@ -546,7 +545,7 @@ func (es *elasticsearchComponent) podTemplate() corev1.PodTemplateSpec {
 }
 
 // render the Elasticsearch CR that the ECK operator uses to create elasticsearch cluster
-func (es *elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
+func (es *elasticsearchComponent) elasticsearchCluster(current *esv1.Elasticsearch) *esv1.Elasticsearch {
 	elasticsearch := &esv1.Elasticsearch{
 		TypeMeta: metav1.TypeMeta{Kind: "Elasticsearch", APIVersion: "elasticsearch.k8s.elastic.co/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -563,7 +562,7 @@ func (es *elasticsearchComponent) elasticsearchCluster() *esv1.Elasticsearch {
 					},
 				},
 			},
-			NodeSets: es.nodeSets(),
+			NodeSets: es.nodeSets(current),
 		},
 	}
 
@@ -639,7 +638,7 @@ func memoryQuantityToJVMHeapSize(q *resource.Quantity) string {
 // nodeSets calculates the number of NodeSets needed for the Elasticsearch cluster. Multiple NodeSets are returned only
 // if the "nodeSets" field has been set in the LogStorage CR. The number of Nodes for the cluster will be distributed as
 // evenly as possible between the NodeSets.
-func (es *elasticsearchComponent) nodeSets() []esv1.NodeSet {
+func (es *elasticsearchComponent) nodeSets(currentES *esv1.Elasticsearch) []esv1.NodeSet {
 	nodeConfig := es.cfg.LogStorage.Spec.Nodes
 	pvcTemplate := es.pvcTemplate()
 
@@ -651,10 +650,12 @@ func (es *elasticsearchComponent) nodeSets() []esv1.NodeSet {
 		return nil
 	}
 
+	name := nodeSetName(pvcTemplate, currentES)
+
 	var nodeSets []esv1.NodeSet
 	if len(nodeConfig.NodeSets) < 1 {
 		nodeSet := es.nodeSetTemplate(pvcTemplate)
-		nodeSet.Name = nodeSetName(pvcTemplate)
+		nodeSet.Name = name
 		nodeSet.Count = int32(nodeConfig.Count)
 		nodeSet.PodTemplate = es.podTemplate()
 
@@ -678,7 +679,7 @@ func (es *elasticsearchComponent) nodeSets() []esv1.NodeSet {
 
 			nodeSet := es.nodeSetTemplate(pvcTemplate)
 			// Each NodeSet needs a unique name, so just add the index as a suffix
-			nodeSet.Name = fmt.Sprintf("%s-%d", nodeSetName(pvcTemplate), i)
+			nodeSet.Name = fmt.Sprintf("%s-%d", name, i)
 			nodeSet.Count = int32(numNodes)
 
 			podTemplate := es.podTemplate()
@@ -769,24 +770,59 @@ func (es *elasticsearchComponent) nodeSetTemplate(pvcTemplate corev1.PersistentV
 	}
 }
 
-// nodeSetName returns thumbprint of PersistentVolumeClaim object as string.
-// As storage requirements of NodeSets are immutable,
-// renaming a NodeSet automatically creates a new StatefulSet with new PersistentVolumeClaim.
-// https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-orchestration.html#k8s-orchestration-limitations
-func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim) string {
-	pvcTemplateHash := fnv.New64a()
-	templateBytes, err := json.Marshal(pvcTemplate)
-	if err != nil {
-		log.V(5).Info("Failed to create unique name for ElasticSearch NodeSet.", "err", err)
-		return "es"
+// nodeSetName resolves the name that should be configured on the NodeSet by deciding to either retain the existing
+// name or generate a new random string to force a rename. A rename must be forced when we know that the current
+// NodeSet does not match the storage requirements outlined by LogStorage. This rename triggers the eck-operator
+// to create a new NodeSet, which is required because VolumeClaimTemplates on a StatefulSet are immutable.
+// https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-orchestration.html
+func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim, currentES *esv1.Elasticsearch) string {
+	// We expect the following preconditions to be met, but we check for them explicitly to indicate developer error.
+	if currentES != nil && len(currentES.Spec.NodeSets) == 0 {
+		panic("ElasticSearch CR has no NodeSets")
+	}
+	if currentES != nil && len(currentES.Spec.NodeSets[0].VolumeClaimTemplates) != 1 {
+		panic(fmt.Sprintf("ElasticSearch CR has %d VolumeClaimTemplates in it's NodeSets, expected 1", len(currentES.Spec.NodeSets[0].VolumeClaimTemplates)))
+	}
+	if currentES != nil && currentES.Spec.NodeSets[0].VolumeClaimTemplates[0].Spec.StorageClassName == nil {
+		panic("ElasticSearch CR's VolumeClaimTemplate has no StorageClassName")
+	}
+	if pvcTemplate.Spec.StorageClassName == nil {
+		panic("Rendered VolumeClaimTemplate has no StorageClassName")
 	}
 
-	if _, err := pvcTemplateHash.Write(templateBytes); err != nil {
-		log.V(5).Info("Failed to create unique name for ElasticSearch NodeSet.", "err", err)
-		return "es"
+	// Determine if we need to generate a new name
+	var nameMustBeGenerated bool
+	var existingName *string
+	if currentES == nil {
+		nameMustBeGenerated = true
+	} else {
+		currentPVCTemplate := currentES.Spec.NodeSets[0].VolumeClaimTemplates[0]
+
+		storageClassNamesMatch := *pvcTemplate.Spec.StorageClassName == *currentPVCTemplate.Spec.StorageClassName
+		resourceRequirementsMatch := reflect.DeepEqual(currentPVCTemplate.Spec.Resources, pvcTemplate.Spec.Resources)
+
+		if !storageClassNamesMatch || !resourceRequirementsMatch {
+			nameMustBeGenerated = true
+		}
+
+		splitExistingName := strings.Split(currentES.Spec.NodeSets[0].Name, "-")[0]
+		existingName = &splitExistingName
 	}
 
-	return hex.EncodeToString(pvcTemplateHash.Sum(nil))
+	// Generate a new name if necessary
+	var name string
+	if nameMustBeGenerated {
+		for {
+			name = rand.String(12)
+			if existingName == nil || name != *existingName {
+				break
+			}
+		}
+	} else {
+		name = *existingName
+	}
+
+	return name
 }
 
 // This is a list of components that belong to Curator which has been decommissioned since it is no longer supported

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/ptr"
 
 	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 
@@ -503,7 +504,22 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 						},
 					},
 				}
-				cfg.Elasticsearch = &esv1.Elasticsearch{}
+				cfg.Elasticsearch = &esv1.Elasticsearch{
+					Spec: esv1.ElasticsearchSpec{
+						NodeSets: []esv1.NodeSet{
+							{
+								Name: "default",
+								VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+									{
+										Spec: corev1.PersistentVolumeClaimSpec{
+											StorageClassName: ptr.ToPtr("tigera-elasticsearch"),
+										},
+									},
+								},
+							},
+						},
+					},
+				}
 
 				component := render.LogStorage(cfg)
 


### PR DESCRIPTION
## Description
### Context
tigera-operator configures the eck-operator to deploy a StatefulSet by specifying a NodeSet in the Elasticsearch CR. The name of the resulting StatefulSet is the name of the NodeSet.

tigera-operator sets the NodeSet name by hashing the PersistentVolumeClaim template of the NodeSet. 

This ensures that if the PVC template changes as a result of LogStorage changes, a new name for the NodeSet is generated, which creates a new StatefulSet with the new PVC template (rather than updating the existing StatefulSet).

A new StatefulSet must be created, since a StatefulSet's PVC template can not be updated after the StatefulSet has been created.

### Issue
The upgrade of k8s.io/apimachinery to v0.34.3 has changed how k8s objects serialize. Specifically, `creationTimestamp` now has an `omitzero` json tag. This change has resulted in the same PersistentVolumeClaim resulting in different hashes depending on the version of tigera-operator (and what version of apimachinery it uses)

The primary impact here is that when users upgrade Calico Enteprise to a newer version, which has an operator with apimachinery >= v0.34.3, tigera-operator computes a different name for the NodeSet (due to the serialization change), and this triggers a new StatefulSet and PVC to be created, even though no LogStorage properties changed.

This recreation could lead to one of two things:
- A slow upgrade on clusters with dynamic provisioning, as new PVs are provisioned and filled with the data from the old PVs
- A stalled upgrade on clusters without dynamic provisioning/available PVs, as the new ES pods wait for PVs to be provisioned

### Proposal
This PR changes the behaviour of NodeSet name generation as follows:
* We change the name of a NodeSet when we know that the already existing PVC template of the NodeSet does not match what it should be based on the LogStorage configuration. Otherwise, we keep the existing name.
* When we need to change (or create) a name for a NodeSet, we choose a random string

This has the key property of retaining the existing NodeSet name, regardless of how it was generated, if the existing PVC in the NodeSet matches the configuration found in LogStorage.

### Alternative approaches
It was attempted to simply augment the serialization to retain the `creationTimestamp: null` that previous versions of apimachinery would create. Unfortunately all attempted approaches resulted in field orders changing, which also meant a different hash.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Updated Elasticsearch NodeSet name generation to prevent unnecessary recreations of the Elasticsearch StatefulSet.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
