### PR TITLE
Fix missing managedclusters RBAC for calico-webhooks

### DIFF
--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -393,6 +393,13 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 			Resources: []string{"subjectaccessreviews"},
 			Verbs:     []string{"create"},
 		},
+		{
+			// The ManagedCluster cleanup controller watches ManagedCluster objects and clears their
+			// installation manifest field after creation.
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"managedclusters"},
+			Verbs:     []string{"list", "watch", "update"},
+		},
 	}
 
 	cr := &rbacv1.ClusterRole{

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -92,6 +92,21 @@ var _ = Describe("Webhooks rendering tests", func() {
 		}
 
 		rtest.ExpectResources(resources, expectedResources)
+
+		// Verify the ClusterRole includes expected rules.
+		cr := rtest.GetResource(resources, webhooks.WebhooksName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(cr.Rules).To(ContainElements(
+			rbacv1.PolicyRule{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"managedclusters"},
+				Verbs:     []string{"list", "watch", "update"},
+			},
+		))
 	})
 
 	It("should render all resources for Enterprise with the correct image", func() {


### PR DESCRIPTION
The calico-webhooks pod runs a ManagedCluster cleanup controller that watches `ManagedCluster` objects and clears the `InstallationManifest` field after creation. The operator wasn't including the necessary RBAC permissions (list, watch, update on `managedclusters`) in the `calico-webhooks` ClusterRole, so the controller was hitting continuous "Failed to watch" errors from the reflector.

This adds the missing `projectcalico.org/managedclusters` permissions to the ClusterRole rendered by the operator.