### PR TITLE
feat(overriding dashboard resources): Set resources on calico-dashboa…

### DIFF
--- a/api/v1/manager_types.go
+++ b/api/v1/manager_types.go
@@ -67,8 +67,8 @@ type ManagerDeploymentPodSpec struct {
 // ManagerDeploymentContainer is a Manager Deployment container.
 type ManagerDeploymentContainer struct {
 	// Name is an enum which identifies the Manager Deployment container by name.
-	// Supported values are: calico-voltron, calico-manager, calico-ui-apis, tigera-voltron (deprecated), tigera-manager (deprecated), tigera-ui-apis (deprecated), tigera-es-proxy (deprecated)
-	// +kubebuilder:validation:Enum=calico-voltron;calico-manager;calico-ui-apis;tigera-voltron;tigera-manager;tigera-ui-apis
+	// Supported values are: calico-voltron, calico-manager, calico-ui-apis, calico-dashboard-api, tigera-voltron (deprecated), tigera-manager (deprecated), tigera-ui-apis (deprecated), tigera-es-proxy (deprecated)
+	// +kubebuilder:validation:Enum=calico-voltron;calico-manager;calico-ui-apis;calico-dashboard-api;tigera-voltron;tigera-manager;tigera-ui-apis
 	Name string `json:"name"`
 
 	// Resources allows customization of limits and requests for compute resources such as cpu and memory.

--- a/pkg/imports/crds/operator/operator.tigera.io_managers.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_managers.yaml
@@ -69,11 +69,12 @@ spec:
                                       name:
                                         description: |-
                                           Name is an enum which identifies the Manager Deployment container by name.
-                                          Supported values are: calico-voltron, calico-manager, calico-ui-apis, tigera-voltron (deprecated), tigera-manager (deprecated), tigera-ui-apis (deprecated), tigera-es-proxy (deprecated)
+                                          Supported values are: calico-voltron, calico-manager, calico-ui-apis, calico-dashboard-api, tigera-voltron (deprecated), tigera-manager (deprecated), tigera-ui-apis (deprecated), tigera-es-proxy (deprecated)
                                         enum:
                                           - calico-voltron
                                           - calico-manager
                                           - calico-ui-apis
+                                          - calico-dashboard-api
                                           - tigera-voltron
                                           - tigera-manager
                                           - tigera-ui-apis


### PR DESCRIPTION
…rd-api

```release-note
Users can now override the resources and/or limits on the calico-dashboard-api container in the manager deployment.
```


```
$kubectl patch manager tigera-secure -p '{"spec":{"managerDeployment":{"spec":{"template":{"spec":{"containers":[{"name":"calico-dash
  board-api","resources":{"limits":{"cpu":"522m","memory":"525Mi"},"requests":{"cpu":"115m","memory":"150Mi"}}}]}}}}}}' --type=merge
... (wait some time)
$ k get deploy -n calico-system calico-manager -o yaml | grep 522 -C 10
            command:
            - /usr/bin/dashboard-api
            - -ready
          failureThreshold: 3
          initialDelaySeconds: 5
          periodSeconds: 30
          successThreshold: 1
          timeoutSeconds: 5
        resources:
          limits:
            cpu: 522m
            memory: 525Mi
          requests:
            cpu: 115m
            memory: 150Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          privileged: false
```