### PR TITLE
[cherry-pick][v1.40]Mount additional tunnel ca for Voltron (#4697)

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
-	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -158,7 +157,8 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 			// We need to watch for es-gateway certificate because ui-apis still creates a
 			// client to talk to elastic via es-gateway
 			render.ManagerTLSSecretName, relasticsearch.PublicCertSecret,
-			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret, render.PacketCaptureServerCert,
+			render.VoltronTunnelSecretName, render.VoltronAdditionalTunnelSecretName,
+			render.ComplianceServerCertSecret, render.PacketCaptureServerCert,
 			render.ManagerInternalTLSSecretName, monitor.PrometheusServerTLSSecretName, certificatemanagement.CASecretName,
 		} {
 			if err = utils.AddSecretsWatch(c, secretName, namespace); err != nil {
@@ -654,33 +654,47 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	}
 
+	// If an additional tunnel CA secret has been provisioned in the truth namespace, Voltron
+	// will mount it and serve TLS from it. This is only relevant for management clusters
+	// (Voltron is what consumes the additional CA). The secret is managed out-of-band; the
+	// controller just watches and consumes it.
+	var additionalTunnelServerCert certificatemanagement.KeyPairInterface
+	if managementCluster != nil {
+		additionalTunnelServerCert, err = r.resolveAdditionalTunnelCert(ctx, helper.TruthNamespace())
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error resolving additional tunnel CA", err, logc)
+			return reconcile.Result{}, err
+		}
+	}
+
 	managerCfg := &render.ManagerConfiguration{
-		VoltronRouteConfig:      routeConfig,
-		KeyValidatorConfig:      keyValidatorConfig,
-		TrustedCertBundle:       trustedBundle,
-		TLSKeyPair:              tlsSecret,
-		VoltronLinseedKeyPair:   linseedVoltronServerCert,
-		PullSecrets:             pullSecrets,
-		OpenShift:               r.provider.IsOpenShift(),
-		Installation:            installation,
-		ManagementCluster:       managementCluster,
-		NonClusterHost:          nonclusterhost,
-		TunnelServerCert:        tunnelServerCert,
-		InternalTLSKeyPair:      internalTrafficSecret,
-		ClusterDomain:           r.clusterDomain,
-		ESLicenseType:           elasticLicenseType,
-		Replicas:                replicas,
-		Compliance:              complianceCR,
-		ComplianceLicenseActive: complianceLicenseFeatureActive,
-		ComplianceNamespace:     utils.NewNamespaceHelper(r.multiTenant, render.ComplianceNamespace, request.Namespace).InstallNamespace(),
-		Namespace:               helper.InstallNamespace(),
-		TruthNamespace:          helper.TruthNamespace(),
-		Tenant:                  tenant,
-		ExternalElastic:         r.elasticExternal,
-		BindingNamespaces:       namespaces,
-		OSSTenantNamespaces:     ossTenantNamespaces,
-		Manager:                 instance,
-		CACertCommonName:        certificateManager.CACertCommonName(),
+		VoltronRouteConfig:         routeConfig,
+		KeyValidatorConfig:         keyValidatorConfig,
+		TrustedCertBundle:          trustedBundle,
+		TLSKeyPair:                 tlsSecret,
+		VoltronLinseedKeyPair:      linseedVoltronServerCert,
+		PullSecrets:                pullSecrets,
+		OpenShift:                  r.provider.IsOpenShift(),
+		Installation:               installation,
+		ManagementCluster:          managementCluster,
+		NonClusterHost:             nonclusterhost,
+		TunnelServerCert:           tunnelServerCert,
+		AdditionalTunnelServerCert: additionalTunnelServerCert,
+		InternalTLSKeyPair:         internalTrafficSecret,
+		ClusterDomain:              r.clusterDomain,
+		ESLicenseType:              elasticLicenseType,
+		Replicas:                   replicas,
+		Compliance:                 complianceCR,
+		ComplianceLicenseActive:    complianceLicenseFeatureActive,
+		ComplianceNamespace:        utils.NewNamespaceHelper(r.multiTenant, render.ComplianceNamespace, request.Namespace).InstallNamespace(),
+		Namespace:                  helper.InstallNamespace(),
+		TruthNamespace:             helper.TruthNamespace(),
+		Tenant:                     tenant,
+		ExternalElastic:            r.elasticExternal,
+		BindingNamespaces:          namespaces,
+		OSSTenantNamespaces:        ossTenantNamespaces,
+		Manager:                    instance,
+		CACertCommonName:           certificateManager.CACertCommonName(),
 	}
 
 	// Render the desired objects from the CRD and create or update them.
