### PR TITLE
[v1.40] Set VOLTRON_CA_SIGNER_NAME env var for certificate management

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -564,7 +564,7 @@ func (cm *certificateManager) GetKeyPair(cli client.Client, secretName, secretNa
 // CACertCommonName returns the CommonName from the CA certificate's Subject field.
 func (cm *certificateManager) CACertCommonName() string {
 	if cm.Certificate != nil {
-		return cm.Certificate.Subject.CommonName
+		return cm.Subject.CommonName
 	}
 	return ""
 }

--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -119,6 +119,8 @@ type CertificateManager interface {
 	// SignCertificate signs a certificate using the certificate manager's private key. The function is assuming that the
 	// public key of the requestor is already set in the certificate template.
 	SignCertificate(certificate *x509.Certificate) ([]byte, error)
+	// CACertCommonName returns the CommonName from the CA certificate's Subject field.
+	CACertCommonName() string
 }
 
 type Option func(cm *certificateManager) error
@@ -557,6 +559,14 @@ func (cm *certificateManager) GetCertificate(cli client.Client, secretName, secr
 func (cm *certificateManager) GetKeyPair(cli client.Client, secretName, secretNamespace string, dnsNames []string) (certificatemanagement.KeyPairInterface, error) {
 	keyPair, _, err := cm.getKeyPair(cli, secretName, secretNamespace, false, dnsNames)
 	return keyPair, err
+}
+
+// CACertCommonName returns the CommonName from the CA certificate's Subject field.
+func (cm *certificateManager) CACertCommonName() string {
+	if cm.Certificate != nil {
+		return cm.Certificate.Subject.CommonName
+	}
+	return ""
 }
 
 // CertificateManagement returns the CertificateManagement object or nil if it is not configured.

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -680,6 +680,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		BindingNamespaces:       namespaces,
 		OSSTenantNamespaces:     ossTenantNamespaces,
 		Manager:                 instance,
+		CACertCommonName:        certificateManager.CACertCommonName(),
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -549,6 +549,10 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_SERVER_CERT", Value: linseedCertPath})
 	}
 
+	if c.cfg.Installation != nil && c.cfg.Installation.CertificateManagement != nil {
+		env = append(env, corev1.EnvVar{Name: "CA_SIGNER_NAME", Value: c.cfg.Installation.CertificateManagement.SignerName})
+	}
+
 	if c.cfg.KeyValidatorConfig != nil {
 		env = append(env, c.cfg.KeyValidatorConfig.RequiredEnv("VOLTRON_")...)
 	}

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -550,7 +550,7 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 	}
 
 	if c.cfg.Installation != nil && c.cfg.Installation.CertificateManagement != nil {
-		env = append(env, corev1.EnvVar{Name: "CA_SIGNER_NAME", Value: c.cfg.Installation.CertificateManagement.SignerName})
+		env = append(env, corev1.EnvVar{Name: "VOLTRON_CA_SIGNER_NAME", Value: c.cfg.Installation.CertificateManagement.SignerName})
 	}
 
 	if c.cfg.KeyValidatorConfig != nil {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -187,6 +187,10 @@ type ManagerConfiguration struct {
 	ExternalElastic bool
 
 	Manager *operatorv1.Manager
+
+	// CACertCommonName is the CommonName from the CA certificate used for operator-managed certificates.
+	// Passed to Voltron so it can identify the correct CA issuer public key.
+	CACertCommonName string
 }
 
 type managerComponent struct {
@@ -549,8 +553,8 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_SERVER_CERT", Value: linseedCertPath})
 	}
 
-	if c.cfg.Installation != nil && c.cfg.Installation.CertificateManagement != nil {
-		env = append(env, corev1.EnvVar{Name: "VOLTRON_CA_SIGNER_NAME", Value: c.cfg.Installation.CertificateManagement.SignerName})
+	if c.cfg.CACertCommonName != "" {
+		env = append(env, corev1.EnvVar{Name: "VOLTRON_CA_SIGNER_NAME", Value: c.cfg.CACertCommonName})
 	}
 
 	if c.cfg.KeyValidatorConfig != nil {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -840,7 +840,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		resources := renderObjects(renderConfig{
 			oidc:                    false,
 			managementCluster:       nil,
-			installation:            &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{CACert: cert}, ControlPlaneReplicas: &replicas},
+			installation:            &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{CACert: cert, SignerName: "my-domain/my-signer"}, ControlPlaneReplicas: &replicas},
 			compliance:              compliance,
 			complianceFeatureActive: true,
 			ns:                      render.ManagerNamespace,
@@ -877,6 +877,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Volumes[0].Secret).To(BeNil())
 		Expect(deployment.Spec.Template.Spec.Volumes[2].Name).To(Equal(render.ManagerInternalTLSSecretName))
 		Expect(deployment.Spec.Template.Spec.Volumes[2].Secret).To(BeNil())
+
+		voltronContainer := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.VoltronName)
+		rtest.ExpectEnv(voltronContainer.Env, "CA_SIGNER_NAME", "my-domain/my-signer")
 	})
 
 	It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -840,7 +840,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		resources := renderObjects(renderConfig{
 			oidc:                    false,
 			managementCluster:       nil,
-			installation:            &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{CACert: cert, SignerName: "my-domain/my-signer"}, ControlPlaneReplicas: &replicas},
+			installation:            &operatorv1.InstallationSpec{CertificateManagement: &operatorv1.CertificateManagement{CACert: cert}, ControlPlaneReplicas: &replicas},
 			compliance:              compliance,
 			complianceFeatureActive: true,
 			ns:                      render.ManagerNamespace,
@@ -879,7 +879,14 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Volumes[2].Secret).To(BeNil())
 
 		voltronContainer := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.VoltronName)
