### PR TITLE
Fix concurrent-append panic in override-field recording

### DIFF
--- a/pkg/render/common/components/components.go
+++ b/pkg/render/common/components/components.go
@@ -17,7 +17,6 @@ package components
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	kbv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/kibana/v1"
 	envoyapi "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -291,18 +290,26 @@ func GetPriorityClassName(overrides any) string {
 	return ""
 }
 
-func getField(overrides any, fieldNames ...string) (value reflect.Value) {
+// normalizeFieldPath applies type-specific path adjustments before lookup.
+// Extracted so test code that wraps getField can reproduce the same path
+// transformations when recording.
+func normalizeFieldPath(overrides any, fieldNames []string) []string {
 	// SPECIAL CASE: ComplianceReporterPodTemplate doesn't follow the Spec, Template, Spec, ...
 	// pattern that all our other override structures follow.  Instead it skips the top-level
 	// Spec and has Template, Spec, ...
 	if _, isComplianceReporterPodTemplate := overrides.(*operator.ComplianceReporterPodTemplate); isComplianceReporterPodTemplate {
-		if fieldNames[0] == "Spec" {
-			fieldNames = fieldNames[1:]
+		if len(fieldNames) > 0 && fieldNames[0] == "Spec" {
+			return fieldNames[1:]
 		}
 	}
+	return fieldNames
+}
 
-	// Record that we're handling `fieldNames`.  See `overrideFieldsHandledInLastApplyCall` for why.
-	recordHandledField(fieldNames)
+// getField is a var rather than a func so tests can swap in a recording
+// wrapper. Production code never replaces it. See recordHandledFields in the
+// test file. NOT safe to swap concurrently with calls.
+var getField = func(overrides any, fieldNames ...string) (value reflect.Value) {
+	fieldNames = normalizeFieldPath(overrides, fieldNames)
 
 	typ := reflect.TypeOf(overrides)
 	for _, fieldName := range fieldNames {
@@ -330,8 +337,6 @@ func getField(overrides any, fieldNames ...string) (value reflect.Value) {
 
 // applyReplicatedPodResourceOverrides takes the given replicated pod resource data and applies the overrides.
 func applyReplicatedPodResourceOverrides(r *replicatedPodResource, overrides any) *replicatedPodResource {
-	resetHandledFields()
-
 	// If `overrides` has a Metadata field, and it's non-nil, non-clashing labels and annotations from that
 	// metadata are added into `r.labels` and `r.annotations`.
 	if metadata := GetMetadata(overrides); metadata != nil {
@@ -448,20 +453,6 @@ func applyReplicatedPodResourceOverrides(r *replicatedPodResource, overrides any
 	}
 
 	return r
-}
-
-// For UT purposes, only, this variable stores the override fields that were handled in that most
-// recent `applyReplicatedPodResourceOverrides` call.  UT code then checks that the structures we
-// use for `overrides` do not have any _other_ fields than those (except for known special cases).
-var overrideFieldsHandledInLastApplyCall []string
-
-func resetHandledFields() {
-	overrideFieldsHandledInLastApplyCall = nil
-}
-
-func recordHandledField(fieldNames []string) {
-	dottedName := strings.Join(fieldNames, ".")
-	overrideFieldsHandledInLastApplyCall = append(overrideFieldsHandledInLastApplyCall, dottedName)
 }
 
 // ApplyDaemonSetOverrides applies the overrides to the given DaemonSet.

--- a/pkg/render/common/components/components_test.go
+++ b/pkg/render/common/components/components_test.go
@@ -1299,7 +1299,7 @@ func recordHandledFields() (recorded func() []string, restore func()) {
 		rec = append(rec, strings.Join(normalizeFieldPath(overrides, fieldNames), "."))
 		return original(overrides, fieldNames...)
 	}
-	return func() []string { return rec }, func() { getField = original }
+	return func() []string { return append([]string(nil), rec...) }, func() { getField = original }
 }
 
 // defaultedDaemonSet returns a DaemonSet with its fields populated.

--- a/pkg/render/common/components/components_test.go
+++ b/pkg/render/common/components/components_test.go
@@ -135,11 +135,14 @@ var _ = Describe("Common components render tests", func() {
 
 	DescribeTable("check for unhandled fields",
 		func(overrides any, expectUnhandled bool, allowedExtraFields ...string) {
-			// Call applyReplicatedPodResourceOverrides to discover all the fields that
+			// Wrap getField so we can observe which paths the production
+			// code accesses, then run it to discover all the fields that
 			// we handle.
+			recorded, restore := recordHandledFields()
+			defer restore()
 			r := &replicatedPodResource{}
 			applyReplicatedPodResourceOverrides(r, overrides)
-			handledFields := append(overrideFieldsHandledInLastApplyCall, allowedExtraFields...)
+			handledFields := append(recorded(), allowedExtraFields...)
 
 			// Now traverse the structure to find any unhandled fields.
 			unhandledFields := findUnhandled(handledFields, "", reflect.TypeOf(overrides))
@@ -1275,6 +1278,28 @@ func addContainer(cs []corev1.Container) []corev1.Container {
 	containers = append(containers, cs[0])
 	containers = append(containers, newContainer)
 	return containers
+}
+
+// recordHandledFields swaps the package-level getField with a wrapper that
+// records each field path accessed, then returns:
+//   - recorded: a closure returning the accumulated paths
+//   - restore: a function (typically deferred) that restores the original getField
+//
+// The wrapper passes raw fieldNames through to the original getField, so any
+// per-type path adjustments made there are unchanged. Recording mirrors those
+// adjustments via normalizeFieldPath so the recorded paths match the field
+// names we actually look up.
+//
+// NOT safe under parallel test execution: the swap mutates package state.
+// All "check for unhandled fields" entries run serially in this Describe.
+func recordHandledFields() (recorded func() []string, restore func()) {
+	var rec []string
+	original := getField
+	getField = func(overrides any, fieldNames ...string) reflect.Value {
+		rec = append(rec, strings.Join(normalizeFieldPath(overrides, fieldNames), "."))
+		return original(overrides, fieldNames...)
+	}
+	return func() []string { return rec }, func() { getField = original }
 }
 
 // defaultedDaemonSet returns a DaemonSet with its fields populated.


### PR DESCRIPTION
  The package-level overrideFieldsHandledInLastApplyCall slice was
  documented as UT-only, but getField appended to it on every call —
  including from production paths like ValidateReplicatedPodResourceOverrides.
  Concurrent reconcilers racing on the unsynchronized append produced
  "invalid memory address or nil pointer dereference" panics from
  growslice tearing the slice header.

  Move the recording out of production entirely:

  - getField becomes a function var. Production never replaces it.
  - Tests use recordHandledFields() to swap in a wrapper that records paths into a closure-local slice and restore the original via deferred cleanup. No package-level mutable slice; nothing for concurrent reconcilers to race on.
  - The ComplianceReporterPodTemplate Spec-strip is extracted into normalizeFieldPath so the test wrapper can mirror it when recording.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Fixed a panic caused by concurrent reconcilers racing on an unsynchronized slice used to track handled override fields.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
