### PR TITLE
Register ManagedCluster webhook and pass MCM flags

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -516,11 +516,13 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		}
 
 		webhooksCfg := webhooks.Configuration{
-			PullSecrets:  pullSecrets,
-			KeyPair:      webhooksTLS,
-			Installation: installationSpec,
-			APIServer:    &instance.Spec,
-			OpenShift:    r.opts.DetectedProvider.IsOpenShift(),
+			PullSecrets:       pullSecrets,
+			KeyPair:           webhooksTLS,
+			Installation:      installationSpec,
+			APIServer:         &instance.Spec,
+			ManagementCluster: managementCluster,
+			MultiTenant:       r.opts.MultiTenant,
+			OpenShift:         r.opts.DetectedProvider.IsOpenShift(),
 		}
 		components = append(components, webhooks.Component(&webhooksCfg))
 		certKeyPairOptions = append(certKeyPairOptions, rcertificatemanagement.NewKeyPairOption(webhooksTLS, true, true))

--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -178,6 +178,38 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 		},
 	}
 
+	// On management clusters, pass flags so the ManagedCluster webhook can
+	// generate the installation manifest with the correct tunnel address and certs.
+	if c.cfg.ManagementCluster != nil {
+		mc := c.cfg.ManagementCluster
+		if mc.Spec.Address != "" {
+			dep.Spec.Template.Spec.Containers[0].Args = append(
+				dep.Spec.Template.Spec.Containers[0].Args,
+				fmt.Sprintf("--mcm-management-cluster-addr=%s", mc.Spec.Address),
+			)
+		}
+
+		secretName := render.TunnelSecretName(mc)
+		dep.Spec.Template.Spec.Containers[0].Args = append(
+			dep.Spec.Template.Spec.Containers[0].Args,
+			fmt.Sprintf("--mcm-tunnel-secret-name=%s", secretName),
+		)
+
+		if mc.Spec.TLS != nil && mc.Spec.TLS.SecretName == render.ManagerTLSSecretName {
+			dep.Spec.Template.Spec.Containers[0].Args = append(
+				dep.Spec.Template.Spec.Containers[0].Args,
+				"--mcm-management-cluster-ca-type=Public",
+			)
+		}
+
+		if c.cfg.MultiTenant {
+			dep.Spec.Template.Spec.Containers[0].Args = append(
+				dep.Spec.Template.Spec.Containers[0].Args,
+				"--multi-tenant=true",
+			)
+		}
+	}
+
 	if c.cfg.Installation.ControlPlaneReplicas != nil && *c.cfg.Installation.ControlPlaneReplicas > 1 {
 		dep.Spec.Template.Spec.Affinity = podaffinity.NewPodAntiAffinity(WebhooksName, []string{common.CalicoNamespace})
 	}
@@ -378,7 +410,7 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 		},
 	}
 
-	// Create a MutatingWebhookConfiguration for UISettings webhooks.
+	// Create a MutatingWebhookConfiguration for Enterprise-only mutating webhooks.
 	mwc := &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "api.projectcalico.org",
@@ -419,6 +451,40 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 				MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
 			},
 		},
+	}
+
+	// On management clusters, register the ManagedCluster webhook. This webhook
+	// generates the installation manifest (including tunnel certs) when a
+	// ManagedCluster CR is created.
+	if c.cfg.ManagementCluster != nil {
+		mwc.Webhooks = append(mwc.Webhooks, admissionregistrationv1.MutatingWebhook{
+			Name: "managedclusters.api.projectcalico.org",
+			Rules: []admissionregistrationv1.RuleWithOperations{
+				{
+					Operations: []admissionregistrationv1.OperationType{
+						admissionregistrationv1.Create,
+					},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"projectcalico.org"},
+						APIVersions: []string{"v3"},
+						Resources:   []string{"managedclusters"},
+						Scope:       ptr.To(admissionregistrationv1.AllScopes),
+					},
+				},
+			},
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				Service: &admissionregistrationv1.ServiceReference{
+					Namespace: common.CalicoNamespace,
+					Name:      WebhooksName,
+					Path:      ptr.To("/managedcluster"),
+				},
+				CABundle: c.cfg.KeyPair.GetCertificatePEM(),
+			},
+			AdmissionReviewVersions: []string{"v1"},
+			SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+			TimeoutSeconds:          ptr.To(int32(10)),
+			FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
+		})
 	}
 
 	// Create a ClusterRole and ClusterRoleBinding for the webhook service account.

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -173,6 +173,85 @@ var _ = Describe("Webhooks rendering tests", func() {
 				components.ComponentTigeraWebhooks.Version)))
 	})
 
