### PR TITLE
Reduce calico-node readiness probe period to 10s

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1750,9 +1750,11 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Pr
 	}
 	rp := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: readinessCmd}},
-		// Set the TimeoutSeconds greater than the default of 1 to allow additional time on loaded nodes.
-		// This timeout should be less than the PeriodSeconds (30s in controller/utils/component.go).
-		TimeoutSeconds: 10,
+		// Use a shorter period than the global default (30s) so that calico-node is
+		// marked ready promptly after startup. The global default is too slow for
+		// calico-node, which typically becomes ready within ~10s of container start.
+		PeriodSeconds:  10,
+		TimeoutSeconds: 5,
 	}
 	return lp, rp
 }

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -3224,7 +3224,8 @@ func verifyProbesAndLifecycle(ds *appsv1.DaemonSet, isOpenshift, isEnterprise bo
 	// Verify readiness and liveness probes.
 	expectedReadiness := &corev1.Probe{
 		ProbeHandler:   corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}}},
-		TimeoutSeconds: 10,
+		PeriodSeconds:  10,
+		TimeoutSeconds: 5,
 	}
 	expectedLiveness := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
The operator sets a global default `periodSeconds: 30` for readiness probes across all components. For calico-node, this means it takes ~35-40s to report ready even though BGP peers typically establish within ~10s of container start. The first probe fires at t=0 (always fails since nothing is running yet), and the next one doesn't come until t=30, by which point everything has been ready for ~20s.

This sets `periodSeconds: 10` explicitly on the calico-node readiness probe, overriding the global default. Also reduces `timeoutSeconds` from 10 to 5 since it should be less than the probe period, and the readiness check itself (BIRD socket query + Felix HTTP GET) is fast.

```release-note
Reduce calico-node readiness probe period from 30s to 10s, cutting the time for nodes to report ready from ~35-40s to ~15-20s.
```