### PR TITLE
Avoid false GKE provider detection

### DIFF
--- a/pkg/controller/utils/discovery.go
+++ b/pkg/controller/utils/discovery.go
@@ -30,6 +30,8 @@ import (
 
 var log = logf.Log.WithName("discovery")
 
+const gkeNodeLabelPrefix = "cloud.google.com/gke-"
+
 // RequiresTigeraSecure determines if the configuration requires we start the tigera secure
 // controllers.
 func RequiresTigeraSecure(clientset *kubernetes.Clientset) (bool, error) {
@@ -79,7 +81,7 @@ func MultiTenant(ctx context.Context, c kubernetes.Interface) (bool, error) {
 
 func AutoDiscoverProvider(ctx context.Context, clientset kubernetes.Interface) (operatorv1.Provider, error) {
 	// First, try to determine the platform based on the present API groups.
-	if platform, err := autodetectFromGroup(clientset); err != nil {
+	if platform, err := autodetectFromGroup(ctx, clientset); err != nil {
 		return operatorv1.ProviderNone, fmt.Errorf("failed to check provider based on API groups: %s", err)
 	} else if platform != operatorv1.ProviderNone {
 		// We detected a platform. Use it.
@@ -141,15 +143,18 @@ func isOpenshift(c kubernetes.Interface) (bool, error) {
 }
 
 // autodetectFromGroup auto detects the platform based on the API groups that are present.
-func autodetectFromGroup(c kubernetes.Interface) (operatorv1.Provider, error) {
+func autodetectFromGroup(ctx context.Context, c kubernetes.Interface) (operatorv1.Provider, error) {
 	groups, err := c.Discovery().ServerGroups()
 	if err != nil {
 		return operatorv1.ProviderNone, err
 	}
 	for _, g := range groups.Groups {
 		if g.Name == "networking.gke.io" {
-			// Running on GKE.
-			return operatorv1.ProviderGKE, nil
+			if isGKE, err := hasGKENodeLabels(ctx, c); err != nil {
+				return operatorv1.ProviderNone, err
+			} else if isGKE {
+				return operatorv1.ProviderGKE, nil
+			}
 		}
 
 		if g.Name == "core.tanzu.vmware.com" {
@@ -157,6 +162,21 @@ func autodetectFromGroup(c kubernetes.Interface) (operatorv1.Provider, error) {
 		}
 	}
 	return operatorv1.ProviderNone, nil
+}
+
+func hasGKENodeLabels(ctx context.Context, c kubernetes.Interface) (bool, error) {
+	nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, node := range nodes.Items {
+		for label := range node.Labels {
+			if strings.HasPrefix(label, gkeNodeLabelPrefix) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // isDockerEE returns true if running on a Docker Enterprise cluster, and false otherwise.

--- a/pkg/controller/utils/discovery_test.go
+++ b/pkg/controller/utils/discovery_test.go
@@ -76,13 +76,30 @@ var _ = Describe("provider discovery", func() {
 	})
 
 	It("should detect GKE based on API resource networking.gke.io existence", func() {
-		c := fake.NewClientset()
+		c := fake.NewClientset(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gke-node",
+				Labels: map[string]string{
+					"cloud.google.com/gke-nodepool": "default-pool",
+				},
+			},
+		})
 		c.Resources = []*metav1.APIResourceList{{
 			GroupVersion: "networking.gke.io/v1",
 		}}
 		p, e := AutoDiscoverProvider(context.Background(), c)
 		Expect(e).To(BeNil())
 		Expect(p).To(Equal(operatorv1.ProviderGKE))
+	})
+
+	It("should not detect GKE based only on API resource networking.gke.io existence", func() {
+		c := fake.NewClientset()
+		c.Resources = []*metav1.APIResourceList{{
+			GroupVersion: "networking.gke.io/v1",
+		}}
+		p, e := AutoDiscoverProvider(context.Background(), c)
+		Expect(e).To(BeNil())
+		Expect(p).To(Equal(operatorv1.ProviderNone))
 	})
 
 	It("should detect TKG based on API resource core.tanzu.vmware.com existence", func() {


### PR DESCRIPTION
## Description

Bug fix for #4530. GKE provider auto-detection no longer treats the `networking.gke.io` API group by itself as proof that the cluster is GKE, because third-party projects can install APIs in that group on non-GKE clusters. The detection now requires a GKE-specific node label in addition to the API group before applying GKE defaults such as the CNI type and binary path.

Testing done:
- `go test ./pkg/controller/utils`

Components affected:
- provider auto-discovery
- Installation defaulting that depends on the detected provider

Closes #4530

## Release Note

```release-note
Avoid incorrectly auto-detecting non-GKE clusters as GKE when they only expose the networking.gke.io API group.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
