### PR TITLE
fix(istio): BPF-compatible egress rules for ztunnel and istiod policies

### DIFF
--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -319,6 +319,20 @@ func (c *IstioComponent) istiodCalicoSystemPolicy() *v3.NetworkPolicy {
 		},
 	}
 
+	// In BPF mode, CTLB is disabled for Istio ambient compatibility. Without CTLB and
+	// kube-proxy, return traffic (SYN-ACKs) from istiod to ztunnel on remote nodes may not
+	// be matched by conntrack. Allow explicit egress to ztunnel pods to ensure cross-node
+	// ztunnel<->istiod communication works.
+	if c.cfg.Installation.BPFEnabled() {
+		egressRules = append(egressRules, v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
+				Selector: networkpolicy.KubernetesAppSelector(IstioZTunnelDaemonSetName),
+			},
+		})
+	}
+
 	// * Port 15012, gRPC, XDS and CA services (TLS and mTLS)
 	//   ztunnel and waypoints connect to it to request certs and dataplane
 	//   info.
@@ -385,6 +399,20 @@ func (c *IstioComponent) ztunnelCalicoSystemPolicy() *v3.NetworkPolicy {
 			Destination: networkpolicy.CreateServiceSelectorEntityRule(c.cfg.IstioNamespace, IstioIstiodServiceName),
 		},
 	}
+
+	// In BPF mode, CTLB is disabled for Istio ambient compatibility. Service-based egress
+	// selectors don't resolve correctly for cross-node traffic without CTLB and kube-proxy.
+	// Add a direct pod-selector rule so ztunnel can reach istiod by pod IP on any node.
+	if c.cfg.Installation.BPFEnabled() {
+		egressRules = append(egressRules, v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
+				Selector: networkpolicy.KubernetesAppSelector(IstioIstiodDeploymentName),
+			},
+		})
+	}
+
 	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, c.cfg.Installation.KubernetesProvider.IsOpenShift())
 
 	return &v3.NetworkPolicy{

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -279,6 +279,58 @@ var _ = Describe("Istio Component Rendering", func() {
 			Expect(foundIstiodRule).To(BeTrue(), "Expected egress rule for istiod service")
 		})
 
+		It("should add pod-selector egress rules when BPF dataplane is enabled", func() {
+			bpfDataplane := operatorv1.LinuxDataplaneBPF
+			cfg.Installation.CalicoNetwork = &operatorv1.CalicoNetworkSpec{
+				LinuxDataplane: &bpfDataplane,
+			}
+			_, component, err := istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(component.ResolveImages(getCalicoTestImageSet())).ShouldNot(HaveOccurred())
+			objsToCreate, _ := component.Objects()
+
+			// Verify istiod policy has egress rule to ztunnel pods
+			istiodPolicy, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, istio.IstioIstiodPolicyName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(istiodPolicy.Spec.Egress).To(HaveLen(2))
+			Expect(istiodPolicy.Spec.Egress[1].Destination.Selector).To(Equal(
+				networkpolicy.KubernetesAppSelector(istio.IstioZTunnelDaemonSetName),
+			))
+
+			// Verify ztunnel policy has pod-selector egress rule to istiod
+			ztunnelPolicy, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, istio.IstioZTunnelPolicyName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			foundPodSelectorRule := false
+			for _, rule := range ztunnelPolicy.Spec.Egress {
+				if rule.Destination.Selector == networkpolicy.KubernetesAppSelector(istio.IstioIstiodDeploymentName) {
+					foundPodSelectorRule = true
+					break
+				}
+			}
+			Expect(foundPodSelectorRule).To(BeTrue(), "Expected pod-selector egress rule for istiod when BPF enabled")
+		})
+
+		It("should not add pod-selector egress rules when BPF dataplane is not enabled", func() {
+			_, component, err := istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(component.ResolveImages(getCalicoTestImageSet())).ShouldNot(HaveOccurred())
+			objsToCreate, _ := component.Objects()
+
+			// Verify istiod policy has only 1 egress rule (kube API server)
+			istiodPolicy, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, istio.IstioIstiodPolicyName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(istiodPolicy.Spec.Egress).To(HaveLen(1))
+
+			// Verify ztunnel policy has no pod-selector rule for istiod
+			ztunnelPolicy, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, istio.IstioZTunnelPolicyName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			for _, rule := range ztunnelPolicy.Spec.Egress {
+				Expect(rule.Destination.Selector).NotTo(Equal(
+					networkpolicy.KubernetesAppSelector(istio.IstioIstiodDeploymentName),
+				), "Should not have pod-selector egress rule for istiod when BPF is not enabled")
+			}
+		})
+
 		It("should set TRANSPARENT_NETWORK_POLICIES env var on ztunnel", func() {
 			_, component, err := istio.Istio(cfg)
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
## Description

Bug fix: When BPF dataplane is enabled with Istio ambient mode, CTLB must be disabled. Without CTLB and kube-proxy, the operator-managed calico-system tier policies for ztunnel and istiod block cross-node communication:

- **ztunnel policy**: The service-based egress selector for istiod doesn't resolve correctly for cross-node traffic without CTLB
- **istiod policy**: No egress rule allows return traffic (SYN-ACKs) to ztunnel pods on remote nodes

This causes 4/5 ztunnel pods to fail with `XDS client connection error connecting to istiod.calico-system.svc:15012` — only the one co-located with istiod works.

**Fix:** Add pod-selector-based egress rules (conditioned on `BPFEnabled()`) to both policies:
- ztunnel: allow egress to `k8s-app == 'istiod'` pods directly
- istiod: allow egress to `k8s-app == 'ztunnel'` pods

**Testing:**
- Added render unit tests verifying rules appear when BPF is enabled and are absent otherwise
- Manually verified on a CaliEnt BPF+ambient cluster (5 nodes, gcp-kubeadm) — all 5 ztunnel pods reach Ready with this fix

**Components affected:** Istio component renderer (`pkg/render/istio/istio.go`)

**Related issues:** [CORE-12597](https://tigera.atlassian.net/browse/CORE-12597)

**Related PRs:**
- [tigera/calico-private#11384](https://github.com/tigera/calico-private/pull/11384) — BPF ambient policy fix (includes temporary felix-side workaround to be removed once this PR merges)
- [projectcalico/calico#12353](https://github.com/projectcalico/calico/pull/12353) — OSS equivalent

## Release Note

```release-note
Fix Istio ambient mode on BPF dataplane: add pod-selector-based egress rules to the ztunnel and istiod calico-system tier policies so that cross-node ztunnel-to-istiod communication works when connect-time load balancing (CTLB) is disabled.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

[CORE-12597]: https://tigera.atlassian.net/browse/CORE-12597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