### PR TITLE
Fix release version check and add version check escape hatch

### DIFF
--- a/hack/release/build.go
+++ b/hack/release/build.go
@@ -71,6 +71,7 @@ var buildCommand = &cli.Command{
 		enterpriseGitBranchFlag,
 		hashreleaseFlag,
 		skipValidationFlag,
+		versionCheckFlag,
 		extensionTimeoutFlag,
 	},
 	Before: buildBefore,

--- a/hack/release/checks.go
+++ b/hack/release/checks.go
@@ -26,11 +26,11 @@ import (
 
 // check that the git working tree is clean.
 var checkGitClean = func(ctx context.Context) (context.Context, error) {
-	version, err := command.GitVersion()
+	out, err := command.Git("status", "--porcelain")
 	if err != nil {
-		return ctx, fmt.Errorf("error getting git version: %w", err)
+		return ctx, fmt.Errorf("checking git working tree status: %w", err)
 	}
-	if strings.Contains(version, "dirty") {
+	if strings.TrimSpace(out) != "" {
 		return ctx, fmt.Errorf("git working tree is dirty, please commit or stash changes before proceeding")
 	}
 	return ctx, nil
@@ -45,7 +45,10 @@ var checkVersionMatchesGitVersion = func(ctx context.Context, c *cli.Command) (c
 		checkLog.Debug("Skipping version check for hashrelease")
 		return ctx, nil
 	}
-	gitVer, err := command.GitVersion()
+	// Not using command.GitVersion() so that on a clean tagged HEAD it returns bare "vX.Y.Z"
+	// for accurate comparison against the user-provided version.
+	// command.GitVersion() uses --long for build-identifier purposes and would always append "-0-g<sha>".
+	gitVer, err := command.Git("describe", "--tags", "--abbrev=12", "--dirty")
 	if err != nil {
 		return ctx, fmt.Errorf("getting git version: %w", err)
 	}

--- a/hack/release/checks.go
+++ b/hack/release/checks.go
@@ -79,6 +79,10 @@ var checkVersionFormat = func(ctx context.Context, c *cli.Command) (context.Cont
 }
 
 var checkVersion = func(ctx context.Context, c *cli.Command) (context.Context, error) {
+	if !c.Bool(versionCheckFlag.Name) {
+		logrus.Warn("Skipping version check, this is not recommended for releases")
+		return ctx, nil
+	}
 	ctx, err := checkVersionFormat(ctx, c)
 	if err != nil {
 		return ctx, err

--- a/hack/release/flags.go
+++ b/hack/release/flags.go
@@ -461,7 +461,7 @@ var (
 	skipValidationFlag      = &cli.BoolFlag{
 		Name:     "skip-validation",
 		Category: developmentFlagCategory,
-		Usage:    "Skip various validation steps (development and testing purposes only)",
+		Usage:    "Skip various validation steps except version check (development and testing purposes only)",
 		Sources:  cli.EnvVars("SKIP_VALIDATION"),
 		Value:    false,
 	}
@@ -478,5 +478,12 @@ var (
 		Usage:    "Skip checking that the current git branch is master or a release branch (development and testing purposes only)",
 		Sources:  cli.EnvVars("SKIP_BRANCH_CHECK"),
 		Value:    false,
+	}
+	versionCheckFlag = &cli.BoolWithInverseFlag{
+		Name:     "version-check",
+		Category: developmentFlagCategory,
+		Usage:    "Check that the provided version is valid and matches the git version. (development and testing purposes only)",
+		Sources:  cli.EnvVars("VERSION_CHECK"),
+		Value:    true,
 	}
 )

--- a/hack/release/publish.go
+++ b/hack/release/publish.go
@@ -42,6 +42,7 @@ var publishCommand = &cli.Command{
 		registryFlag,
 		hashreleaseFlag,
 		skipValidationFlag,
+		versionCheckFlag,
 		createGithubReleaseFlag,
 		githubTokenFlag,
 		draftGithubReleaseFlag,


### PR DESCRIPTION
## Description

`checkVersionMatchesGitVersion` compared `--version` against `command.GitVersion()`, whose `--long` flag forces `vX.Y.Z-0-g<sha>` on a tagged HEAD — never matching the bare version. Broke the v1.42.0 publish job.

- Drop `--long` at this call site.
- Switch `checkGitClean` to `git status --porcelain` so it doesn't piggyback on describe output.
- Add `--no-version-check` (default off) on `build` and `publish` as an escape hatch for future regressions in the check.

## Release Note

```release-note
TBD
```