### PR TITLE
Restrict ingress traffic to calico-webhooks

### DIFF
--- a/pkg/apis/register.go
+++ b/pkg/apis/register.go
@@ -105,6 +105,8 @@ func calicoSchemeBuilder(useV3 bool) func(*runtime.Scheme) error {
 			&v3.LicenseKeyList{},
 			&v3.NetworkPolicy{},
 			&v3.NetworkPolicyList{},
+			&v3.NetworkSet{},
+			&v3.NetworkSetList{},
 			&v3.PolicyRecommendationScope{},
 			&v3.PolicyRecommendationScopeList{},
 			&v3.Tier{},

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -41,6 +41,8 @@ import (
 	apiserver "github.com/tigera/operator/pkg/common/validation/apiserver"
 	webhooksvalidation "github.com/tigera/operator/pkg/common/validation/webhooks"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/controller/installation"
+	"github.com/tigera/operator/pkg/controller/ippool"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 	"github.com/tigera/operator/pkg/controller/options"
@@ -515,12 +517,20 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			return reconcile.Result{}, err
 		}
 
+		// Fetch the active IP pools.
+		currentPools, err := installation.GetActivePools(ctx, r.client)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying IP pools", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+
 		webhooksCfg := webhooks.Configuration{
 			PullSecrets:       pullSecrets,
 			KeyPair:           webhooksTLS,
 			Installation:      installationSpec,
 			APIServer:         &instance.Spec,
 			ManagementCluster: managementCluster,
+			IPPools:           ippool.CRDPoolsToOperator(currentPools.Items),
 			MultiTenant:       r.opts.MultiTenant,
 			OpenShift:         r.opts.DetectedProvider.IsOpenShift(),
 		}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -408,8 +408,8 @@ type ReconcileInstallation struct {
 	newComponentHandler func(log logr.Logger, client client.Client, scheme *runtime.Scheme, cr metav1.Object) utils.ComponentHandler
 }
 
-// getActivePools returns the full set of enabled IP pools in the cluster.
-func getActivePools(ctx context.Context, client client.Client) (*v3.IPPoolList, error) {
+// GetActivePools returns the full set of enabled IP pools in the cluster.
+func GetActivePools(ctx context.Context, client client.Client) (*v3.IPPoolList, error) {
 	allPools := v3.IPPoolList{}
 	if err := client.List(ctx, &allPools); err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("unable to list IPPools: %s", err.Error())
@@ -443,7 +443,7 @@ func updateInstallationWithDefaults(ctx context.Context, client client.Client, i
 		awsNode = nil
 	}
 
-	currentPools, err := getActivePools(ctx, client)
+	currentPools, err := GetActivePools(ctx, client)
 	if err != nil {
 		return fmt.Errorf("unable to list IPPools: %s", err.Error())
 	}
@@ -955,7 +955,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	}
 
 	// Wait for IP pools to be programmed. This may be done out-of-band by the user, or by the operator's IP pool controller.
-	currentPools, err := getActivePools(ctx, r.client)
+	currentPools, err := GetActivePools(ctx, r.client)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "error querying IP pools", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -43,8 +43,9 @@ import (
 const (
 	WebhooksTLSSecretName = "calico-webhooks-tls"
 
-	WebhooksName            = "calico-webhooks"
-	WebhooksSecretsRBACName = "calico-webhooks-secrets-access"
+	WebhooksName              = "calico-webhooks"
+	WebhooksSecretsRBACName   = "calico-webhooks-secrets-access"
+	WebhooksPodNetworkSetName = "calico-webhooks-pods"
 )
 
 var WebhooksPolicyName = fmt.Sprintf("%s.%s", networkpolicy.CalicoTierName, WebhooksName)
@@ -57,6 +58,7 @@ type Configuration struct {
 	Installation      *operatorv1.InstallationSpec
 	APIServer         *operatorv1.APIServerSpec
 	ManagementCluster *operatorv1.ManagementCluster
+	IPPools           []operatorv1.IPPool
 	MultiTenant       bool
 	OpenShift         bool
 }
@@ -229,6 +231,7 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 	// Network policy to allow traffic to/from the webhook pod. Skip if host networking is
 	// enabled, since network policy is ineffective for host-networked pods.
 	var np *v3.NetworkPolicy
+	var ns *v3.NetworkSet
 	if !dep.Spec.Template.Spec.HostNetwork {
 		egressRules := networkpolicy.AppendDNSEgressRules(nil, c.cfg.OpenShift)
 		egressRules = append(egressRules,
@@ -241,6 +244,67 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 				Action: v3.Pass,
 			},
 		)
+
+		ingressRules := []v3.Rule{
+			{
+				// Rule 1: Allow traffic from the kube-apiserver using serviceSelector.
+				// This is the most robust way to identify the apiserver.
+				Action:   v3.Allow,
+				Protocol: &networkpolicy.TCPProtocol,
+				Source:   networkpolicy.KubeAPIServerEntityRule,
+				Destination: v3.EntityRule{
+					Ports: networkpolicy.Ports(uint16(containerPort)),
+				},
+			},
+		}
+
+		// Rule 2: Explicitly deny all other pods in the cluster using a NetworkSet.
+		// Using a NetworkSet is more efficient than label selectors on every pod in large clusters.
+		var podCIDRs []string
+		for _, pool := range c.cfg.IPPools {
+			podCIDRs = append(podCIDRs, pool.CIDR)
+		}
+		if len(podCIDRs) == 0 && c.cfg.Installation.CalicoNetwork != nil {
+			for _, pool := range c.cfg.Installation.CalicoNetwork.IPPools {
+				podCIDRs = append(podCIDRs, pool.CIDR)
+			}
+		}
+
+		if len(podCIDRs) > 0 {
+			ns = &v3.NetworkSet{
+				TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      WebhooksPodNetworkSetName,
+					Namespace: common.CalicoNamespace,
+					Labels: map[string]string{
+						WebhooksPodNetworkSetName: "",
+					},
+				},
+				Spec: v3.NetworkSetSpec{
+					Nets: podCIDRs,
+				},
+			}
+
+			ingressRules = append(ingressRules, v3.Rule{
+				Action: v3.Deny,
+				Source: v3.EntityRule{
+					Selector: fmt.Sprintf("has(%s)", WebhooksPodNetworkSetName),
+				},
+			})
+		}
+
+		ingressRules = append(ingressRules,
+			v3.Rule{
+				// Rule 3: Fallback allow-port rule for compatibility with SNAT environments.
+				// Because of Rule 2, this will only match non-pod traffic.
+				Action:   v3.Allow,
+				Protocol: &networkpolicy.TCPProtocol,
+				Destination: v3.EntityRule{
+					Ports: networkpolicy.Ports(uint16(containerPort)),
+				},
+			},
+		)
+
 		np = &v3.NetworkPolicy{
 			TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 			ObjectMeta: metav1.ObjectMeta{
@@ -252,16 +316,8 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 				Tier:     networkpolicy.CalicoTierName,
 				Selector: networkpolicy.KubernetesAppSelector(WebhooksName),
 				Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
-				Ingress: []v3.Rule{
-					{
-						Action:   v3.Allow,
-						Protocol: &networkpolicy.TCPProtocol,
-						Destination: v3.EntityRule{
-							Ports: networkpolicy.Ports(uint16(containerPort)),
-						},
-					},
-				},
-				Egress: egressRules,
+				Ingress:  ingressRules,
+				Egress:   egressRules,
 			},
 		}
 	}
@@ -553,6 +609,9 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 	if np != nil {
 		objs = append(objs, np)
 	}
+	if ns != nil {
+		objs = append(objs, ns)
+	}
 	objs = append(objs, dep, svc, vwc)
 	if c.cfg.Installation.Variant.IsEnterprise() {
 		objs = append(objs, mwc)
@@ -561,6 +620,15 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 
 	// Management clusters need access to the tunnel CA secret for signing managed cluster certificates.
 	var objsToDelete []client.Object
+	if ns == nil {
+		objsToDelete = append(objsToDelete, &v3.NetworkSet{
+			TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      WebhooksPodNetworkSetName,
+				Namespace: common.CalicoNamespace,
+			},
+		})
+	}
 	if c.cfg.ManagementCluster != nil {
 		objs = append(objs, render.TunnelSecretRBAC(WebhooksSecretsRBACName, WebhooksName, c.cfg.ManagementCluster, c.cfg.MultiTenant)...)
 	} else {

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Webhooks rendering tests", func() {
 			Installation: installation,
 			APIServer:    apiServerSpec,
 			KeyPair:      kp,
+			IPPools:      []operatorv1.IPPool{{CIDR: "192.168.0.0/16"}},
 		}
 	})
 
