### PR TITLE
Run csi-node-driver-registrar from combined calico image

### DIFF
--- a/config/calico_versions.yml
+++ b/config/calico_versions.yml
@@ -23,8 +23,6 @@ components:
     version: master
   csi:
     version: master
-  csi-node-driver-registrar:
-    version: master
   key-cert-provisioner:
     version: master
   whisker:

--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -54,15 +54,6 @@ var (
 		variant:   calicoVariant,
 	}
 {{- end }}
-{{ with index .Components "csi-node-driver-registrar" }}
-	ComponentCalicoCSIRegistrar = Component{
-		Version:   "{{ .Version }}",
-		Image:     "{{ .Image }}",
-		Registry:  "{{ .Registry }}",
-		imagePath: "{{ .ImagePath }}",
-		variant:   calicoVariant,
-	}
-{{- end }}
 {{ with index .Components.whisker }}
 	ComponentCalicoWhisker = Component{
 		Version:   "{{ .Version }}",
@@ -158,7 +149,6 @@ var (
 		ComponentCalicoNode,
 		ComponentCalicoNodeFIPS,
 		ComponentCalicoNodeWindows,
-		ComponentCalicoCSIRegistrar,
 		ComponentCalicoWhisker,
 		ComponentCalicoEnvoyGateway,
 		ComponentCalicoEnvoyProxy,

--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -41,7 +41,6 @@ var (
 		"calicoctl":                   "ctl",
 		"flexvol":                     "pod2daemon-flexvol",
 		"csi":                         "csi",
-		"csi-node-driver-registrar":   "node-driver-registrar",
 		"typha":                       "typha",
 		"key-cert-provisioner":        "key-cert-provisioner",
 		"apiserver":                   "apiserver",

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -52,14 +52,6 @@ var (
 		variant:   calicoVariant,
 	}
 
-	ComponentCalicoCSIRegistrar = Component{
-		Version:   "master",
-		Image:     "node-driver-registrar",
-		Registry:  "",
-		imagePath: "",
-		variant:   calicoVariant,
-	}
-
 	ComponentCalicoWhisker = Component{
 		Version:   "master",
 		Image:     "whisker",
@@ -145,7 +137,6 @@ var (
 		ComponentCalicoNode,
 		ComponentCalicoNodeFIPS,
 		ComponentCalicoNodeWindows,
-		ComponentCalicoCSIRegistrar,
 		ComponentCalicoWhisker,
 		ComponentCalicoEnvoyGateway,
 		ComponentCalicoEnvoyProxy,

--- a/pkg/controller/installation/windows_controller_test.go
+++ b/pkg/controller/installation/windows_controller_test.go
@@ -731,7 +731,6 @@ var _ = Describe("windows-controller installation tests", func() {
 							Images: []operator.Image{
 								{Image: "calico/calico", Digest: "sha256:calicocombinedhash"},
 								{Image: "calico/node", Digest: "sha256:tigeranodehash"},
-								{Image: "calico/node-driver-registrar", Digest: "sha256:caliconodedriverregistrarhash"},
 							},
 						},
 					}

--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -139,9 +139,10 @@ func (c *csiComponent) csiAffinities() *corev1.Affinity {
 
 func (c *csiComponent) csiContainers() []corev1.Container {
 	mountPropagation := corev1.MountPropagationBidirectional
-	var csiCommand []string
+	var csiCommand, registrarCommand []string
 	if c.useCombinedImage {
 		csiCommand = []string{components.CalicoBinaryPath, "component", "csi"}
+		registrarCommand = []string{"/usr/bin/csi-node-driver-registrar"}
 	}
 	csiContainer := corev1.Container{
 		Name:            CSIContainerName,
@@ -188,6 +189,7 @@ func (c *csiComponent) csiContainers() []corev1.Container {
 	registrarContainer := corev1.Container{
 		Name:            CSIRegistrarContainerName,
 		Image:           c.csiRegistrarImage,
+		Command:         registrarCommand,
 		ImagePullPolicy: ImagePullPolicy(),
 		Args: []string{
 			"--v=5",
@@ -390,7 +392,7 @@ func (c *csiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 		if err != nil {
 			return err
 		}
-		c.csiRegistrarImage, err = components.GetReference(components.ComponentCalicoCSIRegistrar, reg, path, prefix, is)
+		c.csiRegistrarImage = c.csiImage
 	} else {
 		c.csiImage, err = components.GetReference(components.ComponentTigeraCSI, reg, path, prefix, is)
 		if err != nil {

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -309,8 +309,9 @@ var _ = Describe("CSI rendering tests", func() {
 		Expect(comp.ResolveImages(nil)).To(BeNil())
 		createObjs, _ := comp.Objects()
 		dsResource := rtest.GetResource(createObjs, "csi-node-driver", common.CalicoNamespace, "apps", "v1", "DaemonSet")
-		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image).To(Equal(fmt.Sprintf("%s%s%s:%s", components.CalicoRegistry, components.CalicoImagePath, components.ComponentCalico.Image, components.ComponentCalico.Version)))
-		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("%s%s%s:%s", components.CalicoRegistry, components.CalicoImagePath, components.ComponentCalicoCSIRegistrar.Image, components.ComponentCalicoCSIRegistrar.Version)))
+		expectedImage := fmt.Sprintf("%s%s%s:%s", components.CalicoRegistry, components.CalicoImagePath, components.ComponentCalico.Image, components.ComponentCalico.Version)
+		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image).To(Equal(expectedImage))
+		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(Equal(expectedImage))
 	})
 
 	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
@@ -323,7 +324,7 @@ var _ = Describe("CSI rendering tests", func() {
 		createObjs, _ := comp.Objects()
 		dsResource := rtest.GetResource(createObjs, "csi-node-driver", common.CalicoNamespace, "apps", "v1", "DaemonSet")
 		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
-		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).NotTo(ContainSubstring("-fips"))
+		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(ContainSubstring("-fips"))
 	})
 
 	It("should render the labels when the provider is openshift", func() {


### PR DESCRIPTION
## Description

The OSS combined-image work in https://github.com/tigera/operator/pull/4608 missed the CSI registrar sidecar. The combined `calico/calico` image already ships `/usr/bin/csi-node-driver-registrar` alongside the rest of the binaries, but `ResolveImages` still pointed the sidecar at the now-retired `calico/node-driver-registrar` image — new hashreleases stopped publishing that image and pulls began failing.

This change has the registrar container reuse the combined image and exec the bundled binary directly. The registrar's `main` is upstream code we don't own, so it isn't folded into the `calico` monobinary as a subcommand — the container just execs `/usr/bin/csi-node-driver-registrar` from the combined image. In FIPS mode the registrar now inherits the `-fips` tag from the combined image (test expectation flipped accordingly).

`ComponentCalicoCSIRegistrar` and its `gen-versions` template / `config/calico_versions.yml` entry are dropped now that nothing references them.

A matching change is needed on the calico side to drop the `csi-node-driver-registrar` mapping from `release/internal/pinnedversion/pinnedversion.go` so future hashreleases stop trying to publish the retired image.

```release-note
NONE
```
