### PR TITLE
Only render IDS managed-cluster watch binding on management clusters

### DIFF
--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -17,6 +17,7 @@ package render
 import (
 	"crypto/x509"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -170,7 +171,8 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 		c.intrusionDetectionDeployment(),
 	)
 
-	if !c.cfg.ManagedCluster {
+	if c.cfg.ManagementCluster {
+		// Only needed on management clusters.
 		objs = append(objs, c.managedClustersWatchRoleBinding())
 	}
 	if c.cfg.Tenant.MultiTenant() {
@@ -185,6 +187,22 @@ func (c *intrusionDetectionComponent) Objects() ([]client.Object, []client.Objec
 		// allow-tigera Tier was renamed to calico-system
 		networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("intrusion-detection-controller", c.cfg.Namespace),
 		networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("default-deny", c.cfg.Namespace),
+	}
+
+	if !c.cfg.ManagementCluster {
+		// These aren't needed unless we're a management cluster. Delete
+		// both variants in case a cluster switches from management to
+		// standalone (or to clean up bindings rendered by older versions).
+		objsToDelete = append(objsToDelete,
+			&rbacv1.RoleBinding{
+				TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: IntrusionDetectionManagedClustersWatchRoleBindingName, Namespace: c.cfg.Namespace},
+			},
+			&rbacv1.ClusterRoleBinding{
+				TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: IntrusionDetectionManagedClustersWatchRoleBindingName},
+			},
+		)
 	}
 
 	if !c.cfg.ManagedCluster && !c.cfg.Tenant.MultiTenant() {
@@ -701,6 +719,10 @@ func (c *intrusionDetectionComponent) intrusionDetectionControllerContainer() co
 		{
 			Name:  "LINSEED_TOKEN",
 			Value: GetLinseedTokenPath(c.cfg.ManagedCluster),
+		},
+		{
+			Name:  "MANAGEMENT_CLUSTER",
+			Value: strconv.FormatBool(c.cfg.ManagementCluster),
 		},
 	}
 

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -124,7 +124,6 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.IntrusionDetectionManagedClustersWatchRoleBindingName}},
 			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.pod"}},
 			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.globalnetworkpolicy"}},
 			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.globalnetworkset"}},
@@ -156,6 +155,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			{Name: "LINSEED_CLIENT_CERT", Value: "/intrusion-detection-tls/tls.crt"},
 			{Name: "LINSEED_CLIENT_KEY", Value: "/intrusion-detection-tls/tls.key"},
 			{Name: "LINSEED_TOKEN", Value: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
+			{Name: "MANAGEMENT_CLUSTER", Value: "false"},
 		}
 		Expect(idc.Spec.Template.Spec.Containers[0].Env).To(Equal(idcExpectedEnvVars))
 		Expect(idc.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
@@ -249,15 +249,27 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			},
 		))
 
-		roleBindingWatchManagedClusters := rtest.GetResource(resources, render.IntrusionDetectionManagedClustersWatchRoleBindingName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-		Expect(roleBindingWatchManagedClusters.RoleRef.Name).To(Equal(render.ManagedClustersWatchClusterRoleName))
-		Expect(roleBindingWatchManagedClusters.Subjects).To(ConsistOf([]rbacv1.Subject{
+		// The managed-clusters watch binding should not be rendered on standalone clusters.
+		Expect(rtest.GetResource(resources, render.IntrusionDetectionManagedClustersWatchRoleBindingName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")).To(BeNil())
+	})
+
+	It("should render the managed-clusters watch ClusterRoleBinding on a management cluster", func() {
+		cfg.ManagementCluster = true
+		component := render.IntrusionDetection(cfg)
+		resources, _ := component.Objects()
+
+		crb := rtest.GetResource(resources, render.IntrusionDetectionManagedClustersWatchRoleBindingName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+		Expect(crb.RoleRef.Name).To(Equal(render.ManagedClustersWatchClusterRoleName))
+		Expect(crb.Subjects).To(ConsistOf([]rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      render.IntrusionDetectionName,
 				Namespace: render.IntrusionDetectionNamespace,
 			},
 		}))
+
+		idc := rtest.GetResource(resources, "intrusion-detection-controller", render.IntrusionDetectionNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(idc.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "MANAGEMENT_CLUSTER", Value: "true"}))
 	})
 
 	It("should render finalizers rbac resources in the IDS ClusterRole for an Openshift management/standalone cluster", func() {
@@ -301,7 +313,6 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
 			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "intrusion-detection-controller", Namespace: "tigera-intrusion-detection"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.IntrusionDetectionManagedClustersWatchRoleBindingName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.pod"}},
 			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.globalnetworkpolicy"}},
 			&v3.GlobalAlertTemplate{ObjectMeta: metav1.ObjectMeta{Name: "policy.globalnetworkset"}},
@@ -689,6 +700,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 			cfg.BindNamespaces = []string{tenantANamespace, tenantBNamespace}
 			cfg.Tenant = tenantA
 			cfg.ExternalElastic = true
+			cfg.ManagementCluster = true
 		})
 
 		It("should render multi-tenant resources", func() {
@@ -742,6 +754,15 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 					Action:      v3.Allow,
 					Protocol:    &networkpolicy.TCPProtocol,
 					Destination: networkpolicy.CreateEntityRule(tenantANamespace, "tigera-linseed", 8444),
+				},
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Destination: v3.EntityRule{
+						NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", tenantANamespace),
+						Selector:          "k8s-app == 'calico-manager'",
+						Ports:             networkpolicy.Ports(9443),
+					},
 				},
 				{
 					Action:      v3.Allow,


### PR DESCRIPTION
The intrusion-detection-controller binding to `calico-managed-cluster-watch` is rendered for any non-managed cluster, but the `ClusterRole` it binds to is only rendered when `ManagementCluster` is set. On standalone clusters that produces a dangling binding referring to a ClusterRole that doesn't exist, and the IDS pod logs a constant stream of `cannot list managedclusters ... RBAC: clusterrole.rbac.authorization.k8s.io "calico-managed-cluster-watch" not found` errors.

This PR gates the binding on `ManagementCluster` so it matches the ClusterRole's gating, and explicitly cleans up both the `RoleBinding` and `ClusterRoleBinding` variants on non-management clusters in case a cluster transitions from management to standalone (or had the binding leftover from an older version). It also passes a `MANAGEMENT_CLUSTER` env var through to the IDS container so the controller itself can skip the `ManagedCluster` watch on standalone clusters - that side lives in https://github.com/tigera/calico-private.

```release-note
Stops the intrusion-detection-controller from logging repeated RBAC errors about ManagedClusters on standalone clusters.
```