### PR TITLE
Fix sync-versions GHA for older release branches

### DIFF
--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           git config --global credential.helper store
           echo "https://marvin-tigera:${GITHUB_TOKEN}@github.com" > ~/.git-credentials
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
         env:
           GITHUB_TOKEN: ${{ secrets.MARVIN_PAT }}
 


### PR DESCRIPTION
Follow-up to #4544 — the `GIT_CLONE_URL_BASE` variable only exists on master, so passing it on the make command line has no effect on older release branches where the SSH URL is hardcoded in the `fetch_crds` function. This was causing `release-v1.38` (and likely other older branches) to fail with SSH auth errors.

Adds a git `insteadOf` config to rewrite `git@github.com:` URLs to `https://github.com/` at the git level, which works regardless of which branch's Makefile is checked out.