### PR TITLE
feat(logstorage): validate replicas < node count to prevent ILM stall

### DIFF
--- a/pkg/controller/logstorage/initializer/initializing_controller.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -166,6 +166,27 @@ func FillDefaults(opr *operatorv1.LogStorage) {
 	}
 }
 
+func validateLogStorage(spec *operatorv1.LogStorageSpec) error {
+	if err := validateReplicasForNodeCount(spec); err != nil {
+		return err
+	}
+	return validateComponentResources(spec)
+}
+
+func validateReplicasForNodeCount(spec *operatorv1.LogStorageSpec) error {
+	if spec.Nodes == nil || spec.Indices == nil || spec.Indices.Replicas == nil {
+		return nil
+	}
+	replicas := int(*spec.Indices.Replicas)
+	nodeCount := int(spec.Nodes.Count)
+	if replicas > 0 && nodeCount <= replicas {
+		return fmt.Errorf("LogStorage spec.indices.replicas (%d) must be less than spec.nodes.count (%d); "+
+			"replica shards cannot be allocated when there are not enough nodes. "+
+			"For a single-node Elasticsearch cluster, set spec.indices.replicas to 0", replicas, nodeCount)
+	}
+	return nil
+}
+
 func validateComponentResources(spec *operatorv1.LogStorageSpec) error {
 	if spec.ComponentResources == nil {
 		return fmt.Errorf("LogStorage spec.ComponentResources is nil %+v", spec)
@@ -230,7 +251,7 @@ func (r *LogStorageInitializer) Reconcile(ctx context.Context, request reconcile
 
 	// Default and validate the object.
 	FillDefaults(ls)
-	err = validateComponentResources(&ls.Spec)
+	err = validateLogStorage(&ls.Spec)
 	if err != nil {
 		// Invalid - mark it as such and return.
 		r.setConditionDegraded(ctx, ls, reqLogger)

--- a/pkg/controller/logstorage/initializer/initializing_controller_test.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -177,6 +177,26 @@ var _ = Describe("LogStorage Initializing controller", func() {
 			Expect(ls.Status.State).Should(Equal(operatorv1.TigeraStatusReady))
 		})
 
+		It("sets a degraded status when replicas >= node count", func() {
+			var replicas int32 = 1
+			ls := &operatorv1.LogStorage{}
+			ls.Name = "tigera-secure"
+			FillDefaults(ls)
+			ls.Spec.Indices.Replicas = &replicas
+			ls.Spec.Nodes.Count = 1
+			Expect(cli.Create(ctx, ls)).ShouldNot(HaveOccurred())
+
+			r, err := NewTestInitializer(cli, scheme, mockStatus, operatorv1.ProviderNone, dns.DefaultClusterDomain)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).Should(HaveOccurred())
+			Expect(mockStatus.AssertNumberOfCalls(GinkgoT(), "SetDegraded", 1)).Should(BeTrue())
+
+			ls = &operatorv1.LogStorage{}
+			Expect(cli.Get(ctx, client.ObjectKey{Name: "tigera-secure"}, ls)).ShouldNot(HaveOccurred())
+			Expect(ls.Status.State).Should(Equal(operatorv1.TigeraStatusDegraded))
+		})
+
 		It("handles LogStorage deletion", func() {
 			// Create a LogStorage instance.
 			ls := &operatorv1.LogStorage{}
@@ -263,6 +283,59 @@ var _ = Describe("LogStorage Initializing controller", func() {
 			Expect(cli.Get(ctx, client.ObjectKey{Name: "tigera-secure"}, ls)).ShouldNot(HaveOccurred())
 			Expect(ls.Spec.ComponentResources).NotTo(BeNil())
 			Expect(reflect.DeepEqual(expectedComponentResources, ls.Spec.ComponentResources)).To(BeTrue())
+		})
+	})
+
+	Context("validateReplicasForNodeCount", func() {
+		It("should return an error when replicas is 1 and node count is 1", func() {
+			var replicas int32 = 1
+			spec := &operatorv1.LogStorageSpec{
+				Nodes:   &operatorv1.Nodes{Count: 1},
+				Indices: &operatorv1.Indices{Replicas: &replicas},
+			}
+			Expect(validateReplicasForNodeCount(spec)).NotTo(BeNil())
+		})
+
+		It("should return an error when replicas equals node count", func() {
+			var replicas int32 = 2
+			spec := &operatorv1.LogStorageSpec{
+				Nodes:   &operatorv1.Nodes{Count: 2},
+				Indices: &operatorv1.Indices{Replicas: &replicas},
+			}
+			Expect(validateReplicasForNodeCount(spec)).NotTo(BeNil())
+		})
+
+		It("should return nil when replicas is 0 and node count is 1", func() {
+			var replicas int32 = 0
+			spec := &operatorv1.LogStorageSpec{
+				Nodes:   &operatorv1.Nodes{Count: 1},
+				Indices: &operatorv1.Indices{Replicas: &replicas},
+			}
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
+		})
+
+		It("should return nil when replicas is 1 and node count is 2", func() {
+			var replicas int32 = 1
+			spec := &operatorv1.LogStorageSpec{
+				Nodes:   &operatorv1.Nodes{Count: 2},
+				Indices: &operatorv1.Indices{Replicas: &replicas},
+			}
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
+		})
+
+		It("should return nil when indices is nil", func() {
+			spec := &operatorv1.LogStorageSpec{
+				Nodes: &operatorv1.Nodes{Count: 1},
+			}
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
+		})
+
+		It("should return nil when nodes is nil", func() {
+			var replicas int32 = 1
+			spec := &operatorv1.LogStorageSpec{
+				Indices: &operatorv1.Indices{Replicas: &replicas},
+			}
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
## Description

On single-node ES clusters with replicas: 1, replica shards can never be allocated. This causes the ILM warm phase migrate action to wait indefinitely for shard copies to become active, blocking progression to the delete phase and causing indices to accumulate beyond retention.

Add validation in the LogStorage initializer that rejects configurations where `indices.replicas >= nodes.count`, with a clear error message guiding users to set replicas to 0 for single-node deployments.

For CE v3.21.

Jira ticket: CI-1940

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Add validation for logstorage node count and replicas setting.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
