### PR TITLE
deps: Bump Elasticsearch and Kibana to 8.19.12

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -47,13 +47,13 @@ components:
     version: v3.23.0-1.0
   # eck-kibana holds the version of Kibana built for tigera/kibana
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.12
   kibana:
     image: kibana
     version: v3.23.0-1.0
   # eck-elasticsearch holds the version of Elasticsearch built for tigera/elasticsearch
   eck-elasticsearch:
-    version: 8.19.10
+    version: 8.19.12
   elasticsearch:
     image: elasticsearch
     version: v3.23.0-1.0

--- a/hack/release/prep_test.go
+++ b/hack/release/prep_test.go
@@ -57,7 +57,7 @@ components:
   cni:
     version: master
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.12
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
@@ -88,7 +88,7 @@ components:
   cni:
     version: v1.32.4
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.12
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -85,12 +85,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version: "8.19.10",
+		Version: "8.19.12",
 		variant: enterpriseVariant,
 	}
 
 	ComponentEckKibana = Component{
-		Version: "8.19.10",
+		Version: "8.19.12",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
## Description

Bump Elasticsarch and Kibana to 8.19.12.

Related PR: https://github.com/tigera/calico-private/pull/10989

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Bump Elasticsearch and Kibana to 8.19.12.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
