### PR TITLE
Update KubeAPIServerEntityRule

### DIFF
--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -196,9 +196,10 @@ func AllowTigeraDefaultDeny(namespace string) *v3.NetworkPolicy {
 
 // Entity rules not belonging to Calico/Tigera components.
 var KubeAPIServerEntityRule = v3.EntityRule{
-	NamespaceSelector: "projectcalico.org/name == 'default'",
-	Selector:          "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-	Ports:             Ports(443, 6443, 12388),
+	Services: &v3.ServiceMatch{
+		Name:      "kubernetes",
+		Namespace: "default",
+	},
 }
 
 var KubeAPIServerServiceSelectorEntityRule = v3.EntityRule{

--- a/pkg/render/testutils/expected_policies/apiserver.json
+++ b/pkg/render/testutils/expected_policies/apiserver.json
@@ -65,13 +65,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/apiserver_ocp.json
+++ b/pkg/render/testutils/expected_policies/apiserver_ocp.json
@@ -76,13 +76,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/dex.json
+++ b/pkg/render/testutils/expected_policies/dex.json
@@ -109,13 +109,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/dex_ocp.json
+++ b/pkg/render/testutils/expected_policies/dex_ocp.json
@@ -120,13 +120,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/elastic-operator.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator.json
@@ -28,13 +28,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
@@ -39,13 +39,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/guardian.json
+++ b/pkg/render/testutils/expected_policies/guardian.json
@@ -142,13 +142,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/guardian_ocp.json
+++ b/pkg/render/testutils/expected_policies/guardian_ocp.json
@@ -153,13 +153,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
@@ -63,13 +63,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
@@ -74,13 +74,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_management.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_management.json
@@ -74,13 +74,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_management_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_management_ocp.json
@@ -85,13 +85,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone.json
@@ -63,13 +63,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone_ocp.json
@@ -74,13 +74,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/packetcapture.json
+++ b/pkg/render/testutils/expected_policies/packetcapture.json
@@ -33,13 +33,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/packetcapture_managed.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed.json
@@ -33,13 +33,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
@@ -33,13 +33,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/packetcapture_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_ocp.json
@@ -33,13 +33,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/prometheus-operator.json
+++ b/pkg/render/testutils/expected_policies/prometheus-operator.json
@@ -28,13 +28,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       }
     ]

--- a/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
@@ -39,13 +39,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       }
     ]

--- a/pkg/render/testutils/expected_policies/prometheus.json
+++ b/pkg/render/testutils/expected_policies/prometheus.json
@@ -40,13 +40,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {

--- a/pkg/render/testutils/expected_policies/prometheus_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus_ocp.json
@@ -51,13 +51,10 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'default'",
-          "selector": "(provider == 'kubernetes' && component == 'apiserver' && endpoints.projectcalico.org/serviceName == 'kubernetes')",
-          "ports": [
-            443,
-            6443,
-            12388
-          ]
+          "services": {
+            "name": "kubernetes",
+	    "namespace": "default"
+	  }
         }
       },
       {


### PR DESCRIPTION
## Description

Instead of allowing egress traffic to KubeAPI sever counting on auto created networksets on enterprise, select the destination using service match selector. This will be necessary for the plan to move `allow-tigera` to `calico-system` tier, that still being planned and designed by engineer team.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note-not-required
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
