### PR TITLE
Add centralized field ownership tracker for shared resources

### DIFF
--- a/pkg/controller/installation/bpf.go
+++ b/pkg/controller/installation/bpf.go
@@ -15,41 +15,34 @@
 package installation
 
 import (
-	"errors"
 	"reflect"
 	"strconv"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-	"github.com/tigera/operator/pkg/controller/utils"
 
 	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/controller/utils/fieldowner"
 	"github.com/tigera/operator/pkg/render"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
-// bpfValidateAnnotations validate Felix Configuration annotations match BPF Enabled spec for all scenarios.
-func bpfValidateAnnotations(fc *v3.FelixConfiguration) error {
-	var annotationValue *bool
-	if fc.Annotations[render.BPFOperatorAnnotation] != "" {
-		v, err := strconv.ParseBool(fc.Annotations[render.BPFOperatorAnnotation])
-		annotationValue = &v
-		if err != nil {
-			return err
-		}
+const installationControllerName = "installation"
+
+func setBPFEnabledOnFelixConfiguration(fc *v3.FelixConfiguration, bpfEnabled bool) error {
+	t := fieldowner.ForObject(installationControllerName, fc)
+	t.MigrateAnnotation(fc, "BPFEnabled", render.BPFOperatorAnnotation)
+
+	desired := strconv.FormatBool(bpfEnabled)
+	shouldSet, err := t.Manage("BPFEnabled", fieldowner.FormatValue(fc.Spec.BPFEnabled), desired, fieldowner.ConflictError)
+	if err != nil {
+		return err
 	}
-
-	// The values are considered matching if one of the following is true:
-	// - Both values are nil
-	// - Neither are nil and they have the same value.
-	// Otherwise, the we consider the annotation to not match the spec field.
-	match := annotationValue == nil && fc.Spec.BPFEnabled == nil
-	match = match || annotationValue != nil && fc.Spec.BPFEnabled != nil && *annotationValue == *fc.Spec.BPFEnabled
-
-	if !match {
-		return errors.New(`unable to set bpfEnabled: FelixConfiguration "default" has been modified by someone else, refusing to override potential user configuration`)
+	if shouldSet {
+		fc.Spec.BPFEnabled = &bpfEnabled
 	}
-
+	t.Flush(fc)
 	return nil
 }
 
@@ -71,7 +64,6 @@ func isRolloutCompleteWithBPFVolumes(ds *appsv1.DaemonSet) bool {
 
 	for _, volume := range ds.Spec.Template.Spec.Volumes {
 		if volume.Name == render.BPFVolumeName {
-			// return ds.Status.CurrentNumberScheduled == ds.Status.UpdatedNumberScheduled && ds.Status.CurrentNumberScheduled == ds.Status.NumberAvailable
 			if ds.Status.CurrentNumberScheduled == ds.Status.UpdatedNumberScheduled && ds.Status.CurrentNumberScheduled == ds.Status.NumberAvailable {
 				return true
 			} else {
@@ -80,28 +72,6 @@ func isRolloutCompleteWithBPFVolumes(ds *appsv1.DaemonSet) bool {
 		}
 	}
 	return false
-}
-
-func setBPFEnabledOnFelixConfiguration(fc *v3.FelixConfiguration, bpfEnabled bool) error {
-	err := bpfValidateAnnotations(fc)
-	if err != nil {
-		return err
-	}
-
-	text := strconv.FormatBool(bpfEnabled)
-
-	// Add an annotation matching the field value. This allows the operator to compare the annotation to the field
-	// when performing an update to determine if another entity has modified the value since the last write.
-	var fcAnnotations map[string]string
-	if fc.Annotations == nil {
-		fcAnnotations = make(map[string]string)
-	} else {
-		fcAnnotations = fc.Annotations
-	}
-	fcAnnotations[render.BPFOperatorAnnotation] = text
-	fc.SetAnnotations(fcAnnotations)
-	fc.Spec.BPFEnabled = &bpfEnabled
-	return nil
 }
 
 func bpfEnabledOnDaemonsetWithEnvVar(ds *appsv1.DaemonSet) (bool, error) {

--- a/pkg/controller/installation/bpf_test.go
+++ b/pkg/controller/installation/bpf_test.go
@@ -15,29 +15,37 @@
 package installation
 
 import (
-	"strconv"
-
-	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-	"github.com/tigera/operator/pkg/common"
-
-	"github.com/tigera/operator/pkg/render"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render"
 )
 
-var _ = Describe("BPF functional tests", func() {
-	Context("Annotations validation tests", func() {
-		var fc *v3.FelixConfiguration
-		var textTrue, textFalse string
-		var enabled, notEnabled bool
+const managedFieldsAnnotation = "operator.tigera.io/managed-fields-installation"
 
-		textTrue = strconv.FormatBool(true)
-		textFalse = strconv.FormatBool(false)
+// trackedFields parses the consolidated managed-fields annotation on the FC.
+func trackedFields(fc *v3.FelixConfiguration) map[string]string {
+	raw, ok := fc.Annotations[managedFieldsAnnotation]
+	if !ok {
+		return nil
+	}
+	var fields map[string]string
+	ExpectWithOffset(1, json.Unmarshal([]byte(raw), &fields)).To(Succeed())
+	return fields
+}
+
+var _ = Describe("BPF functional tests", func() {
+	Context("setBPFEnabledOnFelixConfiguration conflict detection", func() {
+		var fc *v3.FelixConfiguration
+		var enabled, notEnabled bool
 
 		enabled = true
 		notEnabled = false
@@ -52,57 +60,86 @@ var _ = Describe("BPF functional tests", func() {
 			}
 		})
 
-		It("should return error if the value is not a boolean", func() {
-			fc.Annotations[render.BPFOperatorAnnotation] = "NotBoolean"
-			err := bpfValidateAnnotations(fc)
-			Expect(err).Should(HaveOccurred())
-		})
-
-		It("should return error if the annotation is nil and the spec field is not", func() {
-			fc.Annotations = nil
-			fc.Spec.BPFEnabled = &enabled
-			err := bpfValidateAnnotations(fc)
-			Expect(err).Should(HaveOccurred())
-		})
-
-		It("should return error if the annotation is not nil and the spec field is", func() {
-			fc.Annotations[render.BPFOperatorAnnotation] = textFalse
-			err := bpfValidateAnnotations(fc)
-			Expect(err).Should(HaveOccurred())
-		})
-
-		It("should return error if the annotation is true and the spec field is false", func() {
-			fc.Annotations[render.BPFOperatorAnnotation] = textTrue
+		It("should error when spec was modified out-of-band (tracked true, spec false)", func() {
+			// Simulate: operator previously set BPFEnabled=true, user changed to false.
+			fc.Annotations[managedFieldsAnnotation] = `{"BPFEnabled":"true"}`
 			fc.Spec.BPFEnabled = &notEnabled
-			err := bpfValidateAnnotations(fc)
+			err := setBPFEnabledOnFelixConfiguration(fc, true)
 			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("modified by another actor"))
 		})
 
-		It("should return error if the annotation is false and the spec field is true", func() {
-			fc.Annotations[render.BPFOperatorAnnotation] = textFalse
+		It("should error when spec was modified out-of-band (tracked false, spec true)", func() {
+			fc.Annotations[managedFieldsAnnotation] = `{"BPFEnabled":"false"}`
 			fc.Spec.BPFEnabled = &enabled
-			err := bpfValidateAnnotations(fc)
+			err := setBPFEnabledOnFelixConfiguration(fc, false)
 			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("modified by another actor"))
 		})
 
-		It("should return valid if both annotation and the spec field are nil", func() {
+		It("should succeed when both are nil (fresh install)", func() {
 			fc.Annotations = nil
-			err := bpfValidateAnnotations(fc)
+			err := setBPFEnabledOnFelixConfiguration(fc, true)
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(*fc.Spec.BPFEnabled).To(BeTrue())
+			Expect(trackedFields(fc)).To(HaveKeyWithValue("BPFEnabled", "true"))
 		})
 
-		It("should return valid if the annotation is false and the spec field is false", func() {
-			fc.Annotations[render.BPFOperatorAnnotation] = textFalse
+		It("should succeed when tracked matches spec", func() {
+			fc.Annotations[managedFieldsAnnotation] = `{"BPFEnabled":"false"}`
 			fc.Spec.BPFEnabled = &notEnabled
-			err := bpfValidateAnnotations(fc)
+			err := setBPFEnabledOnFelixConfiguration(fc, false)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
-		It("should return valid if the annotation is true and the spec field is true", func() {
-			fc.Annotations[render.BPFOperatorAnnotation] = textTrue
-			fc.Spec.BPFEnabled = &enabled
-			err := bpfValidateAnnotations(fc)
+		It("should update tracked value when operator changes desired value", func() {
+			fc.Annotations[managedFieldsAnnotation] = `{"BPFEnabled":"false"}`
+			fc.Spec.BPFEnabled = &notEnabled
+			err := setBPFEnabledOnFelixConfiguration(fc, true)
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(*fc.Spec.BPFEnabled).To(BeTrue())
+			Expect(trackedFields(fc)).To(HaveKeyWithValue("BPFEnabled", "true"))
+		})
+	})
+
+	Context("Legacy annotation migration", func() {
+		It("should migrate old per-field annotation to consolidated tracker", func() {
+			fc := &v3.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+					Annotations: map[string]string{
+						render.BPFOperatorAnnotation: "true",
+					},
+				},
+				Spec: v3.FelixConfigurationSpec{
+					BPFEnabled: boolPtr(true),
+				},
+			}
+
+			err := setBPFEnabledOnFelixConfiguration(fc, true)
+			Expect(err).ShouldNot(HaveOccurred())
+			// Old annotation should be removed.
+			Expect(fc.Annotations).NotTo(HaveKey(render.BPFOperatorAnnotation))
+			// New consolidated annotation should exist.
+			Expect(trackedFields(fc)).To(HaveKeyWithValue("BPFEnabled", "true"))
+		})
+
+		It("should detect conflict after migrating legacy annotation", func() {
+			fc := &v3.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+					Annotations: map[string]string{
+						render.BPFOperatorAnnotation: "true",
+					},
+				},
+				Spec: v3.FelixConfigurationSpec{
+					BPFEnabled: boolPtr(false), // User changed it.
+				},
+			}
+
+			err := setBPFEnabledOnFelixConfiguration(fc, true)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("modified by another actor"))
 		})
 	})
 
@@ -263,29 +300,22 @@ var _ = Describe("BPF functional tests", func() {
 			}
 		})
 
-		It("should return error if annotation validation failed", func() {
-			fc.Annotations = make(map[string]string)
-			fc.Annotations[render.BPFOperatorAnnotation] = "NotBoolean"
-			err := bpfValidateAnnotations(fc)
-			Expect(err).Should(HaveOccurred())
-			err = setBPFEnabledOnFelixConfiguration(fc, true)
-			Expect(err).Should(HaveOccurred())
-		})
-
-		It("should set correct annotation", func() {
+		It("should set correct annotation and spec value", func() {
 			err := setBPFEnabledOnFelixConfiguration(fc, true)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			annotations := fc.Annotations[render.BPFOperatorAnnotation]
-			Expect(annotations).To(Equal("true"))
+			Expect(trackedFields(fc)).To(HaveKeyWithValue("BPFEnabled", "true"))
 			Expect(*fc.Spec.BPFEnabled).To(Equal(true))
 
 			err = setBPFEnabledOnFelixConfiguration(fc, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			annotations = fc.Annotations[render.BPFOperatorAnnotation]
-			Expect(annotations).To(Equal("false"))
+			Expect(trackedFields(fc)).To(HaveKeyWithValue("BPFEnabled", "false"))
 			Expect(*fc.Spec.BPFEnabled).To(Equal(false))
 		})
 	})
 })
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -71,6 +71,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/controller/utils/fieldowner"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
@@ -1835,114 +1836,119 @@ func getOrCreateTyphaNodeTLSConfig(cli client.Client, certificateManager certifi
 }
 
 func (r *ReconcileInstallation) setNftablesMode(_ context.Context, install *operatorv1.Installation, fc *v3.FelixConfiguration, reqLogger logr.Logger) (bool, error) {
-	updated := false
+	if install.Spec.CalicoNetwork.LinuxDataplane == nil {
+		return false, nil
+	}
 
-	// Set the FelixConfiguration nftables dataplane mode based on the operator configuration. We do this unconditonally because
-	// we don't need to handle upgrades from versions that were previously FelixConfiguration only - nftables mode has always
-	// been controlled by the operator.
-	if install.Spec.CalicoNetwork.LinuxDataplane != nil {
-		nftablesMode := v3.NFTablesModeDisabled
-		if install.Spec.IsNftables() {
-			// The operator is configured to use the nftables dataplane.
-			if install.Spec.BPFEnabled() {
-				// For BPF mode, we always use nftables, as we don't use the upstream kube-proxy and so don't need to
-				// worry about compatibility with its mode of operation.
-				nftablesMode = v3.NFTablesModeEnabled
-			} else {
-				// Otherwise, kube-proxy is running - configure Felix to auto-detect whether it should use nftables or iptables on
-				// a per-node basis, allowing for smoother upgrades.
-				nftablesMode = v3.NFTablesModeAuto
-			}
+	// Determine the desired nftables mode based on the operator configuration. NFTablesMode has always
+	// been controlled by the operator, so we use ConflictError to reject out-of-band modifications.
+	nftablesMode := v3.NFTablesModeDisabled
+	if install.Spec.IsNftables() {
+		if install.Spec.BPFEnabled() {
+			// For BPF mode, we always use nftables, as we don't use the upstream kube-proxy and so don't need to
+			// worry about compatibility with its mode of operation.
+			nftablesMode = v3.NFTablesModeEnabled
+		} else {
+			// Otherwise, kube-proxy is running - configure Felix to auto-detect whether it should use nftables or iptables on
+			// a per-node basis, allowing for smoother upgrades.
+			nftablesMode = v3.NFTablesModeAuto
 		}
-		updated = fc.Spec.NFTablesMode == nil || *fc.Spec.NFTablesMode != nftablesMode
+	}
+
+	t := fieldowner.ForObject(installationControllerName, fc)
+	shouldSet, err := t.Manage("NFTablesMode", fieldowner.FormatValue(fc.Spec.NFTablesMode), string(nftablesMode), fieldowner.ConflictError)
+	if err != nil {
+		return false, err
+	}
+	if shouldSet {
 		fc.Spec.NFTablesMode = &nftablesMode
+		reqLogger.Info("Patching nftables mode", "nftablesMode", nftablesMode)
 	}
-	if updated {
-		reqLogger.Info("Patching nftables mode", "nftablesMode", *fc.Spec.NFTablesMode)
-	}
-	return updated, nil
+	t.Flush(fc)
+	return shouldSet, nil
 }
 
-// setDefaultOnFelixConfiguration will take the passed in fc and add any defaulting needed
-// based on the install config.
+// setDefaultsOnFelixConfiguration sets default values on the FelixConfiguration based on the
+// Installation config. All fields use ConflictDefer — if a user has modified an operator-set
+// default, the operator backs off and lets the user's value persist.
 func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Context, install *operatorv1.Installation, fc *v3.FelixConfiguration, reqLogger logr.Logger, needNsMigration bool) (bool, error) {
 	updated := false
+	t := fieldowner.ForObject(installationControllerName, fc)
 
+	// RouteTableRange defaults depend on the CNI plugin.
+	var desiredRouteTableRange *v3.RouteTableRange
 	switch install.Spec.CNI.Type {
-	// If we're using the AWS CNI plugin we need to ensure the route tables that calico-node
-	// uses do not conflict with the ones the AWS CNI plugin uses so default them
-	// in the FelixConfiguration if they are not already set.
 	case operatorv1.PluginAmazonVPC:
-		if fc.Spec.RouteTableRange == nil {
-			updated = true
-			// Defaulting based on that AWS might be using the following:
-			// - The ENI device number + 1
-			//   Currently the max number of ENIs for any host is 15.
-			//   p4d.24xlarge is reported to support 4x15 ENI but it uses 4 cards
-			//   and AWS CNI only uses ENIs on card 0.
-			// - The VLAN table ID + 100 (there is doubt if this is true)
-			fc.Spec.RouteTableRange = &v3.RouteTableRange{
-				Min: 65,
-				Max: 99,
-			}
-		}
+		desiredRouteTableRange = &v3.RouteTableRange{Min: 65, Max: 99}
 	case operatorv1.PluginGKE:
-		if fc.Spec.RouteTableRange == nil {
+		desiredRouteTableRange = &v3.RouteTableRange{Min: 10, Max: 250}
+	}
+	if desiredRouteTableRange != nil {
+		shouldSet, err := t.Manage("RouteTableRange", fieldowner.FormatValue(fc.Spec.RouteTableRange), fieldowner.FormatValue(desiredRouteTableRange), fieldowner.ConflictDefer)
+		if err != nil {
+			return false, err
+		}
+		if shouldSet {
+			fc.Spec.RouteTableRange = desiredRouteTableRange
 			updated = true
-			// Don't conflict with the GKE CNI plugin's routes.
-			fc.Spec.RouteTableRange = &v3.RouteTableRange{
-				Min: 10,
-				Max: 250,
-			}
 		}
 	}
 
-	// Determine the felix health port to use. Prefer the configuration from FelixConfiguration,
-	// but default to 9099 (or 9199 on OpenShift). We will also write back whatever we select to FelixConfiguration.
+	// Default the felix health port. 9099 normally, 9199 on OpenShift.
 	felixHealthPort := 9099
 	if install.Spec.KubernetesProvider.IsOpenShift() {
 		felixHealthPort = 9199
 	}
-	if fc.Spec.HealthPort == nil {
+	shouldSet, err := t.Manage("HealthPort", fieldowner.FormatValue(fc.Spec.HealthPort), fieldowner.FormatValue(felixHealthPort), fieldowner.ConflictDefer)
+	if err != nil {
+		return false, err
+	}
+	if shouldSet {
 		fc.Spec.HealthPort = &felixHealthPort
 		updated = true
 	}
+
+	// VXLAN defaults. MKE uses non-standard values to avoid conflict with docker swarm vxlan.
 	vxlanVNI := 4096
 	vxlanPort := 4789
-	// MKE uses a vxlanVNI:4096 and vxlanPort:4789 for its docker swarm vxlan.
-	// This results in a conflict with calico's VXLAN and the vxlan.calico interface
-	// gets deleted. To fix this we change the vxlanVNI to 10000 as recommended by
-	// MKE docs (https://docs.mirantis.com/mke/3.7/cli-ref/mke-cli-install.html).
 	if install.Spec.KubernetesProvider == operatorv1.ProviderDockerEE {
 		vxlanVNI = 10000
-		// We are using a flow based VXLAN device for
-		// ebpf dataplane. This requires changing the default VXLAN port to
-		// 8472 to avoid conflict with the host's VXLAN interface.
 		if install.Spec.BPFEnabled() {
 			vxlanPort = 8472
 		}
 	}
-
-	if fc.Spec.VXLANVNI == nil {
+	shouldSet, err = t.Manage("VXLANVNI", fieldowner.FormatValue(fc.Spec.VXLANVNI), fieldowner.FormatValue(vxlanVNI), fieldowner.ConflictDefer)
+	if err != nil {
+		return false, err
+	}
+	if shouldSet {
 		fc.Spec.VXLANVNI = &vxlanVNI
 		updated = true
 	}
-
-	if fc.Spec.VXLANPort == nil {
+	shouldSet, err = t.Manage("VXLANPort", fieldowner.FormatValue(fc.Spec.VXLANPort), fieldowner.FormatValue(vxlanPort), fieldowner.ConflictDefer)
+	if err != nil {
+		return false, err
+	}
+	if shouldSet {
 		fc.Spec.VXLANPort = &vxlanPort
 		updated = true
 	}
 
-	if install.Spec.KubernetesProvider == operatorv1.ProviderDockerEE {
-		// Set bpfHostConntrackBypass to false for eBPF dataplane to work with MKE
-		if install.Spec.BPFEnabled() && fc.Spec.BPFHostConntrackBypass == nil {
+	// BPFHostConntrackBypass must be disabled for eBPF on MKE.
+	if install.Spec.KubernetesProvider == operatorv1.ProviderDockerEE && install.Spec.BPFEnabled() {
+		shouldSet, err = t.Manage("BPFHostConntrackBypass", fieldowner.FormatValue(fc.Spec.BPFHostConntrackBypass), "false", fieldowner.ConflictDefer)
+		if err != nil {
+			return false, err
+		}
+		if shouldSet {
 			disableBPFHostConntrackBypass(fc)
 			updated = true
 		}
 	}
 
+	// Some platforms need a different default for DNSTrustedServers because their DNS service
+	// is not named "kube-dns".
 	if install.Spec.Variant == operatorv1.TigeraSecureEnterprise {
-		// Some platforms need a different default setting for dnsTrustedServers, because their DNS service is not named "kube-dns".
 		dnsService := ""
 		switch install.Spec.KubernetesProvider {
 		case operatorv1.ProviderOpenShift:
@@ -1953,24 +1959,25 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 		if dnsService != "" {
 			felixDefault := "k8s-service:kube-dns"
 			trustedServers := []string{dnsService}
-			// Keep any other values that are already configured, excepting the value
-			// that we are setting and the kube-dns default.
-			existingSetting := ""
 			if fc.Spec.DNSTrustedServers != nil {
-				existingSetting = strings.Join(*(fc.Spec.DNSTrustedServers), ",")
-				for _, server := range *(fc.Spec.DNSTrustedServers) {
+				for _, server := range *fc.Spec.DNSTrustedServers {
 					if server != felixDefault && server != dnsService {
 						trustedServers = append(trustedServers, server)
 					}
 				}
 			}
-			newSetting := strings.Join(trustedServers, ",")
-			if newSetting != existingSetting {
+			shouldSet, err = t.Manage("DNSTrustedServers", fieldowner.FormatValue(fc.Spec.DNSTrustedServers), fieldowner.FormatValue(trustedServers), fieldowner.ConflictDefer)
+			if err != nil {
+				return false, err
+			}
+			if shouldSet {
 				fc.Spec.DNSTrustedServers = &trustedServers
 				updated = true
 			}
 		}
 	}
+
+	t.Flush(fc)
 
 	// If BPF is enabled, but not set on FelixConfiguration, do so here. This could happen when an older
 	// version of operator is replaced by the new one. Older versions of the operator used an
@@ -1981,7 +1988,7 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 	// If calico-node daemonset exists, we need to check the ENV VAR and set FelixConfiguration accordingly.
 	// Otherwise, this is a fresh install in eBPF mode, set the felix config.
 	ds := &appsv1.DaemonSet{}
-	err := r.client.Get(ctx, types.NamespacedName{Namespace: common.CalicoNamespace, Name: common.NodeDaemonSetName}, ds)
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: common.CalicoNamespace, Name: common.NodeDaemonSetName}, ds)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			reqLogger.Error(err, "An error occurred when getting the Daemonset resource")

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -72,6 +73,19 @@ var (
 )
 
 var errMismatchedError = fmt.Errorf("installation spec.kubernetesProvider 'DockerEnterprise' does not match auto-detected value 'OpenShift'")
+
+// bpfTrackedValue extracts the BPFEnabled value from the consolidated field ownership annotation.
+func bpfTrackedValue(fc *v3.FelixConfiguration) string {
+	raw, ok := fc.Annotations["operator.tigera.io/managed-fields-installation"]
+	if !ok {
+		return ""
+	}
+	var fields map[string]string
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		return ""
+	}
+	return fields["BPFEnabled"]
+}
 
 type fakeNamespaceMigration struct{}
 
@@ -1382,7 +1396,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// Should set correct annoation and BPFEnabled field.
 			Expect(fc.Annotations).NotTo(BeNil())
-			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("false"))
+			Expect(bpfTrackedValue(fc)).To(Equal("false"))
 			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
 			Expect(*fc.Spec.BPFEnabled).To(BeFalse())
 		})
@@ -1488,7 +1502,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// Should set correct annoation and BPFEnabled field.
 			Expect(fc.Annotations).NotTo(BeNil())
-			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("true"))
+			Expect(bpfTrackedValue(fc)).To(Equal("true"))
 			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
 			Expect(*fc.Spec.BPFEnabled).To(BeTrue())
 		})
@@ -1506,7 +1520,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// Should set correct annoation and BPFEnabled field.
 			Expect(fc.Annotations).NotTo(BeNil())
-			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("true"))
+			Expect(bpfTrackedValue(fc)).To(Equal("true"))
 			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
 			Expect(*fc.Spec.BPFEnabled).To(BeTrue())
 		})
@@ -1527,7 +1541,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// Should set correct annoation and BPFEnabled field.
 			Expect(fc.Annotations).NotTo(BeNil())
-			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("true"))
+			Expect(bpfTrackedValue(fc)).To(Equal("true"))
 			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
 			Expect(*fc.Spec.BPFEnabled).To(BeTrue())
 
@@ -1546,7 +1560,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// Should set correct annoation and BPFEnabled field.
 			Expect(fc.Annotations).NotTo(BeNil())
-			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("false"))
+			Expect(bpfTrackedValue(fc)).To(Equal("false"))
 			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
 			Expect(*fc.Spec.BPFEnabled).To(BeFalse())
 		})
@@ -1576,7 +1590,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// Should set correct annoation and BPFEnabled field.
 			Expect(fc.Annotations).NotTo(BeNil())
-			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("true"))
+			Expect(bpfTrackedValue(fc)).To(Equal("true"))
 			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
 			Expect(*fc.Spec.BPFEnabled).To(BeTrue())
 		})

--- a/pkg/controller/utils/fieldowner/fieldowner.go
+++ b/pkg/controller/utils/fieldowner/fieldowner.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fieldowner provides a centralized mechanism for tracking operator field ownership
+// on shared Kubernetes resources like FelixConfiguration and BGPConfiguration. It replaces
+// ad-hoc per-field annotation tracking with a single, consistent API.
+//
+// The operator and end users both modify these shared resources. The tracker uses a per-controller
+// annotation (JSON map of field name → last-written value) to detect when a user has modified a
+// field the operator previously set, and applies a configurable conflict policy to decide whether
+// to error, defer to the user, or override.
+package fieldowner
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const annotationPrefix = "operator.tigera.io/managed-fields-"
+
+// ConflictPolicy determines how to handle user modifications to operator-managed fields.
+type ConflictPolicy int
+
+const (
+	// ConflictError returns an error when a user has modified an operator-managed field.
+	// Use for fields where the operator must maintain control (e.g., BPFEnabled).
+	ConflictError ConflictPolicy = iota
+
+	// ConflictDefer releases operator ownership when a user modifies the field,
+	// allowing the user's value to persist. Use for defaulted fields where user
+	// intent should win (e.g., HealthPort, VXLANVNI).
+	ConflictDefer
+
+	// ConflictOverride always applies the operator's desired value regardless of
+	// user changes. Use only for fields the operator unconditionally controls.
+	ConflictOverride
+)
+
+// Tracker manages operator field ownership on a shared Kubernetes resource. Each controller
+// that writes to a shared resource should create its own Tracker (identified by controller name)
+// to avoid cross-controller annotation conflicts.
+//
+// Usage:
+//
+//	t := fieldowner.ForObject("installation", fc)
+//	if shouldSet, err := t.Manage("BPFEnabled", current, desired, fieldowner.ConflictError); err != nil {
+//	    return err
+//	} else if shouldSet {
+//	    fc.Spec.BPFEnabled = &desired
+//	}
+//	t.Flush(fc)
+type Tracker struct {
+	annotationKey string
+	fields        map[string]string
+}
+
+// ForObject creates a Tracker loaded from the given object's annotations.
+// controllerName identifies the controller managing these fields and is used
+// as part of the annotation key to avoid cross-controller conflicts.
+func ForObject(controllerName string, obj client.Object) *Tracker {
+	t := &Tracker{
+		annotationKey: annotationPrefix + controllerName,
+		fields:        make(map[string]string),
+	}
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		if raw, ok := annotations[t.annotationKey]; ok {
+			_ = json.Unmarshal([]byte(raw), &t.fields)
+		}
+	}
+	return t
+}
+
+// Manage evaluates whether the operator should set a field based on the given conflict policy.
+// current is the string representation of the field's current value ("" for nil/unset).
+// desired is the string representation of the operator's desired value.
+//
+// Returns shouldSet=true if the caller should apply the desired value to the spec.
+// The caller is responsible for actually setting the spec field; the tracker only manages
+// the annotation bookkeeping.
+//
+// Call Flush after all Manage/Release calls to write changes back to the object.
+func (t *Tracker) Manage(field, current, desired string, policy ConflictPolicy) (bool, error) {
+	tracked, wasTracked := t.fields[field]
+	userModified := wasTracked && tracked != current
+
+	switch policy {
+	case ConflictError:
+		if userModified {
+			return false, fmt.Errorf(
+				"field %q has been modified by another actor (operator last set %q, current value %q); refusing to override",
+				field, tracked, current,
+			)
+		}
+		// First time seeing a field that already has the value we want — adopt it.
+		if !wasTracked && current != "" && current == desired {
+			t.fields[field] = desired
+			return false, nil
+		}
+		// First time seeing a field with a different value — someone else set it.
+		if !wasTracked && current != "" && current != desired {
+			return false, fmt.Errorf(
+				"field %q already has value %q which differs from desired %q; refusing to override potential user configuration",
+				field, current, desired,
+			)
+		}
+		if current == desired && wasTracked {
+			return false, nil
+		}
+		t.fields[field] = desired
+		return true, nil
+
+	case ConflictDefer:
+		if userModified {
+			delete(t.fields, field)
+			return false, nil
+		}
+		// Not tracked and already has a value — assume user/other set it, don't claim.
+		if !wasTracked && current != "" {
+			return false, nil
+		}
+		if current == desired && wasTracked {
+			return false, nil
+		}
+		t.fields[field] = desired
+		return current != desired, nil
+
+	case ConflictOverride:
+		t.fields[field] = desired
+		return current != desired, nil
+	}
+
+	return false, fmt.Errorf("unknown conflict policy: %d", policy)
+}
+
+// Release removes operator ownership of a field. Call this when a controller
+// no longer needs to manage a field (e.g., during cleanup/finalization).
+//
+// Call Flush after all Manage/Release calls to write changes back to the object.
+func (t *Tracker) Release(field string) {
+	delete(t.fields, field)
+}
+
+// IsManaged returns true if the operator is currently tracking the given field.
+func (t *Tracker) IsManaged(field string) bool {
+	_, ok := t.fields[field]
+	return ok
+}
+
+// ManagedFields returns a copy of all currently tracked field names and their last-written values.
+func (t *Tracker) ManagedFields() map[string]string {
+	out := make(map[string]string, len(t.fields))
+	maps.Copy(out, t.fields)
+	return out
+}
+
+// MigrateAnnotation migrates a legacy per-field annotation into the consolidated tracker.
+// If the old annotation exists on the object, its value is adopted into the tracker and
+// the old annotation is removed from the object. This enables incremental migration from
+// the old per-field annotation pattern.
+func (t *Tracker) MigrateAnnotation(obj client.Object, field, oldAnnotationKey string) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+	val, ok := annotations[oldAnnotationKey]
+	if !ok {
+		return
+	}
+	if _, exists := t.fields[field]; !exists {
+		t.fields[field] = val
+	}
+	delete(annotations, oldAnnotationKey)
+	obj.SetAnnotations(annotations)
+}
+
+// Flush writes the tracker's state back to the object's annotations.
+// Must be called after all Manage/Release calls and before patching the object.
+func (t *Tracker) Flush(obj client.Object) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	if len(t.fields) == 0 {
+		delete(annotations, t.annotationKey)
+	} else {
+		raw, _ := json.Marshal(t.fields)
+		annotations[t.annotationKey] = string(raw)
+	}
+	obj.SetAnnotations(annotations)
+}
+
+// FormatValue converts a value to its string representation for use with Manage.
+// Returns "" for nil values and nil pointers. For pointer types, dereferences before
+// formatting. Uses fmt.Sprint for primitive types and JSON for structs/maps/slices.
+func FormatValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Pointer {
+		if val.IsNil() {
+			return ""
+		}
+		return FormatValue(val.Elem().Interface())
+	}
+	switch val.Kind() {
+	case reflect.Struct, reflect.Map, reflect.Slice:
+		raw, _ := json.Marshal(v)
+		return string(raw)
+	default:
+		return fmt.Sprint(v)
+	}
+}

--- a/pkg/controller/utils/fieldowner/fieldowner_suite_test.go
+++ b/pkg/controller/utils/fieldowner/fieldowner_suite_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fieldowner_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestFieldOwner(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+	reporterConfig.JUnitReport = "../../../../report/ut/fieldowner_suite.xml"
+	ginkgo.RunSpecs(t, "pkg/controller/utils/fieldowner Suite", suiteConfig, reporterConfig)
+}

--- a/pkg/controller/utils/fieldowner/fieldowner_test.go
+++ b/pkg/controller/utils/fieldowner/fieldowner_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fieldowner_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tigera/operator/pkg/controller/utils/fieldowner"
+)
+
+// newObj creates a minimal client.Object for testing with optional annotations.
+func newObj(annotations map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "default",
+			Annotations: annotations,
+		},
+	}
+}
+
+var _ = Describe("Tracker", func() {
+	Context("ForObject", func() {
+		It("should handle an object with no annotations", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			Expect(t.ManagedFields()).To(BeEmpty())
+		})
+
+		It("should load existing tracked fields from annotation", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"Foo":"bar","Baz":"123"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			Expect(t.ManagedFields()).To(Equal(map[string]string{
+				"Foo": "bar",
+				"Baz": "123",
+			}))
+		})
+
+		It("should isolate trackers by controller name", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-alpha": `{"F1":"a"}`,
+				"operator.tigera.io/managed-fields-beta":  `{"F2":"b"}`,
+			})
+			tAlpha := fieldowner.ForObject("alpha", obj)
+			tBeta := fieldowner.ForObject("beta", obj)
+			Expect(tAlpha.IsManaged("F1")).To(BeTrue())
+			Expect(tAlpha.IsManaged("F2")).To(BeFalse())
+			Expect(tBeta.IsManaged("F1")).To(BeFalse())
+			Expect(tBeta.IsManaged("F2")).To(BeTrue())
+		})
+	})
+
+	Context("ConflictError policy", func() {
+		It("should set an untracked field with no current value", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "", "desired", fieldowner.ConflictError)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeTrue())
+		})
+
+		It("should adopt an untracked field whose current value matches desired", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "val", "val", fieldowner.ConflictError)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeFalse())
+
+			// Should now be tracked.
+			Expect(t.IsManaged("F")).To(BeTrue())
+		})
+
+		It("should error on an untracked field whose current value differs from desired", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			_, err := t.Manage("F", "user-val", "desired", fieldowner.ConflictError)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("refusing to override"))
+		})
+
+		It("should not set a tracked field that already has the desired value", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"val"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "val", "val", fieldowner.ConflictError)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeFalse())
+		})
+
+		It("should update a tracked field to a new desired value", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"old"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "old", "new", fieldowner.ConflictError)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeTrue())
+
+			t.Flush(obj)
+			Expect(obj.Annotations["operator.tigera.io/managed-fields-test"]).To(ContainSubstring(`"F":"new"`))
+		})
+
+		It("should error when a tracked field was modified by a user", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"operator-set"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			_, err := t.Manage("F", "user-changed", "operator-set", fieldowner.ConflictError)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("modified by another actor"))
+		})
+	})
+
+	Context("ConflictDefer policy", func() {
+		It("should set an untracked field with no current value", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "", "default-val", fieldowner.ConflictDefer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeTrue())
+		})
+
+		It("should not claim an untracked field that already has a value", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "existing", "default-val", fieldowner.ConflictDefer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeFalse())
+			Expect(t.IsManaged("F")).To(BeFalse())
+		})
+
+		It("should release ownership when user modifies a tracked field", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"operator-default"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "user-changed", "operator-default", fieldowner.ConflictDefer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeFalse())
+			Expect(t.IsManaged("F")).To(BeFalse())
+		})
+
+		It("should not re-set a tracked field that already has the desired value", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"val"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "val", "val", fieldowner.ConflictDefer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeFalse())
+		})
+
+		It("should update a tracked field to a new desired value when not user-modified", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"old"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "old", "new", fieldowner.ConflictDefer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeTrue())
+		})
+	})
+
+	Context("ConflictOverride policy", func() {
+		It("should always set when values differ", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"operator-set"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "user-changed", "operator-wants", fieldowner.ConflictOverride)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeTrue())
+		})
+
+		It("should not set when current equals desired", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			shouldSet, err := t.Manage("F", "val", "val", fieldowner.ConflictOverride)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeFalse())
+		})
+	})
+
+	Context("Release", func() {
+		It("should remove a tracked field", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"val","G":"other"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			t.Release("F")
+			Expect(t.IsManaged("F")).To(BeFalse())
+			Expect(t.IsManaged("G")).To(BeTrue())
+		})
+
+		It("should be a no-op for untracked fields", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			t.Release("nonexistent")
+			Expect(t.ManagedFields()).To(BeEmpty())
+		})
+	})
+
+	Context("Flush", func() {
+		It("should write tracked fields to the annotation", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+			_, _ = t.Manage("A", "", "1", fieldowner.ConflictError)
+			_, _ = t.Manage("B", "", "2", fieldowner.ConflictError)
+			t.Flush(obj)
+
+			Expect(obj.Annotations).To(HaveKey("operator.tigera.io/managed-fields-test"))
+			var fields map[string]string
+			Expect(json.Unmarshal([]byte(obj.Annotations["operator.tigera.io/managed-fields-test"]), &fields)).To(Succeed())
+			Expect(fields).To(Equal(map[string]string{"A": "1", "B": "2"}))
+		})
+
+		It("should remove the annotation when no fields are tracked", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"F":"val"}`,
+			})
+			t := fieldowner.ForObject("test", obj)
+			t.Release("F")
+			t.Flush(obj)
+			Expect(obj.Annotations).NotTo(HaveKey("operator.tigera.io/managed-fields-test"))
+		})
+
+		It("should preserve other annotations", func() {
+			obj := newObj(map[string]string{
+				"other-annotation": "keep-me",
+			})
+			t := fieldowner.ForObject("test", obj)
+			_, _ = t.Manage("F", "", "val", fieldowner.ConflictError)
+			t.Flush(obj)
+			Expect(obj.Annotations["other-annotation"]).To(Equal("keep-me"))
+			Expect(obj.Annotations).To(HaveKey("operator.tigera.io/managed-fields-test"))
+		})
+	})
+
+	Context("MigrateAnnotation", func() {
+		It("should migrate a legacy annotation into the tracker", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/bpfEnabled": "true",
+			})
+			t := fieldowner.ForObject("test", obj)
+			t.MigrateAnnotation(obj, "BPFEnabled", "operator.tigera.io/bpfEnabled")
+
+			Expect(t.IsManaged("BPFEnabled")).To(BeTrue())
+			Expect(t.ManagedFields()["BPFEnabled"]).To(Equal("true"))
+			// Old annotation should be removed.
+			Expect(obj.Annotations).NotTo(HaveKey("operator.tigera.io/bpfEnabled"))
+		})
+
+		It("should not overwrite an existing tracked value", func() {
+			obj := newObj(map[string]string{
+				"operator.tigera.io/managed-fields-test": `{"BPFEnabled":"false"}`,
+				"operator.tigera.io/bpfEnabled":          "true",
+			})
+			t := fieldowner.ForObject("test", obj)
+			t.MigrateAnnotation(obj, "BPFEnabled", "operator.tigera.io/bpfEnabled")
+
+			// Should keep the existing tracked value, not the legacy one.
+			Expect(t.ManagedFields()["BPFEnabled"]).To(Equal("false"))
+			// But the old annotation should still be removed.
+			Expect(obj.Annotations).NotTo(HaveKey("operator.tigera.io/bpfEnabled"))
+		})
+
+		It("should be a no-op when the legacy annotation doesn't exist", func() {
+			obj := newObj(map[string]string{"other": "val"})
+			t := fieldowner.ForObject("test", obj)
+			t.MigrateAnnotation(obj, "BPFEnabled", "operator.tigera.io/bpfEnabled")
+			Expect(t.IsManaged("BPFEnabled")).To(BeFalse())
+		})
+	})
+
+	Context("FormatValue", func() {
+		It("should return empty string for nil", func() {
+			Expect(fieldowner.FormatValue(nil)).To(Equal(""))
+		})
+
+		It("should return empty string for nil pointer", func() {
+			var p *bool
+			Expect(fieldowner.FormatValue(p)).To(Equal(""))
+		})
+
+		It("should format bool pointer", func() {
+			v := true
+			Expect(fieldowner.FormatValue(&v)).To(Equal("true"))
+		})
+
+		It("should format int pointer", func() {
+			v := 9099
+			Expect(fieldowner.FormatValue(&v)).To(Equal("9099"))
+		})
+
+		It("should format string value", func() {
+			Expect(fieldowner.FormatValue("Enabled")).To(Equal("Enabled"))
+		})
+
+		It("should format struct as JSON", func() {
+			type Range struct {
+				Min int `json:"min"`
+				Max int `json:"max"`
+			}
+			r := Range{Min: 65, Max: 99}
+			Expect(fieldowner.FormatValue(r)).To(Equal(`{"min":65,"max":99}`))
+		})
+	})
+
+	Context("multiple fields in one tracker", func() {
+		It("should independently track multiple fields", func() {
+			obj := newObj(nil)
+			t := fieldowner.ForObject("test", obj)
+
+			shouldSet, err := t.Manage("A", "", "1", fieldowner.ConflictError)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeTrue())
+
+			shouldSet, err = t.Manage("B", "", "2", fieldowner.ConflictDefer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeTrue())
+
+			shouldSet, err = t.Manage("C", "existing", "3", fieldowner.ConflictDefer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldSet).To(BeFalse()) // defers to existing
+
+			t.Flush(obj)
+
+			var fields map[string]string
+			Expect(json.Unmarshal([]byte(obj.Annotations["operator.tigera.io/managed-fields-test"]), &fields)).To(Succeed())
+			Expect(fields).To(Equal(map[string]string{"A": "1", "B": "2"}))
+		})
+	})
+})


### PR DESCRIPTION
The operator manages several FelixConfiguration fields using three inconsistent patterns: annotation-based tracking (BPF), nil-check defaulting (HealthPort, VXLANVNI, etc.), and unconditional writes (NFTablesMode). This replaces all three with a centralized `fieldowner.Tracker` in `pkg/controller/utils/fieldowner/`.

Each controller gets a per-controller annotation (`operator.tigera.io/managed-fields-<controller>`) storing a JSON map of field name → last-written value. On each reconcile the tracker compares the stored value to the current spec value to detect out-of-band modifications, regardless of how the change was made.

Three conflict policies per field:
- **ConflictError** — reject out-of-band modifications, go degraded (`BPFEnabled`, `NFTablesMode`)
- **ConflictDefer** — release ownership if user modifies the field, let their value persist (`HealthPort`, `VXLANVNI`, `VXLANPort`, `RouteTableRange`, `BPFHostConntrackBypass`, `DNSTrustedServers`)
- **ConflictOverride** — always apply the operator's value (not yet used, will be used for applicationlayer/gatewayapi fields)

The BPF field includes `MigrateAnnotation()` for backward compat with the old `operator.tigera.io/bpfEnabled` annotation. Remaining controllers (Istio, applicationlayer, gatewayapi, egressgateway) will be migrated in follow-up PRs.

Related design doc: https://github.com/tigera/designs/pull/14