### PR TITLE
Add ClusterInformation write-protection to webhook config

### DIFF
--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -329,7 +329,7 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 				AdmissionReviewVersions: []string{"v1"},
 				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
 				TimeoutSeconds:          ptr.To[int32](5),
-				FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
+				FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
 			},
 			{
 				// This webhook is for audit logging. The webhook controller will get events for all relevant Calico API types


### PR DESCRIPTION
Adds `clusterinformations` to the `ValidatingWebhookConfiguration` managed by the operator. This routes Create/Update/Delete requests to the `/cluster-info` handler on the webhook server, which blocks writes from non-system users — matching the behavior of the aggregated API server.

The handler itself is in projectcalico/calico#12010.

Ref: CORE-12369