### PR TITLE
chore(deps): update coraza-coreruleset/v4 to v4.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/containernetworking/cni v1.2.3
-	github.com/corazawaf/coraza-coreruleset/v4 v4.11.0
+	github.com/corazawaf/coraza-coreruleset/v4 v4.23.0
 	github.com/elastic/cloud-on-k8s/v2 v2.0.0-20250129010100-648f902d9807
 	github.com/envoyproxy/gateway v1.5.7
 	github.com/go-ldap/ldap v3.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/containerd/stargz-snapshotter/estargz v0.17.0 h1:+TyQIsR/zSFI1Rm31EQB
 github.com/containerd/stargz-snapshotter/estargz v0.17.0/go.mod h1:s06tWAiJcXQo9/8AReBCIo/QxcXFZ2n4qfsRnpl71SM=
 github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8FuJbEslXM=
 github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
-github.com/corazawaf/coraza-coreruleset/v4 v4.11.0 h1:847e2uM27rzOBGTTmbh/il0r4fNQ1yvVqSpoq7e9kS8=
-github.com/corazawaf/coraza-coreruleset/v4 v4.11.0/go.mod h1:yeZPZUM23HVL0jMAzLfKF3M7XjCQBXDrvcQT/gkjwhg=
+github.com/corazawaf/coraza-coreruleset/v4 v4.23.0 h1:e7f2tRhOBFN8YtL72wqy2cMPS6o64XyMgS81dRbw2/c=
+github.com/corazawaf/coraza-coreruleset/v4 v4.23.0/go.mod h1:tRjsdtj39+at47dLCpE8ChoDa2FK2IAwTWIpDT8Z62g=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
## Description

Dependency update: bump github.com/corazawaf/coraza-coreruleset/v4 from v4.11.0 to v4.23.0 to pick up the latest OWASP CRS rules and fixes. Used in `pkg/render/applicationlayer/ruleset/embed.go`.

## Release Note

```release-note
TBD
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

Closes: EV-6418