### PR TITLE
Add DatastoreMigration RBAC to kube-controllers ClusterRole

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -409,6 +409,13 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration) []rbacv1.
 			Resources: []string{"datastoremigrations", "datastoremigrations/status"},
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
+		{
+			// The datastore migration controller needs to list/watch CRDs to determine
+			// which API group is active.
+			APIGroups: []string{"apiextensions.k8s.io"},
+			Resources: []string{"customresourcedefinitions"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
 	}
 
 	if cfg.Installation.KubernetesProvider.IsOpenShift() {

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -403,6 +403,12 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration) []rbacv1.
 			Resources: []string{"virtualmachineinstances", "virtualmachines"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
+		{
+			// The datastore migration controller watches DatastoreMigration CRs and updates their status.
+			APIGroups: []string{"migration.projectcalico.org"},
+			Resources: []string{"datastoremigrations", "datastoremigrations/status"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
+		},
 	}
 
 	if cfg.Installation.KubernetesProvider.IsOpenShift() {

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -266,7 +266,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(25), "cluster role should have 25 rules")
+		Expect(clusterRole.Rules).To(HaveLen(26), "cluster role should have 26 rules")
 
 		ms := rtest.GetResource(resources, kubecontrollers.KubeControllerMetrics, common.CalicoNamespace, "", "v1", "Service").(*corev1.Service)
 		Expect(ms.Spec.ClusterIP).To(Equal("None"), "metrics service should be headless")
@@ -353,7 +353,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(23), "cluster role should have 23 rules")
+		Expect(clusterRole.Rules).To(HaveLen(24), "cluster role should have 24 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},
@@ -564,7 +564,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(23), "cluster role should have 23 rules")
+		Expect(clusterRole.Rules).To(HaveLen(24), "cluster role should have 24 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -266,7 +266,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(26), "cluster role should have 26 rules")
+		Expect(clusterRole.Rules).To(HaveLen(27), "cluster role should have 27 rules")
 
 		ms := rtest.GetResource(resources, kubecontrollers.KubeControllerMetrics, common.CalicoNamespace, "", "v1", "Service").(*corev1.Service)
 		Expect(ms.Spec.ClusterIP).To(Equal("None"), "metrics service should be headless")
@@ -353,7 +353,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(24), "cluster role should have 24 rules")
+		Expect(clusterRole.Rules).To(HaveLen(25), "cluster role should have 25 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},
@@ -564,7 +564,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(24), "cluster role should have 24 rules")
+		Expect(clusterRole.Rules).To(HaveLen(25), "cluster role should have 25 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},


### PR DESCRIPTION
Grant kube-controllers access to `datastoremigrations` and `datastoremigrations/status` in the `migration.projectcalico.org` API group so it can drive the datastore migration workflow.

This is the first in a series of PRs adding operator support for datastore migration. Subsequent PRs will add CALICO_API_GROUP env var injection and DatastoreMigration CR awareness.