### PR TITLE
Defer Gateway API watch in waypoint secrets controller

### DIFF
--- a/pkg/controller/istio/waypoint/waypoint_secrets_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_secrets_controller.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,9 +63,12 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return nil
 	}
 
+	gatewayWatchReady := &utils.ReadyFlag{}
+
 	r := &ReconcileWaypointSecrets{
-		Client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
+		Client:            mgr.GetClient(),
+		scheme:            mgr.GetScheme(),
+		gatewayWatchReady: gatewayWatchReady,
 	}
 
 	c, err := ctrlruntime.NewController("istio-waypoint-secrets-controller", mgr, controller.Options{Reconciler: r})
@@ -72,8 +76,13 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return fmt.Errorf("failed to create istio-waypoint-secrets-controller: %w", err)
 	}
 
-	// Watch Gateway resources, filtering for istio-waypoint class only.
-	err = c.WatchObject(&gapi.Gateway{}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
+	// Defer the Gateway watch — the Gateway API CRD may not be installed yet.
+	// The Istio reconciler creates it during reconciliation, so we use a background
+	// goroutine that retries until the CRD appears.
+	gatewayObj := &gapi.Gateway{
+		TypeMeta: metav1.TypeMeta{Kind: "Gateway", APIVersion: "gateway.networking.k8s.io/v1"},
+	}
+	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, gatewayWatchReady, []client.Object{gatewayObj}, predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			gw, ok := e.Object.(*gapi.Gateway)
 			return ok && string(gw.Spec.GatewayClassName) == IstioWaypointClassName
@@ -91,9 +100,6 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 			return ok && string(gw.Spec.GatewayClassName) == IstioWaypointClassName
 		},
 	})
-	if err != nil {
-		return fmt.Errorf("istio-waypoint-secrets-controller failed to watch Gateway resource: %w", err)
-	}
 
 	// Watch Istio CR for pull secret config changes.
 	err = c.WatchObject(&operatorv1.Istio{}, &handler.EnqueueRequestForObject{})
@@ -119,6 +125,8 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 type ReconcileWaypointSecrets struct {
 	client.Client
 	scheme *runtime.Scheme
+
+	gatewayWatchReady *utils.ReadyFlag
 }
 
 func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -138,9 +146,9 @@ func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconc
 		return reconcile.Result{}, err
 	}
 
-	// Build the desired set of secrets if Istio is active.
+	// Build the desired set of secrets if Istio is active and the Gateway watch is established.
 	targetNamespaces := map[string]bool{}
-	if istioActive {
+	if istioActive && r.gatewayWatchReady.IsReady() {
 		_, installationSpec, err := utils.GetInstallationSpec(ctx, r)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/pkg/controller/istio/waypoint/waypoint_secrets_controller_test.go
+++ b/pkg/controller/istio/waypoint/waypoint_secrets_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 )
 
@@ -57,9 +58,13 @@ var _ = Describe("Waypoint pull secrets controller tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cli.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
 
+		gatewayWatchReady := &utils.ReadyFlag{}
+		gatewayWatchReady.MarkAsReady()
+
 		r = &ReconcileWaypointSecrets{
-			Client: cli,
-			scheme: scheme,
+			Client:            cli,
+			scheme:            scheme,
+			gatewayWatchReady: gatewayWatchReady,
 		}
 
 		installation = &operatorv1.Installation{
@@ -355,6 +360,26 @@ var _ = Describe("Waypoint pull secrets controller tests", func() {
 
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("when Gateway watch is not yet ready", func() {
+		It("should skip Gateway listing and not create secrets", func() {
+			r.gatewayWatchReady = &utils.ReadyFlag{}
+
+			createPullSecret("my-pull-secret")
+			installation.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+				{Name: "my-pull-secret"},
+			}
+			Expect(cli.Create(ctx, installation)).NotTo(HaveOccurred())
+			Expect(cli.Create(ctx, istioCR)).NotTo(HaveOccurred())
+			createWaypointGateway("waypoint", "user-ns")
+
+			_, err := doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			secrets := listTrackedSecrets()
+			Expect(secrets).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
The waypoint secrets controller (#4483) registers a `WatchObject` for Gateway resources at startup. On clusters without Gateway API CRDs installed, the informer cache sync times out after ~2 minutes and crashes the entire operator manager, putting it into CrashLoopBackOff. This breaks basic operator functionality (e.g., IP pool creation) on clusters that don't have Gateway API CRDs.

Switch to the existing `WaitToAddResourceWatch` pattern used elsewhere in the operator, which retries the watch registration in a background goroutine with exponential backoff until the CRD appears. Gate the `Reconcile()` Gateway listing behind a `ReadyFlag` to avoid unnecessary `List()` calls before the watch is established.

```release-note
Fix operator crash on clusters without Gateway API CRDs installed.
```