### PR TITLE
Fix manager and Installation both reconciling default deny policy

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -97,10 +97,19 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 
 	go utils.WaitToAddLicenseKeyWatch(c, opts.K8sClientset, log, licenseAPIReady)
 	go utils.WaitToAddTierWatch(networkpolicy.CalicoTierName, c, opts.K8sClientset, log, tierWatchReady)
-	go utils.WaitToAddNetworkPolicyWatches(c, opts.K8sClientset, log, []types.NamespacedName{
+	policiesToWatch := []types.NamespacedName{
 		{Name: render.ManagerPolicyName, Namespace: helper.InstallNamespace()},
-		{Name: networkpolicy.CalicoComponentDefaultDenyPolicyName, Namespace: helper.InstallNamespace()},
-	})
+	}
+	// The default-deny policy in calico-system is owned by the Installation
+	// controller; only watch it here when we render it ourselves, i.e. in
+	// multi-tenant mode where the Manager lives in a tenant namespace.
+	if helper.InstallNamespace() != common.CalicoNamespace {
+		policiesToWatch = append(policiesToWatch, types.NamespacedName{
+			Name:      networkpolicy.CalicoComponentDefaultDenyPolicyName,
+			Namespace: helper.InstallNamespace(),
+		})
+	}
+	go utils.WaitToAddNetworkPolicyWatches(c, opts.K8sClientset, log, policiesToWatch)
 
 	// Watch for changes to primary resource Manager
 	err = c.WatchObject(&operatorv1.Manager{}, &handler.EnqueueRequestForObject{})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -276,9 +276,18 @@ func (c *managerComponent) Objects() ([]client.Object, []client.Object) {
 
 	objsToCreate = append(objsToCreate,
 		c.managerCalicoSystemNetworkPolicy(),
-		networkpolicy.CalicoSystemDefaultDeny(c.cfg.Namespace),
 		managerServiceAccount(c.cfg.Namespace),
 	)
+	// The default-deny policy in calico-system is owned by the Installation
+	// controller, which uses a selector that excludes calico-apiserver so the
+	// API server remains reachable. Skip rendering it here when the Manager is
+	// being installed into calico-system (single-tenant), otherwise the two
+	// controllers fight over the policy's selector. In multi-tenant mode the
+	// Manager lives in a tenant namespace that Installation doesn't manage, so
+	// the Manager is responsible for the default-deny there.
+	if c.cfg.Namespace != common.CalicoNamespace {
+		objsToCreate = append(objsToCreate, networkpolicy.CalicoSystemDefaultDeny(c.cfg.Namespace))
+	}
 	objsToCreate = append(objsToCreate, c.getTLSObjects()...)
 	objsToCreate = append(objsToCreate, c.managerService())
 	objsToCreate = append(objsToCreate, c.managerExternalNameService())

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -79,7 +79,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		// Should render the correct resources.
 		expectedResourcesToCreate := []client.Object{
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-system.manager-access", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-system.default-deny", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerServiceAccount, Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRole}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRoleBinding}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -592,7 +591,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		// Should render the correct resources.
 		expectedResources := []client.Object{
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-system.manager-access", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-system.default-deny", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerServiceAccount, Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRole}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRoleBinding}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
@@ -894,7 +892,6 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 
 		expectedResources := []client.Object{
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-system.manager-access", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
-			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "calico-system.default-deny", Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerServiceAccount, Namespace: render.ManagerNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRole}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.ManagerClusterRoleBinding}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},


### PR DESCRIPTION
## Description

**Type:** Bug fix

**What:** The Manager controller and the Installation controller were both creating a `NetworkPolicy` named `calico-system.default-deny` in the `calico-system` namespace, each with a different selector:

- Installation controller: `k8s-app != 'calico-apiserver'` (intentionally excludes the API server pod so it stays reachable)
- Manager controller: `all()` (via the generic `networkpolicy.CalicoSystemDefaultDeny` helper)

On every reconcile each controller overwrote the other's spec, causing the selector to flap continuously. When the `all()` variant was in effect, the default-deny matched `calico-apiserver` pods, breaking API server connectivity in the cluster.

**Why merge:** This is a real-world problem seen on MCM management clusters (single-tenant), where the Manager is installed into `calico-system` alongside Installation's resources. The flapping can interrupt API server traffic and is not self-healing.

**Fix:** Give the policy a single owner.
- In single-tenant mode (`c.cfg.Namespace == calico-system`), the Manager renderer no longer emits the default-deny — Installation owns it with the correct API-server-excluding selector.
- In multi-tenant mode, the Manager still emits the default-deny into the tenant namespace, because Installation does not manage that namespace.
- The Manager controller's network policy watch list is updated to match (only watches the default-deny in multi-tenant mode).

**Components affected:**
- `pkg/render/manager.go` — conditional render of `CalicoSystemDefaultDeny`
- `pkg/controller/manager/manager_controller.go` — conditional watch registration
- `pkg/render/manager_test.go` — remove the default-deny from single-tenant expected-resources blocks; multi-tenant expectations already cover the MT branch

**Testing:**
- `go build ./...` — clean
- `go test ./pkg/render/...` — pass (includes single-tenant and multi-tenant manager render expectations)
- `go test ./pkg/controller/manager/...` — pass
- The existing multi-tenant tests at `pkg/render/manager_test.go` already assert `calico-system.default-deny` is rendered into `tenantANamespace` / `tenantBNamespace`, exercising the MT branch of the new conditional. No new tests were added because both branches are already covered.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
