### PR TITLE
[release-v1.42] EV-6557: grant tigera-noncluster-host SA create access to Linseed policyactivity

### DIFF
--- a/pkg/render/nonclusterhost/nonclusterhost.go
+++ b/pkg/render/nonclusterhost/nonclusterhost.go
@@ -191,9 +191,9 @@ func (c *nonClusterHostComponent) clusterRole() *rbacv1.ClusterRole {
 			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
-			// Allow post flow logs to linseed.
+			// Allow posting flow logs and policy activity logs to linseed.
 			APIGroups: []string{"linseed.tigera.io"},
-			Resources: []string{"flowlogs"},
+			Resources: []string{"flowlogs", "policyactivity"},
 			Verbs:     []string{"create"},
 		},
 	}...)

--- a/pkg/render/nonclusterhost/nonclusterhost_test.go
+++ b/pkg/render/nonclusterhost/nonclusterhost_test.go
@@ -148,7 +148,7 @@ var _ = Describe("NonClusterHost rendering tests", func() {
 			},
 			rbacv1.PolicyRule{
 				APIGroups: []string{"linseed.tigera.io"},
-				Resources: []string{"flowlogs"},
+				Resources: []string{"flowlogs", "policyactivity"},
 				Verbs:     []string{"create"},
 			},
 			rbacv1.PolicyRule{


### PR DESCRIPTION
Cherry-pick of #4725 to release-v1.42.

## Summary

- Add `policyactivity` to the `linseed.tigera.io` `create` rule on the `tigera-noncluster-host` ClusterRole.
- Update the matching test expectation.

## Why

Non-cluster host (NCH) fluent-bit posts policy activity records to voltron at `/ingestion/api/v1/policy_activity/logs/bulk`. Voltron's proxy authorizes each request against the caller's k8s RBAC with resource `policyactivity` in group `linseed.tigera.io`. Without this permission, voltron returns 401 Unauthorized and NCH policy activity logs never reach Linseed.

## Test plan

- [x] `go test ./pkg/render/nonclusterhost/...` passes.

## Release Note

```release-note
Grant the tigera-noncluster-host ClusterRole create access on linseed.tigera.io/policyactivity so non-cluster host policy activity logs reach Linseed.
```
