### PR TITLE
[v1.36] Deprecate the nonPrivileged field in Installation CRD

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023-2026 Tigera, Inc. All rights reserved.
 /*
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -154,6 +154,8 @@ type InstallationSpec struct {
 	// +optional
 	CertificateManagement *CertificateManagement `json:"certificateManagement,omitempty"`
 
+	// Deprecated. NonPrivileged is deprecated and will be removed from the API in a future release.
+	// Enabling this field is not supported and will cause errors.
 	// NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.
 	// +optional
 	NonPrivileged *NonPrivilegedType `json:"nonPrivileged,omitempty"`

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -451,12 +451,6 @@ func fillDefaults(instance *operator.Installation, currentPools *crdv1.IPPoolLis
 	if len(instance.Spec.Variant) == 0 {
 		// Default to installing Calico.
 		instance.Spec.Variant = operator.Calico
-	}
-
-	// Default to running Calico as privileged.
-	if instance.Spec.NonPrivileged == nil {
-		npd := operator.NonPrivilegedDisabled
-		instance.Spec.NonPrivileged = &npd
 	}
 
 	if instance.Spec.TyphaAffinity == nil {

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,8 +63,6 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(*instance.Spec.CalicoNetwork.BGP).To(Equal(operator.BGPEnabled))
 		Expect(*instance.Spec.CalicoNetwork.LinuxPolicySetupTimeoutSeconds).To(BeZero())
 		Expect(*instance.Spec.ControlPlaneReplicas).To(Equal(int32(2)))
-		Expect(instance.Spec.NonPrivileged).NotTo(BeNil())
-		Expect(*instance.Spec.NonPrivileged).To(Equal(operator.NonPrivilegedDisabled))
 		Expect(instance.Spec.KubeletVolumePluginPath).To(Equal(filepath.Clean("/var/lib/kubelet")))
 		Expect(*instance.Spec.Logging.CNI.LogSeverity).To(Equal(operator.LogLevelInfo))
 		Expect(*instance.Spec.Logging.CNI.LogFileMaxCount).To(Equal(uint32(10)))
@@ -100,8 +98,6 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(*instance.Spec.CalicoNetwork.BGP).To(Equal(operator.BGPEnabled))
 		Expect(*instance.Spec.CalicoNetwork.LinuxPolicySetupTimeoutSeconds).To(BeZero())
 		Expect(*instance.Spec.ControlPlaneReplicas).To(Equal(int32(2)))
-		Expect(instance.Spec.NonPrivileged).NotTo(BeNil())
-		Expect(*instance.Spec.NonPrivileged).To(Equal(operator.NonPrivilegedDisabled))
 		Expect(instance.Spec.KubeletVolumePluginPath).To(Equal(filepath.Clean("/var/lib/kubelet")))
 	})
 
@@ -124,12 +120,10 @@ var _ = Describe("Defaulting logic tests", func() {
 		miMode := operator.MultiInterfaceModeNone
 		dpIptables := operator.LinuxDataplaneIptables
 		winDataplaneDisabled := operator.WindowsDataplaneDisabled
-		nonPrivileged := operator.NonPrivilegedEnabled
 		instance := &operator.Installation{
 			Spec: operator.InstallationSpec{
-				Variant:       operator.Calico,
-				NonPrivileged: &nonPrivileged,
-				Registry:      "test-reg/",
+				Variant:  operator.Calico,
+				Registry: "test-reg/",
 				ImagePullSecrets: []v1.LocalObjectReference{
 					{
 						Name: "pullSecret1",
@@ -217,12 +211,10 @@ var _ = Describe("Defaulting logic tests", func() {
 		dpBPF := operator.LinuxDataplaneBPF
 		winDataplaneDisabled := operator.WindowsDataplaneDisabled
 		hpEnabled := operator.HostPortsEnabled
-		npDisabled := operator.NonPrivilegedDisabled
 		instance := &operator.Installation{
 			Spec: operator.InstallationSpec{
-				Variant:       operator.TigeraSecureEnterprise,
-				NonPrivileged: &npDisabled,
-				Registry:      "test-reg/",
+				Variant:  operator.TigeraSecureEnterprise,
+				Registry: "test-reg/",
 				ImagePullSecrets: []v1.LocalObjectReference{
 					{
 						Name: "pullSecret1",

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025, 2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026, 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -328,19 +328,9 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 		}
 	}
 
-	// Verify that we are running in non-privileged mode only with the appropriate feature set
+	// Verify that non-privileged mode is not Enabled, since it's been deprecated.
 	if instance.Spec.NonPrivileged != nil && *instance.Spec.NonPrivileged == operatorv1.NonPrivilegedEnabled {
-		// BPF must be disabled
-		if instance.Spec.CalicoNetwork != nil &&
-			instance.Spec.CalicoNetwork.LinuxDataplane != nil &&
-			*instance.Spec.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneBPF {
-			return fmt.Errorf("Non-privileged Calico is not supported when BPF dataplane is enabled")
-		}
-
-		// Only allowed to run as non-privileged for OS Calico
-		if instance.Spec.Variant == operatorv1.TigeraSecureEnterprise {
-			return fmt.Errorf("Non-privileged Calico is not supported for spec.Variant=%s", operatorv1.TigeraSecureEnterprise)
-		}
+		return fmt.Errorf("non-privileged Calico is deprecated and cannot be Enabled; please, remove this field from your installation spec")
 	}
 
 	// Verify the CalicoNodeDaemonSet overrides, if specified, is valid.

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019, 2022-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -360,19 +360,9 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should not allow Calico to run in non-privileged mode if BPF is enabled", func() {
-		np := operator.NonPrivilegedEnabled
-		bpf := operator.LinuxDataplaneBPF
-		instance.Spec.NonPrivileged = &np
-		instance.Spec.CalicoNetwork.LinuxDataplane = &bpf
-		err := validateCustomResource(instance)
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("should not allow Calico to run in non-privileged mode with Tigera Secure Enterprise", func() {
+	It("should not allow Calico to run in non-privileged mode, since it's deprecated", func() {
 		np := operator.NonPrivilegedEnabled
 		instance.Spec.NonPrivileged = &np
-		instance.Spec.Variant = operator.TigeraSecureEnterprise
 		err := validateCustomResource(instance)
 		Expect(err).To(HaveOccurred())
 	})

--- a/pkg/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/crds/operator/operator.tigera.io_installations.yaml
@@ -5846,8 +5846,10 @@ spec:
                     type: string
                 type: object
               nonPrivileged:
-                description: NonPrivileged configures Calico to be run in non-privileged
-                  containers as non-root users where possible.
+                description: |-
+                  Deprecated. NonPrivileged is deprecated and will be removed from the API in a future release.
+                  Enabling this field is not supported and will cause errors.
+                  NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.
                 type: string
               registry:
                 description: |-
@@ -13323,8 +13325,10 @@ spec:
                         type: string
                     type: object
                   nonPrivileged:
-                    description: NonPrivileged configures Calico to be run in non-privileged
-                      containers as non-root users where possible.
+                    description: |-
+                      Deprecated. NonPrivileged is deprecated and will be removed from the API in a future release.
+                      Enabling this field is not supported and will cause errors.
+                      NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.
                     type: string
                   registry:
                     description: |-

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import (
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration"
-	"github.com/tigera/operator/pkg/ptr"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	"github.com/tigera/operator/pkg/render/common/configmap"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -929,10 +928,6 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 		initContainers = append(initContainers, c.bpffsInitContainer())
 	}
 
-	if c.runAsNonPrivileged() {
-		initContainers = append(initContainers, c.hostPathInitContainer())
-	}
-
 	var affinity *corev1.Affinity
 	if c.cfg.Installation.KubernetesProvider.IsAKS() {
 		affinity = &corev1.Affinity{
@@ -1051,18 +1046,10 @@ func (c *nodeComponent) nodeVolumes() []corev1.Volume {
 		c.cfg.TLS.NodeSecret.Volume(),
 	}
 
-	if c.runAsNonPrivileged() {
-		volumes = append(volumes,
-			corev1.Volume{Name: "var-run", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run"}}},
-			corev1.Volume{Name: "var-lib", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib"}}},
-			corev1.Volume{Name: "var-log", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log"}}},
-		)
-	} else {
-		volumes = append(volumes,
-			c.varRunCalicoVolume(),
-			corev1.Volume{Name: "var-lib-calico", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/calico", Type: &dirOrCreate}}},
-		)
-	}
+	volumes = append(volumes,
+		c.varRunCalicoVolume(),
+		corev1.Volume{Name: "var-lib-calico", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/calico", Type: &dirOrCreate}}},
+	)
 
 	if c.cfg.Installation.BPFEnabled() {
 		volumes = append(volumes,
@@ -1280,19 +1267,6 @@ func (c *nodeComponent) cniEnvvars() []corev1.EnvVar {
 // nodeContainer creates the main node container.
 func (c *nodeComponent) nodeContainer() corev1.Container {
 	sc := securitycontext.NewRootContext(true)
-	if c.runAsNonPrivileged() {
-		sc = securitycontext.NewNonRootContext()
-		// Set the group to be the root user group since all container users should be a member
-		sc.RunAsGroup = ptr.Int64ToPtr(0)
-		sc.Capabilities.Add = []corev1.Capability{
-			"NET_ADMIN",
-			"NET_BIND_SERVICE",
-			"NET_RAW",
-		}
-		// Set the privilege escalation to true so that routes, ipsets can be programmed.
-		sc.AllowPrivilegeEscalation = ptr.BoolToPtr(true)
-		sc.Capabilities.Drop = []corev1.Capability{}
-	}
 
 	lp, rp := c.nodeLivenessReadinessProbes()
 
@@ -1324,18 +1298,10 @@ func (c *nodeComponent) nodeVolumeMounts() []corev1.VolumeMount {
 		corev1.VolumeMount{MountPath: "/var/run/nodeagent", Name: "policysync"},
 		c.cfg.TLS.NodeSecret.VolumeMount(c.SupportedOSType()),
 	)
-	if c.runAsNonPrivileged() {
-		nodeVolumeMounts = append(nodeVolumeMounts,
-			corev1.VolumeMount{MountPath: "/var/run", Name: "var-run"},
-			corev1.VolumeMount{MountPath: "/var/lib", Name: "var-lib"},
-			corev1.VolumeMount{MountPath: "/var/log", Name: "var-log"},
-		)
-	} else {
-		nodeVolumeMounts = append(nodeVolumeMounts,
-			corev1.VolumeMount{MountPath: "/var/run/calico", Name: "var-run-calico"},
-			corev1.VolumeMount{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
-		)
-	}
+	nodeVolumeMounts = append(nodeVolumeMounts,
+		corev1.VolumeMount{MountPath: "/var/run/calico", Name: "var-run-calico"},
+		corev1.VolumeMount{MountPath: "/var/lib/calico", Name: "var-lib-calico"},
+	)
 	if c.cfg.Installation.BPFEnabled() {
 		nodeVolumeMounts = append(nodeVolumeMounts, corev1.VolumeMount{MountPath: "/sys/fs/bpf", Name: BPFVolumeName})
 	}
@@ -1753,47 +1719,6 @@ func (c *nodeComponent) nodeMetricsService() *corev1.Service {
 			},
 		},
 	}
-}
-
-// hostPathInitContainer creates an init container that changes the permissions on hostPath volumes
-// so that they can be written to by a non-root container.
-func (c *nodeComponent) hostPathInitContainer() corev1.Container {
-	mounts := []corev1.VolumeMount{
-		{
-			MountPath: "/var/run",
-			Name:      "var-run",
-			ReadOnly:  false,
-		},
-		{
-			MountPath: "/var/lib",
-			Name:      "var-lib",
-			ReadOnly:  false,
-		},
-		{
-			MountPath: "/var/log",
-			Name:      "var-log",
-			ReadOnly:  false,
-		},
-	}
-
-	return corev1.Container{
-		Name:            "hostpath-init",
-		Image:           c.nodeImage,
-		ImagePullPolicy: ImagePullPolicy(),
-		Command:         []string{"sh", "-c", "calico-node -hostpath-init"},
-		Env: []corev1.EnvVar{
-			{Name: "NODE_USER_ID", Value: "10001"},
-		},
-		SecurityContext: securitycontext.NewRootContext(true),
-		VolumeMounts:    mounts,
-	}
-}
-
-// runAsNonPrivileged checks to ensure that all of the proper installation values are set for running
-// Calico as non-privileged.
-func (c *nodeComponent) runAsNonPrivileged() bool {
-	// Check that the NonPrivileged flag is set
-	return c.cfg.Installation.NonPrivileged != nil && *c.cfg.Installation.NonPrivileged == operatorv1.NonPrivilegedEnabled
 }
 
 // getAutodetectionMethod returns the IP auto detection method in a form understandable by the calico/node

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,13 +47,12 @@ import (
 )
 
 var (
-	bgpEnabled           = operatorv1.BGPEnabled
-	bgpDisabled          = operatorv1.BGPDisabled
-	nonPrivilegedEnabled = operatorv1.NonPrivilegedEnabled
-	logSeverity          = operatorv1.LogLevelDebug
-	logFileMaxAgeDays    = uint32(5)
-	logFileMaxCount      = uint32(5)
-	logFileMaxSize       = resource.MustParse("1Mi")
+	bgpEnabled        = operatorv1.BGPEnabled
+	bgpDisabled       = operatorv1.BGPDisabled
+	logSeverity       = operatorv1.LogLevelDebug
+	logFileMaxAgeDays = uint32(5)
+	logFileMaxCount   = uint32(5)
+	logFileMaxSize    = resource.MustParse("1Mi")
 )
 
 var _ = Describe("Node rendering tests", func() {
@@ -845,158 +844,6 @@ var _ = Describe("Node rendering tests", func() {
 				Expect(len(ds.Spec.Template.Spec.Containers[0].Env)).To(Equal(len(expectedNodeEnv)))
 
 				verifyProbesAndLifecycle(ds, false, true)
-			})
-
-			It("should render all resources with the appropriate permissions when running as non-privileged", func() {
-				expectedResources := []struct {
-					name    string
-					ns      string
-					group   string
-					version string
-					kind    string
-				}{
-					{name: "calico-node", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
-					{name: "calico-node", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-					{name: "calico-node", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-					{name: "calico-cni-plugin", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ServiceAccount"},
-					{name: "calico-cni-plugin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRole"},
-					{name: "calico-cni-plugin", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
-					{name: "cni-config", ns: common.CalicoNamespace, group: "", version: "v1", kind: "ConfigMap"},
-					{name: common.NodeDaemonSetName, ns: common.CalicoNamespace, group: "apps", version: "v1", kind: "DaemonSet"},
-				}
-
-				defaultInstance.FlexVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
-				defaultInstance.NonPrivileged = &nonPrivilegedEnabled
-				component := render.Node(&cfg)
-				Expect(component.ResolveImages(nil)).To(BeNil())
-				resources, _ := component.Objects()
-				Expect(len(resources)).To(Equal(len(expectedResources)))
-
-				// Should render the correct resources.
-				i := 0
-				for _, expectedRes := range expectedResources {
-					rtest.ExpectResourceTypeAndObjectMetadata(resources[i], expectedRes.name, expectedRes.ns, expectedRes.group, expectedRes.version, expectedRes.kind)
-					i++
-				}
-
-				dsResource := rtest.GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
-				Expect(dsResource).ToNot(BeNil())
-
-				// The DaemonSet should have the correct security context.
-				ds := dsResource.(*appsv1.DaemonSet)
-
-				// The pod template should have node critical priority
-				Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal(render.NodePriorityClassName))
-
-				nodeContainer := rtest.GetContainer(ds.Spec.Template.Spec.Containers, "calico-node")
-				Expect(nodeContainer).ToNot(BeNil())
-				Expect(nodeContainer.SecurityContext).ToNot(BeNil())
-				Expect(*nodeContainer.SecurityContext.AllowPrivilegeEscalation).To(BeTrue())
-				Expect(*nodeContainer.SecurityContext.Privileged).To(BeFalse())
-				Expect(*nodeContainer.SecurityContext.RunAsGroup).To(BeEquivalentTo(0))
-				Expect(*nodeContainer.SecurityContext.RunAsNonRoot).To(BeTrue())
-				Expect(*nodeContainer.SecurityContext.RunAsUser).To(BeEquivalentTo(10001))
-				Expect(nodeContainer.SecurityContext.Capabilities).To(Equal(
-					&corev1.Capabilities{
-						Drop: []corev1.Capability{},
-						Add: []corev1.Capability{
-							"NET_ADMIN",
-							"NET_BIND_SERVICE",
-							"NET_RAW",
-						},
-					},
-				))
-				Expect(nodeContainer.SecurityContext.SeccompProfile).To(Equal(
-					&corev1.SeccompProfile{
-						Type: corev1.SeccompProfileTypeRuntimeDefault,
-					}))
-
-				// hostpath init container should have the correct env and security context.
-				hostPathContainer := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "hostpath-init")
-				rtest.ExpectEnv(hostPathContainer.Env, "NODE_USER_ID", "10001")
-				Expect(*hostPathContainer.SecurityContext.RunAsUser).To(Equal(int64(0)))
-
-				// Verify hostpath init container volume mounts.
-				expectedHostPathInitVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/var/run", Name: "var-run"},
-					{MountPath: "/var/lib", Name: "var-lib"},
-					{MountPath: "/var/log", Name: "var-log"},
-				}
-				Expect(hostPathContainer.VolumeMounts).To(ConsistOf(expectedHostPathInitVolumeMounts))
-
-				// Node image override results in correct image.
-				calicoNodeImage := fmt.Sprintf("docker.io/%s:%s", components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)
-				Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal(calicoNodeImage))
-
-				// Validate correct number of init containers.
-				Expect(len(ds.Spec.Template.Spec.InitContainers)).To(Equal(3))
-
-				// CNI container uses image override.
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").Image).To(Equal(fmt.Sprintf("docker.io/%s:%s", components.ComponentCalicoCNI.Image, components.ComponentCalicoCNI.Version)))
-
-				// Verify the Flex volume container image.
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "flexvol-driver").Image).To(Equal(fmt.Sprintf("docker.io/%s:%s", components.ComponentCalicoFlexVolume.Image, components.ComponentCalicoFlexVolume.Version)))
-
-				// Verify the mount-bpffs image and command.
-				mountBpffs := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "mount-bpffs")
-				Expect(mountBpffs).To(BeNil())
-
-				// Verify volumes.
-				fileOrCreate := corev1.HostPathFileOrCreate
-				dirOrCreate := corev1.HostPathDirectoryOrCreate
-				expectedVols := []corev1.Volume{
-					{Name: "lib-modules", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/lib/modules"}}},
-					{Name: "var-run", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run"}}},
-					{Name: "var-lib", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib"}}},
-					{Name: "var-log", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log"}}},
-					{Name: "xtables-lock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run/xtables.lock", Type: &fileOrCreate}}},
-					{Name: "cni-bin-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/opt/cni/bin", Type: &dirOrCreate}}},
-					{Name: "cni-net-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/etc/cni/net.d"}}},
-					{Name: "cni-log-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log/calico/cni"}}},
-					{Name: "policysync", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/nodeagent", Type: &dirOrCreate}}},
-					{
-						Name: "tigera-ca-bundle",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "tigera-ca-bundle",
-								},
-							},
-						},
-					},
-					{
-						Name: render.NodeTLSSecretName,
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName:  render.NodeTLSSecretName,
-								DefaultMode: &defaultMode,
-							},
-						},
-					},
-					{Name: "flexvol-driver-host", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds", Type: &dirOrCreate}}},
-				}
-				Expect(ds.Spec.Template.Spec.Volumes).To(ConsistOf(expectedVols))
-
-				// Verify volume mounts.
-				expectedNodeVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/lib/modules", Name: "lib-modules", ReadOnly: true},
-					{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-					{MountPath: "/run/xtables.lock", Name: "xtables-lock"},
-					{MountPath: "/var/run", Name: "var-run"},
-					{MountPath: "/var/lib", Name: "var-lib"},
-					{MountPath: "/var/log", Name: "var-log"},
-					{MountPath: "/var/run/nodeagent", Name: "policysync"},
-					{MountPath: "/etc/pki/tls/certs", Name: "tigera-ca-bundle", ReadOnly: true},
-					{MountPath: "/node-certs", Name: render.NodeTLSSecretName, ReadOnly: true},
-					{MountPath: "/var/log/calico/cni", Name: "cni-log-dir", ReadOnly: false},
-				}
-				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
-
-				expectedCNIVolumeMounts := []corev1.VolumeMount{
-					{MountPath: "/host/opt/cni/bin", Name: "cni-bin-dir"},
-					{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
-				}
-				Expect(rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "install-cni").VolumeMounts).To(ConsistOf(expectedCNIVolumeMounts))
 			})
 
 			It("should render all resources when using Calico CNI on EKS", func() {


### PR DESCRIPTION
## Cherry-pick history
- Pick onto **release-v1.36**: tigera/operator#4433
## Description

Since the iptables version bump to v1.8.8, the non-privileged mode is no longer supported. This PR deprecates the `Installation.spec.nonPrivileged` field.

**Changes:**
- Removed the logic that consumes this field in the node render path.
- Marked the field as deprecated in the Installation CRD.
- Added validation: if a user sets the field to Enabled, the Operator sets Calico to Degraded with a clear error message explaining that the feature is deprecated and no longer supported.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
- Dropped support to the non-privileged mode and deprecated the `Installation.spec.nonPrivileged` field. The Operator ignores this setting and will mark Calico as Degraded if it is set to Enabled.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

