### PR TITLE
Add TigeraStatus warnings for ignored resources and override correlation

### DIFF
--- a/pkg/controller/applicationlayer/applicationlayer_controller_test.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller_test.go
@@ -83,6 +83,8 @@ var _ = Describe("Application layer controller tests", func() {
 			}
 			mockStatus = &status.MockStatus{}
 			mockStatus.On("OnCRFound").Return()
+			mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return()
+			mockStatus.On("ClearWarning", mock.Anything).Return()
 
 			r = ReconcileApplicationLayer{
 				client:          c,

--- a/pkg/controller/clusterconnection/clusterconnection_controller_test.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller_test.go
@@ -83,6 +83,8 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 		c = ctrlrfake.DefaultFakeClientBuilder(clientScheme).WithObjectTracker(&objTrackerWithCalls).Build()
 		ctx = context.Background()
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("Run").Return()
 		mockStatus.On("AddDaemonsets", mock.Anything)
 		mockStatus.On("AddDeployments", mock.Anything)
@@ -326,6 +328,8 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 
 			It("should degrade and wait when tier is ready, but tier watch is not ready", func() {
 				mockStatus = &status.MockStatus{}
+				mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+				mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 				mockStatus.On("Run").Return()
 				mockStatus.On("OnCRFound").Return()
 				mockStatus.On("SetMetaData", mock.Anything).Return()
@@ -377,6 +381,8 @@ var _ = Describe("ManagementClusterConnection controller tests", func() {
 
 			It("should degrade and wait when tier and license are ready, but tier watch is not ready", func() {
 				mockStatus = &status.MockStatus{}
+				mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+				mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 				mockStatus.On("Run").Return()
 				mockStatus.On("OnCRFound").Return()
 				mockStatus.On("SetMetaData", mock.Anything).Return()

--- a/pkg/controller/egressgateway/egressgateway_controller_test.go
+++ b/pkg/controller/egressgateway/egressgateway_controller_test.go
@@ -87,6 +87,8 @@ var _ = Describe("Egress Gateway controller tests", func() {
 				},
 			}
 			mockStatus = &status.MockStatus{}
+			mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+			mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 			mockStatus.On("OnCRFound").Return()
 
 			r = ReconcileEgressGateway{

--- a/pkg/controller/gatewayapi/gatewayapi_controller_test.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller_test.go
@@ -97,6 +97,8 @@ var _ = Describe("Gateway API controller tests", func() {
 			},
 		}
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("AddDaemonsets", mock.Anything).Return()
 		mockStatus.On("AddDeployments", mock.Anything).Return()

--- a/pkg/controller/goldmane/controller_test.go
+++ b/pkg/controller/goldmane/controller_test.go
@@ -105,6 +105,8 @@ var _ = Describe("Goldmane controller tests", func() {
 		Expect(cli.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("OnCRNotFound").Return().Maybe()
 		mockStatus.On("SetMetaData", mock.Anything).Return()

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -75,6 +75,8 @@ var _ = Describe("Istio controller tests", func() {
 
 		// Set up a mock status
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("AddDaemonsets", mock.Anything).Maybe().Return()
 		mockStatus.On("AddDeployments", mock.Anything).Maybe().Return()
 		mockStatus.On("AddStatefulSets", mock.Anything).Maybe().Return()

--- a/pkg/controller/logstorage/dashboards/dashboards_controller_test.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller_test.go
@@ -151,6 +151,8 @@ var _ = Describe("LogStorage Dashboards controller", func() {
 	Context("Zero tenant", func() {
 		BeforeEach(func() {
 			mockStatus = &status.MockStatus{}
+			mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+			mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 			mockStatus.On("Run").Return()
 			mockStatus.On("AddDaemonsets", mock.Anything)
 			mockStatus.On("AddDeployments", mock.Anything)

--- a/pkg/controller/logstorage/elastic/elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/elastic_controller_test.go
@@ -198,6 +198,8 @@ var _ = Describe("LogStorage controller", func() {
 					})).NotTo(HaveOccurred())
 
 				mockStatus = &status.MockStatus{}
+				mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+				mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 				mockStatus.On("Run").Return()
 			})
 
@@ -317,6 +319,8 @@ var _ = Describe("LogStorage controller", func() {
 					})).NotTo(HaveOccurred())
 
 				mockStatus = &status.MockStatus{}
+				mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+				mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 				mockStatus.On("Run").Return()
 				mockStatus.On("AddStatefulSets", mock.Anything)
 				mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()
@@ -1148,6 +1152,8 @@ var _ = Describe("LogStorage controller", func() {
 					})).ShouldNot(HaveOccurred())
 
 					mockStatus = &status.MockStatus{}
+					mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+					mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 					mockStatus.On("Run").Return()
 					mockStatus.On("OnCRFound").Return()
 					// mockStatus.On("SetMetaData", mock.Anything).Return()
@@ -1206,6 +1212,8 @@ var _ = Describe("LogStorage controller", func() {
 				setUpLogStorageComponents(cli, ctx, "", certificateManager)
 
 				mockStatus = &status.MockStatus{}
+				mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+				mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 				mockStatus.On("Run").Return()
 				mockStatus.On("AddStatefulSets", mock.Anything)
 				mockStatus.On("RemoveCertificateSigningRequests", mock.Anything)

--- a/pkg/controller/logstorage/elastic/external_elastic_controller_test.go
+++ b/pkg/controller/logstorage/elastic/external_elastic_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/stretchr/testify/mock"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
@@ -182,6 +183,8 @@ var _ = Describe("External ES Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()},
 			})).NotTo(HaveOccurred())
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("Run").Return()
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ReadyToMonitor")

--- a/pkg/controller/logstorage/esmetrics/esmetrics_controller_test.go
+++ b/pkg/controller/logstorage/esmetrics/esmetrics_controller_test.go
@@ -97,6 +97,8 @@ var _ = Describe("LogStorage Linseed controller", func() {
 		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("Run").Return()
 		mockStatus.On("AddDeployments", mock.Anything)
 		mockStatus.On("ReadyToMonitor")

--- a/pkg/controller/logstorage/initializer/initializing_controller_test.go
+++ b/pkg/controller/logstorage/initializer/initializing_controller_test.go
@@ -121,6 +121,8 @@ var _ = Describe("LogStorage Initializing controller", func() {
 			Expect(cli.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}})).NotTo(HaveOccurred())
 
 			mockStatus = &status.MockStatus{}
+			mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+			mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 			mockStatus.On("Run")
 			mockStatus.On("OnCRFound")
 			mockStatus.On("SetMetaData", mock.Anything)

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
@@ -154,6 +154,8 @@ var _ = Describe("LogStorage ES kube-controllers controller", func() {
 		Expect(cli.Create(ctx, pullSecret)).NotTo(HaveOccurred())
 
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("Run").Return()
 		mockStatus.On("AddDaemonsets", mock.Anything)
 		mockStatus.On("AddDeployments", mock.Anything)

--- a/pkg/controller/logstorage/linseed/linseed_controller_test.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller_test.go
@@ -158,6 +158,8 @@ var _ = Describe("LogStorage Linseed controller", func() {
 	Context("Single tenant", func() {
 		BeforeEach(func() {
 			mockStatus = &status.MockStatus{}
+			mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+			mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 			mockStatus.On("Run").Return()
 			mockStatus.On("AddDaemonsets", mock.Anything)
 			mockStatus.On("AddDeployments", mock.Anything)
@@ -316,6 +318,8 @@ var _ = Describe("LogStorage Linseed controller", func() {
 			Expect(cli.Create(ctx, tenant)).ShouldNot(HaveOccurred())
 
 			mockStatus = &status.MockStatus{}
+			mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+			mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 			mockStatus.On("Run").Return()
 			mockStatus.On("AddDaemonsets", mock.Anything)
 			mockStatus.On("AddDeployments", mock.Anything)

--- a/pkg/controller/logstorage/secrets/secret_controller_test.go
+++ b/pkg/controller/logstorage/secrets/secret_controller_test.go
@@ -171,6 +171,8 @@ var _ = Describe("LogStorage Secrets controller", func() {
 		Expect(cli.Create(ctx, install)).ShouldNot(HaveOccurred())
 
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("Run").Return()
 		mockStatus.On("AddDaemonsets", mock.Anything)
 		mockStatus.On("AddDeployments", mock.Anything)

--- a/pkg/controller/nonclusterhost/nonclusterhost_controller_test.go
+++ b/pkg/controller/nonclusterhost/nonclusterhost_controller_test.go
@@ -56,6 +56,8 @@ var _ = Describe("NonClusterHost controller tests", func() {
 		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("ClearDegraded")
 		mockStatus.On("IsAvailable").Return(true)
 		mockStatus.On("OnCRFound").Return()

--- a/pkg/controller/secrets/tenant_controller_test.go
+++ b/pkg/controller/secrets/tenant_controller_test.go
@@ -157,6 +157,8 @@ var _ = Describe("Tenant controller", func() {
 
 		// Create the reconciler for the test.
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("Run").Return()
 		mockStatus.On("OnCRFound").Return()
 		mockStatus.On("ReadyToMonitor")

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -78,7 +78,23 @@ const (
 	defaultProbePeriodSeconds    = 10
 	defaultProbeTimeoutSeconds   = 1
 	defaultProbeFailureThreshold = 3
+
+	customOverridesAnnotation = "operator.tigera.io/custom-overrides"
 )
+
+// hasOverride checks if the workload has a specific override type configured.
+func hasOverride(annotations map[string]string, overrideType string) bool {
+	val, ok := annotations[customOverridesAnnotation]
+	if !ok {
+		return false
+	}
+	for _, t := range strings.Split(val, ",") {
+		if t == overrideType {
+			return true
+		}
+	}
+	return false
+}
 
 type podIssueSeverity int
 
@@ -669,7 +685,7 @@ func (m *statusManager) syncState() {
 		}
 
 		revision := m.currentDaemonSetRevision(ds)
-		podIssues = append(podIssues, m.diagnosePods(fmt.Sprintf("DaemonSet %q", dsnn.String()), ds.Spec.Selector, ds.Namespace, revision)...)
+		podIssues = append(podIssues, m.diagnosePods(fmt.Sprintf("DaemonSet %q", dsnn.String()), ds.Spec.Selector, ds.Namespace, revision, ds.Annotations)...)
 	}
 
 	for _, depnn := range m.deployments {
@@ -706,7 +722,7 @@ func (m *statusManager) syncState() {
 		}
 
 		revision := m.currentDeploymentRevision(dep)
-		podIssues = append(podIssues, m.diagnosePods(fmt.Sprintf("Deployment %q", depnn.String()), dep.Spec.Selector, dep.Namespace, revision)...)
+		podIssues = append(podIssues, m.diagnosePods(fmt.Sprintf("Deployment %q", depnn.String()), dep.Spec.Selector, dep.Namespace, revision, dep.Annotations)...)
 	}
 
 	for _, depnn := range m.statefulsets {
@@ -740,7 +756,7 @@ func (m *statusManager) syncState() {
 			continue
 		}
 
-		podIssues = append(podIssues, m.diagnosePods(fmt.Sprintf("StatefulSet %q", depnn.String()), ss.Spec.Selector, ss.Namespace, ss.Status.UpdateRevision)...)
+		podIssues = append(podIssues, m.diagnosePods(fmt.Sprintf("StatefulSet %q", depnn.String()), ss.Spec.Selector, ss.Namespace, ss.Status.UpdateRevision, ss.Annotations)...)
 	}
 
 	for _, depnn := range m.cronjobs {
@@ -822,8 +838,10 @@ func (m *statusManager) removeTigeraStatus() {
 // diagnosePods lists pods matching the selector and returns a podIssue for each
 // unhealthy pod found. Each issue is stamped with the given workload identifier
 // for downstream grouping. If currentRevision is non-empty, pods not matching
-// that revision are marked as old-revision.
-func (m *statusManager) diagnosePods(workload string, selector *metav1.LabelSelector, namespace string, currentRevision string) []podIssue {
+// that revision are marked as old-revision. workloadAnnotations carries the
+// owning workload's annotations so override hints can be correlated with pod
+// failures.
+func (m *statusManager) diagnosePods(workload string, selector *metav1.LabelSelector, namespace string, currentRevision string, workloadAnnotations map[string]string) []podIssue {
 	l := corev1.PodList{}
 	s, err := metav1.LabelSelectorAsMap(selector)
 	if err != nil {
@@ -851,14 +869,14 @@ func (m *statusManager) diagnosePods(workload string, selector *metav1.LabelSele
 		}
 
 		// Check init and regular container statuses for errors.
-		if iss := diagnoseContainers(p, p.Status.InitContainerStatuses, isOldRevision); len(iss) > 0 {
+		if iss := diagnoseContainers(p, p.Status.InitContainerStatuses, isOldRevision, workloadAnnotations); len(iss) > 0 {
 			for i := range iss {
 				iss[i].workload = workload
 			}
 			issues = append(issues, iss...)
 			continue
 		}
-		if iss := diagnoseContainers(p, p.Status.ContainerStatuses, isOldRevision); len(iss) > 0 {
+		if iss := diagnoseContainers(p, p.Status.ContainerStatuses, isOldRevision, workloadAnnotations); len(iss) > 0 {
 			for i := range iss {
 				iss[i].workload = workload
 			}
@@ -904,11 +922,15 @@ func (m *statusManager) diagnosePods(workload string, selector *metav1.LabelSele
 					continue
 				}
 				if time.Since(cond.LastTransitionTime.Time) > grace {
+					msg := fmt.Sprintf("Pod %s/%s is running but not ready", p.Namespace, p.Name)
+					if hasOverride(workloadAnnotations, "readinessProbe") {
+						msg += "; custom readiness probe configuration is in effect"
+					}
 					issues = append(issues, podIssue{
 						workload:      workload,
 						severity:      severityFailing,
 						issueType:     issueNotReady,
-						message:       fmt.Sprintf("Pod %s/%s is running but not ready", p.Namespace, p.Name),
+						message:       msg,
 						isOldRevision: isOldRevision,
 					})
 					break
@@ -962,7 +984,7 @@ func readinessGracePeriod(p corev1.Pod) time.Duration {
 
 // diagnoseContainers checks a list of container statuses for known error states and
 // returns a podIssue for each one found.
-func diagnoseContainers(p corev1.Pod, statuses []corev1.ContainerStatus, isOldRevision bool) []podIssue {
+func diagnoseContainers(p corev1.Pod, statuses []corev1.ContainerStatus, isOldRevision bool, workloadAnnotations map[string]string) []podIssue {
 	var issues []podIssue
 	for _, c := range statuses {
 		if c.State.Waiting != nil {
@@ -976,8 +998,14 @@ func diagnoseContainers(p corev1.Pod, statuses []corev1.ContainerStatus, isOldRe
 					exitCode = lt.ExitCode
 					if lt.Reason == terminationReasonError && lt.ExitCode == exitCodeSIGKILL {
 						msg += " (exit code 137, possible liveness probe failure)"
+						if hasOverride(workloadAnnotations, "livenessProbe") {
+							msg += "; custom liveness probe configuration is in effect"
+						}
 					} else {
 						msg += fmt.Sprintf(" (%s, exit code %d)", lt.Reason, lt.ExitCode)
+						if lt.Reason == "OOMKilled" && hasOverride(workloadAnnotations, "resources") {
+							msg += "; custom resource limits are in effect"
+						}
 					}
 				}
 				issues = append(issues, podIssue{

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -577,20 +577,20 @@ var _ = Describe("Status reporting tests", func() {
 
 				It("should not flag a pod unready for less than the grace period", func() {
 					Expect(client.Create(ctx, notReadyPod("recently-unready", time.Now().Add(-10*time.Second)))).NotTo(HaveOccurred())
-					issues := sm.diagnosePods("Test", selector, "NS1", "")
+					issues := sm.diagnosePods("Test", selector, "NS1", "", nil)
 					Expect(issues).To(BeEmpty())
 				})
 
 				It("should flag a pod unready for longer than the grace period", func() {
 					Expect(client.Create(ctx, notReadyPod("long-unready", time.Now().Add(-90*time.Second)))).NotTo(HaveOccurred())
-					issues := sm.diagnosePods("Test", selector, "NS1", "")
+					issues := sm.diagnosePods("Test", selector, "NS1", "", nil)
 					Expect(issues).To(HaveLen(1))
 					Expect(issues[0].issueType).To(Equal(issueNotReady))
 				})
 
 				It("should not flag a pod with an unset LastTransitionTime", func() {
 					Expect(client.Create(ctx, notReadyPod("no-transition-time", time.Time{}))).NotTo(HaveOccurred())
-					issues := sm.diagnosePods("Test", selector, "NS1", "")
+					issues := sm.diagnosePods("Test", selector, "NS1", "", nil)
 					Expect(issues).To(BeEmpty())
 				})
 
@@ -605,13 +605,13 @@ var _ = Describe("Status reporting tests", func() {
 					}
 					pod := withReadinessProbe(notReadyPod("slow-start", time.Now().Add(-90*time.Second)), probe)
 					Expect(client.Create(ctx, pod)).NotTo(HaveOccurred())
-					issues := sm.diagnosePods("Test", selector, "NS1", "")
+					issues := sm.diagnosePods("Test", selector, "NS1", "", nil)
 					Expect(issues).To(BeEmpty())
 
 					// Once it has been unready past the derived window, it is flagged.
 					pod2 := withReadinessProbe(notReadyPod("slow-start-stuck", time.Now().Add(-400*time.Second)), probe)
 					Expect(client.Create(ctx, pod2)).NotTo(HaveOccurred())
-					issues = sm.diagnosePods("Test", selector, "NS1", "")
+					issues = sm.diagnosePods("Test", selector, "NS1", "", nil)
 					Expect(issues).To(HaveLen(1))
 					Expect(issues[0].issueType).To(Equal(issueNotReady))
 				})
@@ -622,7 +622,7 @@ var _ = Describe("Status reporting tests", func() {
 					probe := &corev1.Probe{PeriodSeconds: 10, TimeoutSeconds: 1, FailureThreshold: 3}
 					pod := withReadinessProbe(notReadyPod("tight-probe", time.Now().Add(-45*time.Second)), probe)
 					Expect(client.Create(ctx, pod)).NotTo(HaveOccurred())
-					issues := sm.diagnosePods("Test", selector, "NS1", "")
+					issues := sm.diagnosePods("Test", selector, "NS1", "", nil)
 					Expect(issues).To(BeEmpty())
 				})
 			})
@@ -1244,7 +1244,7 @@ var _ = Describe("Status reporting tests", func() {
 					},
 				},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].issueType).To(Equal(issueCrashLoopBackOff))
 			Expect(issues[0].severity).To(Equal(severityFailing))
@@ -1270,7 +1270,7 @@ var _ = Describe("Status reporting tests", func() {
 					},
 				},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].message).To(ContainSubstring("possible liveness probe failure"))
 		})
@@ -1289,7 +1289,7 @@ var _ = Describe("Status reporting tests", func() {
 					},
 				},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].issueType).To(Equal(issueImagePull))
 			Expect(issues[0].severity).To(Equal(severityFailing))
@@ -1309,7 +1309,7 @@ var _ = Describe("Status reporting tests", func() {
 					},
 				},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].issueType).To(Equal(issueTerminated))
 		})
@@ -1320,7 +1320,7 @@ var _ = Describe("Status reporting tests", func() {
 				Spec:       corev1.PodSpec{},
 				Status:     corev1.PodStatus{Phase: corev1.PodFailed},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].issueType).To(Equal(issuePodFailed))
 			Expect(issues[0].severity).To(Equal(severityFailing))
@@ -1337,7 +1337,7 @@ var _ = Describe("Status reporting tests", func() {
 					},
 				},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].issueType).To(Equal(issueNotReady))
 			Expect(issues[0].severity).To(Equal(severityFailing))
@@ -1358,7 +1358,7 @@ var _ = Describe("Status reporting tests", func() {
 					},
 				},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].issueType).To(Equal(issuePending))
 			Expect(issues[0].severity).To(Equal(severityProgressing))
@@ -1371,7 +1371,7 @@ var _ = Describe("Status reporting tests", func() {
 				Spec:       corev1.PodSpec{},
 				Status:     corev1.PodStatus{Phase: corev1.PodPending},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(1))
 			Expect(issues[0].issueType).To(Equal(issuePending))
 			Expect(issues[0].severity).To(Equal(severityProgressing))
@@ -1402,7 +1402,7 @@ var _ = Describe("Status reporting tests", func() {
 				Status:     corev1.PodStatus{Phase: corev1.PodPending},
 			})).NotTo(HaveOccurred())
 
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(HaveLen(2))
 		})
 
@@ -1417,8 +1417,87 @@ var _ = Describe("Status reporting tests", func() {
 					},
 				},
 			})).NotTo(HaveOccurred())
-			issues := sm.diagnosePods("Test", selector, "ns", "")
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
 			Expect(issues).To(BeEmpty())
+		})
+
+		It("should add readiness probe hint when pod is not ready and readinessProbe override is configured", func() {
+			Expect(cl.Create(ctx, &corev1.Pod{
+				ObjectMeta: podMeta,
+				Spec:       corev1.PodSpec{},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.ContainersReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Minute))},
+					},
+				},
+			})).NotTo(HaveOccurred())
+			overrides := map[string]string{"operator.tigera.io/custom-overrides": "readinessProbe,resources"}
+			issues := sm.diagnosePods("Test", selector, "ns", "", overrides)
+			Expect(issues).To(HaveLen(1))
+			Expect(issues[0].message).To(ContainSubstring("custom readiness probe configuration is in effect"))
+		})
+
+		It("should add liveness probe hint when pod has possible liveness failure and livenessProbe override is configured", func() {
+			Expect(cl.Create(ctx, &corev1.Pod{
+				ObjectMeta: podMeta,
+				Spec:       corev1.PodSpec{},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "c1",
+							State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{Reason: terminationReasonError, ExitCode: exitCodeSIGKILL},
+							},
+						},
+					},
+				},
+			})).NotTo(HaveOccurred())
+			overrides := map[string]string{"operator.tigera.io/custom-overrides": "livenessProbe"}
+			issues := sm.diagnosePods("Test", selector, "ns", "", overrides)
+			Expect(issues).To(HaveLen(1))
+			Expect(issues[0].message).To(ContainSubstring("custom liveness probe configuration is in effect"))
+		})
+
+		It("should add resources hint when pod is OOMKilled and resources override is configured", func() {
+			Expect(cl.Create(ctx, &corev1.Pod{
+				ObjectMeta: podMeta,
+				Spec:       corev1.PodSpec{},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "c1",
+							State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled", ExitCode: 137},
+							},
+						},
+					},
+				},
+			})).NotTo(HaveOccurred())
+			overrides := map[string]string{"operator.tigera.io/custom-overrides": "resources"}
+			issues := sm.diagnosePods("Test", selector, "ns", "", overrides)
+			Expect(issues).To(HaveLen(1))
+			Expect(issues[0].message).To(ContainSubstring("custom resource limits are in effect"))
+		})
+
+		It("should not add hints when no override annotation is present", func() {
+			Expect(cl.Create(ctx, &corev1.Pod{
+				ObjectMeta: podMeta,
+				Spec:       corev1.PodSpec{},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.ContainersReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Minute))},
+					},
+				},
+			})).NotTo(HaveOccurred())
+			issues := sm.diagnosePods("Test", selector, "ns", "", nil)
+			Expect(issues).To(HaveLen(1))
+			Expect(issues[0].message).NotTo(ContainSubstring("custom"))
 		})
 	})
 

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -50,6 +51,10 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 )
+
+// errObjectIgnored is returned by createOrUpdateObject when an existing object has the
+// unsupported.operator.tigera.io/ignore annotation.
+var errObjectIgnored = fmt.Errorf("object has unsupported ignore annotation")
 
 const TLS_CIPHERS_ENV_VAR_NAME = "TLS_CIPHER_SUITES"
 
@@ -321,7 +326,7 @@ func (c *componentHandler) createOrUpdateObject(ctx context.Context, obj client.
 	// The object exists. Update it, unless the user has marked it as "ignored".
 	if IgnoreObject(cur) {
 		logCtx.Info("Ignoring annotated object")
-		return nil
+		return errObjectIgnored
 	}
 	logCtx.V(2).Info("Resource already exists, update it")
 
@@ -495,7 +500,19 @@ func (c *componentHandler) CreateOrUpdateOrDelete(ctx context.Context, component
 	conflictRetry:
 		err := c.createOrUpdateObject(ctx, obj.DeepCopyObject().(client.Object), osType, installationSpec)
 		if err != nil {
-			if errors.IsAlreadyExists(err) {
+			if stderrors.Is(err, errObjectIgnored) {
+				if status != nil {
+					kind := obj.GetObjectKind().GroupVersionKind().Kind
+					if kind == "" {
+						kind = reflect.TypeOf(obj).Elem().Name()
+					}
+					warningKey := fmt.Sprintf("ignore-%s-%s", kind, key)
+					status.SetWarning(warningKey, fmt.Sprintf(
+						"%s %q has the unsupported ignore annotation; the operator is not managing this resource",
+						kind, key,
+					))
+				}
+			} else if errors.IsAlreadyExists(err) {
 				// Remember that we've had an "already exists" error, but otherwise
 				// carry on.
 				alreadyExistsErr = err
@@ -520,6 +537,16 @@ func (c *componentHandler) CreateOrUpdateOrDelete(ctx context.Context, component
 			statefulsets = append(statefulsets, key)
 		case *batchv1.CronJob:
 			cronJobs = append(cronJobs, key)
+		}
+
+		// Object updated normally - clear any stale ignore warning.
+		if err == nil && status != nil {
+			kind := obj.GetObjectKind().GroupVersionKind().Kind
+			if kind == "" {
+				kind = reflect.TypeOf(obj).Elem().Name()
+			}
+			warningKey := fmt.Sprintf("ignore-%s-%s", kind, key)
+			status.ClearWarning(warningKey)
 		}
 
 		continue

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -2187,6 +2188,61 @@ var _ = Describe("Component handler tests", func() {
 				corev1.VolumeMount{Name: "y"},
 				corev1.VolumeMount{Name: "z"},
 			))
+		})
+	})
+
+	Context("unsupported ignore annotation", func() {
+		It("should return errObjectIgnored from createOrUpdateObject when object has ignore annotation", func() {
+			ds := &apps.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ignored-ds",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"unsupported.operator.tigera.io/ignore": "true",
+					},
+				},
+				Spec: apps.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+					},
+				},
+			}
+			Expect(c.Create(ctx, ds)).NotTo(HaveOccurred())
+
+			rendered := ds.DeepCopy()
+			rendered.Annotations = nil
+			rendered.SetGroupVersionKind(apps.SchemeGroupVersion.WithKind("DaemonSet"))
+			err := handler.(*componentHandler).createOrUpdateObject(ctx, rendered, rmeta.OSTypeLinux, nil)
+			Expect(stderrors.Is(err, errObjectIgnored)).To(BeTrue())
+		})
+
+		It("should not return an error from CreateOrUpdateOrDelete when object has ignore annotation", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ignored-cm",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"unsupported.operator.tigera.io/ignore": "true",
+					},
+				},
+			}
+			Expect(c.Create(ctx, cm)).NotTo(HaveOccurred())
+
+			rendered := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ignored-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{"key": "value"},
+			}
+			fc := &fakeComponent{
+				objs:            []client.Object{rendered},
+				supportedOSType: rmeta.OSTypeLinux,
+			}
+			err := handler.CreateOrUpdateOrDelete(ctx, fc, sm)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/pkg/controller/whisker/controller_test.go
+++ b/pkg/controller/whisker/controller_test.go
@@ -105,6 +105,8 @@ var _ = Describe("whisker controller tests", func() {
 
 		// Set up a mock status
 		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
 		mockStatus.On("AddDaemonsets", mock.Anything).Return()
 		mockStatus.On("AddDeployments", mock.Anything).Return()
 		mockStatus.On("AddStatefulSets", mock.Anything).Return()

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1334,8 +1334,10 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			Expect(d.Labels).To(HaveLen(2))
 			Expect(d.Labels["apiserver"]).To(Equal("true"))
 			Expect(d.Labels["top-level"]).To(Equal("label1"))
-			Expect(d.Annotations).To(HaveLen(1))
+			Expect(d.Annotations).To(HaveLen(2))
 			Expect(d.Annotations["top-level"]).To(Equal("annot1"))
+			// The render package records the applied resource override in an annotation.
+			Expect(d.Annotations["operator.tigera.io/custom-overrides"]).To(Equal("resources"))
 
 			Expect(d.Spec.MinReadySeconds).To(Equal(minReadySeconds))
 
@@ -2402,8 +2404,10 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			Expect(d.Labels).To(HaveLen(2))
 			Expect(d.Labels["apiserver"]).To(Equal("true"))
 			Expect(d.Labels["top-level"]).To(Equal("label1"))
-			Expect(d.Annotations).To(HaveLen(1))
+			Expect(d.Annotations).To(HaveLen(2))
 			Expect(d.Annotations["top-level"]).To(Equal("annot1"))
+			// The render package records the applied resource override in an annotation.
+			Expect(d.Annotations["operator.tigera.io/custom-overrides"]).To(Equal("resources"))
 
 			Expect(d.Spec.MinReadySeconds).To(Equal(minReadySeconds))
 

--- a/pkg/render/common/components/components.go
+++ b/pkg/render/common/components/components.go
@@ -17,6 +17,7 @@ package components
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	envoyapi "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -35,6 +36,10 @@ import (
 )
 
 var log = logf.Log.WithName("components")
+
+// CustomOverridesAnnotation is set on workloads when the render package applies user-specified
+// probe timing or resource overrides. The value is a comma-separated list of override types.
+const CustomOverridesAnnotation = "operator.tigera.io/custom-overrides"
 
 // containerNameAliases maps deprecated container names to their current names.
 // When a user provides an override using a deprecated name, it is transparently
@@ -402,6 +407,28 @@ func applyReplicatedPodResourceOverrides(r *replicatedPodResource, overrides any
 	// probe timing overrides are applied to the corresponding container.
 	if cos := GetContainerOverrides(overrides); cos != nil {
 		mergeContainerOverrides(r.podTemplateSpec.Spec.Containers, cos)
+
+		// Track which override types were applied for status correlation.
+		seen := map[string]bool{}
+		var overrideTypes []string
+		for _, co := range cos {
+			if co.ReadinessProbe != nil && !seen["readinessProbe"] {
+				seen["readinessProbe"] = true
+				overrideTypes = append(overrideTypes, "readinessProbe")
+			}
+			if co.LivenessProbe != nil && !seen["livenessProbe"] {
+				seen["livenessProbe"] = true
+				overrideTypes = append(overrideTypes, "livenessProbe")
+			}
+			if co.Resources != nil && !seen["resources"] {
+				seen["resources"] = true
+				overrideTypes = append(overrideTypes, "resources")
+			}
+		}
+		if len(overrideTypes) > 0 {
+			r.annotations = common.MapExistsOrInitialize(r.annotations)
+			r.annotations[CustomOverridesAnnotation] = strings.Join(overrideTypes, ",")
+		}
 	}
 
 	// If `overrides` has a Spec.Template.Spec.Affinity field, and it's non-nil, it sets

--- a/pkg/render/common/components/components_test.go
+++ b/pkg/render/common/components/components_test.go
@@ -607,6 +607,7 @@ var _ = Describe("Common components render tests", func() {
 				expected := defaultedDaemonSet()
 				Expect(expected.Spec.Template.Spec.Containers).To(HaveLen(2))
 				expected.Spec.Template.Spec.Containers[0].Resources = resources1
+				expected.Annotations[CustomOverridesAnnotation] = "resources"
 				Expect(result.Spec.Template.Spec.Containers).To(ContainElements(expected.Spec.Template.Spec.Containers))
 				Expect(result).To(Equal(expected))
 			}),
@@ -1074,6 +1075,7 @@ var _ = Describe("Common components render tests", func() {
 				expected := defaultedDeployment()
 				Expect(expected.Spec.Template.Spec.Containers).To(HaveLen(2))
 				expected.Spec.Template.Spec.Containers[0].Resources = resources1
+				expected.Annotations[CustomOverridesAnnotation] = "resources"
 				Expect(result.Spec.Template.Spec.Containers).To(ContainElements(expected.Spec.Template.Spec.Containers))
 				Expect(result).To(Equal(expected))
 			}),
@@ -1264,6 +1266,95 @@ var _ = Describe("Common components render tests", func() {
 		for _, c := range d.Spec.Template.Spec.Containers {
 			Expect(c.Resources).To(Equal(overrideResources), "container %q should have overridden resources", c.Name)
 		}
+	})
+
+	Describe("custom-overrides annotation", func() {
+		It("should set annotation when readiness probe override is applied", func() {
+			d := appsv1.Deployment{}
+			d.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:  "compliance-server",
+					Image: "test-image",
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/health"}},
+					},
+				},
+			}
+
+			period := int32(30)
+			overrides := &v1.ComplianceServerDeployment{
+				Spec: &v1.ComplianceServerDeploymentSpec{
+					Template: &v1.ComplianceServerDeploymentPodTemplateSpec{
+						Spec: &v1.ComplianceServerDeploymentPodSpec{
+							Containers: []v1.ComplianceServerDeploymentContainer{
+								{
+									Name:           "compliance-server",
+									ReadinessProbe: &v1.ProbeOverride{PeriodSeconds: &period},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ApplyDeploymentOverrides(&d, overrides)
+			Expect(d.Annotations).To(HaveKeyWithValue(CustomOverridesAnnotation, "readinessProbe"))
+		})
+
+		It("should set annotation with multiple override types", func() {
+			d := appsv1.Deployment{}
+			d.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:  "compliance-server",
+					Image: "test-image",
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/health"}},
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/health"}},
+					},
+				},
+			}
+
+			period := int32(30)
+			overrideResources := corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+			}
+			overrides := &v1.ComplianceServerDeployment{
+				Spec: &v1.ComplianceServerDeploymentSpec{
+					Template: &v1.ComplianceServerDeploymentPodTemplateSpec{
+						Spec: &v1.ComplianceServerDeploymentPodSpec{
+							Containers: []v1.ComplianceServerDeploymentContainer{
+								{
+									Name:           "compliance-server",
+									ReadinessProbe: &v1.ProbeOverride{PeriodSeconds: &period},
+									LivenessProbe:  &v1.ProbeOverride{PeriodSeconds: &period},
+									Resources:      &overrideResources,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ApplyDeploymentOverrides(&d, overrides)
+			ann := d.Annotations[CustomOverridesAnnotation]
+			Expect(ann).To(ContainSubstring("readinessProbe"))
+			Expect(ann).To(ContainSubstring("livenessProbe"))
+			Expect(ann).To(ContainSubstring("resources"))
+		})
+
+		It("should not set annotation when no probe or resource overrides", func() {
+			d := appsv1.Deployment{}
+			d.Spec.Template.Spec.Containers = []corev1.Container{
+				{Name: "compliance-server", Image: "test-image"},
+			}
+			overrides := &v1.ComplianceServerDeployment{
+				Spec: &v1.ComplianceServerDeploymentSpec{},
+			}
+			ApplyDeploymentOverrides(&d, overrides)
+			Expect(d.Annotations).NotTo(HaveKey(CustomOverridesAnnotation))
+		})
 	})
 })
 

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -271,8 +271,10 @@ var _ = Describe("CSI rendering tests", func() {
 
 			Expect(ds.Labels).To(HaveLen(1))
 			Expect(ds.Labels["top-level"]).To(Equal("label1"))
-			Expect(ds.Annotations).To(HaveLen(1))
+			Expect(ds.Annotations).To(HaveLen(2))
 			Expect(ds.Annotations["top-level"]).To(Equal("annot1"))
+			// The render package records the applied resource override in an annotation.
+			Expect(ds.Annotations["operator.tigera.io/custom-overrides"]).To(Equal("resources"))
 			// At runtime, the operator will also add some standard labels to the
 			// daemonset such as "k8s-app=csi-node-driver". But the csi-node-driver daemonset object
 			// produced by the render will have 1 label (name) so we expect one plus the one

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -994,8 +994,10 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 			Expect(d.Labels).To(HaveLen(1))
 			Expect(d.Labels["top-level"]).To(Equal("label1"))
-			Expect(d.Annotations).To(HaveLen(1))
+			Expect(d.Annotations).To(HaveLen(2))
 			Expect(d.Annotations["top-level"]).To(Equal("annot1"))
+			// The render package records the applied resource override in an annotation.
+			Expect(d.Annotations["operator.tigera.io/custom-overrides"]).To(Equal("resources"))
 
 			Expect(d.Spec.MinReadySeconds).To(Equal(minReadySeconds))
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -3213,8 +3213,10 @@ var _ = Describe("Node rendering tests", func() {
 
 					Expect(ds.Labels).To(HaveLen(1))
 					Expect(ds.Labels["top-level"]).To(Equal("label1"))
-					Expect(ds.Annotations).To(HaveLen(1))
+					Expect(ds.Annotations).To(HaveLen(2))
 					Expect(ds.Annotations["top-level"]).To(Equal("annot1"))
+					// The render package records the applied resource override in an annotation.
+					Expect(ds.Annotations["operator.tigera.io/custom-overrides"]).To(Equal("resources"))
 
 					Expect(ds.Spec.MinReadySeconds).To(Equal(minReadySeconds))
 

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -681,8 +681,10 @@ var _ = Describe("Typha rendering tests", func() {
 
 			Expect(d.Labels).To(HaveLen(1))
 			Expect(d.Labels["top-level"]).To(Equal("label1"))
-			Expect(d.Annotations).To(HaveLen(1))
+			Expect(d.Annotations).To(HaveLen(2))
 			Expect(d.Annotations["top-level"]).To(Equal("annot1"))
+			// The render package records the applied resource override in an annotation.
+			Expect(d.Annotations["operator.tigera.io/custom-overrides"]).To(Equal("resources"))
 
 			Expect(d.Spec.MinReadySeconds).To(Equal(minReadySeconds))
 			Expect(d.Spec.Strategy).To(Equal(appsv1.DeploymentStrategy{

--- a/pkg/render/windows_test.go
+++ b/pkg/render/windows_test.go
@@ -2633,8 +2633,10 @@ var _ = Describe("Windows rendering tests", func() {
 
 			Expect(ds.Labels).To(HaveLen(1))
 			Expect(ds.Labels["top-level"]).To(Equal("label1"))
-			Expect(ds.Annotations).To(HaveLen(1))
+			Expect(ds.Annotations).To(HaveLen(2))
 			Expect(ds.Annotations["top-level"]).To(Equal("annot1"))
+			// The render package records the applied resource override in an annotation.
+			Expect(ds.Annotations["operator.tigera.io/custom-overrides"]).To(Equal("resources"))
 
 			Expect(ds.Spec.MinReadySeconds).To(Equal(minReadySeconds))
 


### PR DESCRIPTION
## Description

Adds two status manager improvements.

**Unsupported ignore annotation warning:** When a resource has the `unsupported.operator.tigera.io/ignore` annotation, the operator silently skips managing it. This was invisible in TigeraStatus - now a warning surfaces in the Available condition message so users know the operator isn't managing that resource.

**Override correlation hints:** When the operator applies user-specified probe timing or resource overrides and the corresponding pod is failing, the status manager now includes a hint in the diagnostic message. For example, if a pod is failing readiness and the user has custom readiness probe configuration, the message says "Pod X is running but not ready; custom readiness probe configuration is in effect". Similarly for liveness probe failures (exit code 137) and OOMKilled with custom resource limits.

The override correlation works via an annotation (`operator.tigera.io/custom-overrides`) that the render package sets on workloads when applying overrides. The status manager reads this annotation when diagnosing pod failures.

### Example TigeraStatus messages

Pod crash looping with OOMKilled and custom resource limits:
```
Pod calico-system/calico-node-abc has crash looping container: calico-node (OOMKilled, exit code 137); custom resource limits are in effect
```

Pod failing readiness with custom probe config:
```
Pod calico-system/calico-node-xyz is running but not ready; custom readiness probe configuration is in effect
```

Possible liveness failure with custom liveness config:
```
Pod calico-system/compliance-server-abc has crash looping container: compliance-server (exit code 137, possible liveness probe failure); custom liveness probe configuration is in effect
```

Unsupported ignore annotation (in Available condition message):
```
All objects available; DaemonSet "calico-system/calico-node" has the unsupported ignore annotation; the operator is not managing this resource
```

```release-note
None
```