@@ -84,6 +85,7 @@ var _ = Describe("Webhooks rendering tests", func() {
 		expectedResources := []client.Object{
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksPolicyName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
+			&v3.NetworkSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhooks-pods", Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "api.projectcalico.org"}, TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"}},
@@ -123,6 +125,7 @@ var _ = Describe("Webhooks rendering tests", func() {
 		expectedResources := []client.Object{
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksPolicyName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
+			&v3.NetworkSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhooks-pods", Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "api.projectcalico.org"}, TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"}},
@@ -396,10 +399,29 @@ var _ = Describe("Webhooks rendering tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc.Spec.Ports[0].TargetPort.IntValue()).To(Equal(6443))
 
-		// Verify the network policy defaults to 6443.
+		// Verify the network policy.
 		np := rtest.GetResource(resources, webhooks.WebhooksPolicyName, common.CalicoNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+		Expect(np.Spec.Ingress).To(HaveLen(3))
+
+		// Rule 1: Allow from kube-apiserver.
+		Expect(np.Spec.Ingress[0].Action).To(Equal(v3.Allow))
+		Expect(np.Spec.Ingress[0].Source.Services).To(Equal(&v3.ServiceMatch{
+			Namespace: "default",
+			Name:      "kubernetes",
+		}))
 		Expect(np.Spec.Ingress[0].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
-		Expect(np.Spec.Ingress[0].Destination.Ports[0].MaxPort).To(Equal(uint16(6443)))
+
+		// Rule 2: Deny from pod CIDRs via NetworkSet.
+		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Deny))
+		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(calico-webhooks-pods)"))
+
+		// Rule 3: Fallback allow.
+		Expect(np.Spec.Ingress[2].Action).To(Equal(v3.Allow))
+		Expect(np.Spec.Ingress[2].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
+
+		// Verify the NetworkSet.
+		ns := rtest.GetResource(resources, "calico-webhooks-pods", common.CalicoNamespace, "projectcalico.org", "v3", "NetworkSet").(*v3.NetworkSet)
+		Expect(ns.Spec.Nets).To(ConsistOf("192.168.0.0/16"))
 	})
 
 	It("should use custom container port", func() {
@@ -435,9 +457,34 @@ var _ = Describe("Webhooks rendering tests", func() {
 
 		// Verify the network policy uses the custom port.
 		np := rtest.GetResource(resources, webhooks.WebhooksPolicyName, common.CalicoNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
-		Expect(np.Spec.Ingress[0].Destination.Ports).To(HaveLen(1))
+		Expect(np.Spec.Ingress).To(HaveLen(3))
 		Expect(np.Spec.Ingress[0].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
-		Expect(np.Spec.Ingress[0].Destination.Ports[0].MaxPort).To(Equal(uint16(customPort)))
+		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Deny))
+		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(calico-webhooks-pods)"))
+		Expect(np.Spec.Ingress[2].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
+
+		// Verify the NetworkSet.
+		ns := rtest.GetResource(resources, "calico-webhooks-pods", common.CalicoNamespace, "projectcalico.org", "v3", "NetworkSet").(*v3.NetworkSet)
+		Expect(ns.Spec.Nets).To(ConsistOf("192.168.0.0/16"))
+	})
+
+	It("should skip NetworkSet and Rule 2 when no IP pools are provided", func() {
+		cfg.IPPools = nil
+		cfg.Installation.CalicoNetwork = nil
+
+		component := webhooks.Component(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		resources, _ := component.Objects()
+
+		// Verify the network policy only has 2 rules (Rule 1 and Rule 3).
+		np := rtest.GetResource(resources, webhooks.WebhooksPolicyName, common.CalicoNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+		Expect(np.Spec.Ingress).To(HaveLen(2))
+		Expect(np.Spec.Ingress[0].Action).To(Equal(v3.Allow)) // Apiserver
+		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Allow)) // Fallback
+
+		// Verify the NetworkSet is not present.
+		ns := rtest.GetResource(resources, "calico-webhooks-pods", common.CalicoNamespace, "projectcalico.org", "v3", "NetworkSet")
+		Expect(ns).To(BeNil())
 	})
 
 	It("should not use host network by default on non-EKS", func() {


### PR DESCRIPTION
This PR restricts ingress to the webhooks by adding a three-rule policy: 
1. Allow from the kube-apiserver using the serviceSelector (this is the robust way to handle it).
2. Explicitly deny from all pod CIDRs in the cluster to block random pod-to-pod traffic.
3. Fallback to allow the webhook port to handle cases where the apiserver might be SNATed to a node or external IP.

I've also exported GetActivePools from the installation controller so the apiserver controller can fetch the full set of cluster IP pools for the CIDR-based deny rule.