### PR TITLE
EV-6557: grant tigera-noncluster-host SA create access to Linseed policyactivity

### DIFF
--- a/pkg/render/nonclusterhost/nonclusterhost.go
+++ b/pkg/render/nonclusterhost/nonclusterhost.go
@@ -191,9 +191,9 @@ func (c *nonClusterHostComponent) clusterRole() *rbacv1.ClusterRole {
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
-			// Allow post flow logs to linseed.
+			// Allow posting flow logs and policy activity logs to linseed.
 			APIGroups: []string{"linseed.tigera.io"},
-			Resources: []string{"flowlogs"},
+			Resources: []string{"flowlogs", "policyactivity"},
 			Verbs:     []string{"create"},
 		},
 	}...)

--- a/pkg/render/nonclusterhost/nonclusterhost_test.go
+++ b/pkg/render/nonclusterhost/nonclusterhost_test.go
@@ -148,7 +148,7 @@ var _ = Describe("NonClusterHost rendering tests", func() {
 			},
 			rbacv1.PolicyRule{
 				APIGroups: []string{"linseed.tigera.io"},
-				Resources: []string{"flowlogs"},
+				Resources: []string{"flowlogs", "policyactivity"},
 				Verbs:     []string{"create"},
 			},
 			rbacv1.PolicyRule{


### PR DESCRIPTION
## Summary

- Add `policyactivity` to the `linseed.tigera.io` `create` rule on the `tigera-noncluster-host` ClusterRole.
- Update the matching test expectation.

## Why

Non-cluster host (NCH) fluent-bit posts policy activity records to voltron at `/ingestion/api/v1/policy_activity/logs/bulk`. Voltron's proxy authorizes each request against the caller's k8s RBAC with resource `policyactivity` in group `linseed.tigera.io` (see voltron `main.go` NCH route `AuthorizationAttributesFunc`). Without this permission, voltron returns 401 Unauthorized and NCH policy activity logs never reach Linseed.

The in-cluster fluentd-node SA already has this permission (`pkg/render/fluentd.go:1012`). This patch brings the NCH SA to parity for the NCH ingestion path.

This is the NCH counterpart of #4712, which granted the calico-manager SA `get` on the same resource for the query-side path.

## Test plan

- [x] `go test ./pkg/render/nonclusterhost/...` passes.
- [ ] Manually verified on a standalone cluster with non-cluster hosts that NCH fluent-bit POSTs to voltron's policy_activity ingestion path succeed end-to-end and `calicoctl get sgnps --show-policy-activities` returns fresh timestamps for HEP-tier SGNPs.

## Release Note

```release-note
Grant the tigera-noncluster-host ClusterRole create access on linseed.tigera.io/policyactivity so non-cluster host policy activity logs reach Linseed.
```
