### PR TITLE
fix(istio): Set platform=openshift for istio on OpenShift

### DIFF
--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -121,8 +121,17 @@ func Istio(cfg *Configuration) (*IstioComponentCRDs, *IstioComponent, error) {
 			},
 		},
 	}
+	// Set platform on all charts that have platform-specific behavior.
+	// The embedded Helm charts use zzz_profile.yaml to load platform profiles
+	// (e.g., profile-platform-openshift.yaml) which configure CNI paths, SCC
+	// RBAC rules, SELinux options, and sidecar injection settings.
 	if cfg.Installation.KubernetesProvider.IsGKE() {
 		istioResOpts.IstioCNIOpts.Global.Platform = "gke"
+	}
+	if cfg.Installation.KubernetesProvider.IsOpenShift() {
+		istioResOpts.IstioCNIOpts.Global.Platform = "openshift"
+		istioResOpts.IstiodOpts.Global.Platform = "openshift"
+		istioResOpts.ZTunnelOpts.Global.Platform = "openshift"
 	}
 	resources, err := istioResOpts.GetResources(cfg.Scheme)
 	if err != nil {

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -731,4 +731,158 @@ var _ = Describe("Istio Component Rendering", func() {
 			rtest.ExpectResources(objsToCreate, expectedResources)
 		})
 	})
