### PR TITLE
Bump bundled Istio from 1.28.1 to 1.29.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ endif
 
 # To update the Istio version, see "Updating the bundled version of Istio" in docs/common_tasks.md.
 ISTIO_HELM_REPO ?= https://istio-release.storage.googleapis.com/charts
-ISTIO_VERSION ?= 1.28.1
+ISTIO_VERSION ?= 1.29.2
 ISTIO_RESOURCES_DIR = pkg/render/istio
 ISTIO_CHARTS = base istiod cni ztunnel
 ISTIO_CHART_FILES = $(addprefix $(ISTIO_RESOURCES_DIR)/,$(addsuffix .tgz,$(ISTIO_CHARTS)))


### PR DESCRIPTION
## Description

- Bump bundled Istio from 1.28.1 to 1.29.2 (`ISTIO_VERSION` in `Makefile`).
- Chart tarballs are gitignored; refresh with `make istio_charts`.
- The operator overrides none of the knobs that changed upstream — every observed diff is a stock chart default (pilot/cni/ztunnel image tags, `istio-cni` `AMBIENT_RECONCILE_POD_RULES_ON_STARTUP=true`, `terminationGracePeriodSeconds` 5s → 30s, pilot `crlConfigMapName` now templatable, CRD numeric `minimum` relaxations).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note-not-required
Update bundled Istio version to 1.29.2, including CVE fixes for moby/spdystream, prometheus/prometheus, and opentelemetry-go/otel/sdk.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
