### PR TITLE
ci: Remove docker restarts from semaphore pipelines

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,12 +28,7 @@ global_job_config:
       - ssh-add ~/.keys/*
       # Free up some space
       - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
-      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-      # how much we churn docker containers during testing.  Disable it.
-      - sudo systemctl stop docker
-      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-      - sudo systemctl start docker
+      # Get the code
       - checkout
       # Note that the 'cache restore' commands require that the "Build" block has been run. The "Build" block is what populates
       # the cache, therefore every block that requires the use of these cached items must make the "Build" block one of


### PR DESCRIPTION
Semaphore used to have a copy-on-write NBD file mounted on `/var/lib/docker`, which we would unmount for performance's sake. They've since removed this approach, but our code to handle it remains.

Unfortunately, Docker lately seems to be using the OCI/containerd image store format for fresh installs, so unless you already have a populated and configured `/var/lib/docker` you will get images being built as OCI manifests which cannot be combined together using `docker manifest`.

Removing the unmounting of `/var/lib/docker` resolves the issue and has the additional benefit of simplifying the pipeline.

It may be preferable in the future to reconfigure our build process to, rather than build multiple separate images and manifest them together, instead build one manifest from the start; this would allow us to include the annotations Docker is trying to add, such as the automatic SBOM information and provenance metadata. For now, this is simpler, however.