### PR TITLE
Default BPFKubeProxyHealthzPort to 0 when kube-proxy is not managed

### DIFF
--- a/pkg/controller/installation/bpf.go
+++ b/pkg/controller/installation/bpf.go
@@ -129,3 +129,11 @@ func disableBPFHostConntrackBypass(fc *v3.FelixConfiguration) {
 	hostConntrackBypassDisabled := false
 	fc.Spec.BPFHostConntrackBypass = &hostConntrackBypassDisabled
 }
+
+// disableBPFKubeProxyHealthz disables Felix's BPF kube-proxy healthz server by setting
+// BPFKubeProxyHealthzPort to 0. Use when Calico runs in BPF mode but the platform's
+// kube-proxy is still running (e.g. AKS) and holds the default port (10256).
+func disableBPFKubeProxyHealthz(fc *v3.FelixConfiguration) {
+	port := 0
+	fc.Spec.BPFKubeProxyHealthzPort = &port
+}

--- a/pkg/controller/installation/bpf.go
+++ b/pkg/controller/installation/bpf.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 // bpfValidateAnnotations validate Felix Configuration annotations match BPF Enabled spec for all scenarios.
@@ -134,6 +135,5 @@ func disableBPFHostConntrackBypass(fc *v3.FelixConfiguration) {
 // BPFKubeProxyHealthzPort to 0. Use when Calico runs in BPF mode but the platform's
 // kube-proxy is still running (e.g. AKS) and holds the default port (10256).
 func disableBPFKubeProxyHealthz(fc *v3.FelixConfiguration) {
-	port := 0
-	fc.Spec.BPFKubeProxyHealthzPort = &port
+	fc.Spec.BPFKubeProxyHealthzPort = ptr.To(0)
 }

--- a/pkg/controller/installation/bpf_test.go
+++ b/pkg/controller/installation/bpf_test.go
@@ -288,4 +288,27 @@ var _ = Describe("BPF functional tests", func() {
 			Expect(*fc.Spec.BPFEnabled).To(Equal(false))
 		})
 	})
+
+	Context("disableBPFKubeProxyHealthz tests", func() {
+		It("should set BPFKubeProxyHealthzPort to 0", func() {
+			fc := &v3.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       v3.FelixConfigurationSpec{},
+			}
+			disableBPFKubeProxyHealthz(fc)
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).ShouldNot(BeNil())
+			Expect(*fc.Spec.BPFKubeProxyHealthzPort).To(Equal(0))
+		})
+
+		It("should overwrite an existing value", func() {
+			existing := 12345
+			fc := &v3.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       v3.FelixConfigurationSpec{BPFKubeProxyHealthzPort: &existing},
+			}
+			disableBPFKubeProxyHealthz(fc)
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).ShouldNot(BeNil())
+			Expect(*fc.Spec.BPFKubeProxyHealthzPort).To(Equal(0))
+		})
+	})
 })

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1988,6 +1988,16 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 		}
 	}
 
+	// When BPF is enabled but the operator is not managing kube-proxy (e.g. on AKS, where
+	// the platform owns the kube-proxy DaemonSet), the platform's kube-proxy keeps the
+	// default healthz port (10256), and Felix's BPF kube-proxy healthz server would fail
+	// to bind. Default the port to 0 (disabled) so calico-node starts cleanly. Users can
+	// still override by setting BPFKubeProxyHealthzPort explicitly on FelixConfiguration.
+	if install.Spec.BPFEnabled() && !install.Spec.KubeProxyManagementEnabled() && fc.Spec.BPFKubeProxyHealthzPort == nil {
+		disableBPFKubeProxyHealthz(fc)
+		updated = true
+	}
+
 	if install.Spec.Variant.IsEnterprise() {
 		// Some platforms need a different default setting for dnsTrustedServers, because their DNS service is not named "kube-dns".
 		dnsService := ""

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1559,6 +1559,73 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(*fc.Spec.BPFHostConntrackBypass).To(BeFalse())
 		})
 
