### PR TITLE
Add license grace period warning to monitor TigeraStatus

### DIFF
--- a/pkg/controller/monitor/monitor_controller.go
+++ b/pkg/controller/monitor/monitor_controller.go
@@ -494,9 +494,18 @@ func (r *ReconcileMonitor) Reconcile(ctx context.Context, request reconcile.Requ
 	r.status.ReadyToMonitor()
 
 	if licenseExpired {
+		r.status.ClearWarning("license-grace-period")
 		r.status.SetDegraded(operatorv1.ResourceValidationError,
 			"License is expired - Contact Tigera support or email licensing@tigera.io", nil, reqLogger)
 		return reconcile.Result{}, nil
+	}
+
+	// Check license grace period warning.
+	if licenseStatus == utils.LicenseStatusInGracePeriod {
+		r.status.SetWarning("license-grace-period",
+			"License has expired and is within the grace period. Please renew your license to avoid service disruption.")
+	} else {
+		r.status.ClearWarning("license-grace-period")
 	}
 
 	// Check BYO certificate expiry warnings.

--- a/pkg/controller/monitor/monitor_controller_test.go
+++ b/pkg/controller/monitor/monitor_controller_test.go
@@ -679,6 +679,9 @@ var _ = Describe("Monitor controller tests", func() {
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.ElasticsearchMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).To(HaveOccurred())
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.FluentdMetrics, Namespace: common.TigeraPrometheusNamespace}, sm)).To(HaveOccurred())
 
+			// Grace period warning should be cleared when license is fully expired.
+			mockStatus.AssertCalled(GinkgoT(), "ClearWarning", "license-grace-period")
+
 			// Verify that other Prometheus resources are still created.
 			am := &monitoringv1.Alertmanager{}
 			Expect(cli.Get(ctx, client.ObjectKey{Name: monitor.CalicoNodeAlertmanager, Namespace: common.TigeraPrometheusNamespace}, am)).NotTo(HaveOccurred())
@@ -689,6 +692,9 @@ var _ = Describe("Monitor controller tests", func() {
 		It("should not set degraded status when license is valid", func() {
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
+
+			// Grace period warning should be cleared when license is valid.
+			mockStatus.AssertCalled(GinkgoT(), "ClearWarning", "license-grace-period")
 
 			// ServiceMonitors should be created with a valid license.
 			sm := &monitoringv1.ServiceMonitor{}
@@ -714,6 +720,10 @@ var _ = Describe("Monitor controller tests", func() {
 			// Should requeue to re-reconcile when the grace period expires.
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 			Expect(result.RequeueAfter).To(BeNumerically("~", 89*24*time.Hour, 1*time.Hour))
+
+			// Grace period warning should be visible in TigeraStatus.
+			mockStatus.AssertCalled(GinkgoT(), "SetWarning", "license-grace-period",
+				"License has expired and is within the grace period. Please renew your license to avoid service disruption.")
 
 			// ServiceMonitors should still be created during the grace period.
 			sm := &monitoringv1.ServiceMonitor{}


### PR DESCRIPTION
## Description

Surface a warning in TigeraStatus when the license is in the grace period so users can see it via `kubectl get tigerastatus` instead of only in controller logs. The warning is cleared on both the expired and valid license paths to handle all state transitions cleanly.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Operator now surfaces a warning in TigeraStatus when the license is within its grace period.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.