### PR TITLE
[v1.38] fix(windows): pass CNI_PLUGIN_TYPE env var to uninstall-calico initContainer and other Containers

### DIFF
--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -218,6 +218,7 @@ func (c *windowsComponent) cniEnvVars() []corev1.EnvVar {
 
 	envVars := []corev1.EnvVar{
 		{Name: "SLEEP", Value: "false"},
+		{Name: "CNI_PLUGIN_TYPE", Value: string(c.cfg.Installation.CNI.Type)},
 		{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 		{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 		{Name: "CNI_NET_DIR", Value: cniNetDir},
@@ -412,6 +413,7 @@ func (c *windowsComponent) windowsVolumes() []corev1.Volume {
 func (c *windowsComponent) uninstallEnvVars() []corev1.EnvVar {
 	envVars := []corev1.EnvVar{
 		{Name: "SLEEP", Value: "false"},
+		{Name: "CNI_PLUGIN_TYPE", Value: string(c.cfg.Installation.CNI.Type)},
 		{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 		{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 		{Name: "CNI_NET_DIR", Value: "/host/etc/cni/net.d"},
@@ -539,6 +541,7 @@ func (c *windowsComponent) windowsEnvVars() []corev1.EnvVar {
 	}
 
 	windowsEnv := []corev1.EnvVar{
+		{Name: "CNI_PLUGIN_TYPE", Value: string(c.cfg.Installation.CNI.Type)},
 		{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 		{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 		{Name: "CLUSTER_TYPE", Value: clusterType},

--- a/pkg/render/windows_test.go
+++ b/pkg/render/windows_test.go
@@ -386,6 +386,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
+					{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 					{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 					{Name: "CALICO_MANAGE_CNI", Value: "true"},
@@ -457,6 +458,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 				expectedCNIEnv := []corev1.EnvVar{
 					{Name: "SLEEP", Value: "false"},
+					{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 					{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 					{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
@@ -489,6 +491,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 				expectedUninstallEnv := []corev1.EnvVar{
 					{Name: "SLEEP", Value: "false"},
+					{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 					{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 					{Name: "CNI_NET_DIR", Value: "/host/etc/cni/net.d"},
@@ -853,6 +856,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 				// Verify env
 				expectedNodeEnv := []corev1.EnvVar{
+					{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 					{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 					{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 					{Name: "CALICO_MANAGE_CNI", Value: "true"},
@@ -935,6 +939,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 				expectedCNIEnv := []corev1.EnvVar{
 					{Name: "SLEEP", Value: "false"},
+					{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 					{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 					{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
@@ -967,6 +972,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 				expectedUninstallEnv := []corev1.EnvVar{
 					{Name: "SLEEP", Value: "false"},
+					{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 					{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 					{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 					{Name: "CNI_NET_DIR", Value: "/host/etc/cni/net.d"},
@@ -1177,6 +1183,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		// Verify env
 		expectedNodeEnv := []corev1.EnvVar{
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_MANAGE_CNI", Value: "true"},
@@ -1226,6 +1233,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		expectedCNIEnv := []corev1.EnvVar{
 			{Name: "SLEEP", Value: "false"},
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 			{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 			{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
@@ -1259,6 +1267,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		expectedUninstallEnv := []corev1.EnvVar{
 			{Name: "SLEEP", Value: "false"},
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 			{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 			{Name: "CNI_NET_DIR", Value: "/host/etc/cni/net.d"},
@@ -1377,6 +1386,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		// Verify env
 		expectedNodeEnv := []corev1.EnvVar{
+			{Name: "CNI_PLUGIN_TYPE", Value: "AmazonVPC"},
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "none"},
@@ -1515,6 +1525,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 			// Verify env
 			expectedEnvs := []corev1.EnvVar{
+				{Name: "CNI_PLUGIN_TYPE", Value: string(cni)},
 				{Name: "CALICO_NETWORKING_BACKEND", Value: "none"},
 				{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 			}
@@ -1621,6 +1632,7 @@ var _ = Describe("Windows rendering tests", func() {
 		Expect(ds.Spec.Template.Spec.Volumes).To(ConsistOf(expectedVols))
 
 		expectedNodeEnv := []corev1.EnvVar{
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_MANAGE_CNI", Value: "true"},
@@ -1763,6 +1775,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		expectedNodeEnv := []corev1.EnvVar{
 			// Default envvars.
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_MANAGE_CNI", Value: "true"},
@@ -1918,6 +1931,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		expectedNodeEnv := []corev1.EnvVar{
 			// Default envvars.
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_MANAGE_CNI", Value: "true"},
@@ -2441,6 +2455,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		// Verify env
 		expectedNodeEnv := []corev1.EnvVar{
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "DATASTORE_TYPE", Value: "kubernetes"},
 			{Name: "WAIT_FOR_DATASTORE", Value: "true"},
 			{Name: "CALICO_NETWORKING_BACKEND", Value: "none"},
@@ -2484,6 +2499,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		expectedCNIEnv := []corev1.EnvVar{
 			{Name: "SLEEP", Value: "false"},
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 			{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 			{Name: "CNI_NET_DIR", Value: "/etc/cni/net.d"},
@@ -2516,6 +2532,7 @@ var _ = Describe("Windows rendering tests", func() {
 
 		expectedUninstallEnv := []corev1.EnvVar{
 			{Name: "SLEEP", Value: "false"},
+			{Name: "CNI_PLUGIN_TYPE", Value: "Calico"},
 			{Name: "CNI_BIN_DIR", Value: "/host/opt/cni/bin"},
 			{Name: "CNI_CONF_NAME", Value: "10-calico.conflist"},
 			{Name: "CNI_NET_DIR", Value: "/host/etc/cni/net.d"},


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v1.38**: tigera/operator#4340
## Description

Used to skip clean up and to skip running the token refresher when using non-Calico CNI (https://github.com/projectcalico/calico/pull/11614).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

