### PR TITLE
Fix concurrent-append panic in override-field recording (#4703)

### DIFF
--- a/pkg/render/common/components/components.go
+++ b/pkg/render/common/components/components.go
@@ -453,13 +453,25 @@ func applyReplicatedPodResourceOverrides(r *replicatedPodResource, overrides any
 // For UT purposes, only, this variable stores the override fields that were handled in that most
 // recent `applyReplicatedPodResourceOverrides` call.  UT code then checks that the structures we
 // use for `overrides` do not have any _other_ fields than those (except for known special cases).
-var overrideFieldsHandledInLastApplyCall []string
+// Writes to it are gated on recordHandledFields: production reconcilers run many Apply*Overrides
+// calls concurrently, and an unsynchronized append on a shared slice races during growslice
+// (see issue #4703). Tests that inspect the slice must set recordHandledFields = true.
+var (
+	overrideFieldsHandledInLastApplyCall []string
+	recordHandledFields                  bool
+)
 
 func resetHandledFields() {
+	if !recordHandledFields {
+		return
+	}
 	overrideFieldsHandledInLastApplyCall = nil
 }
 
 func recordHandledField(fieldNames []string) {
+	if !recordHandledFields {
+		return
+	}
 	dottedName := strings.Join(fieldNames, ".")
 	overrideFieldsHandledInLastApplyCall = append(overrideFieldsHandledInLastApplyCall, dottedName)
 }

--- a/pkg/render/common/components/components_test.go
+++ b/pkg/render/common/components/components_test.go
@@ -135,6 +135,8 @@ var _ = Describe("Common components render tests", func() {
 
 	DescribeTable("check for unhandled fields",
 		func(overrides any, expectUnhandled bool, allowedExtraFields ...string) {
+			recordHandledFields = true
+			defer func() { recordHandledFields = false }()
 			// Call applyReplicatedPodResourceOverrides to discover all the fields that
 			// we handle.
 			r := &replicatedPodResource{}


### PR DESCRIPTION
## Description

Bug fix for a panic in the tigera-operator.

The package-level `overrideFieldsHandledInLastApplyCall` slice in `pkg/render/common/components` is documented as UT-only, but `getField` appends to it on every call — including from production code paths such as `ValidateReplicatedPodResourceOverrides` → `GetMetadata`. Multiple controllers reconcile concurrently, so the unsynchronized appends race; when two goroutines trigger `growslice` at once the slice header tears and `memmove` dereferences a bogus pointer, producing `runtime error: invalid memory address or nil pointer dereference` panics from `recordHandledField`.

This PR gates the recording (and its `resetHandledFields` companion) on a new package-level `recordHandledFields` flag. Production reconcilers never touch the shared slice. The one unit test that reads the slice (`check for unhandled fields`) flips the flag on for the duration of the test.

**Components affected:** `pkg/render/common/components`. The fix is entirely internal to that package — all production callers (across `pkg/render/*` and `pkg/common/validation`) go through the same `GetMetadata` / `GetContainers` / `GetNodeSelector` / etc. accessors and get the new no-op behavior for free.

**Observed panic (v1.40.7):**

```
panic: runtime error: invalid memory address or nil pointer dereference
...
runtime.memmove
runtime.growslice
github.com/tigera/operator/pkg/render/common/components.recordHandledField
    /go/src/github.com/tigera/operator/pkg/render/common/components/components.go:384
github.com/tigera/operator/pkg/render/common/components.getField
    /go/src/github.com/tigera/operator/pkg/render/common/components/components.go:230
github.com/tigera/operator/pkg/render/common/components.GetMetadata
    /go/src/github.com/tigera/operator/pkg/render/common/components/components.go:50
github.com/tigera/operator/pkg/common/validation.ValidateReplicatedPodResourceOverrides
    /go/src/github.com/tigera/operator/pkg/common/validation/overrides.go:39
github.com/tigera/operator/pkg/controller/installation.validateCustomResource
    /go/src/github.com/tigera/operator/pkg/controller/installation/validation.go:351
```

The `growslice` → `memmove` signature is the textbook concurrent-`append` race.

**Testing:**
- `go build ./...`
- `go test -race -count=1 ./pkg/render/common/components/...` (the existing `check for unhandled fields` table test still passes, now with the flag toggled per-case)

Fixes #4703.

## Release Note

```release-note
Fixed a panic in the tigera-operator caused by concurrent reconcilers racing on an unsynchronized slice used to track handled override fields.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.