### PR TITLE
[release-v1.42] Allow hostnet apiserver traffic through webhooks policy

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -41,8 +41,6 @@ import (
 	apiserver "github.com/tigera/operator/pkg/common/validation/apiserver"
 	webhooksvalidation "github.com/tigera/operator/pkg/common/validation/webhooks"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
-	"github.com/tigera/operator/pkg/controller/installation"
-	"github.com/tigera/operator/pkg/controller/ippool"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 	"github.com/tigera/operator/pkg/controller/options"
@@ -517,20 +515,12 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			return reconcile.Result{}, err
 		}
 
-		// Fetch the active IP pools.
-		currentPools, err := installation.GetActivePools(ctx, r.client)
-		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying IP pools", err, reqLogger)
-			return reconcile.Result{}, err
-		}
-
 		webhooksCfg := webhooks.Configuration{
 			PullSecrets:       pullSecrets,
 			KeyPair:           webhooksTLS,
 			Installation:      installationSpec,
 			APIServer:         &instance.Spec,
 			ManagementCluster: managementCluster,
-			IPPools:           ippool.CRDPoolsToOperator(currentPools.Items),
 			MultiTenant:       r.opts.MultiTenant,
 			OpenShift:         r.opts.DetectedProvider.IsOpenShift(),
 		}

