### PR TITLE
Add Message column to TigeraStatus kubectl output

### DIFF
--- a/api/v1/tigerastatus_types.go
+++ b/api/v1/tigerastatus_types.go
@@ -45,6 +45,7 @@ type TigeraStatusStatus struct {
 // +kubebuilder:printcolumn:name="Progressing",type="string",JSONPath=".status.conditions[?(@.type=='Progressing')].status",description="Whether the component is processing changes."
 // +kubebuilder:printcolumn:name="Degraded",type="string",JSONPath=".status.conditions[?(@.type=='Degraded')].status",description="Whether the component is degraded."
 // +kubebuilder:printcolumn:name="Since",type="date",JSONPath=".status.conditions[?(@.type=='Available')].lastTransitionTime",description="The time the component's Available status last changed."
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Degraded')].message",description="Error message when the component is degraded.",priority=0
 type TigeraStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/imports/crds/operator/operator.tigera.io_tigerastatuses.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_tigerastatuses.yaml
@@ -30,6 +30,10 @@ spec:
           jsonPath: .status.conditions[?(@.type=='Available')].lastTransitionTime
           name: Since
           type: date
+        - description: Error message when the component is degraded.
+          jsonPath: .status.conditions[?(@.type=='Degraded')].message
+          name: Message
+          type: string
       name: v1
       schema:
         openAPIV3Schema:


### PR DESCRIPTION
```release-note
Display the Degraded condition's message when running `kubectl get tigerastatus`, making it easier to see error details at a glance without needing to describe the resource.
```

The output will now look like this:

```
$ k get tigerastatus
NAME                          AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
apiserver                     True        False         False      175m    All objects available
calico                        True        False         False      65s     All objects available
intrusion-detection           True        False         False      172m    All objects available
ippools                       True        False         False      3h9m    All objects available
log-collector                 True        False         False      174m    All objects available
log-storage                   True        False         False      3h9m    All objects available
log-storage-access            True        False         False      171m    All objects available
log-storage-dashboards        True        False         False      172m    All objects available
log-storage-elastic           True        False         False      172m    All objects available
log-storage-esmetrics         True        False         False      175m    All objects available
log-storage-kubecontrollers   True        False         False      171m    All objects available
log-storage-secrets           True        False         False      3h9m    All objects available
manager                       False       False         True       55s     Pod calico-system/calico-manager-7c7cb5b58-5bhg9 has crash looping container: calico-ui-apis
monitor                       True        False         False      115s    All objects available
policy-recommendation         True        False         False      175m    All objects available
tiers                         True        False         False      3h8m    All objects available
```