### PR TITLE
Set control-plane tolerations and replicas on webhooks deployment

### DIFF
--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -27,6 +27,7 @@ import (
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/common/podaffinity"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -112,7 +113,7 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 			Namespace: common.CalicoNamespace,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: ptr.To[int32](1),
+			Replicas: c.cfg.Installation.ControlPlaneReplicas,
 			Strategy: appsv1.DeploymentStrategy{
 				// Use RollingUpdate to avoid downtime during rollouts. Since this is a webhook with
 				// FailurePolicy=Fail, using Recreate would cause a window where no webhook pod is running,
@@ -130,6 +131,7 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 				Spec: corev1.PodSpec{
 					HostNetwork:        render.HostNetworkRequired(c.cfg.Installation),
 					ServiceAccountName: WebhooksName,
+					Tolerations:        c.tolerations(),
 					ImagePullSecrets:   secret.GetReferenceList(c.cfg.PullSecrets),
 					Containers: []corev1.Container{{
 						Name:            WebhooksName,
@@ -171,6 +173,10 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 				},
 			},
 		},
+	}
+
+	if c.cfg.Installation.ControlPlaneReplicas != nil && *c.cfg.Installation.ControlPlaneReplicas > 1 {
+		dep.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(WebhooksName, []string{common.CalicoNamespace})
 	}
 
 	if overrides := c.cfg.APIServer.CalicoWebhooksDeployment; overrides != nil {
@@ -430,4 +436,16 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 
 func (c *component) Ready() bool {
 	return true
+}
+
+// tolerations creates the tolerations used by the webhooks deployment.
+func (c *component) tolerations() []corev1.Toleration {
+	if render.HostNetworkRequired(c.cfg.Installation) {
+		return rmeta.TolerateAll
+	}
+	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
+	if c.cfg.Installation.KubernetesProvider.IsGKE() {
+		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
+	}
+	return tolerations
 }

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -138,6 +138,31 @@ var _ = Describe("Webhooks rendering tests", func() {
 				components.ComponentTigeraWebhooks.Version)))
 	})
 
+	It("should set control plane tolerations by default", func() {
+		component := webhooks.Component(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		resources, _ := component.Objects()
+
+		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(dep.Spec.Template.Spec.Tolerations).To(ConsistOf(
+			corev1.Toleration{Key: "node-role.kubernetes.io/master", Effect: corev1.TaintEffectNoSchedule},
+			corev1.Toleration{Key: "node-role.kubernetes.io/control-plane", Effect: corev1.TaintEffectNoSchedule},
+		))
+	})
+
+	It("should use ControlPlaneReplicas from the installation", func() {
+		var replicas int32 = 3
+		installation.ControlPlaneReplicas = &replicas
+		component := webhooks.Component(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		resources, _ := component.Objects()
+
+		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(*dep.Spec.Replicas).To(Equal(int32(3)))
+		Expect(dep.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		Expect(dep.Spec.Template.Spec.Affinity.PodAntiAffinity).NotTo(BeNil())
+	})
+
 	It("should apply deployment overrides", func() {
 		apiServerSpec.CalicoWebhooksDeployment = &operatorv1.CalicoWebhooksDeployment{
 			Spec: &operatorv1.CalicoWebhooksDeploymentSpec{


### PR DESCRIPTION
The webhooks deployment was missing the control-plane tolerations that the apiserver deployment has, which meant the webhooks pod couldn't be scheduled on nodes with the `node-role.kubernetes.io/control-plane:NoSchedule` taint. This showed up in the calico-private k8s-test (which runs in v3 CRD mode) after consolidating the helm values to pin both the apiserver and webhooks deployments to the control-plane node.

This brings the webhooks deployment in line with the apiserver deployment:

- Add `TolerateControlPlane` tolerations (and `TolerateAll` when host-networked, GKE ARM64 toleration on GKE)
- Use `Installation.ControlPlaneReplicas` instead of hardcoding 1
- Add pod anti-affinity when replicas > 1

Related: tigera/calico-private#11029