--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -43,9 +43,8 @@ import (
 const (
 	WebhooksTLSSecretName = "calico-webhooks-tls"
 
-	WebhooksName              = "calico-webhooks"
-	WebhooksSecretsRBACName   = "calico-webhooks-secrets-access"
-	WebhooksPodNetworkSetName = "calico-webhooks-pods"
+	WebhooksName            = "calico-webhooks"
+	WebhooksSecretsRBACName = "calico-webhooks-secrets-access"
 )
 
 var WebhooksPolicyName = fmt.Sprintf("%s.%s", networkpolicy.CalicoTierName, WebhooksName)
@@ -58,7 +57,6 @@ type Configuration struct {
 	Installation      *operatorv1.InstallationSpec
 	APIServer         *operatorv1.APIServerSpec
 	ManagementCluster *operatorv1.ManagementCluster
-	IPPools           []operatorv1.IPPool
 	MultiTenant       bool
 	OpenShift         bool
 }
@@ -231,7 +229,6 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 	// Network policy to allow traffic to/from the webhook pod. Skip if host networking is
 	// enabled, since network policy is ineffective for host-networked pods.
 	var np *v3.NetworkPolicy
-	var ns *v3.NetworkSet
 	if !dep.Spec.Template.Spec.HostNetwork {
 		egressRules := networkpolicy.AppendDNSEgressRules(nil, c.cfg.OpenShift)
 		egressRules = append(egressRules,
@@ -245,10 +242,32 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 			},
 		)
 
+		// Rule 1: Allow traffic from the kube-apiserver using serviceSelector.
+		// This covers the common case where the apiserver source IP survives unmodified
+		// to the webhook pod and matches the kubernetes Service's endpoints.
+		//
+		// Rule 2: Deny traffic from any Kubernetes workload endpoint. The selector
+		// "has(projectcalico.org/orchestrator)" matches only pods — Calico adds this
+		// label to every workload endpoint but not to NetworkSets or host endpoints, so
+		// a user-created NetworkSet (which could otherwise be picked up by a bare
+		// namespaceSelector: all()) does not short-circuit this deny. Traffic that has
+		// been SNAT'd to a node tunnel address (e.g. a hostnet apiserver sending through
+		// an IPIP/VXLAN overlay) arrives from the node, not from a workload endpoint,
+		// and so falls through to Rule 3. This is what makes the policy work for hostnet
+		// apiservers whose traffic arrives at the webhook with a tunnel IP source.
+		//
+		// Rule 3: Fallback allow for everything else on the webhook port. In practice
+		// this covers node-sourced traffic (including the SNAT'd hostnet-apiserver case
+		// above) and cluster-external sources routed to the pod.
+		//
+		// TODO: This three-rule structure exists because Calico's policy model has no
+		// native way to say "any node" or "any tunnel IP" as a source. If we add a
+		// first-class selector for that (e.g. a built-in label on host endpoints, or a
+		// Source match for tunnel-sourced traffic), we could collapse these rules into a
+		// single explicit allow from {apiserver service endpoints, cluster nodes} and
+		// drop the fallback.
 		ingressRules := []v3.Rule{
 			{
-				// Rule 1: Allow traffic from the kube-apiserver using serviceSelector.
-				// This is the most robust way to identify the apiserver.
 				Action:   v3.Allow,
 				Protocol: &networkpolicy.TCPProtocol,
 				Source:   networkpolicy.KubeAPIServerEntityRule,
@@ -256,54 +275,21 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 					Ports: networkpolicy.Ports(uint16(containerPort)),
 				},
 			},
-		}
-
-		// Rule 2: Explicitly deny all other pods in the cluster using a NetworkSet.
-		// Using a NetworkSet is more efficient than label selectors on every pod in large clusters.
-		var podCIDRs []string
-		for _, pool := range c.cfg.IPPools {
-			podCIDRs = append(podCIDRs, pool.CIDR)
-		}
-		if len(podCIDRs) == 0 && c.cfg.Installation.CalicoNetwork != nil {
-			for _, pool := range c.cfg.Installation.CalicoNetwork.IPPools {
-				podCIDRs = append(podCIDRs, pool.CIDR)
-			}
-		}
-
-		if len(podCIDRs) > 0 {
-			ns = &v3.NetworkSet{
-				TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      WebhooksPodNetworkSetName,
-					Namespace: common.CalicoNamespace,
-					Labels: map[string]string{
-						WebhooksPodNetworkSetName: "",
-					},
-				},
-				Spec: v3.NetworkSetSpec{
-					Nets: podCIDRs,
-				},
-			}
-
-			ingressRules = append(ingressRules, v3.Rule{
+			{
 				Action: v3.Deny,
 				Source: v3.EntityRule{
-					Selector: fmt.Sprintf("has(%s)", WebhooksPodNetworkSetName),
+					NamespaceSelector: "all()",
+					Selector:          "has(projectcalico.org/orchestrator)",
 				},
-			})
-		}
-
-		ingressRules = append(ingressRules,
-			v3.Rule{
-				// Rule 3: Fallback allow-port rule for compatibility with SNAT environments.
-				// Because of Rule 2, this will only match non-pod traffic.
+			},
+			{
 				Action:   v3.Allow,
 				Protocol: &networkpolicy.TCPProtocol,
 				Destination: v3.EntityRule{
 					Ports: networkpolicy.Ports(uint16(containerPort)),
 				},
 			},
-		)
+		}
 
 		np = &v3.NetworkPolicy{
 			TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
@@ -609,26 +595,13 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 	if np != nil {
 		objs = append(objs, np)
 	}
-	if ns != nil {
-		objs = append(objs, ns)
-	}
 	objs = append(objs, dep, svc, vwc)
 	if c.cfg.Installation.Variant == operatorv1.TigeraSecureEnterprise {
 		objs = append(objs, mwc)
 	}
 	objs = append(objs, cr, crb)
 
-	// Management clusters need access to the tunnel CA secret for signing managed cluster certificates.
 	var objsToDelete []client.Object
-	if ns == nil {
-		objsToDelete = append(objsToDelete, &v3.NetworkSet{
-			TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      WebhooksPodNetworkSetName,
-				Namespace: common.CalicoNamespace,
-			},
-		})
-	}
 	if c.cfg.ManagementCluster != nil {
 		objs = append(objs, render.TunnelSecretRBAC(WebhooksSecretsRBACName, WebhooksName, c.cfg.ManagementCluster, c.cfg.MultiTenant)...)
 	} else {

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -73,7 +73,6 @@ var _ = Describe("Webhooks rendering tests", func() {
 			Installation: installation,
 			APIServer:    apiServerSpec,
 			KeyPair:      kp,
-			IPPools:      []operatorv1.IPPool{{CIDR: "192.168.0.0/16"}},
 		}
 	})
 
