### PR TITLE
[EV-6485] fix(istio): set correct CA_TRUSTED_NODE_ACCOUNTS namespace on OpenShift

### DIFF
--- a/pkg/render/istio/config.go
+++ b/pkg/render/istio/config.go
@@ -42,9 +42,10 @@ type BaseOpts struct {
 }
 
 type IstiodOpts struct {
-	Image   string        `json:"image,omitempty"`
-	Global  *GlobalConfig `json:"global,omitempty"`
-	Profile string        `json:"profile,omitempty"`
+	Image                   string        `json:"image,omitempty"`
+	Global                  *GlobalConfig `json:"global,omitempty"`
+	Profile                 string        `json:"profile,omitempty"`
+	TrustedZtunnelNamespace string        `json:"trustedZtunnelNamespace,omitempty"`
 }
 
 type IstioCNIOpts struct {

--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -104,7 +104,8 @@ func Istio(cfg *Configuration) (*IstioComponentCRDs, *IstioComponent, error) {
 					Image: istioFakeImageProxyv2,
 				},
 			},
-			Profile: "ambient",
+			Profile:                 "ambient",
+			TrustedZtunnelNamespace: IstioNamespace,
 		},
 		IstioCNIOpts: IstioCNIOpts{
 			Global: &GlobalConfig{

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -882,7 +882,7 @@ var _ = Describe("Istio Component Rendering", func() {
 			Expect(foundPlatformEnv).To(BeTrue(), "Expected PLATFORM=openshift env var on istiod")
 		})
 
-		It("should set trusted ztunnel namespace to kube-system on istiod", func() {
+		It("should set trusted ztunnel namespace to calico-system on istiod", func() {
 			objsToCreate, _ := component.Objects()
 
 			deployment, err := rtest.GetResourceOfType[*appsv1.Deployment](objsToCreate, istio.IstioIstiodDeploymentName, istio.IstioNamespace)
@@ -893,13 +893,13 @@ var _ = Describe("Istio Component Rendering", func() {
 				if container.Name == "discovery" {
 					for _, env := range container.Env {
 						if env.Name == "CA_TRUSTED_NODE_ACCOUNTS" {
-							Expect(env.Value).To(Equal("kube-system/ztunnel"))
+							Expect(env.Value).To(Equal("calico-system/ztunnel"))
 							foundTrustedAccounts = true
 						}
 					}
 				}
 			}
-			Expect(foundTrustedAccounts).To(BeTrue(), "Expected CA_TRUSTED_NODE_ACCOUNTS=kube-system/ztunnel on istiod")
+			Expect(foundTrustedAccounts).To(BeTrue(), "Expected CA_TRUSTED_NODE_ACCOUNTS=calico-system/ztunnel on istiod")
 		})
 
 		It("should set SELinux context on ztunnel", func() {


### PR DESCRIPTION
## Summary
- The embedded Istio Helm chart's OpenShift platform profile hardcodes `trustedZtunnelNamespace: "kube-system"`, but the operator deploys ztunnel to `calico-system`
- This causes istiod to set `CA_TRUSTED_NODE_ACCOUNTS=kube-system/ztunnel`, so it rejects all ztunnel impersonation requests with `"request impersonation authentication failure"`
- Workloads in the ambient mesh cannot obtain SPIFFE certificates, causing connection resets (curl exit code 56) on all mesh traffic
- Fix: explicitly set `trustedZtunnelNamespace` in the istiod Helm values to `IstioNamespace` (`calico-system`), overriding the OpenShift profile default

## Changes
- `pkg/render/istio/config.go`: Add `TrustedZtunnelNamespace` field to `IstiodOpts` struct
- `pkg/render/istio/istio.go`: Set `TrustedZtunnelNamespace: IstioNamespace` in istiod chart values
- `pkg/render/istio/istio_test.go`: Update OpenShift test assertion from `kube-system/ztunnel` to `calico-system/ztunnel`

## Release Note
```release-note
Set correct CA_TRUSTED_NODE_ACCOUNTS namespace on OpenShift
```

Fixes: https://tigera.atlassian.net/browse/EV-6485

## Test plan
- [x] CI render tests pass (updated assertion)
- [x] Deploy on OpenShift cluster and verify `CA_TRUSTED_NODE_ACCOUNTS=calico-system/ztunnel` on istiod
- [x] Verify ztunnel can obtain SPIFFE certs (no impersonation errors in istiod logs)
- [x] Verify ambient mesh traffic flows (curl between pods returns 200)
- [x] Run DE journey test: istio-ambient-mode traffic encryption and Calico network policy enforcement