+	It("should register ManagedCluster webhook and MCM flags on management clusters", func() {
+		installation.Variant = operatorv1.CalicoEnterprise
+		cfg.ManagementCluster = &operatorv1.ManagementCluster{
+			Spec: operatorv1.ManagementClusterSpec{
+				Address: "mgmt.example.com:9449",
+				TLS: &operatorv1.TLS{
+					SecretName: "test-tunnel-secret",
+				},
+			},
+		}
+		component := webhooks.Component(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		resources, _ := component.Objects()
+
+		// The MutatingWebhookConfiguration should have both UISettings and ManagedCluster webhooks.
+		mwc, err := rtest.GetResourceOfType[*admissionregistrationv1.MutatingWebhookConfiguration](resources, "api.projectcalico.org", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mwc.Webhooks).To(HaveLen(2))
+		Expect(mwc.Webhooks[0].Name).To(Equal("uisettings.api.projectcalico.org"))
+		Expect(mwc.Webhooks[1].Name).To(Equal("managedclusters.api.projectcalico.org"))
+		Expect(*mwc.Webhooks[1].ClientConfig.Service.Path).To(Equal("/managedcluster"))
+		Expect(*mwc.Webhooks[1].FailurePolicy).To(Equal(admissionregistrationv1.Fail))
+		Expect(mwc.Webhooks[1].Rules).To(HaveLen(1))
+		Expect(mwc.Webhooks[1].Rules[0].Operations).To(ConsistOf(admissionregistrationv1.Create))
+		Expect(mwc.Webhooks[1].Rules[0].Rule.Resources).To(Equal([]string{"managedclusters"}))
+
+		// The Deployment should include MCM-specific flags.
+		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		args := dep.Spec.Template.Spec.Containers[0].Args
+		Expect(args).To(ContainElement("--mcm-management-cluster-addr=mgmt.example.com:9449"))
+		Expect(args).To(ContainElement("--mcm-tunnel-secret-name=test-tunnel-secret"))
+		Expect(args).NotTo(ContainElement("--mcm-management-cluster-ca-type=Public"))
+		Expect(args).NotTo(ContainElement("--multi-tenant=true"))
+	})
+
+	It("should set Public CA type when tunnel secret is manager-tls", func() {
+		installation.Variant = operatorv1.CalicoEnterprise
+		cfg.ManagementCluster = &operatorv1.ManagementCluster{
+			Spec: operatorv1.ManagementClusterSpec{
+				Address: "mgmt.example.com:9449",
+				TLS: &operatorv1.TLS{
+					SecretName: "manager-tls",
+				},
+			},
+		}
+		component := webhooks.Component(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		resources, _ := component.Objects()
+
+		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		args := dep.Spec.Template.Spec.Containers[0].Args
+		Expect(args).To(ContainElement("--mcm-management-cluster-ca-type=Public"))
+	})
+
+	It("should pass multi-tenant flag when multi-tenancy is enabled", func() {
+		installation.Variant = operatorv1.CalicoEnterprise
+		cfg.ManagementCluster = &operatorv1.ManagementCluster{}
+		cfg.MultiTenant = true
+		component := webhooks.Component(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		resources, _ := component.Objects()
+
+		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		args := dep.Spec.Template.Spec.Containers[0].Args
+		Expect(args).To(ContainElement("--multi-tenant=true"))
+	})
+
+	It("should not register ManagedCluster webhook without ManagementCluster", func() {
+		installation.Variant = operatorv1.CalicoEnterprise
+		component := webhooks.Component(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		resources, _ := component.Objects()
+
+		mwc, err := rtest.GetResourceOfType[*admissionregistrationv1.MutatingWebhookConfiguration](resources, "api.projectcalico.org", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mwc.Webhooks).To(HaveLen(1))
+		Expect(mwc.Webhooks[0].Name).To(Equal("uisettings.api.projectcalico.org"))
+	})
+
 	It("should not include UISettingsGroup rule for Calico", func() {
 		component := webhooks.Component(cfg)
 		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())


### PR DESCRIPTION
The operator's webhook render code was missing the MutatingWebhookConfiguration entry for ManagedCluster resources. The webhook handler exists in calico-webhooks but the API server was never told to call it because the operator didn't register it. Additionally, the apiserver controller wasn't passing ManagementCluster or MultiTenant to the webhooks Configuration, so the MCM deployment flags and tunnel secret RBAC were never rendered.

This fixes three issues:

1. **Missing webhook registration**: Adds a ManagedCluster mutating webhook entry (path `/managedcluster`, Create-only) to the MutatingWebhookConfiguration when ManagementCluster CR is present.

2. **Missing deployment flags**: Adds `--mcm-management-cluster-addr`, `--mcm-tunnel-secret-name`, `--mcm-management-cluster-ca-type`, and `--multi-tenant` flags to the calico-webhooks deployment when ManagementCluster is configured. Without these, the webhook can't read the tunnel CA secret or generate proper installation manifests.

3. **Missing config passthrough**: The apiserver controller now passes ManagementCluster and MultiTenant to the webhooks Configuration struct, which enables both the webhook registration and the tunnel secret RBAC that were already gated on `ManagementCluster != nil` in the render code.

Discovered while validating the MCM tunnel test harness (https://github.com/tigera/calico-private/pull/11509) on a kind cluster.

**Release note:**
```release-note
Fix managed cluster onboarding: register ManagedCluster mutating webhook and pass MCM tunnel configuration to calico-webhooks deployment.
```