### PR TITLE
feat(logstorage): validate replicas < node count to prevent ILM stall

### DIFF
--- a/pkg/controller/logstorage/initializer/initializing_controller.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller.go
@@ -168,33 +168,33 @@ func FillDefaults(opr *operatorv1.LogStorage) {
 	}
 }
 
-func validateLogStorage(spec *operatorv1.LogStorageSpec) (error, string) {
-	err, warning := validateReplicasForNodeCount(spec)
+func validateLogStorage(spec *operatorv1.LogStorageSpec) (string, error) {
+	warning, err := validateReplicasForNodeCount(spec)
 	if err != nil {
-		return err, ""
+		return "", err
 	}
 	if err := validateComponentResources(spec); err != nil {
-		return err, ""
+		return "", err
 	}
-	return nil, warning
+	return warning, nil
 }
 
-func validateReplicasForNodeCount(spec *operatorv1.LogStorageSpec) (error, string) {
+func validateReplicasForNodeCount(spec *operatorv1.LogStorageSpec) (string, error) {
 	if spec.Nodes == nil || spec.Indices == nil || spec.Indices.Replicas == nil {
-		return nil, ""
+		return "", nil
 	}
 
 	replicas := int(*spec.Indices.Replicas)
 	nodeCount := int(spec.Nodes.Count)
 	if replicas > 0 && nodeCount <= replicas {
-		return fmt.Errorf("LogStorage spec.indices.replicas (%d) must be less than spec.nodes.count (%d); replica shards cannot be allocated when there are not enough nodes. For a single-node Elasticsearch cluster, set spec.indices.replicas to 0", replicas, nodeCount), ""
+		return "", fmt.Errorf("LogStorage spec.indices.replicas (%d) must be less than spec.nodes.count (%d); replica shards cannot be allocated when there are not enough nodes. For a single-node Elasticsearch cluster, set spec.indices.replicas to 0", replicas, nodeCount)
 	}
 
 	if replicas > 0 && nodeCount == replicas+1 {
-		return nil, fmt.Sprintf("LogStorage spec.nodes.count (%d) is only 1 more than spec.indices.replicas (%d); this may prevent voluntary pod evictions (e.g., node repaving) due to PodDisruptionBudget constraints. If this is expected for your environment, no action is needed. Otherwise, consider setting spec.nodes.count to at least %d", nodeCount, replicas, replicas+2)
+		return fmt.Sprintf("LogStorage spec.nodes.count (%d) is only 1 more than spec.indices.replicas (%d); this may prevent voluntary pod evictions (e.g., node repaving) due to PodDisruptionBudget constraints. If this is expected for your environment, no action is needed. Otherwise, consider setting spec.nodes.count to at least %d", nodeCount, replicas, replicas+2), nil
 	}
 
-	return nil, ""
+	return "", nil
 }
 
 func validateComponentResources(spec *operatorv1.LogStorageSpec) error {
@@ -261,7 +261,7 @@ func (r *LogStorageInitializer) Reconcile(ctx context.Context, request reconcile
 
 	// Default and validate the object.
 	FillDefaults(ls)
-	err, warning := validateLogStorage(&ls.Spec)
+	warning, err := validateLogStorage(&ls.Spec)
 	if err != nil {
 		// Invalid - mark it as such and return.
 		r.setConditionDegraded(ctx, ls, reqLogger)

--- a/pkg/controller/logstorage/initializer/initializing_controller_test.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller_test.go
@@ -399,7 +399,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 1},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).NotTo(BeNil())
 			Expect(warning).To(BeEmpty())
 		})
@@ -410,7 +410,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 2},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).NotTo(BeNil())
 			Expect(warning).To(BeEmpty())
 		})
@@ -421,7 +421,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 2},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).To(BeNil())
 			Expect(warning).To(ContainSubstring("only 1 more than"))
 		})
@@ -432,7 +432,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 3},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).To(BeNil())
 			Expect(warning).To(ContainSubstring("only 1 more than"))
 		})
@@ -443,7 +443,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 3},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).To(BeNil())
 			Expect(warning).To(BeEmpty())
 		})
@@ -454,7 +454,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 1},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).To(BeNil())
 			Expect(warning).To(BeEmpty())
 		})
@@ -463,7 +463,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 			spec := &operatorv1.LogStorageSpec{
 				Nodes: &operatorv1.Nodes{Count: 1},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).To(BeNil())
 			Expect(warning).To(BeEmpty())
 		})
@@ -473,7 +473,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 			spec := &operatorv1.LogStorageSpec{
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			err, warning := validateReplicasForNodeCount(spec)
+			warning, err := validateReplicasForNodeCount(spec)
 			Expect(err).To(BeNil())
 			Expect(warning).To(BeEmpty())
 		})


### PR DESCRIPTION
## Description

On single-node ES clusters with replicas: 1, replica shards can never be allocated. This causes the ILM warm phase migrate action to wait indefinitely for shard copies to become active, blocking progression to the delete phase and causing indices to accumulate beyond retention.

This PR adds two levels of validation in the LogStorage initializer:

1. **Error** (`nodeCount <= replicas`): Rejects configurations where replica shards cannot be allocated at all, with a clear error message guiding users to set replicas to 0 for single-node deployments.
2. **Warning** (`nodeCount == replicas + 1`): Logs a warning when the node count only exceeds replicas by 1, since the Elasticsearch PodDisruptionBudget will prevent voluntary pod evictions (e.g., node repaving). This is not treated as an error because it is a valid and common configuration (e.g., Calico Cloud 2-node clusters with 1 replica).

For CE master
Jira ticket: CI-1940

## Release Note

```release-note
Add validation for logstorage node count and replicas setting.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.