### PR TITLE
Do not patch felixconfig or bgpconfig when cluster routing mode is not set

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -2068,6 +2068,10 @@ func setClusterRoutingOnFelixConfiguration(
 	fc *v3.FelixConfiguration,
 	reqLogger logr.Logger,
 ) (bool, error) {
+	if install.Spec.CalicoNetwork == nil || install.Spec.CalicoNetwork.ClusterRoutingMode == nil {
+		return false, nil
+	}
+
 	updated := false
 	desiredValue := "Disabled"
 	if felixProgramsClusterRoutes(install) {
@@ -2090,9 +2094,12 @@ func setClusterRoutingOnBGPConfiguration(
 	bgpConfig *v3.BGPConfiguration,
 	reqLogger logr.Logger,
 ) (bool, error) {
+	if install.Spec.CalicoNetwork == nil || install.Spec.CalicoNetwork.ClusterRoutingMode == nil {
+		return false, nil
+	}
+
 	updated := false
 	desiredValue := "Enabled"
-
 	if felixProgramsClusterRoutes(install) {
 		desiredValue = "Disabled"
 	}

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1430,7 +1430,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(pullSecret.Kind).To(Equal("Installation"))
 		})
 
-		It("should correctly patch FelixConfig and BGPConfig with ClusterRouteMode not set", func() {
+		It("should not patch FelixConfig and BGPConfig when ClusterRouteMode not set", func() {
 			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{}
 			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
 			_, err := r.Reconcile(ctx, reconcile.Request{})
@@ -1439,14 +1439,11 @@ var _ = Describe("Testing core-controller installation", func() {
 			fc := &v3.FelixConfiguration{}
 			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(fc.Spec.ProgramClusterRoutes).NotTo(BeNil())
-			Expect(*fc.Spec.ProgramClusterRoutes).To(Equal("Disabled"))
+			Expect(fc.Spec.ProgramClusterRoutes).To(BeNil())
 
 			bgpConfig := &v3.BGPConfiguration{}
 			err = c.Get(ctx, types.NamespacedName{Name: "default"}, bgpConfig)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(bgpConfig.Spec.ProgramClusterRoutes).NotTo(BeNil())
-			Expect(*bgpConfig.Spec.ProgramClusterRoutes).To(Equal("Enabled"))
+			Expect(err).Should(HaveOccurred())
 		})
 
 		It("should correctly patch FelixConfig and BGPConfig with ClusterRouteMode set to BIRD", func() {


### PR DESCRIPTION
## Description

When clusterRoutingMode in the installation resource is not set, Operator should not patch FelixConfig or BGPConfig. This allows users to set programClusterRoutes in FelixConfig and BGPConfig without setting clusterRoutingMode in the installation resource.

Pick of https://github.com/tigera/operator/pull/4667
Fixes: https://tigera.atlassian.net/browse/CORE-12626
Related to https://github.com/tigera/operator/pull/4511

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