@@ -717,6 +731,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 				rcertificatemanagement.NewKeyPairOption(linseedVoltronServerCert, true, true),
 				rcertificatemanagement.NewKeyPairOption(internalTrafficSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(tunnelServerCert, false, true),
+				rcertificatemanagement.NewKeyPairOption(additionalTunnelServerCert, false, true),
 			},
 			TrustedBundle: bundleMaker,
 		}),
@@ -827,4 +842,23 @@ func getVoltronRouteConfig(ctx context.Context, cli client.Client, managerNamesp
 	}
 
 	return builder.Build()
+}
+
+// resolveAdditionalTunnelCert looks up the additional tunnel CA secret in the truth namespace.
+// When the secret is present, a KeyPair is returned so that Voltron mounts the CA and gets the
+// corresponding environment variables set. When the secret is absent, (nil, nil) is returned and
+// Voltron runs without the additional CA. The secret is created and rotated out-of-band; this
+// controller only consumes it.
+func (r *ReconcileManager) resolveAdditionalTunnelCert(
+	ctx context.Context,
+	truthNamespace string,
+) (certificatemanagement.KeyPairInterface, error) {
+	secret, err := utils.GetSecret(ctx, r.client, render.VoltronAdditionalTunnelSecretName, truthNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s secret: %w", render.VoltronAdditionalTunnelSecretName, err)
+	}
+	if secret == nil {
+		return nil, nil
+	}
+	return certificatemanagement.NewKeyPair(secret, nil, ""), nil
 }

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +43,6 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
-	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	tigerakvc "github.com/tigera/operator/pkg/render/common/authentication/tigera/key_validator_config"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -158,7 +158,8 @@ func Add(mgr manager.Manager, opts options.AddOptions) error {
 			// We need to watch for es-gateway certificate because ui-apis still creates a
 			// client to talk to elastic via es-gateway
 			render.ManagerTLSSecretName, relasticsearch.PublicCertSecret,
-			render.VoltronTunnelSecretName, render.ComplianceServerCertSecret, render.PacketCaptureServerCert,
+			render.VoltronTunnelSecretName, render.VoltronAdditionalTunnelSecretName,
+			render.ComplianceServerCertSecret, render.PacketCaptureServerCert,
 			render.ManagerInternalTLSSecretName, monitor.PrometheusServerTLSSecretName, certificatemanagement.CASecretName,
 		} {
 			if err = utils.AddSecretsWatch(c, secretName, namespace); err != nil {
@@ -654,33 +655,47 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 	}
 
+	// If an additional tunnel CA secret has been provisioned in the truth namespace, Voltron
+	// will mount it and serve TLS from it. This is only relevant for management clusters
+	// (Voltron is what consumes the additional CA). The secret is managed out-of-band; the
+	// controller just watches and consumes it.
+	var additionalTunnelServerCert certificatemanagement.KeyPairInterface
+	if managementCluster != nil {
+		additionalTunnelServerCert, err = r.resolveAdditionalTunnelCert(ctx, helper.TruthNamespace())
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error resolving additional tunnel CA", err, logc)
+			return reconcile.Result{}, err
+		}
+	}
+
 	managerCfg := &render.ManagerConfiguration{
-		VoltronRouteConfig:      routeConfig,
-		KeyValidatorConfig:      keyValidatorConfig,
-		TrustedCertBundle:       trustedBundle,
-		TLSKeyPair:              tlsSecret,
-		VoltronLinseedKeyPair:   linseedVoltronServerCert,
-		PullSecrets:             pullSecrets,
-		OpenShift:               r.provider.IsOpenShift(),
-		Installation:            installation,
-		ManagementCluster:       managementCluster,
-		NonClusterHost:          nonclusterhost,
-		TunnelServerCert:        tunnelServerCert,
-		InternalTLSKeyPair:      internalTrafficSecret,
-		ClusterDomain:           r.clusterDomain,
-		ESLicenseType:           elasticLicenseType,
-		Replicas:                replicas,
-		Compliance:              complianceCR,
-		ComplianceLicenseActive: complianceLicenseFeatureActive,
-		ComplianceNamespace:     utils.NewNamespaceHelper(r.multiTenant, render.ComplianceNamespace, request.Namespace).InstallNamespace(),
-		Namespace:               helper.InstallNamespace(),
-		TruthNamespace:          helper.TruthNamespace(),
-		Tenant:                  tenant,
-		ExternalElastic:         r.elasticExternal,
-		BindingNamespaces:       namespaces,
-		OSSTenantNamespaces:     ossTenantNamespaces,
-		Manager:                 instance,
-		CACertCommonName:        certificateManager.CACertCommonName(),
+		VoltronRouteConfig:         routeConfig,
+		KeyValidatorConfig:         keyValidatorConfig,
+		TrustedCertBundle:          trustedBundle,
+		TLSKeyPair:                 tlsSecret,
+		VoltronLinseedKeyPair:      linseedVoltronServerCert,
+		PullSecrets:                pullSecrets,
+		OpenShift:                  r.provider.IsOpenShift(),
+		Installation:               installation,
+		ManagementCluster:          managementCluster,
+		NonClusterHost:             nonclusterhost,
+		TunnelServerCert:           tunnelServerCert,
+		AdditionalTunnelServerCert: additionalTunnelServerCert,
+		InternalTLSKeyPair:         internalTrafficSecret,
+		ClusterDomain:              r.clusterDomain,
+		ESLicenseType:              elasticLicenseType,
+		Replicas:                   replicas,
+		Compliance:                 complianceCR,
+		ComplianceLicenseActive:    complianceLicenseFeatureActive,
+		ComplianceNamespace:        utils.NewNamespaceHelper(r.multiTenant, render.ComplianceNamespace, request.Namespace).InstallNamespace(),
+		Namespace:                  helper.InstallNamespace(),
+		TruthNamespace:             helper.TruthNamespace(),
+		Tenant:                     tenant,
+		ExternalElastic:            r.elasticExternal,
+		BindingNamespaces:          namespaces,
+		OSSTenantNamespaces:        ossTenantNamespaces,
+		Manager:                    instance,
+		CACertCommonName:           certificateManager.CACertCommonName(),
 	}
 
 	// Render the desired objects from the CRD and create or update them.
