### PR TITLE
[v1.42] Grant calico-node RBAC for caliconodestatuses/status subresource

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -497,6 +497,14 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				Verbs: []string{"get", "list", "watch", "update"},
 			},
 			{
+				// calico/node updates the status subresource of caliconodestatus objects.
+				APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+				Resources: []string{
+					"caliconodestatuses/status",
+				},
+				Verbs: []string{"update"},
+			},
+			{
 				// For migration code in calico/node startup only. Remove when the migration
 				// code is removed from node.
 				APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/4643 to release-v1.42.

The CalicoNodeStatus CRD now has a status subresource, which means status updates go through a separate /status endpoint. Kubernetes treats this as a distinct RBAC resource, so calico-node needs explicit permission to update caliconodestatuses/status in addition to the existing caliconodestatuses permission.

Without this, calico-node gets a 403 Forbidden when trying to write node status via UpdateStatus.