### PR TITLE
[master] ev-6393

### DIFF
--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -290,7 +290,12 @@ var _ = Describe("Monitor controller tests", func() {
 					Params: map[string][]string{"match[]": {"{__name__=~\".+\"}"}},
 					Port:   "web",
 					Path:   "/federate",
-					Scheme: ptr.To(monitoringv1.SchemeHTTPS),
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							TargetLabel: "__scheme__",
+							Replacement: ptr.To("https"),
+						},
+					},
 					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 							TLSConfig: &monitoringv1.TLSConfig{

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -610,7 +610,12 @@ func (mc *monitorComponent) prometheus() *monitoringv1.Prometheus {
 						Name:      CalicoNodeAlertmanager,
 						Namespace: &promNamespace,
 						Port:      intstr.FromString("web"),
-						Scheme:    ptr.To(monitoringv1.SchemeHTTP),
+						RelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								TargetLabel: "__scheme__",
+								Replacement: ptr.To("http"),
+							},
+						},
 					},
 				},
 			},
@@ -830,7 +835,12 @@ func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMoni
 			Interval:      "5s",
 			Port:          "calico-metrics-port",
 			ScrapeTimeout: "5s",
-			Scheme:        ptr.To(monitoringv1.SchemeHTTPS),
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "__scheme__",
+					Replacement: ptr.To("https"),
+				},
+			},
 			HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 				HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 					TLSConfig: mc.tlsConfig(render.CalicoNodeMetricsService),
@@ -842,7 +852,12 @@ func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMoni
 			Interval:      "5s",
 			Port:          "calico-bgp-metrics-port",
 			ScrapeTimeout: "5s",
-			Scheme:        ptr.To(monitoringv1.SchemeHTTPS),
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "__scheme__",
+					Replacement: ptr.To("https"),
+				},
+			},
 			HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 				HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 					TLSConfig: mc.tlsConfig(render.CalicoNodeMetricsService),
@@ -857,7 +872,12 @@ func (mc *monitorComponent) serviceMonitorCalicoNode() *monitoringv1.ServiceMoni
 			Interval:      "5s",
 			Port:          "felix-metrics-port",
 			ScrapeTimeout: "5s",
-			Scheme:        ptr.To(monitoringv1.SchemeHTTP),
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "__scheme__",
+					Replacement: ptr.To("http"),
+				},
+			},
 		})
 	}
 
@@ -914,10 +934,15 @@ func (mc *monitorComponent) serviceMonitorElasticsearch() *monitoringv1.ServiceM
 					Interval:      "5s",
 					Port:          "metrics-port",
 					ScrapeTimeout: "5s",
-					Scheme:        ptr.To(monitoringv1.SchemeHTTPS),
 					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 							TLSConfig: mc.tlsConfig(esmetrics.ElasticsearchMetricsName),
+						},
+					},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							TargetLabel: "__scheme__",
+							Replacement: ptr.To("https"),
 						},
 					},
 				},
@@ -954,10 +979,15 @@ func (mc *monitorComponent) serviceMonitorFluentd() *monitoringv1.ServiceMonitor
 					Interval:      "5s",
 					Port:          render.FluentdMetricsPortName,
 					ScrapeTimeout: "5s",
-					Scheme:        ptr.To(monitoringv1.SchemeHTTPS),
 					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 							TLSConfig: mc.tlsConfig(render.FluentdPrometheusTLSSecretName),
+						},
+					},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							TargetLabel: "__scheme__",
+							Replacement: ptr.To("https"),
 						},
 					},
 				},
@@ -980,11 +1010,16 @@ func (mc *monitorComponent) serviceMonitorQueryServer() *monitoringv1.ServiceMon
 			NamespaceSelector: monitoringv1.NamespaceSelector{MatchNames: []string{render.QueryserverNamespace}},
 			Endpoints: []monitoringv1.Endpoint{
 				{
-					HonorLabels:     true,
-					Interval:        "5s",
-					Port:            "queryserver",
-					ScrapeTimeout:   "5s",
-					Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
+					HonorLabels:   true,
+					Interval:      "5s",
+					Port:          "queryserver",
+					ScrapeTimeout: "5s",
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							TargetLabel: "__scheme__",
+							Replacement: ptr.To("https"),
+						},
+					},
 					BearerTokenFile: bearerTokenFile,
 					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