@@ -717,6 +732,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 				rcertificatemanagement.NewKeyPairOption(linseedVoltronServerCert, true, true),
 				rcertificatemanagement.NewKeyPairOption(internalTrafficSecret, true, true),
 				rcertificatemanagement.NewKeyPairOption(tunnelServerCert, false, true),
+				rcertificatemanagement.NewKeyPairOption(additionalTunnelServerCert, false, true),
 			},
 			TrustedBundle: bundleMaker,
 		}),
@@ -827,4 +843,23 @@ func getVoltronRouteConfig(ctx context.Context, cli client.Client, managerNamesp
 	}
 
 	return builder.Build()
+}
+
+// resolveAdditionalTunnelCert looks up the additional tunnel CA secret in the truth namespace.
+// When the secret is present, a KeyPair is returned so that Voltron mounts the CA and gets the
+// corresponding environment variables set. When the secret is absent, (nil, nil) is returned and
+// Voltron runs without the additional CA. The secret is created and rotated out-of-band; this
+// controller only consumes it.
+func (r *ReconcileManager) resolveAdditionalTunnelCert(
+	ctx context.Context,
+	truthNamespace string,
+) (certificatemanagement.KeyPairInterface, error) {
+	secret, err := utils.GetSecret(ctx, r.client, render.VoltronAdditionalTunnelSecretName, truthNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s secret: %w", render.VoltronAdditionalTunnelSecretName, err)
+	}
+	if secret == nil {
+		return nil, nil
+	}
+	return certificatemanagement.NewKeyPair(secret, nil, ""), nil
 }

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -98,6 +98,12 @@ const (
 	DashboardAPIPort         = "8444"
 	DashboardAPIHealthPort   = "8090"
 	DashboardAPIName         = "tigera-dashboard-api"
+
+	// VoltronAdditionalTunnelSecretName is the name of an optional, pre-provisioned secret
+	// in the truth namespace that holds an additional CA used by Voltron for tunnel server
+	// certificates. When the secret is present the manager controller wires it into the
+	// Voltron deployment. It is managed out-of-band; the operator only consumes it.
+	VoltronAdditionalTunnelSecretName = "calico-management-additional-cluster-connection"
 )
 
 // Manager returns a component for rendering namespaced manager resources.