+
+	Describe("OpenShift Platform Configuration", func() {
+		var component *istio.IstioComponent
+
+		BeforeEach(func() {
+			cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+
+			_, comp, err := istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			component = comp
+		})
+
+		It("should render all workloads successfully on OpenShift", func() {
+			objsToCreate, objsToDelete := component.Objects()
+
+			// OpenShift adds: NetworkAttachmentDefinition (CNI/Multus) +
+			// ztunnel ClusterRole + ztunnel ClusterRoleBinding (SCC)
+			Expect(objsToCreate).To(HaveLen(35))
+			Expect(objsToDelete).To(BeEmpty())
+		})
+
+		It("should include SCC use rule in istio-cni ClusterRole", func() {
+			objsToCreate, _ := component.Objects()
+
+			clusterRole, err := rtest.GetResourceOfType[*rbacv1.ClusterRole](objsToCreate, "istio-cni", "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Verify the OpenShift SCC rule is present
+			foundSCCRule := false
+			for _, rule := range clusterRole.Rules {
+				for _, apiGroup := range rule.APIGroups {
+					if apiGroup == "security.openshift.io" {
+						Expect(rule.Resources).To(ContainElement("securitycontextconstraints"))
+						Expect(rule.Verbs).To(ContainElement("use"))
+						Expect(rule.ResourceNames).To(ContainElement("privileged"))
+						foundSCCRule = true
+					}
+				}
+			}
+			Expect(foundSCCRule).To(BeTrue(), "Expected SCC 'use' rule in istio-cni ClusterRole for OpenShift")
+		})
+
+		It("should include SCC use rule in ztunnel ClusterRole", func() {
+			objsToCreate, _ := component.Objects()
+
+			clusterRole, err := rtest.GetResourceOfType[*rbacv1.ClusterRole](objsToCreate, "ztunnel", "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			foundSCCRule := false
+			for _, rule := range clusterRole.Rules {
+				for _, apiGroup := range rule.APIGroups {
+					if apiGroup == "security.openshift.io" {
+						Expect(rule.Resources).To(ContainElement("securitycontextconstraints"))
+						Expect(rule.Verbs).To(ContainElement("use"))
+						Expect(rule.ResourceNames).To(ContainElement("privileged"))
+						foundSCCRule = true
+					}
+				}
+			}
+			Expect(foundSCCRule).To(BeTrue(), "Expected SCC 'use' rule in ztunnel ClusterRole for OpenShift")
+		})
+
+		It("should use OpenShift CNI bin directory", func() {
+			objsToCreate, _ := component.Objects()
+
+			daemonset, err := rtest.GetResourceOfType[*appsv1.DaemonSet](objsToCreate, istio.IstioCNIDaemonSetName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Verify the hostPath volume uses /var/lib/cni/bin (OpenShift path)
+			foundCNIBinVolume := false
+			for _, vol := range daemonset.Spec.Template.Spec.Volumes {
+				if vol.Name == "cni-bin-dir" && vol.HostPath != nil {
+					Expect(vol.HostPath.Path).To(Equal("/var/lib/cni/bin"))
+					foundCNIBinVolume = true
+				}
+			}
+			Expect(foundCNIBinVolume).To(BeTrue(), "Expected cni-bin-dir volume with OpenShift path /var/lib/cni/bin")
+		})
+
+		It("should use Multus CNI config directory", func() {
+			objsToCreate, _ := component.Objects()
+
+			daemonset, err := rtest.GetResourceOfType[*appsv1.DaemonSet](objsToCreate, istio.IstioCNIDaemonSetName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Verify the hostPath volume uses /etc/cni/multus/net.d (Multus config dir)
+			foundCNINetVolume := false
+			for _, vol := range daemonset.Spec.Template.Spec.Volumes {
+				if vol.Name == "cni-net-dir" && vol.HostPath != nil {
+					Expect(vol.HostPath.Path).To(Equal("/etc/cni/multus/net.d"))
+					foundCNINetVolume = true
+				}
+			}
+			Expect(foundCNINetVolume).To(BeTrue(), "Expected cni-net-dir volume with Multus path /etc/cni/multus/net.d")
+		})
+
+		It("should set PLATFORM env var on istiod", func() {
+			objsToCreate, _ := component.Objects()
+
+			deployment, err := rtest.GetResourceOfType[*appsv1.Deployment](objsToCreate, istio.IstioIstiodDeploymentName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			foundPlatformEnv := false
+			for _, container := range deployment.Spec.Template.Spec.Containers {
+				if container.Name == "discovery" {
+					for _, env := range container.Env {
+						if env.Name == "PLATFORM" {
+							Expect(env.Value).To(Equal("openshift"))
+							foundPlatformEnv = true
+						}
+					}
+				}
+			}
+			Expect(foundPlatformEnv).To(BeTrue(), "Expected PLATFORM=openshift env var on istiod")
+		})
+
+		It("should set trusted ztunnel namespace to kube-system on istiod", func() {
+			objsToCreate, _ := component.Objects()
+
+			deployment, err := rtest.GetResourceOfType[*appsv1.Deployment](objsToCreate, istio.IstioIstiodDeploymentName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			foundTrustedAccounts := false
+			for _, container := range deployment.Spec.Template.Spec.Containers {
+				if container.Name == "discovery" {
+					for _, env := range container.Env {
+						if env.Name == "CA_TRUSTED_NODE_ACCOUNTS" {
+							Expect(env.Value).To(Equal("kube-system/ztunnel"))
+							foundTrustedAccounts = true
+						}
+					}
+				}
+			}
+			Expect(foundTrustedAccounts).To(BeTrue(), "Expected CA_TRUSTED_NODE_ACCOUNTS=kube-system/ztunnel on istiod")
+		})
+
+		It("should set SELinux context on ztunnel", func() {
+			objsToCreate, _ := component.Objects()
+
+			daemonset, err := rtest.GetResourceOfType[*appsv1.DaemonSet](objsToCreate, istio.IstioZTunnelDaemonSetName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			foundSELinux := false
+			for _, container := range daemonset.Spec.Template.Spec.Containers {
+				if container.Name == "istio-proxy" {
+					Expect(container.SecurityContext).NotTo(BeNil())
+					Expect(container.SecurityContext.SELinuxOptions).NotTo(BeNil())
+					Expect(container.SecurityContext.SELinuxOptions.Type).To(Equal("spc_t"))
+					foundSELinux = true
+				}
+			}
+			Expect(foundSELinux).To(BeTrue(), "Expected SELinux type spc_t on ztunnel container")
+		})
+	})
 })

--- a/pkg/render/istio/resources.go
+++ b/pkg/render/istio/resources.go
@@ -17,6 +17,7 @@ package istio
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -25,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -168,7 +170,17 @@ func (r *ResourceOpts) parseManifest(scheme *runtime.Scheme, manifest string, is
 
 		obj, _, err := universalDeserializer.Decode(rawObj.Raw, nil, nil)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error deserializing object: %w", err)
+			if !runtime.IsNotRegisteredError(err) {
+				return nil, nil, fmt.Errorf("error deserializing object: %w", err)
+			}
+			// Type not registered in scheme — decode as Unstructured.
+			// This handles platform-specific types like NetworkAttachmentDefinition
+			// from OpenShift profiles.
+			u := &unstructured.Unstructured{}
+			if jsonErr := json.Unmarshal(rawObj.Raw, &u.Object); jsonErr != nil {
+				return nil, nil, fmt.Errorf("error deserializing unstructured object: %w", jsonErr)
+			}
+			obj = u
 		}
 
 		clientObj, ok := obj.(client.Object)


### PR DESCRIPTION
## Description

Bug fix — the operator set `global.platform` for GKE but not for OpenShift when rendering the embedded Istio Helm charts. Each chart has a `zzz_profile.yaml` loader that activates `profile-platform-openshift.yaml` when `global.platform=openshift` — the profiles were already correct, they were just never being activated.

This caused multiple failures on OpenShift clusters:

1. **CNI binary path** defaulted to `/opt/cni/bin` instead of `/var/lib/cni/bin` → `read-only file system` / `no such file or directory`
2. **Missing SCC RBAC rules** on both `istio-cni` and `ztunnel` ClusterRoles → `permission denied` on UDS socket creation
3. **Missing SELinux `spc_t` context** on ztunnel containers
4. **Missing `PLATFORM` env var** and `CA_TRUSTED_NODE_ACCOUNTS=kube-system/ztunnel` on istiod
5. **Missing Multus-aware sidecar injection** configuration in istiod

The fix sets `global.platform=openshift` on all three affected charts (CNI, istiod, ztunnel). The base chart is unaffected (no templates consume platform values).

Also adds an `unstructured.Unstructured` fallback in `parseManifest` for types not registered in the scheme (e.g., `NetworkAttachmentDefinition` from the OpenShift Multus provider profile).

**Components affected:** `pkg/render/istio/`

**Testing:**
- 8 new unit tests for OpenShift platform configuration covering all three charts
- All 32 istio render tests pass
- Verified rendered output: ClusterRoles include SCC rules, DaemonSet volumes use correct OCP paths, istiod has PLATFORM env var, ztunnel has SELinux context

**Links:** [EV-6376](https://tigera.atlassian.net/browse/EV-6376), [CI-1931](https://tigera.atlassian.net/browse/CI-1931)

## Release Note

```release-note
Fix Istio service mesh components (istio-cni, istiod, ztunnel) failing on OpenShift due to missing platform detection. The operator now sets platform=openshift on all embedded Istio Helm charts, activating correct CNI binary paths (/var/lib/cni/bin), Multus provider configuration, SCC RBAC rules, SELinux contexts, and trusted ztunnel namespace settings.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

[EV-6376]: https://tigera.atlassian.net/browse/EV-6376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