### PR TITLE
bug(recommended labels): Previously existing k8s-app label changed.

### DIFF
--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -165,6 +165,25 @@ var _ = Describe("Monitor controller tests", func() {
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeMonitor, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.ElasticsearchMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).NotTo(HaveOccurred())
+
+			// Verify the recommended labels are correct on these resources.
+			Expect(p.Labels).To(Equal(map[string]string{
+				"k8s-app":                      "tigera-prometheus",
+				"app.kubernetes.io/instance":   "tigera-secure",
+				"app.kubernetes.io/managed-by": "tigera-operator",
+				"app.kubernetes.io/name":       "tigera-prometheus",
+				"app.kubernetes.io/part-of":    "Calico",
+				"app.kubernetes.io/component":  "",
+			}))
+			Expect(am.Labels).To(Equal(map[string]string{
+				"k8s-app":                      "calico-node-alertmanager",
+				"app.kubernetes.io/instance":   "tigera-secure",
+				"app.kubernetes.io/managed-by": "tigera-operator",
+				"app.kubernetes.io/name":       "calico-node-alertmanager",
+				"app.kubernetes.io/part-of":    "Calico",
+				"app.kubernetes.io/component":  "",
+			}))
+
 		})
 
 		It("should create Prometheus related resources even when a cert with missing key usages is configured for other components", func() {

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -1056,10 +1056,15 @@ func sanitizeLabel(input string) string {
 // addNameLabel sets the name of the application.
 // For more on recommended labels see: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 func addNameLabel(obj metav1.Object, name string) {
+	k8sapp := obj.GetLabels()["k8s-app"]
 	if obj.GetLabels()["app.kubernetes.io/name"] == "" {
-		obj.GetLabels()["app.kubernetes.io/name"] = sanitizeLabel(name)
+		if k8sapp != "" {
+			obj.GetLabels()["app.kubernetes.io/name"] = k8sapp
+		} else {
+			obj.GetLabels()["app.kubernetes.io/name"] = sanitizeLabel(name)
+		}
 	}
-	if obj.GetLabels()["k8s-app"] == "" {
+	if k8sapp == "" {
 		obj.GetLabels()["k8s-app"] = sanitizeLabel(name)
 	}
 }

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -541,6 +541,9 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      CalicoNodePrometheus,
 			Namespace: common.TigeraPrometheusNamespace,
+			Labels: map[string]string{
+				"k8s-app": TigeraPrometheusObjectName,
+			},
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{


### PR DESCRIPTION
bug(recommended labels): Previously existing k8s-app label changed

Due to the parent Prometheus object not having labels, the recommended labels code would override the existing k8s-app label on Spec.CommonPrometheusFields.PodMetadata.Labels

We also use the value for k8s-app as the name of choice when unset. This way k8s-app and app.kubernetes.io/name are always the same unless specified differently.