### PR TITLE
[release-v1.40] fix(kibana): discard unknown saved objects on upgrade from 7.x

### DIFF
--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -239,6 +239,8 @@ func (k *kibana) kibanaCR() *kbv1.Kibana {
 		"xpack.fleet.isAirGapped":    true,
 		"xpack.fleet.packages":       []string{},
 		"xpack.fleet.registryUrl":    "http://localhost:5601",
+		// Without this, upgrades from Kibana 7.x crashloop on orphan `ingest_manager_settings` docs.
+		"migrations.discardUnknownObjects": components.ComponentEckKibana.Version,
 		// Setting this to false will prevent it from connecting to endpoints outside of this cluster.
 		// See: https://www.elastic.co/guide/en/kibana/8.19/settings.html
 		"newsfeed.enabled": false,

--- a/pkg/render/logstorage/kibana/kibana_test.go
+++ b/pkg/render/logstorage/kibana/kibana_test.go
@@ -36,6 +36,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
@@ -151,6 +152,7 @@ var _ = Describe("Kibana rendering tests", func() {
 			Expect(resultKB.Spec.Config.Data["xpack.fleet.isAirGapped"]).To(BeTrue())
 			Expect(resultKB.Spec.Config.Data["xpack.fleet.packages"]).To(Equal([]string{}))
 			Expect(resultKB.Spec.Config.Data["xpack.fleet.registryUrl"]).To(Equal("http://localhost:5601"))
+			Expect(resultKB.Spec.Config.Data["migrations.discardUnknownObjects"]).To(Equal(components.ComponentEckKibana.Version))
 			Expect(resultKB.Spec.Config.Data["newsfeed.enabled"]).To(BeFalse())
 			Expect(resultKB.Spec.Config.Data["xpack.productDocBase.artifactRepositoryUrl"]).To(Equal("http://localhost:5601"))
 		})


### PR DESCRIPTION
## Summary

Cherry-pick of #4741 onto `release-v1.40` for CE 3.22.

## Release Note

```release-note
Fix Kibana crashloop when upgrading from Calico Enterprise 3.20 or earlier to 3.22. The orphan `ingest_manager_settings` saved object left by Fleet 7.17 is now discarded during Kibana 8.x saved-object migration.
```

## Note on CE 3.22.2

CE 3.22.2 ships a `tigera/kibana:v3.22.2` image containing an 8.19.10 Kibana binary, while operator `release-v1.40` has `ComponentEckKibana.Version = "8.19.12"` (anticipating the 3.22.3 image rebuild). Until 3.22.3 ships, customers running 3.22.2 will see Kibana ignore the discard setting with `The flag migrations.discardUnknownObjects is defined but does not match the current kibana version`. Those customers should use the manual workaround with `"8.19.10"` documented on the parent ticket. This fix takes effect automatically from 3.22.3 onward (image + operator aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