@@ -85,7 +84,6 @@ var _ = Describe("Webhooks rendering tests", func() {
 		expectedResources := []client.Object{
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksPolicyName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
-			&v3.NetworkSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhooks-pods", Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "api.projectcalico.org"}, TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"}},
@@ -125,7 +123,6 @@ var _ = Describe("Webhooks rendering tests", func() {
 		expectedResources := []client.Object{
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}},
 			&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksPolicyName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"}},
-			&v3.NetworkSet{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhooks-pods", Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "NetworkSet", APIVersion: "projectcalico.org/v3"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "api.projectcalico.org"}, TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"}},
@@ -411,17 +408,15 @@ var _ = Describe("Webhooks rendering tests", func() {
 		}))
 		Expect(np.Spec.Ingress[0].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
 
-		// Rule 2: Deny from pod CIDRs via NetworkSet.
+		// Rule 2: Deny from any workload endpoint (pod traffic); the orchestrator selector
+		// excludes NetworkSets so a user-defined set doesn't broaden or narrow the rule.
 		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Deny))
-		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(calico-webhooks-pods)"))
+		Expect(np.Spec.Ingress[1].Source.NamespaceSelector).To(Equal("all()"))
+		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(projectcalico.org/orchestrator)"))
 
-		// Rule 3: Fallback allow.
+		// Rule 3: Fallback allow for non-pod sources (including tunnel-SNAT'd hostnet apiserver traffic).
 		Expect(np.Spec.Ingress[2].Action).To(Equal(v3.Allow))
 		Expect(np.Spec.Ingress[2].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
-
-		// Verify the NetworkSet.
-		ns := rtest.GetResource(resources, "calico-webhooks-pods", common.CalicoNamespace, "projectcalico.org", "v3", "NetworkSet").(*v3.NetworkSet)
-		Expect(ns.Spec.Nets).To(ConsistOf("192.168.0.0/16"))
 	})
 
 	It("should use custom container port", func() {
@@ -460,31 +455,9 @@ var _ = Describe("Webhooks rendering tests", func() {
 		Expect(np.Spec.Ingress).To(HaveLen(3))
 		Expect(np.Spec.Ingress[0].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
 		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Deny))
-		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(calico-webhooks-pods)"))
+		Expect(np.Spec.Ingress[1].Source.NamespaceSelector).To(Equal("all()"))
+		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(projectcalico.org/orchestrator)"))
 		Expect(np.Spec.Ingress[2].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
-
-		// Verify the NetworkSet.
-		ns := rtest.GetResource(resources, "calico-webhooks-pods", common.CalicoNamespace, "projectcalico.org", "v3", "NetworkSet").(*v3.NetworkSet)
-		Expect(ns.Spec.Nets).To(ConsistOf("192.168.0.0/16"))
-	})
-
-	It("should skip NetworkSet and Rule 2 when no IP pools are provided", func() {
-		cfg.IPPools = nil
-		cfg.Installation.CalicoNetwork = nil
-
-		component := webhooks.Component(cfg)
-		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
-		resources, _ := component.Objects()
-
-		// Verify the network policy only has 2 rules (Rule 1 and Rule 3).
-		np := rtest.GetResource(resources, webhooks.WebhooksPolicyName, common.CalicoNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
-		Expect(np.Spec.Ingress).To(HaveLen(2))
-		Expect(np.Spec.Ingress[0].Action).To(Equal(v3.Allow)) // Apiserver
-		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Allow)) // Fallback
-
-		// Verify the NetworkSet is not present.
-		ns := rtest.GetResource(resources, "calico-webhooks-pods", common.CalicoNamespace, "projectcalico.org", "v3", "NetworkSet")
-		Expect(ns).To(BeNil())
 	})
 
 	It("should not use host network by default on non-EKS", func() {


### PR DESCRIPTION
Backport of https://github.com/tigera/operator/pull/4739 to release-v1.42.

The webhooks network policy was denying admission requests in clusters where kube-apiserver runs on the host network and the webhook pod is reached over an IPIP/VXLAN overlay. Felix SNATs hostnet-to-overlay-pod traffic to the source node's tunnel address, which is allocated from the pod CIDR, so the CIDR-based deny rule matched.

Switches the deny source to `namespaceSelector: all() && has(projectcalico.org/orchestrator)` so only workload endpoints are denied. Tunnel-SNAT'd traffic isn't from a workload endpoint and falls through to the existing port allow. The `has(projectcalico.org/orchestrator)` guard ensures a user-defined NetworkSet with `namespaceSelector: all()` can't be caught by the rule.

Note: parent PR #4739 is still open; this backport should merge after it lands on master.

```release-note
Fixes the webhook admission controller being unreachable from the Kubernetes API server in clusters where the API server runs on the host network and pods use an overlay (IPIP/VXLAN) network.
```