### PR TITLE
fix(tier cleanup): Deprecated tier cannot be deleted

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1450,6 +1450,10 @@ func (m *managerComponent) deprecatedResources(tenant *operatorv1.Tenant, instal
 				TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 			},
 		}
+		objs = append(objs,
+			networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("manager-access", legacyNamespace),
+			networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("default-deny", legacyNamespace),
+		)
 	}
 
 	managedClustersWatchObj.SetName(managedClustersWatchRoleBindingName)
@@ -1485,8 +1489,6 @@ func (m *managerComponent) deprecatedResources(tenant *operatorv1.Tenant, instal
 
 	// allow-tigera Tier was renamed to calico-system
 	objs = append(objs,
-		networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("manager-access", legacyNamespace),
-		networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("default-deny", legacyNamespace),
 		networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("manager-access", installNS),
 		networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("default-deny", installNS),
 	)

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -1578,6 +1578,8 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			expectedTenantAResourcesToDelete := []client.Object{
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.manager-access", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: "tigera-manager"}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
+				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.manager-access", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
+				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-tigera.default-deny", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.LegacyManagerManagedClustersWatchRoleBindingName}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.LegacyManagerManagedClustersUpdateRBACName}},
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.LegacyManagerManagedClustersUpdateRBACName}},


### PR DESCRIPTION
The manager controller did not clean up deprecated policies, due to trying to delete them from the wrong namespace. As a result, the old tier (allow-tigera) can never be deleted.