+		It("should set BPFKubeProxyHealthzPort to 0 when BPF is enabled and operator does not manage kube-proxy", func() {
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).NotTo(BeNil())
+			Expect(*fc.Spec.BPFKubeProxyHealthzPort).To(Equal(0))
+		})
+
+		It("should not set BPFKubeProxyHealthzPort when BPF is disabled", func() {
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).To(BeNil())
+		})
+
+		It("should not set BPFKubeProxyHealthzPort when BPF is enabled and operator manages kube-proxy", func() {
+			network := operator.LinuxDataplaneBPF
+			kpManagement := operator.KubeProxyManagementEnabled
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{
+				LinuxDataplane:      &network,
+				KubeProxyManagement: &kpManagement,
+			}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).To(BeNil())
+		})
+
+		It("should not overwrite an existing user-set BPFKubeProxyHealthzPort", func() {
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+
+			userPort := 12345
+			Expect(c.Create(ctx, &v3.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       v3.FelixConfigurationSpec{BPFKubeProxyHealthzPort: &userPort},
+			})).NotTo(HaveOccurred())
+
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).NotTo(BeNil())
+			Expect(*fc.Spec.BPFKubeProxyHealthzPort).To(Equal(12345))
+		})
+
 		It("should set BPFEnabled to ture on FelixConfiguration if BPF is enabled on installation", func() {
 			createNodeDaemonSet()
 


### PR DESCRIPTION
## Description

When BPF dataplane is enabled but the operator is not managing the kube-proxy DaemonSet (e.g. on AKS, where the platform owns kube-proxy), kube-proxy keeps running alongside calico-node and holds the default healthz port (`10256`). Felix's BPF kube-proxy healthz server then fails to bind and `calico-node` logs:

```
failed to start proxy healthz on :10256: listen tcp :10256: bind: address already in use
```

Until now the documented workaround was for users to manually set `FelixConfiguration.BPFKubeProxyHealthzPort` to `0` (or to an unused port).

This change has the operator default `BPFKubeProxyHealthzPort` to `0` (disabled) in `setDefaultsOnFelixConfiguration` when:

1. BPF is enabled (`Installation.Spec.BPFEnabled()`),
2. the operator is not managing kube-proxy (`!Installation.Spec.KubeProxyManagementEnabled()`), and
3. the field is currently unset on `FelixConfiguration`.

When the operator manages kube-proxy (i.e. it disables the platform's kube-proxy DaemonSet on BPF nodes), Felix's BPF kube-proxy healthz server keeps the upstream default port and continues to act as the kube-proxy healthz replacement — no behavior change for that path. User-set values on `FelixConfiguration.BPFKubeProxyHealthzPort` are always preserved.

The new helper `disableBPFKubeProxyHealthz` mirrors the existing `disableBPFHostConntrackBypass` pattern.

## Testing

- New unit tests for `disableBPFKubeProxyHealthz` in `pkg/controller/installation/bpf_test.go` (sets to 0 from nil; overwrites existing value).
- New reconcile-driven tests in `pkg/controller/installation/core_controller_test.go` covering all four gating cases:
  - BPF on + KubeProxyManagement disabled → port set to 0 (the AKS case).
  - BPF off → port unset.
  - BPF on + KubeProxyManagement = Enabled → port unset.
  - User-set value → preserved.
- `make ut UT_DIR=./pkg/controller/installation` — 298 of 298 specs pass.

## Related

- Internal: CORE-12755
- OSS PRs that introduced and made the port configurable in Felix: projectcalico/calico#10947, projectcalico/calico#11011

## Release Note

```release-note
On BPF clusters where the operator is not managing kube-proxy (e.g. AKS), the operator now defaults FelixConfiguration.BPFKubeProxyHealthzPort to 0 to avoid a port conflict with the platform's kube-proxy. Users can still override the port explicitly.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
