### PR TITLE
Cherry-pick #4764 to release-v1.42: Fix release version check and add escape hatch

### DIFF
--- a/hack/release/build.go
+++ b/hack/release/build.go
@@ -90,6 +90,7 @@ var buildCommand = &cli.Command{
 		enterpriseGitBranchFlag,
 		hashreleaseFlag,
 		skipValidationFlag,
+		versionCheckFlag,
 		extensionTimeoutFlag,
 	},
 	Before: buildBefore,

--- a/hack/release/checks.go
+++ b/hack/release/checks.go
@@ -25,11 +25,11 @@ import (
 
 // check that the git working tree is clean.
 var checkGitClean = func(ctx context.Context) (context.Context, error) {
-	version, err := gitVersion()
+	out, err := git("status", "--porcelain")
 	if err != nil {
-		return ctx, fmt.Errorf("error getting git version: %w", err)
+		return ctx, fmt.Errorf("checking git working tree status: %w", err)
 	}
-	if strings.Contains(version, "dirty") {
+	if strings.TrimSpace(out) != "" {
 		return ctx, fmt.Errorf("git working tree is dirty, please commit or stash changes before proceeding")
 	}
 	return ctx, nil
@@ -44,7 +44,10 @@ var checkVersionMatchesGitVersion = func(ctx context.Context, c *cli.Command) (c
 		checkLog.Debug("Skipping version check for hashrelease")
 		return ctx, nil
 	}
-	gitVer, err := gitVersion()
+	// Not using gitVersion() so that on a clean tagged HEAD it returns bare "vX.Y.Z"
+	// for accurate comparison against the user-provided version.
+	// gitVersion() uses --long for build-identifier purposes and would always append "-0-g<sha>".
+	gitVer, err := git("describe", "--tags", "--abbrev=12", "--dirty")
 	if err != nil {
 		return ctx, fmt.Errorf("getting git version: %w", err)
 	}
@@ -75,6 +78,10 @@ var checkVersionFormat = func(ctx context.Context, c *cli.Command) (context.Cont
 }
 
 var checkVersion = func(ctx context.Context, c *cli.Command) (context.Context, error) {
+	if !c.Bool(versionCheckFlag.Name) {
+		logrus.Warn("Skipping version check, this is not recommended for releases")
+		return ctx, nil
+	}
 	ctx, err := checkVersionFormat(ctx, c)
 	if err != nil {
 		return ctx, err

--- a/hack/release/flags.go
+++ b/hack/release/flags.go
@@ -441,3 +441,10 @@ var skipRepoCheckFlag = &cli.BoolFlag{
 	Sources: cli.EnvVars("SKIP_REPO_CHECK"),
 	Value:   false,
 }
+
+var versionCheckFlag = &cli.BoolWithInverseFlag{
+	Name:    "version-check",
+	Usage:   "Check that the provided version is valid and matches the git version. (development and testing purposes only)",
+	Sources: cli.EnvVars("VERSION_CHECK"),
+	Value:   true,
+}

--- a/hack/release/publish.go
+++ b/hack/release/publish.go
@@ -40,6 +40,7 @@ var publishCommand = &cli.Command{
 		registryFlag,
 		hashreleaseFlag,
 		skipValidationFlag,
+		versionCheckFlag,
 		createGithubReleaseFlag,
 		githubTokenFlag,
 		draftGithubReleaseFlag,


### PR DESCRIPTION
## Description

Cherry-pick of #4764 to `release-v1.42`.

Bug fix backport for the release tooling. Without this, `make release-build VERSION=v1.42.x` fails on a clean tagged HEAD because `gitVersion()` (which uses `git describe --long`) always appends `-0-g<sha>` and never matches the bare version passed on the command line. Also adds a `--no-version-check` escape hatch so a release can bypass version checks if a future regression breaks the check.

### Conflict resolution notes

`release-v1.42` is older than master, so the patch needed minor adaptation:

- Used the existing `git()` helper instead of `command.Git()` (the `command` package doesn't exist on this branch).
- Kept v1.42's flat flag layout and added only `versionCheckFlag`. Did not pull in the unrelated flag-category refactor (`developmentFlagCategory`, `skipBranchCheckFlag`) from master, since `skipBranchCheckFlag` isn't referenced anywhere on this branch.

### Testing

- `go build ./hack/release/...` — passes
- `gofmt -l` — clean
- `go vet ./hack/release/...` — clean

## Release Note

```release-note
TBD
```

## For PR author

- [x] Tests for change. (n/a — release tooling backport)
- [x] If changing pkg/apis/, run `make gen-files` (n/a)
- [x] If changing versions, run `make gen-versions` (n/a)