-		rtest.ExpectEnv(voltronContainer.Env, "VOLTRON_CA_SIGNER_NAME", "my-domain/my-signer")
+		var caSignerName string
+		for _, e := range voltronContainer.Env {
+			if e.Name == "VOLTRON_CA_SIGNER_NAME" {
+				caSignerName = e.Value
+				break
+			}
+		}
+		Expect(caSignerName).NotTo(BeEmpty(), "Expected VOLTRON_CA_SIGNER_NAME to be set")
 	})
 
 	It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {
@@ -1614,6 +1621,7 @@ func renderObjects(roc renderConfig) []client.Object {
 		Tenant:                  roc.tenant,
 		Manager:                 roc.manager,
 		ExternalElastic:         roc.externalElastic,
+		CACertCommonName:        certificateManager.CACertCommonName(),
 	}
 	component, err := render.Manager(cfg)
 	Expect(err).To(BeNil(), "Expected Manager to create successfully %s", err)

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -879,7 +879,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(deployment.Spec.Template.Spec.Volumes[2].Secret).To(BeNil())
 
 		voltronContainer := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.VoltronName)
-		rtest.ExpectEnv(voltronContainer.Env, "CA_SIGNER_NAME", "my-domain/my-signer")
+		rtest.ExpectEnv(voltronContainer.Env, "VOLTRON_CA_SIGNER_NAME", "my-domain/my-signer")
 	})
 
 	It("should not render PodAffinity when ControlPlaneReplicas is 1", func() {


### PR DESCRIPTION
## Summary
- Backport of #4672 to release-v1.40.
- Expose `CACertCommonName()` on the `CertificateManager` interface and pass it to Voltron via `VOLTRON_CA_SIGNER_NAME` env var.
- Companion to tigera/calico-private#11471.

```release-note
Operator now passes the CA certificate CommonName to Voltron via VOLTRON_CA_SIGNER_NAME, enabling configurable CA issuer identification.
```

## Test plan
- [x] Unit test verifies `VOLTRON_CA_SIGNER_NAME` is set and non-empty when certificate management is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)