### PR TITLE
Avoid duplicate kube-controllers tolerations

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -16,6 +16,7 @@ package kubecontrollers
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -638,9 +639,9 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 	if c.cfg.MetricsServerTLS != nil && c.cfg.MetricsServerTLS.UseCertificateManagement() {
 		initContainers = append(initContainers, c.cfg.MetricsServerTLS.InitContainer(c.cfg.Namespace, sc))
 	}
-	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
+	tolerations := appendUniqueTolerations(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateCriticalAddonsAndControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {
-		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
+		tolerations = appendUniqueTolerations(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 	podSpec := corev1.PodSpec{
 		NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,
@@ -682,6 +683,16 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 		rcomp.ApplyDeploymentOverrides(&d, overrides)
 	}
 	return &d
+}
+
+func appendUniqueTolerations(tolerations []corev1.Toleration, toAppend ...corev1.Toleration) []corev1.Toleration {
+	for _, toleration := range toAppend {
+		if slices.Contains(tolerations, toleration) {
+			continue
+		}
+		tolerations = append(tolerations, toleration)
+	}
+	return tolerations
 }
 
 func (c *kubeControllersComponent) controllersClusterRoleBinding() *rbacv1.ClusterRoleBinding {

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -638,6 +638,14 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Tolerations).To(ContainElements(append(rmeta.TolerateControlPlane, t)))
 	})
 
+	It("should not duplicate default tolerations when they are specified as ControlPlaneTolerations", func() {
+		instance.ControlPlaneTolerations = []corev1.Toleration{rmeta.TolerateCriticalAddonsOnly}
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		resources, _ := component.Objects()
+		d := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(d.Spec.Template.Spec.Tolerations).To(ConsistOf(rmeta.TolerateCriticalAddonsAndControlPlane))
+	})
+
 	It("should render resourcerequirements", func() {
 		rr := &corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{


### PR DESCRIPTION
## Description

Bug fix for #3783. The calico-kube-controllers renderer now appends the operator's default tolerations only when they are not already present in `Installation.spec.controlPlaneTolerations`. This prevents duplicate `CriticalAddonsOnly` tolerations while preserving the default control-plane tolerations and GKE Arm64 toleration behavior.

Testing done:
- `go test ./pkg/render/kubecontrollers`

Components affected:
- calico-kube-controllers rendering

Closes #3783

## Release Note

```release-note
Avoid rendering duplicate tolerations on calico-kube-controllers when matching default tolerations are already configured through Installation controlPlaneTolerations.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
