### PR TITLE
fix(monitor): Update PrometheusSelector to match actual pod labels

### DIFF
--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -318,7 +318,7 @@ func (h *NetworkPolicyHelper) IntrusionDetectionSourceEntityRule() v3.EntityRule
 	return CreateSourceEntityRule(h.namespace("tigera-intrusion-detection"), "intrusion-detection-controller")
 }
 
-const PrometheusSelector = "k8s-app == 'tigera-prometheus'"
+const PrometheusSelector = "k8s-app == 'calico-node-prometheus'"
 
 var PrometheusEntityRule = v3.EntityRule{
 	NamespaceSelector: "projectcalico.org/name == 'tigera-prometheus'",

--- a/pkg/render/testutils/expected_policies/apiserver.json
+++ b/pkg/render/testutils/expected_policies/apiserver.json
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "destination": {
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/apiserver_ocp.json
+++ b/pkg/render/testutils/expected_policies/apiserver_ocp.json
@@ -87,7 +87,7 @@
         "protocol": "TCP",
         "destination": {
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/dex.json
+++ b/pkg/render/testutils/expected_policies/dex.json
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         }
       },

--- a/pkg/render/testutils/expected_policies/dex_ocp.json
+++ b/pkg/render/testutils/expected_policies/dex_ocp.json
@@ -75,7 +75,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         }
       },

--- a/pkg/render/testutils/expected_policies/es-metrics.json
+++ b/pkg/render/testutils/expected_policies/es-metrics.json
@@ -19,7 +19,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/es-metrics_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-metrics_ocp.json
@@ -19,7 +19,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/fluentd_managed.json
+++ b/pkg/render/testutils/expected_policies/fluentd_managed.json
@@ -18,7 +18,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged.json
@@ -19,7 +19,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/fluentd_unmanaged_ocp.json
@@ -19,7 +19,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/guardian.json
+++ b/pkg/render/testutils/expected_policies/guardian.json
@@ -152,7 +152,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector":"k8s-app == 'tigera-prometheus'",
+          "selector":"k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/guardian_ocp.json
+++ b/pkg/render/testutils/expected_policies/guardian_ocp.json
@@ -163,7 +163,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector":"k8s-app == 'tigera-prometheus'",
+          "selector":"k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers.json
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
@@ -63,7 +63,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
@@ -63,7 +63,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "source": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "name == 'tigera-prometheus'"
         },
         "destination": {

--- a/pkg/render/testutils/expected_policies/manager.json
+++ b/pkg/render/testutils/expected_policies/manager.json
@@ -162,7 +162,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/manager_ocp.json
+++ b/pkg/render/testutils/expected_policies/manager_ocp.json
@@ -173,7 +173,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/prometheus-api.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api.json
@@ -41,7 +41,7 @@
         "protocol": "TCP",
         "destination": {
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
@@ -52,7 +52,7 @@
         "protocol": "TCP",
         "destination": {
           "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
-          "selector": "k8s-app == 'tigera-prometheus'",
+          "selector": "k8s-app == 'calico-node-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/prometheus.json
+++ b/pkg/render/testutils/expected_policies/prometheus.json
@@ -8,7 +8,7 @@
   "spec": {
     "order": 1,
     "tier": "allow-tigera",
-    "selector": "k8s-app == 'tigera-prometheus'",
+    "selector": "k8s-app == 'calico-node-prometheus'",
     "types": [
       "Ingress",
       "Egress"

--- a/pkg/render/testutils/expected_policies/prometheus_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus_ocp.json
@@ -8,7 +8,7 @@
   "spec": {
     "order": 1,
     "tier": "allow-tigera",
-    "selector": "k8s-app == 'tigera-prometheus'",
+    "selector": "k8s-app == 'calico-node-prometheus'",
     "types": [
       "Ingress",
       "Egress"


### PR DESCRIPTION
## Description

Bug fix to correct the PrometheusSelector constant that is used by network policies to match Prometheus pods.

**Type**: Bug fix

**Why**: After PR #4327 (feat(recommended labels)), the Prometheus pods have the label `k8s-app=calico-node-prometheus` (derived from the Prometheus CR name via `maps.Copy`), but the `PrometheusSelector` constant was still looking for `k8s-app=tigera-prometheus`. This mismatch caused:
- The `allow-tigera.prometheus` policy to not apply to Prometheus pods
- The `allow-tigera.manager-access` policy egress rule for Prometheus to not match
- Traffic to/from Prometheus to be blocked by default-deny policies

**Testing**:
- All render tests pass (`go test ./pkg/render/...`)
- Manual verification on a cluster confirmed that Prometheus queries through the manager proxy now work after this fix

**Components affected**: 
- `pkg/render/common/networkpolicy/networkpolicy.go` - the PrometheusSelector constant
- Network policies for: manager, guardian, apiserver, kubecontrollers, fluentd, dex, es-metrics, prometheus, prometheus-api

## Release Note

```release-note
Fixed network policies for Prometheus by updating the pod selector to match the actual Prometheus pod label (k8s-app=calico-node-prometheus) instead of the previous incorrect value (k8s-app=tigera-prometheus).
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`