### PR TITLE
Sanitize signer label value for Kubernetes label compliance

### DIFF
--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"time"
 
@@ -207,16 +208,32 @@ func tlsSecretMetadata(certPEM []byte) (labels map[string]string, annotations ma
 	return labels, annotations
 }
 
+// labelUnsafe matches any character that is not alphanumeric, '-', '_', or '.'.
+var labelUnsafe = regexp.MustCompile(`[^A-Za-z0-9_.\-]`)
+
 // signerLabelValue returns a Kubernetes-label-safe signer identifier from the
-// issuer CN, truncated to 63 chars to satisfy the label value length limit.
+// issuer CN. It replaces invalid characters with '-', trims leading/trailing
+// non-alphanumeric characters, and truncates to 63 chars to satisfy the label
+// value constraints.
 func signerLabelValue(cn string) string {
-	if cn == "" {
+	// Replace any character not in [A-Za-z0-9_.-] with '-'.
+	v := labelUnsafe.ReplaceAllString(cn, "-")
+
+	// Trim leading/trailing characters that are not alphanumeric.
+	v = strings.TrimLeft(v, "-_.")
+	v = strings.TrimRight(v, "-_.")
+
+	// Truncate to 63 characters, then trim any trailing non-alphanumeric
+	// chars that truncation may have exposed.
+	if len(v) > 63 {
+		v = v[:63]
+		v = strings.TrimRight(v, "-_.")
+	}
+
+	if v == "" {
 		return "unknown"
 	}
-	if len(cn) > 63 {
-		return cn[:63]
-	}
-	return cn
+	return v
 }
 
 // ipStrings converts a slice of net.IP to their string representations.

--- a/pkg/tls/certificatemanagement/keypair_test.go
+++ b/pkg/tls/certificatemanagement/keypair_test.go
@@ -150,7 +150,7 @@ var _ = Describe("TLS secret metadata", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying labels")
-			Expect(secret.Labels).To(HaveKeyWithValue("certificates.operator.tigera.io/signer", "my-issuer@1234567890"))
+			Expect(secret.Labels).To(HaveKeyWithValue("certificates.operator.tigera.io/signer", "my-issuer-1234567890"))
 
 			By("verifying annotations")
 			Expect(secret.Annotations["certificates.operator.tigera.io/issuer"]).To(Equal("my-issuer@1234567890"))
@@ -172,6 +172,34 @@ var _ = Describe("TLS secret metadata", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(len(secret.Labels["certificates.operator.tigera.io/signer"])).To(Equal(63))
+		})
+
+		It("should sanitize spaces in the signer label", func() {
+			secret, err := certificatemanagement.CreateSelfSignedSecret("my-secret", "my-ns", "My Company Root CA", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(secret.Labels["certificates.operator.tigera.io/signer"]).To(Equal("My-Company-Root-CA"))
+		})
+
+		It("should sanitize commas and equals in the signer label", func() {
+			secret, err := certificatemanagement.CreateSelfSignedSecret("my-secret", "my-ns", "O=Foo, CN=Bar", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(secret.Labels["certificates.operator.tigera.io/signer"]).To(Equal("O-Foo--CN-Bar"))
+		})
+
+		It("should trim leading/trailing special chars after sanitization", func() {
+			secret, err := certificatemanagement.CreateSelfSignedSecret("my-secret", "my-ns", "...leading-and-trailing---", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(secret.Labels["certificates.operator.tigera.io/signer"]).To(Equal("leading-and-trailing"))
+		})
+
+		It("should return unknown when CN becomes empty after sanitization", func() {
+			secret, err := certificatemanagement.CreateSelfSignedSecret("my-secret", "my-ns", "   ", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(secret.Labels["certificates.operator.tigera.io/signer"]).To(Equal("unknown"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- BYO certificate issuer CNs can contain characters invalid in Kubernetes label values (spaces, commas, equals, etc.)
- `signerLabelValue()` now replaces unsafe characters with `-`, trims non-alphanumeric leading/trailing chars, and truncates to 63 chars
- Adds test coverage for spaces, commas/equals, leading/trailing special chars, and empty-after-sanitization

## Test plan
- [x] Unit tests pass: `make ut UT_DIR=./pkg/tls/certificatemanagement`
- [x] Existing `certificatemanager` controller tests pass (29/29)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)