### PR TITLE
Centralize container name alias resolution for overrides

### DIFF
--- a/pkg/render/common/components/components.go
+++ b/pkg/render/common/components/components.go
@@ -36,6 +36,26 @@ import (
 
 var log = logf.Log.WithName("components")
 
+// containerNameAliases maps deprecated container names to their current names.
+// When a user provides an override using a deprecated name, it is transparently
+// resolved to the current name before matching against rendered containers.
+// To support a rename: add an entry mapping old name → current name.
+// Values must not also appear as keys (no transitive aliases).
+var containerNameAliases = map[string]string{
+	"tigera-manager":  "calico-manager",
+	"tigera-voltron":  "calico-voltron",
+	"tigera-ui-apis":  "calico-ui-apis",
+	"tigera-es-proxy": "calico-ui-apis",
+	"tigera-voltron-linseed-tls-key-cert-provisioner": "calico-voltron-linseed-tls-key-cert-provisioner",
+}
+
+func resolveContainerName(name string) string {
+	if current, ok := containerNameAliases[name]; ok {
+		return current
+	}
+	return name
+}
+
 // replicatedPodResource contains the overridable data for a Deployment or DaemonSet.
 type replicatedPodResource struct {
 	labels             map[string]string
@@ -143,7 +163,7 @@ func valueToContainers(value reflect.Value) []corev1.Container {
 		ports := valueToContainerPorts(v)
 		if !resources.IsNil() || ports != nil {
 			container := corev1.Container{
-				Name: name.String(),
+				Name: resolveContainerName(name.String()),
 			}
 			if !resources.IsNil() {
 				container.Resources = *(resources.Interface().(*corev1.ResourceRequirements))

--- a/pkg/render/common/components/components_test.go
+++ b/pkg/render/common/components/components_test.go
@@ -1200,6 +1200,65 @@ var _ = Describe("Common components render tests", func() {
 				}))
 			}),
 	)
+
+	Describe("resolveContainerName", func() {
+		It("should resolve known aliases to current names", func() {
+			Expect(resolveContainerName("tigera-manager")).To(Equal("calico-manager"))
+			Expect(resolveContainerName("tigera-voltron")).To(Equal("calico-voltron"))
+			Expect(resolveContainerName("tigera-ui-apis")).To(Equal("calico-ui-apis"))
+			Expect(resolveContainerName("tigera-es-proxy")).To(Equal("calico-ui-apis"))
+			Expect(resolveContainerName("tigera-voltron-linseed-tls-key-cert-provisioner")).To(Equal("calico-voltron-linseed-tls-key-cert-provisioner"))
+		})
+
+		It("should pass through unknown names unchanged", func() {
+			Expect(resolveContainerName("calico-manager")).To(Equal("calico-manager"))
+			Expect(resolveContainerName("calico-node")).To(Equal("calico-node"))
+			Expect(resolveContainerName("some-other-container")).To(Equal("some-other-container"))
+		})
+	})
+
+	It("should not have transitive aliases (no value appears as a key)", func() {
+		for _, target := range containerNameAliases {
+			_, isAlsoKey := containerNameAliases[target]
+			Expect(isAlsoKey).To(BeFalse(), "alias target %q is also an alias key, creating a transitive chain", target)
+		}
+	})
+
+	It("should apply overrides using deprecated container names to containers with current names", func() {
+		// Create a deployment with containers using current names.
+		d := appsv1.Deployment{}
+		d.Spec.Template.Spec.Containers = []corev1.Container{
+			{Name: "calico-manager"},
+			{Name: "calico-voltron"},
+			{Name: "calico-ui-apis"},
+		}
+		overrideResources := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"cpu": resource.MustParse("2"),
+			},
+		}
+
+		// Apply overrides using deprecated names.
+		overrides := &v1.ManagerDeployment{
+			Spec: &v1.ManagerDeploymentSpec{
+				Template: &v1.ManagerDeploymentPodTemplateSpec{
+					Spec: &v1.ManagerDeploymentPodSpec{
+						Containers: []v1.ManagerDeploymentContainer{
+							{Name: "tigera-manager", Resources: &overrideResources},
+							{Name: "tigera-voltron", Resources: &overrideResources},
+							{Name: "tigera-es-proxy", Resources: &overrideResources},
+						},
+					},
+				},
+			},
+		}
+		ApplyDeploymentOverrides(&d, overrides)
+
+		// Verify overrides were applied to containers with current names.
+		for _, c := range d.Spec.Template.Spec.Containers {
+			Expect(c.Resources).To(Equal(overrideResources), "container %q should have overridden resources", c.Name)
+		}
+	})
 })
 
 func addContainer(cs []corev1.Container) []corev1.Container {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -371,20 +371,6 @@ func (c *managerComponent) managerDeployment() *appsv1.Deployment {
 
 	if c.cfg.Manager != nil {
 		if overrides := c.cfg.Manager.Spec.ManagerDeployment; overrides != nil {
-			// Due to the change of prefix for some components (eg. tigera-manager -> calico-manager) we need to support
-			// the upgrade scenario in a graceful way that doesn't force the user to update the new names. To accomplish
-			// this we will simply perform the substitution from old name to new name before applying the settings to
-			// the deployment
-			if overrides.Spec != nil && overrides.Spec.Template != nil && overrides.Spec.Template.Spec != nil {
-				fixedUpContainers := overrides.Spec.Template.Spec.Containers
-				for i, container := range overrides.Spec.Template.Spec.Containers {
-					container.Name = strings.Replace(container.Name, "tigera-", "calico-", 1)
-					container.Name = strings.Replace(container.Name, "es-proxy", "ui-apis", 1)
-
-					fixedUpContainers[i] = container
-				}
-				overrides.Spec.Template.Spec.Containers = fixedUpContainers
-			}
 			rcomponents.ApplyDeploymentOverrides(d, overrides)
 		}
 	}


### PR DESCRIPTION
Container overrides (resource requests/limits, ports) match rendered containers by
exact name. When we rename a container (e.g., `tigera-manager` → `calico-manager`),
user configuration silently stops working.

Today we have two ad-hoc workarounds for this:
- Guardian kept the legacy name `tigera-guardian` forever
- Manager has a `strings.Replace` block that rewrites old names before applying overrides

This adds a centralized `containerNameAliases` map in `pkg/render/common/components/`
and resolves deprecated names inside `valueToContainers()` — the single funnel point
where CRD override container names become `corev1.Container` objects. This means zero
changes to `mergeContainers`, zero changes to any `Apply*Overrides` callers, and the
ad-hoc manager workaround gets deleted.

To support a future container rename, just add an entry to the map.