### PR TITLE
revert: remove logstorage validation warning message

### DIFF
--- a/pkg/controller/logstorage/initializer/initializing_controller.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller.go
@@ -168,33 +168,26 @@ func FillDefaults(opr *operatorv1.LogStorage) {
 	}
 }
 
-func validateLogStorage(spec *operatorv1.LogStorageSpec) (string, error) {
-	warning, err := validateReplicasForNodeCount(spec)
-	if err != nil {
-		return "", err
+func validateLogStorage(spec *operatorv1.LogStorageSpec) error {
+	if err := validateReplicasForNodeCount(spec); err != nil {
+		return err
 	}
-	if err := validateComponentResources(spec); err != nil {
-		return "", err
-	}
-	return warning, nil
+
+	return validateComponentResources(spec)
 }
 
-func validateReplicasForNodeCount(spec *operatorv1.LogStorageSpec) (string, error) {
+func validateReplicasForNodeCount(spec *operatorv1.LogStorageSpec) error {
 	if spec.Nodes == nil || spec.Indices == nil || spec.Indices.Replicas == nil {
-		return "", nil
+		return nil
 	}
 
 	replicas := int(*spec.Indices.Replicas)
 	nodeCount := int(spec.Nodes.Count)
 	if replicas > 0 && nodeCount <= replicas {
-		return "", fmt.Errorf("LogStorage spec.indices.replicas (%d) must be less than spec.nodes.count (%d); replica shards cannot be allocated when there are not enough nodes. For a single-node Elasticsearch cluster, set spec.indices.replicas to 0", replicas, nodeCount)
+		return fmt.Errorf("LogStorage spec.indices.replicas (%d) must be less than spec.nodes.count (%d); replica shards cannot be allocated when there are not enough nodes. For a single-node Elasticsearch cluster, set spec.indices.replicas to 0", replicas, nodeCount)
 	}
 
-	if replicas > 0 && nodeCount == replicas+1 {
-		return fmt.Sprintf("LogStorage spec.nodes.count (%d) is only 1 more than spec.indices.replicas (%d); this may prevent voluntary pod evictions (e.g., node repaving) due to PodDisruptionBudget constraints. If this is expected for your environment, no action is needed. Otherwise, consider setting spec.nodes.count to at least %d", nodeCount, replicas, replicas+2), nil
-	}
-
-	return "", nil
+	return nil
 }
 
 func validateComponentResources(spec *operatorv1.LogStorageSpec) error {
@@ -261,15 +254,11 @@ func (r *LogStorageInitializer) Reconcile(ctx context.Context, request reconcile
 
 	// Default and validate the object.
 	FillDefaults(ls)
-	warning, err := validateLogStorage(&ls.Spec)
-	if err != nil {
+	if err := validateLogStorage(&ls.Spec); err != nil {
 		// Invalid - mark it as such and return.
 		r.setConditionDegraded(ctx, ls, reqLogger)
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "An error occurred while validating LogStorage", err, reqLogger)
 		return reconcile.Result{}, err
-	}
-	if warning != "" {
-		reqLogger.Info(warning)
 	}
 
 	pullSecrets, err := utils.GetNetworkingPullSecrets(install, r.client)

--- a/pkg/controller/logstorage/initializer/initializing_controller_test.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller_test.go
@@ -204,26 +204,6 @@ var _ = Describe("LogStorage Initializing controller", func() {
 			Expect(ls.Status.State).Should(Equal(operatorv1.TigeraStatusDegraded))
 		})
 
-		It("logs a warning but does not degrade when node count only exceeds replicas by 1", func() {
-			var replicas int32 = 1
-			ls := &operatorv1.LogStorage{}
-			ls.Name = "tigera-secure"
-			FillDefaults(ls)
-			ls.Spec.Indices.Replicas = &replicas
-			ls.Spec.Nodes.Count = 2
-			Expect(cli.Create(ctx, ls)).ShouldNot(HaveOccurred())
-
-			r, err := NewTestInitializer(cli, scheme, mockStatus, operatorv1.ProviderNone, dns.DefaultClusterDomain)
-			Expect(err).ShouldNot(HaveOccurred())
-			_, err = r.Reconcile(ctx, reconcile.Request{})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(mockStatus.AssertNumberOfCalls(GinkgoT(), "SetDegraded", 0)).Should(BeTrue())
-
-			ls = &operatorv1.LogStorage{}
-			Expect(cli.Get(ctx, client.ObjectKey{Name: "tigera-secure"}, ls)).ShouldNot(HaveOccurred())
-			Expect(ls.Status.State).Should(Equal(operatorv1.TigeraStatusReady))
-		})
-
 		It("handles LogStorage deletion", func() {
 			// Create a LogStorage instance.
 			ls := &operatorv1.LogStorage{}
@@ -399,9 +379,7 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 1},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).NotTo(BeNil())
-			Expect(warning).To(BeEmpty())
+			Expect(validateReplicasForNodeCount(spec)).NotTo(BeNil())
 		})
 
 		It("should return an error when replicas equals node count", func() {
@@ -410,72 +388,40 @@ var _ = Describe("LogStorage Initializing controller", func() {
 				Nodes:   &operatorv1.Nodes{Count: 2},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).NotTo(BeNil())
-			Expect(warning).To(BeEmpty())
+			Expect(validateReplicasForNodeCount(spec)).NotTo(BeNil())
 		})
 
-		It("should return a warning when node count is only 1 more than replicas", func() {
-			var replicas int32 = 1
-			spec := &operatorv1.LogStorageSpec{
-				Nodes:   &operatorv1.Nodes{Count: 2},
-				Indices: &operatorv1.Indices{Replicas: &replicas},
-			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).To(BeNil())
-			Expect(warning).To(ContainSubstring("only 1 more than"))
-		})
-
-		It("should return a warning when node count is 3 and replicas is 2", func() {
-			var replicas int32 = 2
-			spec := &operatorv1.LogStorageSpec{
-				Nodes:   &operatorv1.Nodes{Count: 3},
-				Indices: &operatorv1.Indices{Replicas: &replicas},
-			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).To(BeNil())
-			Expect(warning).To(ContainSubstring("only 1 more than"))
-		})
-
-		It("should return no error or warning when node count exceeds replicas by 2 or more", func() {
+		It("should return no error when node count exceeds replicas", func() {
 			var replicas int32 = 1
 			spec := &operatorv1.LogStorageSpec{
 				Nodes:   &operatorv1.Nodes{Count: 3},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).To(BeNil())
-			Expect(warning).To(BeEmpty())
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
 		})
 
-		It("should return no error or warning when replicas is 0 and node count is 1", func() {
+		It("should return no error when replicas is 0 and node count is 1", func() {
 			var replicas int32 = 0
 			spec := &operatorv1.LogStorageSpec{
 				Nodes:   &operatorv1.Nodes{Count: 1},
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).To(BeNil())
-			Expect(warning).To(BeEmpty())
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
 		})
 
-		It("should return no error or warning when indices is nil", func() {
+		It("should return no error when indices is nil", func() {
 			spec := &operatorv1.LogStorageSpec{
 				Nodes: &operatorv1.Nodes{Count: 1},
 			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).To(BeNil())
-			Expect(warning).To(BeEmpty())
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
 		})
 
-		It("should return no error or warning when nodes is nil", func() {
+		It("should return no error when nodes is nil", func() {
 			var replicas int32 = 1
 			spec := &operatorv1.LogStorageSpec{
 				Indices: &operatorv1.Indices{Replicas: &replicas},
 			}
-			warning, err := validateReplicasForNodeCount(spec)
-			Expect(err).To(BeNil())
-			Expect(warning).To(BeEmpty())
+			Expect(validateReplicasForNodeCount(spec)).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
## Summary
- Remove the warning log when LogStorage `spec.nodes.count` only exceeds `spec.indices.replicas` by 1
- The error validation (`replicas >= nodeCount`) added in #4529 is preserved
- Simplify `validateReplicasForNodeCount` and `validateLogStorage` signatures to return only `error`

## Release Note

```release-note
Remove logstorage validation warning message for node count exceeding replicas by 1.
```

## Test plan
- [x] Unit tests updated and passing (`make ut UT_DIR=./pkg/controller/logstorage/initializer`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)