### PR TITLE
[EV-6519] Update ECK CRDs to v3.3.2

### DIFF
--- a/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
+++ b/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -502,7 +502,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -1024,7 +1024,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: autoopsagentpolicies.autoops.k8s.elastic.co
 spec:
   group: autoops.k8s.elastic.co
@@ -1068,6 +1068,32 @@ spec:
                   type: object
                 image:
                   type: string
+                namespaceSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -1141,7 +1167,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -1380,7 +1406,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -1637,7 +1663,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -1894,7 +1920,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -3263,7 +3289,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -3741,7 +3767,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -4309,7 +4335,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: logstashes.logstash.k8s.elastic.co
 spec:
   group: logstash.k8s.elastic.co
@@ -4852,7 +4878,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: packageregistries.packageregistry.k8s.elastic.co
 spec:
   group: packageregistry.k8s.elastic.co
@@ -5094,7 +5120,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.3.2'
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co


### PR DESCRIPTION
## Description

Refreshes the bundled ECK CRDs to track the [`v3.3.2`](https://github.com/elastic/cloud-on-k8s/releases/tag/v3.3.2) release of `elastic/cloud-on-k8s`. Companion to the ECK version bump in `tigera/calico-private`.

The only schema change between v3.3.0 and v3.3.2 is a new optional `namespaceSelector` field on `AutoOpsAgentPolicy.spec` (added in upstream v3.3.1). Plus the `app.kubernetes.io/version` label bump on all 12 CRDs.

No new API groups or resources, so **no RBAC changes are required** — the `autoops.k8s.elastic.co` and `packageregistry.k8s.elastic.co` permissions added during the v3.3.0 upgrade (#4596) already cover this release.

CRDs were copied from `calico-private/charts/crd.projectcalico.org.v1/templates/eck/`, which is the same source `make update-enterprise-crds` pulls from.

### Companion PR

- [tigera/calico-private#11707: Update ECK operator from v3.3.0 to v3.3.2](https://github.com/tigera/calico-private/pull/11707)

### Testing

- `go build ./...` clean
- `go run ./cmd --print-enterprise-crds all` exits 0 (CRDs parse, including the new `namespaceSelector`)
- `go test ./pkg/controller/logstorage/... ./pkg/render/logstorage/...` — all 18 packages pass

## Release Note

```release-note
Update bundled ECK CRDs to v3.3.2.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files` (n/a — no API changes)
- [x] If changing versions, run `make gen-versions` (n/a — `config/enterprise_versions.yml` not touched, matching the v3.3.0 precedent in #4596)