@@ -1366,7 +1401,12 @@ func (mc *monitorComponent) serviceMonitorCalicoKubeControllers() *monitoringv1.
 					Interval:      "5s",
 					Port:          "metrics-port",
 					ScrapeTimeout: "5s",
-					Scheme:        ptr.To(monitoringv1.SchemeHTTPS),
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							TargetLabel: "__scheme__",
+							Replacement: ptr.To("https"),
+						},
+					},
 					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 							TLSConfig: mc.tlsConfig(KubeControllerMetrics),
@@ -1474,10 +1514,18 @@ func (mc *monitorComponent) externalServiceMonitor() (client.Object, bool) {
 	var needsRBAC bool
 	endpoints := make([]monitoringv1.Endpoint, len(mc.cfg.Monitor.ExternalPrometheus.ServiceMonitor.Endpoints))
 	for i, ep := range mc.cfg.Monitor.ExternalPrometheus.ServiceMonitor.Endpoints {
+		relabelConfigs := ep.RelabelConfigs
+		if len(relabelConfigs) == 0 {
+			relabelConfigs = []monitoringv1.RelabelConfig{
+				{
+					TargetLabel: "__scheme__",
+					Replacement: ptr.To("https"),
+				},
+			}
+		}
 		endpoints[i] = monitoringv1.Endpoint{
 			Port:          "web",
 			Path:          "/federate",
-			Scheme:        ptr.To(monitoringv1.SchemeHTTPS),
 			Params:        ep.Params,
 			Interval:      ep.Interval,
 			ScrapeTimeout: ep.ScrapeTimeout,
@@ -1503,7 +1551,7 @@ func (mc *monitorComponent) externalServiceMonitor() (client.Object, bool) {
 			HonorLabels:          ep.HonorLabels,
 			HonorTimestamps:      ep.HonorTimestamps,
 			MetricRelabelConfigs: ep.MetricRelabelConfigs,
-			RelabelConfigs:       ep.RelabelConfigs,
+			RelabelConfigs:       relabelConfigs,
 		}
 		// All requests that go to our prometheus server are first passing through the authn-proxy side-car. This server
 		// will listen to https traffic and performs authn and authz (see also the rbac attributes in externalPrometheusRole()).
@@ -1551,8 +1599,13 @@ func (mc *monitorComponent) typhaServiceMonitor() client.Object {
 					HonorLabels:   true,
 					Interval:      "5s",
 					Port:          render.TyphaMetricsName,
-					Scheme:        ptr.To(monitoringv1.SchemeHTTP),
 					ScrapeTimeout: "5s",
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							TargetLabel: "__scheme__",
+							Replacement: ptr.To("http"),
+						},
+					},
 				},
 			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/pkg/render/monitor/monitor_test.go
+++ b/pkg/render/monitor/monitor_test.go
@@ -359,7 +359,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(prometheusObj.Spec.Alerting.Alertmanagers[0].Name).To(Equal("calico-node-alertmanager"))
 		Expect(*prometheusObj.Spec.Alerting.Alertmanagers[0].Namespace).To(Equal("tigera-prometheus"))
 		Expect(prometheusObj.Spec.Alerting.Alertmanagers[0].Port).To(Equal(intstr.FromString("web")))
-		Expect(*prometheusObj.Spec.Alerting.Alertmanagers[0].Scheme).To(Equal(monitoringv1.SchemeHTTP))
+		Expect(*prometheusObj.Spec.Alerting.Alertmanagers[0].RelabelConfigs[0].Replacement).To(Equal("http"))
 		Expect(*prometheusObj.Spec.ReloadStrategy).To(BeEquivalentTo(monitoringv1.ProcessSignalReloadStrategyType))
 		Expect(*prometheusObj.Spec.SecurityContext.RunAsGroup).To(BeEquivalentTo(10001))
 		Expect(*prometheusObj.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
@@ -506,12 +506,12 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("calico-metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[0].Scheme).To(Equal(monitoringv1.SchemeHTTPS))
+		Expect(*servicemonitorObj.Spec.Endpoints[0].RelabelConfigs[0].Replacement).To(Equal("https"))
 		Expect(servicemonitorObj.Spec.Endpoints[1].HonorLabels).To(BeTrue())
 		Expect(servicemonitorObj.Spec.Endpoints[1].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[1].Port).To(Equal("calico-bgp-metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[1].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[1].Scheme).To(Equal(monitoringv1.SchemeHTTPS))
+		Expect(*servicemonitorObj.Spec.Endpoints[1].RelabelConfigs[0].Replacement).To(Equal("https"))
 
 		servicemonitorObj, ok = rtest.GetResource(toCreate, monitor.ElasticsearchMetrics, common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
 		Expect(ok).To(BeTrue())
@@ -524,7 +524,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[0].Scheme).To(Equal(monitoringv1.SchemeHTTPS))
+		Expect(*servicemonitorObj.Spec.Endpoints[0].RelabelConfigs[0].Replacement).To(Equal("https"))
 
 		servicemonitorObj, ok = rtest.GetResource(toCreate, "fluentd-metrics", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
 		Expect(ok).To(BeTrue())
@@ -544,7 +544,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("fluentd-metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[0].Scheme).To(Equal(monitoringv1.SchemeHTTPS))
+		Expect(*servicemonitorObj.Spec.Endpoints[0].RelabelConfigs[0].Replacement).To(Equal("https"))
 
 		servicemonitorObj, ok = rtest.GetResource(toCreate, "calico-api", common.TigeraPrometheusNamespace, "monitoring.coreos.com", "v1", monitoringv1.ServiceMonitorsKind).(*monitoringv1.ServiceMonitor)
 		Expect(ok).To(BeTrue())
@@ -557,7 +557,7 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("queryserver"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[0].Scheme).To(Equal(monitoringv1.SchemeHTTPS))
+		Expect(*servicemonitorObj.Spec.Endpoints[0].RelabelConfigs[0].Replacement).To(Equal("https"))
 		//nolint:staticcheck // Ignore SA1019 deprecated
 		Expect(servicemonitorObj.Spec.Endpoints[0].BearerTokenFile).To(Equal("/var/run/secrets/kubernetes.io/serviceaccount/token"))
 
@@ -936,8 +936,13 @@ var _ = Describe("monitor rendering tests", func() {
 						HonorLabels:   true,
 						Interval:      "5s",
 						Port:          "calico-typha-metrics",
-						Scheme:        ptr.To(monitoringv1.SchemeHTTP),
 						ScrapeTimeout: "5s",
+						RelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								TargetLabel: "__scheme__",
+								Replacement: ptr.To("http"),
+							},
+						},
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{
@@ -964,17 +969,17 @@ var _ = Describe("monitor rendering tests", func() {
 		Expect(servicemonitorObj.Spec.Endpoints[0].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].Port).To(Equal("calico-metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[0].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[0].Scheme).To(Equal(monitoringv1.SchemeHTTPS))
+		Expect(*servicemonitorObj.Spec.Endpoints[0].RelabelConfigs[0].Replacement).To(Equal("https"))
 		Expect(servicemonitorObj.Spec.Endpoints[1].HonorLabels).To(BeTrue())
 		Expect(servicemonitorObj.Spec.Endpoints[1].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[1].Port).To(Equal("calico-bgp-metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[1].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[1].Scheme).To(Equal(monitoringv1.SchemeHTTPS))
+		Expect(*servicemonitorObj.Spec.Endpoints[1].RelabelConfigs[0].Replacement).To(Equal("https"))
 		Expect(servicemonitorObj.Spec.Endpoints[2].HonorLabels).To(BeTrue())
 		Expect(servicemonitorObj.Spec.Endpoints[2].Interval).To(BeEquivalentTo("5s"))
 		Expect(servicemonitorObj.Spec.Endpoints[2].Port).To(Equal("felix-metrics-port"))
 		Expect(servicemonitorObj.Spec.Endpoints[2].ScrapeTimeout).To(BeEquivalentTo("5s"))
-		Expect(*servicemonitorObj.Spec.Endpoints[2].Scheme).To(Equal(monitoringv1.SchemeHTTP))
+		Expect(*servicemonitorObj.Spec.Endpoints[2].RelabelConfigs[0].Replacement).To(Equal("http"))
 	})
 })
 


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **master**: tigera/operator#4420
Openshift uses older CRDs than us. The Scheme field is incompatible. Luckily, there is an alternative way for setting the scheme as per their documentation:
```
  // Supported values are `HTTP` and `HTTPS`. You can also rewrite the
  // `__scheme__` label via relabeling configuration.
  // If empty, the value defaults to `HTTP`.
  // +kubebuilder:validation:Enum=http;https;HTTP;HTTPS
```


```release-note
Use backwards compatible schema configuration for prometheus endpoints on Openshift.
```

