### PR TITLE
Add LinuxPodInterfaceType to select netkit for pod CNI device

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -496,6 +496,17 @@ const (
 	ContainerIPForwardingDisabled ContainerIPForwardingType = "Disabled"
 )
 
+// LinuxPodInterfaceType specifies the type of virtual device the Calico CNI plugin
+// creates for the pod-side interface on Linux nodes.
+//
+// One of: Veth, Netkit
+type LinuxPodInterfaceType string
+
+const (
+	LinuxPodInterfaceVeth   LinuxPodInterfaceType = "Veth"
+	LinuxPodInterfaceNetkit LinuxPodInterfaceType = "Netkit"
+)
+
 // HostPortsType specifies host port support.
 //
 // One of: Enabled, Disabled
@@ -681,6 +692,19 @@ type CalicoNetworkSpec struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	ContainerIPForwarding *ContainerIPForwardingType `json:"containerIPForwarding,omitempty"`
+
+	// LinuxPodInterfaceType selects the virtual device type the Calico CNI plugin
+	// creates for each pod's interface on Linux nodes. When set to Netkit, the CNI
+	// plugin creates a netkit L2 pair on kernels that support it (Linux 6.7+) and
+	// falls back to a veth pair on older kernels. Netkit is recommended for the BPF
+	// dataplane, where it allows BPF programs to attach via BPF_NETKIT_PRIMARY for
+	// improved throughput and tail-latency under contention; for non-BPF dataplanes
+	// it is functionally equivalent to veth. Only valid when using the Calico CNI
+	// plugin.
+	// Default: Veth
+	// +optional
+	// +kubebuilder:validation:Enum=Veth;Netkit
+	LinuxPodInterfaceType *LinuxPodInterfaceType `json:"linuxPodInterfaceType,omitempty"`
 
 	// Sysctl configures sysctl parameters for tuning plugin
 	// +optional

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -500,6 +500,7 @@ const (
 // creates for the pod-side interface on Linux nodes.
 //
 // One of: Veth, Netkit
+// +kubebuilder:validation:Enum=Veth;Netkit
 type LinuxPodInterfaceType string
 
 const (
@@ -703,7 +704,6 @@ type CalicoNetworkSpec struct {
 	// plugin.
 	// Default: Veth
 	// +optional
-	// +kubebuilder:validation:Enum=Veth;Netkit
 	LinuxPodInterfaceType *LinuxPodInterfaceType `json:"linuxPodInterfaceType,omitempty"`
 
 	// Sysctl configures sysctl parameters for tuning plugin

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1285,6 +1285,11 @@ func (in *CalicoNetworkSpec) DeepCopyInto(out *CalicoNetworkSpec) {
 		*out = new(ContainerIPForwardingType)
 		**out = **in
 	}
+	if in.LinuxPodInterfaceType != nil {
+		in, out := &in.LinuxPodInterfaceType, &out.LinuxPodInterfaceType
+		*out = new(LinuxPodInterfaceType)
+		**out = **in
+	}
 	if in.Sysctl != nil {
 		in, out := &in.Sysctl, &out.Sysctl
 		*out = make([]Sysctl, len(*in))

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -264,6 +264,12 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 			}
 		}
 
+		if instance.Spec.CalicoNetwork.LinuxPodInterfaceType != nil {
+			if instance.Spec.CNI.Type != operatorv1.PluginCalico {
+				return fmt.Errorf("spec.calicoNetwork.linuxPodInterfaceType is supported only for Calico CNI")
+			}
+		}
+
 		if instance.Spec.CalicoNetwork.Sysctl != nil {
 			// CNI tuning plugin
 			pluginData := instance.Spec.CalicoNetwork.Sysctl

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -721,6 +721,10 @@ var _ = Describe("Installation validation tests", func() {
 				cipf := operator.ContainerIPForwardingEnabled
 				inst.Spec.CalicoNetwork.ContainerIPForwarding = &cipf
 			}),
+			Entry("LinuxPodInterfaceType", func(inst *operator.Installation) {
+				nk := operator.LinuxPodInterfaceNetkit
+				inst.Spec.CalicoNetwork.LinuxPodInterfaceType = &nk
+			}),
 		)
 		DescribeTable("should allow IPPool", func(plugin operator.CNIPluginType, ipam operator.IPAMPluginType) {
 			instance.Spec.CNI.Type = plugin

--- a/pkg/controller/utils/merge.go
+++ b/pkg/controller/utils/merge.go
@@ -348,6 +348,11 @@ func mergeCalicoNetwork(cfg, override *operatorv1.CalicoNetworkSpec) *operatorv1
 		out.ContainerIPForwarding = override.ContainerIPForwarding
 	}
 
+	switch compareFields(out.LinuxPodInterfaceType, override.LinuxPodInterfaceType) {
+	case BOnlySet, Different:
+		out.LinuxPodInterfaceType = override.LinuxPodInterfaceType
+	}
+
 	switch compareFields(out.Sysctl, override.Sysctl) {
 	case BOnlySet, Different:
 		out.Sysctl = override.Sysctl

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -1472,6 +1472,21 @@ spec:
                         - VPP
                         - Nftables
                       type: string
+                    linuxPodInterfaceType:
+                      description: |-
+                        LinuxPodInterfaceType selects the virtual device type the Calico CNI plugin
+                        creates for each pod's interface on Linux nodes. When set to Netkit, the CNI
+                        plugin creates a netkit L2 pair on kernels that support it (Linux 6.7+) and
+                        falls back to a veth pair on older kernels. Netkit is recommended for the BPF
+                        dataplane, where it allows BPF programs to attach via BPF_NETKIT_PRIMARY for
+                        improved throughput and tail-latency under contention; for non-BPF dataplanes
+                        it is functionally equivalent to veth. Only valid when using the Calico CNI
+                        plugin.
+                        Default: Veth
+                      enum:
+                        - Veth
+                        - Netkit
+                      type: string
                     linuxPolicySetupTimeoutSeconds:
                       description: |-
                         LinuxPolicySetupTimeoutSeconds delays new pods from running containers
@@ -10693,6 +10708,21 @@ spec:
                             - BPF
                             - VPP
                             - Nftables
+                          type: string
+                        linuxPodInterfaceType:
+                          description: |-
+                            LinuxPodInterfaceType selects the virtual device type the Calico CNI plugin
+                            creates for each pod's interface on Linux nodes. When set to Netkit, the CNI
+                            plugin creates a netkit L2 pair on kernels that support it (Linux 6.7+) and
+                            falls back to a veth pair on older kernels. Netkit is recommended for the BPF
+                            dataplane, where it allows BPF programs to attach via BPF_NETKIT_PRIMARY for
+                            improved throughput and tail-latency under contention; for non-BPF dataplanes
+                            it is functionally equivalent to veth. Only valid when using the Calico CNI
+                            plugin.
+                            Default: Veth
+                          enum:
+                            - Veth
+                            - Netkit
                           type: string
                         linuxPolicySetupTimeoutSeconds:
                           description: |-

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -758,6 +758,14 @@ func (c *nodeComponent) createCalicoPluginConfig() map[string]any {
 		}
 	}
 
+	// device_type tells the Calico CNI plugin which virtual device to create for
+	// the pod interface. Only emit when explicitly set to Netkit: leaving it out
+	// keeps the default (veth) behavior and avoids churning existing CNI configs.
+	if c.cfg.Installation.CalicoNetwork.LinuxPodInterfaceType != nil &&
+		*c.cfg.Installation.CalicoNetwork.LinuxPodInterfaceType == operatorv1.LinuxPodInterfaceNetkit {
+		calicoPluginConfig["device_type"] = "netkit"
+	}
+
 	return calicoPluginConfig
 }
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -2443,6 +2443,69 @@ var _ = Describe("Node rendering tests", func() {
 }`, enableIPv4, enableIPv6)))
 			})
 
+			It("should render device_type=netkit in the cni config when LinuxPodInterface is Netkit", func() {
+				nk := operatorv1.LinuxPodInterfaceNetkit
+				defaultInstance.CalicoNetwork.LinuxPodInterfaceType = &nk
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+				Expect(len(resources)).To(Equal(defaultNumExpectedResources))
+
+				cniCmResource := rtest.GetResource(resources, "cni-config", "calico-system", "", "v1", "ConfigMap")
+				Expect(cniCmResource).ToNot(BeNil())
+				cniCm := cniCmResource.(*corev1.ConfigMap)
+				Expect(cniCm.Data["config"]).To(MatchJSON(fmt.Sprintf(`{
+  "name": "k8s-pod-network",
+  "cniVersion": "0.3.1",
+  "plugins": [
+    {
+      "type": "calico",
+      "calico_api_group": "",
+      "datastore_type": "kubernetes",
+      "mtu": 0,
+      "nodename_file_optional": false,
+      "log_level": "Debug",
+      "log_file_path": "/var/log/calico/cni/cni.log",
+      "log_file_max_size": 1,
+      "log_file_max_age": 5,
+      "log_file_max_count": 5,
+      "device_type": "netkit",
+      "ipam": {
+          "type": "calico-ipam",
+          "assign_ipv4" : "%t",
+          "assign_ipv6" : "%t"
+      },
+      "container_settings": {
+          "allow_ip_forwarding": false
+      },
+      "policy_setup_timeout_seconds": 0,
+      "endpoint_status_dir": "/var/run/calico/endpoint-status",
+      "policy": {
+          "type": "k8s"
+      },
+      "kubernetes": {
+          "kubeconfig": "__KUBECONFIG_FILEPATH__"
+      }
+    },
+    {"type": "portmap", "snat": true, "capabilities": {"portMappings": true}}
+  ]
+}`, enableIPv4, enableIPv6)))
+			})
+
+			It("should not emit device_type in the cni config when LinuxPodInterface is Veth (default)", func() {
+				veth := operatorv1.LinuxPodInterfaceVeth
+				defaultInstance.CalicoNetwork.LinuxPodInterfaceType = &veth
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+				Expect(len(resources)).To(Equal(defaultNumExpectedResources))
+
+				cniCmResource := rtest.GetResource(resources, "cni-config", "calico-system", "", "v1", "ConfigMap")
+				Expect(cniCmResource).ToNot(BeNil())
+				cniCm := cniCmResource.(*corev1.ConfigMap)
+				Expect(cniCm.Data["config"]).NotTo(ContainSubstring("device_type"))
+			})
+
 			It("should render cni config with host-local", func() {
 				defaultInstance.CNI.IPAM.Type = operatorv1.IPAMPluginHostLocal
 				component := render.Node(&cfg)


### PR DESCRIPTION
## Description

Adds `Installation.spec.calicoNetwork.linuxPodInterfaceType` so users can opt the Calico CNI plugin into creating netkit L2 pairs (Linux 6.7+) instead of veth pairs for the pod-side interface. The operator plumbs the field through to the rendered CNI ConfigMap as `"device_type": "netkit"`.

**Depends on [projectcalico/calico#12619](https://github.com/projectcalico/calico/pull/12619)**, which adds the `device_type` knob to the Calico CNI plugin itself. Without that change merged & shipped, setting this field has no effect (the CNI plugin will ignore the unknown key).

The CNI plugin silently falls back to veth on kernels older than 6.7, so the field is safe to set on heterogeneous clusters. For non-BPF dataplanes netkit L2 is functionally equivalent to veth (TC/TCX still attaches); the performance benefit (per ByteDance: ~10% throughput, big P99 improvement under contention) comes when the BPF dataplane uses `BPF_NETKIT_PRIMARY`.

Validation rejects the field for non-Calico CNI plugins, matching `ContainerIPForwarding` / `HostPorts` / `MultiInterfaceMode`. `device_type` is only emitted in the rendered CNI config when the field is explicitly set to `Netkit`, so existing installations are unchanged.

Related: [CORE-10672](https://tigera.atlassian.net/browse/CORE-10672)

### Testing
- `make ut UT_DIR=./pkg/render` — added two render tests covering Netkit (emits `device_type`) and Veth-default (no key emitted).
- `make ut UT_DIR=./pkg/controller/installation` — added validation test entry covering the Calico-CNI-only restriction.
- `make static-checks`, `make format-check`, `make test-crds` — clean.

## Release Note

```release-note
Added `Installation.spec.calicoNetwork.linuxPodInterfaceType` to select between `Veth` (default) and `Netkit` for the Calico CNI pod interface. Requires Calico CNI plugin support for `device_type` (Linux 6.7+ for netkit; older kernels fall back to veth).
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions` (n/a)


[CORE-10672]: https://tigera.atlassian.net/browse/CORE-10672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