### PR TITLE
Fix CNI plugin RBAC during manifest-to-operator migration [v1.40]

### DIFF
--- a/pkg/controller/migration/namespace_migration.go
+++ b/pkg/controller/migration/namespace_migration.go
@@ -189,6 +189,22 @@ func AddBindingForKubeSystemNode(crb *rbacv1.ClusterRoleBinding) {
 	})
 }
 
+// AddBindingForKubeSystemCNIPlugin updates the ClusterRoleBinding passed in
+// to also bind the calico-cni-plugin service account in the kube-system namespace.
+// During migration, nodes that haven't been migrated yet still run the CNI plugin
+// as kube-system:calico-cni-plugin. Without this binding, pod creation fails on
+// those nodes because the CNI plugin loses permissions to access Calico CRDs.
+func AddBindingForKubeSystemCNIPlugin(crb *rbacv1.ClusterRoleBinding) {
+	if crb.Subjects == nil {
+		crb.Subjects = []rbacv1.Subject{}
+	}
+	crb.Subjects = append(crb.Subjects, rbacv1.Subject{
+		Kind:      "ServiceAccount",
+		Name:      "calico-cni-plugin",
+		Namespace: kubeSystem,
+	})
+}
+
 // We create a cluster role and cluster role binding to give the kube-system calico-node
 // permissions to create serviceaccount tokens. This is needed to make sure that the down-level calico-node maintains
 // the permissions it needs in order to launch, since the calico-node clusterrole is shared with the

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -375,6 +375,9 @@ func (c *nodeComponent) cniPluginRoleBinding() *rbacv1.ClusterRoleBinding {
 			},
 		},
 	}
+	if c.cfg.MigrateNamespaces {
+		migration.AddBindingForKubeSystemCNIPlugin(crb)
+	}
 	return crb
 }
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -2047,6 +2047,17 @@ var _ = Describe("Node rendering tests", func() {
 					},
 				))
 
+				cniCrbResource := rtest.GetResource(resources, "calico-cni-plugin", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
+				Expect(cniCrbResource).ToNot(BeNil())
+				cniCrb := cniCrbResource.(*rbacv1.ClusterRoleBinding)
+				Expect(cniCrb.Subjects).To(ContainElement(
+					rbacv1.Subject{
+						Kind:      "ServiceAccount",
+						Name:      "calico-cni-plugin",
+						Namespace: "kube-system",
+					},
+				))
+
 				Expect(rtest.GetResource(resources, "cni-config", "calico-system", "", "v1", "ConfigMap")).ToNot(BeNil())
 
 				dsResource := rtest.GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")


### PR DESCRIPTION
Cherry-pick of #4514 to release-v1.40.

```release-note
Fix pod creation failures during manifest-to-operator migration caused by the calico-cni-plugin
ClusterRoleBinding losing its kube-system subject before all nodes are migrated.
```