@@ -126,6 +132,9 @@ func Manager(cfg *ManagerConfiguration) (Component, error) {
 	tlsAnnotations[cfg.InternalTLSKeyPair.HashAnnotationKey()] = cfg.InternalTLSKeyPair.HashAnnotationValue()
 	if cfg.ManagementCluster != nil {
 		tlsAnnotations[cfg.TunnelServerCert.HashAnnotationKey()] = cfg.TunnelServerCert.HashAnnotationValue()
+		if cfg.AdditionalTunnelServerCert != nil {
+			tlsAnnotations[cfg.AdditionalTunnelServerCert.HashAnnotationKey()] = cfg.AdditionalTunnelServerCert.HashAnnotationValue()
+		}
 	}
 
 	return &managerComponent{
@@ -156,6 +165,12 @@ type ManagerConfiguration struct {
 
 	// KeyPair used by Voltron as the server certificate when establishing an mTLS tunnel with Guardian.
 	TunnelServerCert certificatemanagement.KeyPairInterface
+
+	// AdditionalTunnelServerCert is an optional additional CA used by Voltron for tunnel server
+	// certificates. It is populated by the manager controller when a pre-provisioned secret named
+	// VoltronAdditionalTunnelSecretName exists in the truth namespace, and is mounted into the
+	// Voltron container so Voltron can serve TLS from it.
+	AdditionalTunnelServerCert certificatemanagement.KeyPairInterface
 
 	// TLS KeyPair used by both Voltron and ui-apis, presented by each as part of the mTLS handshake with
 	// other services within the cluster. This is used in both management and standalone clusters.
@@ -382,6 +397,9 @@ func (c *managerComponent) managerVolumes() []corev1.Volume {
 			c.cfg.TunnelServerCert.Volume(),
 			c.cfg.VoltronLinseedKeyPair.Volume(),
 		)
+		if c.cfg.AdditionalTunnelServerCert != nil {
+			v = append(v, c.cfg.AdditionalTunnelServerCert.Volume())
+		}
 	}
 	if c.cfg.KeyValidatorConfig != nil {
 		v = append(v, c.cfg.KeyValidatorConfig.RequiredVolumes()...)
@@ -551,6 +569,15 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_USE_HTTPS_CERT_ON_TUNNEL", Value: strconv.FormatBool(c.cfg.ManagementCluster.Spec.TLS != nil && c.cfg.ManagementCluster.Spec.TLS.SecretName == ManagerTLSSecretName)})
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_SERVER_KEY", Value: linseedKeyPath})
 		env = append(env, corev1.EnvVar{Name: "VOLTRON_LINSEED_SERVER_CERT", Value: linseedCertPath})
+		if c.cfg.AdditionalTunnelServerCert != nil {
+			// Voltron scans a single parent directory for additional cert/key pairs. Each
+			// cert/key pair is mounted into its own subdirectory so multiple can coexist.
+			// The tls.crt from each pair is also used as an additional CA to verify
+			// client (guardian) connections.
+			env = append(env,
+				corev1.EnvVar{Name: "VOLTRON_ADDITIONAL_CERT_KEY_PAIRS_PATH", Value: "/additional-tunnel-certificates"},
+			)
+		}
 	}
 
 	if c.cfg.CACertCommonName != "" {
@@ -571,6 +598,13 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		if c.cfg.ManagementCluster != nil {
 			mounts = append(mounts, c.cfg.TunnelServerCert.VolumeMount(c.SupportedOSType()))
 			mounts = append(mounts, c.cfg.VoltronLinseedKeyPair.VolumeMount(c.SupportedOSType()))
+			if c.cfg.AdditionalTunnelServerCert != nil {
+				mounts = append(mounts, corev1.VolumeMount{
+					Name:      c.cfg.AdditionalTunnelServerCert.GetName(),
+					MountPath: fmt.Sprintf("/additional-tunnel-certificates/%s", c.cfg.AdditionalTunnelServerCert.GetName()),
+					ReadOnly:  true,
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
Pass additional CAs via calico-management-additional-cluster-connection secret and set variables for voltron to pick up that new CA. The new CA will be using secret calico-management-cluster-connection and old CA will be kept as backup in calico-management-additional-cluster-connection secret. Once all managed clusters have been migrated to have client credentials generated by the new CA, we will delete the old CA by deleting secret calico-management-additional-cluster-connection.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
