### PR TITLE
Stop mutating AddToSchemes on every AddToScheme call

### DIFF
--- a/pkg/apis/register.go
+++ b/pkg/apis/register.go
@@ -51,8 +51,10 @@ var (
 
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme, v3 bool) error {
-	AddToSchemes = append(AddToSchemes, calicoSchemeBuilder(v3))
-	return AddToSchemes.AddToScheme(s)
+	if err := AddToSchemes.AddToScheme(s); err != nil {
+		return err
+	}
+	return calicoSchemeBuilder(v3)(s)
 }
 
 func init() {


### PR DESCRIPTION
## Description

`AddToScheme` appended a new `calicoSchemeBuilder` closure to the package-level AddToSchemes slice on every call, so the Nth call ran N accumulated closures against the target scheme. 

In test binaries this caused dozens of "Registering Calico CRD types" log lines and left a latent bug where mixing `v3=true` and `v3=false` within one process would double-register the variable CRD types under both API groups.

Invoke `calicoSchemeBuilder(v3)` directly on the provided scheme instead, leaving AddToSchemes as the init()-populated set of builders.

## Release Note

```release-note
Fixed a bug in `AddToScheme` that was causing superfluous log lines in FV tests.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
