### PR TITLE
EV-6388: L7 logging through Istio Waypoint Proxy

### DIFF
--- a/api/v1/istio_types.go
+++ b/api/v1/istio_types.go
@@ -142,6 +142,14 @@ type IstioSpec struct {
 	// ZTunnelDaemonset defines the resource requirements for the ZTunnelDaemonset component.
 	// +optional
 	ZTunnelDaemonset *ZTunnelDaemonset `json:"ztunnel,omitempty"`
+	// WaypointLogging controls whether L7 logging is enabled on every Gateway
+	// using the istio-waypoint GatewayClass. When Enabled (the default), the
+	// operator injects an l7-collector sidecar into each waypoint pod via
+	// class-level defaults. When Disabled, no sidecar is injected and the
+	// associated EnvoyFilters are not created. Allowed values are Enabled or
+	// Disabled.
+	// +optional
+	WaypointLogging *LogCollectionStatusType `json:"waypointLogging,omitempty"`
 	// DSCPMark define the value of the DSCP mark done by Felix and recognised by Istio CNI for Transparent
 	// NetworkPolicies.
 	// +optional

--- a/api/v1/istio_types.go
+++ b/api/v1/istio_types.go
@@ -181,6 +181,19 @@ type Istio struct {
 	Status IstioStatus `json:"status,omitempty"`
 }
 
+// WaypointLoggingEnabled reports whether waypoint L7 logging should be rendered
+// for this Istio CR. It defaults to true when the field is unset, and is the
+// single source of truth shared by the renderer (which gates the l7-collector
+// sidecar + EnvoyFilters) and the policy-sync predicate (which gates
+// policySyncPathPrefix), so the two never diverge. A nil receiver reports false.
+func (i *Istio) WaypointLoggingEnabled() bool {
+	if i == nil {
+		return false
+	}
+	wl := i.Spec.WaypointLogging
+	return wl == nil || *wl != L7LogCollectionDisabled
+}
+
 // +kubebuilder:object:root=true
 
 // IstioList contains a list of Istio resources.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -6571,6 +6571,11 @@ func (in *IstioSpec) DeepCopyInto(out *IstioSpec) {
 		*out = new(ZTunnelDaemonset)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.WaypointLogging != nil {
+		in, out := &in.WaypointLogging, &out.WaypointLogging
+		*out = new(LogCollectionStatusType)
+		**out = **in
+	}
 	if in.DSCPMark != nil {
 		in, out := &in.DSCPMark, &out.DSCPMark
 		*out = new(numorstring.DSCP)

--- a/pkg/apis/register.go
+++ b/pkg/apis/register.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tigera/operator/pkg/render/istio"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -79,6 +80,9 @@ func init() {
 	AddToSchemes = append(AddToSchemes, corev1.AddToScheme)
 	AddToSchemes = append(AddToSchemes, rbacv1.AddToScheme)
 	AddToSchemes = append(AddToSchemes, appsv1.AddToScheme)
+	// Istio's rendered Helm charts include a HorizontalPodAutoscaler, so the
+	// scheme needs autoscaling/v2 for the universal deserializer to decode them.
+	AddToSchemes = append(AddToSchemes, autoscalingv2.AddToScheme)
 	AddToSchemes = append(AddToSchemes, batchv1.AddToScheme)
 	AddToSchemes = append(AddToSchemes, storagev1.AddToScheme)
 	AddToSchemes = append(AddToSchemes, certificatesv1.AddToScheme)

--- a/pkg/apis/register.go
+++ b/pkg/apis/register.go
@@ -27,6 +27,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/render/istio"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -68,6 +69,9 @@ func init() {
 	AddToSchemes = append(AddToSchemes, policyv1beta1.SchemeBuilder.AddToScheme)
 	AddToSchemes = append(AddToSchemes, gateway.Install)
 	AddToSchemes = append(AddToSchemes, envoy.AddToScheme)
+	// EnvoyFilter is a hand-rolled shim type defined in pkg/render/istio (used
+	// for waypoint L7 logging); register it centrally like the other types.
+	AddToSchemes = append(AddToSchemes, istio.AddEnvoyFilterToScheme)
 	AddToSchemes = append(AddToSchemes, csisecret.AddToScheme)
 	AddToSchemes = append(AddToSchemes, operatorv1.AddToScheme)
 	AddToSchemes = append(AddToSchemes, admissionregistrationv1.AddToScheme)

--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -50,9 +50,9 @@ const ResourceName = "applicationlayer"
 
 var log = logf.Log.WithName("controller_applicationlayer")
 
-const (
-	DefaultPolicySyncPrefix string = "/var/run/nodeagent"
-)
+// DefaultPolicySyncPrefix is the operator-managed value for
+// FelixConfiguration.policySyncPathPrefix.
+const DefaultPolicySyncPrefix = utils.DefaultPolicySyncPrefix
 
 // Add creates a new ApplicationLayer Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -475,26 +475,9 @@ func (r *ReconcileApplicationLayer) isSidecarInjectionEnabled(applicationLayerSp
 		*applicationLayerSpec.SidecarInjection == operatorv1.SidecarEnabled
 }
 
-func (r *ReconcileApplicationLayer) getPolicySyncPathPrefix(fcSpec *v3.FelixConfigurationSpec, al *operatorv1.ApplicationLayer) string {
-	// Respect existing policySyncPathPrefix if it's already set (e.g. EGW)
-	// This will cause policySyncPathPrefix value to remain when ApplicationLayer is disabled.
-	existing := fcSpec.PolicySyncPathPrefix
-	if existing != "" {
-		return existing
-	}
-
-	// There's no existing value, nor is ApplicationLayer enabled
-	if al == nil {
-		return ""
-	}
-
-	// No existing value. However, at least one of the applicationLayer features are enabled
-	spec := &al.Spec
-	if r.isALPEnabled(spec) || r.isWAFEnabled(spec) || r.isLogsCollectionEnabled(spec) ||
-		r.isSidecarInjectionEnabled(spec) {
-		return DefaultPolicySyncPrefix
-	}
-	return ""
+func (r *ReconcileApplicationLayer) getPolicySyncPathPrefix(fcSpec *v3.FelixConfigurationSpec, al *operatorv1.ApplicationLayer, istioNeeds bool) string {
+	alNeeds := utils.ApplicationLayerRequiresPolicySync(al)
+	return utils.DesiredPolicySyncPathPrefix(fcSpec.PolicySyncPathPrefix, alNeeds, istioNeeds)
 }
 
 func (r *ReconcileApplicationLayer) getTProxyMode(al *operatorv1.ApplicationLayer) (bool, string) {
@@ -516,7 +499,26 @@ func (r *ReconcileApplicationLayer) getTProxyMode(al *operatorv1.ApplicationLaye
 // patchFelixConfiguration takes all application layer specs as arguments and patches felix config.
 // If at least one of the specs requires TPROXYMode as "Enabled" it'll be patched as "Enabled" otherwise it is "Disabled".
 func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context, al *operatorv1.ApplicationLayer) error {
-	_, err := utils.PatchFelixConfiguration(ctx, r.client, func(fc *v3.FelixConfiguration) (bool, error) {
+	// Fetch the Istio CR and Installation variant so DesiredPolicySyncPathPrefix
+	// can see whether the istio side still needs the field. Both reads tolerate
+	// NotFound — the istio side has no claim if either is absent.
+	istioCR, err := utils.GetIstio(ctx, r.client)
+	if err != nil {
+		return err
+	}
+	// Use Spec.Variant (via the second return of GetInstallationSpec) so the
+	// gate matches the renderer's decision to ship the L7 waypoint sidecar.
+	var variant operatorv1.ProductVariant
+	if _, spec, ierr := utils.GetInstallationSpec(ctx, r.client); ierr != nil {
+		if !apierrors.IsNotFound(ierr) {
+			return ierr
+		}
+	} else if spec != nil {
+		variant = spec.Variant
+	}
+	istioNeeds := utils.IstioRequiresPolicySync(istioCR, variant)
+
+	_, err = utils.PatchFelixConfiguration(ctx, r.client, func(fc *v3.FelixConfiguration) (bool, error) {
 		var tproxyMode string
 		if ok, v := r.getTProxyMode(al); ok {
 			tproxyMode = v
@@ -538,7 +540,7 @@ func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context,
 			tproxyMode = "Disabled"
 		}
 
-		policySyncPrefix := r.getPolicySyncPathPrefix(&fc.Spec, al)
+		policySyncPrefix := r.getPolicySyncPathPrefix(&fc.Spec, al, istioNeeds)
 		policySyncPrefixSetDesired := fc.Spec.PolicySyncPathPrefix == policySyncPrefix
 		tproxyModeSetDesired := fc.Spec.TPROXYMode != "" && fc.Spec.TPROXYMode == string(tproxyMode)
 		wafEventLogsFileEnabled := al != nil && ((al.Spec.SidecarInjection != nil && *al.Spec.SidecarInjection == operatorv1.SidecarEnabled) ||

--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -50,10 +50,6 @@ const ResourceName = "applicationlayer"
 
 var log = logf.Log.WithName("controller_applicationlayer")
 
-// DefaultPolicySyncPrefix is the operator-managed value for
-// FelixConfiguration.policySyncPathPrefix.
-const DefaultPolicySyncPrefix = utils.DefaultPolicySyncPrefix
-
 // Add creates a new ApplicationLayer Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {

--- a/pkg/controller/applicationlayer/applicationlayer_controller_test.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller_test.go
@@ -148,14 +148,17 @@ var _ = Describe("Application layer controller tests", func() {
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			By("ensuring that PolicySyncPathPrefix is cleared after ALP deletion when nothing else needs it")
+			By("ensuring that felix configuration PolicySyncPathPrefix is left as is, even after ALP deletion")
 			f2 := v3.FelixConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "default",
 				},
 			}
 			Expect(test.GetResource(c, &f2)).To(BeNil())
-			Expect(f2.Spec.PolicySyncPathPrefix).To(Equal(""))
+			// The operator-managed default is shared with egressgateway and
+			// Gateway API, which never clear it; the AL controller must not
+			// clear a value it may not own, so it is preserved here.
+			Expect(f2.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
 		})
 
 		It("should leave PolicySyncPathPrefix set on AL deletion when Istio CR still needs it", func() {

--- a/pkg/controller/applicationlayer/applicationlayer_controller_test.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller_test.go
@@ -148,12 +148,55 @@ var _ = Describe("Application layer controller tests", func() {
 			_, err = r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			By("ensuring that felix configuration PolicySyncPathPrefix is left as is, even after ALP deletion")
+			By("ensuring that PolicySyncPathPrefix is cleared after ALP deletion when nothing else needs it")
 			f2 := v3.FelixConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "default",
 				},
 			}
+			Expect(test.GetResource(c, &f2)).To(BeNil())
+			Expect(f2.Spec.PolicySyncPathPrefix).To(Equal(""))
+		})
+
+		It("should leave PolicySyncPathPrefix set on AL deletion when Istio CR still needs it", func() {
+			// Symmetric coordination: AL cleanup must consult Istio state
+			// before clearing policySyncPathPrefix. With an Istio CR present
+			// on an Enterprise install, the istio side claims the field.
+			mockStatus.On("AddDaemonsets", mock.Anything).Return()
+			mockStatus.On("AddDeployments", mock.Anything).Return()
+			mockStatus.On("IsAvailable").Return(true)
+			mockStatus.On("AddStatefulSets", mock.Anything).Return()
+			mockStatus.On("AddCronJobs", mock.Anything)
+			mockStatus.On("OnCRNotFound").Return()
+			mockStatus.On("ClearDegraded")
+			mockStatus.On("ReadyToMonitor")
+			mockStatus.On("SetMetaData", mock.Anything).Return()
+			Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+			Expect(c.Create(ctx, &operatorv1.Istio{ObjectMeta: metav1.ObjectMeta{Name: "default"}})).NotTo(HaveOccurred())
+
+			enabled := operatorv1.ApplicationLayerPolicyEnabled
+			alSpec := &operatorv1.ApplicationLayer{
+				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+				Spec: operatorv1.ApplicationLayerSpec{
+					ApplicationLayerPolicy: &enabled,
+				},
+			}
+			Expect(c.Create(ctx, alSpec)).NotTo(HaveOccurred())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			f1 := v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			Expect(test.GetResource(c, &f1)).To(BeNil())
+			Expect(f1.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
+
+			Expect(c.Delete(ctx, alSpec)).NotTo(HaveOccurred())
+
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("ensuring AL deletion does not clear policySyncPathPrefix while Istio still needs it")
+			f2 := v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 			Expect(test.GetResource(c, &f2)).To(BeNil())
 			Expect(f2.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
 		})

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -373,6 +373,9 @@ func (r *ReconcileIstio) configureIstioDSCPMark(instance *operatorv1.Istio, fc *
 		return false, nil
 	}
 	fc.Spec.IstioDSCPMark = &istioDSCPMarkDesired
+	if fc.Annotations == nil {
+		fc.Annotations = make(map[string]string)
+	}
 	fc.Annotations[istio.IstioOperatorAnnotationDSCP] = strconv.FormatUint(uint64(istioDSCPMarkDesired.ToUint8()), 10)
 	return true, nil
 }

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strconv"
 
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -61,13 +60,6 @@ var (
 // Start Watches within the Add function for any resources that this controller creates or monitors. This will trigger
 // calls to Reconcile() when an instance of one of the watched resources is modified.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
-	// The Istio helm charts we render include a HorizontalPodAutoscaler, so
-	// the scheme must know about autoscaling/v2 for resources.go's universal
-	// deserializer to decode those manifests.
-	if err := autoscalingv2.AddToScheme(mgr.GetScheme()); err != nil {
-		return fmt.Errorf("failed to register autoscaling/v2 with scheme: %w", err)
-	}
-
 	r := newReconciler(mgr, opts)
 
 	c, err := ctrlruntime.NewController("istio-controller", mgr, controller.Options{Reconciler: r})

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,6 +61,17 @@ var (
 // Start Watches within the Add function for any resources that this controller creates or monitors. This will trigger
 // calls to Reconcile() when an instance of one of the watched resources is modified.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
+	// Register the typed EnvoyFilter so the L7 waypoint resources rendered by
+	// pkg/render/istio can be created/updated via the controller-runtime client.
+	istio.AddEnvoyFilterToScheme(mgr.GetScheme())
+
+	// The Istio helm charts we render include a HorizontalPodAutoscaler, so
+	// the scheme must know about autoscaling/v2 for resources.go's universal
+	// deserializer to decode those manifests.
+	if err := autoscalingv2.AddToScheme(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("failed to register autoscaling/v2 with scheme: %w", err)
+	}
+
 	r := newReconciler(mgr, opts)
 
 	c, err := ctrlruntime.NewController("istio-controller", mgr, controller.Options{Reconciler: r})
@@ -91,6 +103,11 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return fmt.Errorf("istio-controller failed to create periodic reconcile watch: %w", err)
 	}
 
+	// The waypoint pull-secrets controller replicates the Installation pull
+	// secret into namespaces that contain istio-waypoint Gateways, so waypoint
+	// pods can pull the Istio proxy image from a private registry (the
+	// imagePullSecrets reference injected via istiod's global config is
+	// namespace-scoped and the secret must exist in the user namespace).
 	if err := waypoint.Add(mgr, opts); err != nil {
 		return fmt.Errorf("failed to add waypoint pull secrets controller: %w", err)
 	}
@@ -269,20 +286,22 @@ func updateDefaults(istio *operatorv1.Istio) {
 }
 
 func (r *ReconcileIstio) setIstioFelixConfiguration(ctx context.Context, instance *operatorv1.Istio, fc *v3.FelixConfiguration, remove bool) (bool, error) {
-	// Handle Istio Ambient Mode configuration
-	if err := r.configureIstioAmbientMode(fc, remove); err != nil {
+	ambientChanged, err := r.configureIstioAmbientMode(fc, remove)
+	if err != nil {
 		return false, err
 	}
-
-	// Handle Istio DSCP Mark configuration
-	if err := r.configureIstioDSCPMark(instance, fc, remove); err != nil {
+	dscpChanged, err := r.configureIstioDSCPMark(instance, fc, remove)
+	if err != nil {
 		return false, err
 	}
-
-	return true, nil
+	policySyncChanged, err := r.configurePolicySyncPathPrefix(ctx, instance, fc, remove)
+	if err != nil {
+		return false, err
+	}
+	return ambientChanged || dscpChanged || policySyncChanged, nil
 }
 
-func (r *ReconcileIstio) configureIstioAmbientMode(fc *v3.FelixConfiguration, remove bool) error {
+func (r *ReconcileIstio) configureIstioAmbientMode(fc *v3.FelixConfiguration, remove bool) (bool, error) {
 	var annotationMode *string
 	if fc.Annotations[istio.IstioOperatorAnnotationMode] != "" {
 		value := fc.Annotations[istio.IstioOperatorAnnotationMode]
@@ -294,30 +313,37 @@ func (r *ReconcileIstio) configureIstioAmbientMode(fc *v3.FelixConfiguration, re
 		annotationMode != nil && fc.Spec.IstioAmbientMode != nil && *annotationMode == string(*fc.Spec.IstioAmbientMode)
 
 	if !match {
-		return fmt.Errorf("felixconfig IstioAmbientMode modified by user")
+		return false, fmt.Errorf("felixconfig IstioAmbientMode modified by user")
 	}
 
 	if remove {
+		if annotationMode == nil && fc.Spec.IstioAmbientMode == nil {
+			return false, nil
+		}
 		delete(fc.Annotations, istio.IstioOperatorAnnotationMode)
 		fc.Spec.IstioAmbientMode = nil
-	} else {
-		istioModeDesired := v3.IstioAmbientModeEnabled
-		fc.Spec.IstioAmbientMode = &istioModeDesired
-		if fc.Annotations == nil {
-			fc.Annotations = make(map[string]string)
-		}
-		fc.Annotations[istio.IstioOperatorAnnotationMode] = string(istioModeDesired)
+		return true, nil
 	}
 
-	return nil
+	istioModeDesired := v3.IstioAmbientModeEnabled
+	if fc.Spec.IstioAmbientMode != nil && *fc.Spec.IstioAmbientMode == istioModeDesired &&
+		annotationMode != nil && *annotationMode == string(istioModeDesired) {
+		return false, nil
+	}
+	fc.Spec.IstioAmbientMode = &istioModeDesired
+	if fc.Annotations == nil {
+		fc.Annotations = make(map[string]string)
+	}
+	fc.Annotations[istio.IstioOperatorAnnotationMode] = string(istioModeDesired)
+	return true, nil
 }
 
-func (r *ReconcileIstio) configureIstioDSCPMark(instance *operatorv1.Istio, fc *v3.FelixConfiguration, remove bool) error {
+func (r *ReconcileIstio) configureIstioDSCPMark(instance *operatorv1.Istio, fc *v3.FelixConfiguration, remove bool) (bool, error) {
 	var annotationDSCP *numorstring.DSCP
 	if fc.Annotations[istio.IstioOperatorAnnotationDSCP] != "" {
 		value, err := strconv.ParseUint(fc.Annotations[istio.IstioOperatorAnnotationDSCP], 10, 6)
 		if err != nil {
-			return err
+			return false, err
 		}
 		dscp := numorstring.DSCPFromInt(uint8(value))
 		annotationDSCP = &dscp
@@ -328,19 +354,66 @@ func (r *ReconcileIstio) configureIstioDSCPMark(instance *operatorv1.Istio, fc *
 		annotationDSCP != nil && fc.Spec.IstioDSCPMark != nil && annotationDSCP.ToUint8() == fc.Spec.IstioDSCPMark.ToUint8()
 
 	if !match {
-		return fmt.Errorf("felixconfig IstioDSCPMark modified by user")
+		return false, fmt.Errorf("felixconfig IstioDSCPMark modified by user")
 	}
 
 	if remove || instance.Spec.DSCPMark == nil {
+		if annotationDSCP == nil && fc.Spec.IstioDSCPMark == nil {
+			return false, nil
+		}
 		delete(fc.Annotations, istio.IstioOperatorAnnotationDSCP)
 		fc.Spec.IstioDSCPMark = nil
-	} else {
-		istioDSCPMarkDesired := *instance.Spec.DSCPMark
-		fc.Spec.IstioDSCPMark = &istioDSCPMarkDesired
-		fc.Annotations[istio.IstioOperatorAnnotationDSCP] = strconv.FormatUint(uint64(istioDSCPMarkDesired.ToUint8()), 10)
+		return true, nil
 	}
 
-	return nil
+	istioDSCPMarkDesired := *instance.Spec.DSCPMark
+	if fc.Spec.IstioDSCPMark != nil && annotationDSCP != nil &&
+		fc.Spec.IstioDSCPMark.ToUint8() == istioDSCPMarkDesired.ToUint8() &&
+		annotationDSCP.ToUint8() == istioDSCPMarkDesired.ToUint8() {
+		return false, nil
+	}
+	fc.Spec.IstioDSCPMark = &istioDSCPMarkDesired
+	fc.Annotations[istio.IstioOperatorAnnotationDSCP] = strconv.FormatUint(uint64(istioDSCPMarkDesired.ToUint8()), 10)
+	return true, nil
+}
+
+// configurePolicySyncPathPrefix reconciles FelixConfiguration.policySyncPathPrefix
+// for the Istio side. The L7 ambient waypoint pod's l7-collector sidecar
+// dials Felix's nodeagent socket, which Felix only opens when this field
+// is set. The applicationlayer controller writes this same field for the
+// Dikastes/sidecar/WAF flow; both controllers consult each other's state
+// (via utils.{ApplicationLayerRequiresPolicySync,IstioRequiresPolicySync})
+// so that deleting one CR does not strand the other.
+func (r *ReconcileIstio) configurePolicySyncPathPrefix(ctx context.Context, instance *operatorv1.Istio, fc *v3.FelixConfiguration, remove bool) (bool, error) {
+	var istioNeeds bool
+	if !remove {
+		// Mirror the renderer gate at pkg/render/istio/istio.go: it reads
+		// installationSpec.Variant (i.e. Installation.Spec.Variant), so the
+		// policy-sync field tracks the renderer's decision to ship the L7
+		// waypoint sidecar even before Status.Variant catches up.
+		_, installationSpec, err := utils.GetInstallationSpec(ctx, r.Client)
+		if err != nil && !errors.IsNotFound(err) {
+			return false, err
+		}
+		var variant operatorv1.ProductVariant
+		if installationSpec != nil {
+			variant = installationSpec.Variant
+		}
+		istioNeeds = utils.IstioRequiresPolicySync(instance, variant)
+	}
+
+	al, err := utils.GetApplicationLayer(ctx, r.Client)
+	if err != nil {
+		return false, err
+	}
+	alNeeds := utils.ApplicationLayerRequiresPolicySync(al)
+
+	desired := utils.DesiredPolicySyncPathPrefix(fc.Spec.PolicySyncPathPrefix, alNeeds, istioNeeds)
+	if fc.Spec.PolicySyncPathPrefix == desired {
+		return false, nil
+	}
+	fc.Spec.PolicySyncPathPrefix = desired
+	return true, nil
 }
 
 func (r *ReconcileIstio) maintainFinalizer(ctx context.Context, instance *operatorv1.Istio, reqLogger logr.Logger) (res reconcile.Result, err error, finalized bool) {

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -61,10 +61,6 @@ var (
 // Start Watches within the Add function for any resources that this controller creates or monitors. This will trigger
 // calls to Reconcile() when an instance of one of the watched resources is modified.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
-	// Register the typed EnvoyFilter so the L7 waypoint resources rendered by
-	// pkg/render/istio can be created/updated via the controller-runtime client.
-	istio.AddEnvoyFilterToScheme(mgr.GetScheme())
-
 	// The Istio helm charts we render include a HorizontalPodAutoscaler, so
 	// the scheme must know about autoscaling/v2 for resources.go's universal
 	// deserializer to decode those manifests.

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Istio controller tests", func() {
 		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		Expect(admregv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		Expect(autoscalingv2.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		istio.AddEnvoyFilterToScheme(scheme)
 
 		ctx = context.Background()
 		objTrackerWithCalls = test.NewObjectTrackerWithCalls(scheme)
@@ -498,6 +499,129 @@ var _ = Describe("Istio controller tests", func() {
 			Expect(err.Error()).To(ContainSubstring("felixconfig IstioDSCPMark modified by user"))
 		})
 
+		Context("policySyncPathPrefix coordination", func() {
+			// All tests in this block run with Enterprise variant: the L7
+			// waypoint feature that makes Istio claim policySyncPathPrefix
+			// is Enterprise-only. The parent Context's BeforeEach has
+			// already created the Installation as Calico, so we re-read and
+			// patch it to Enterprise here.
+			BeforeEach(func() {
+				inst := &operatorv1.Installation{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, inst)).NotTo(HaveOccurred())
+				inst.Spec.Variant = operatorv1.CalicoEnterprise
+				inst.Status.Variant = operatorv1.CalicoEnterprise
+				Expect(cli.Update(ctx, inst)).NotTo(HaveOccurred())
+			})
+
+			It("sets policySyncPathPrefix to the operator default when no AL is present", func() {
+				fc := &v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+				Expect(cli.Create(ctx, fc)).NotTo(HaveOccurred())
+
+				r := &ReconcileIstio{Client: cli, scheme: scheme, provider: operatorv1.ProviderNone, status: mockStatus}
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				patched := &v3.FelixConfiguration{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, patched)).NotTo(HaveOccurred())
+				Expect(patched.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
+			})
+
+			It("does not stomp a customer override on policySyncPathPrefix", func() {
+				fc := &v3.FelixConfiguration{
+					ObjectMeta: metav1.ObjectMeta{Name: "default"},
+					Spec:       v3.FelixConfigurationSpec{PolicySyncPathPrefix: "/var/run/customer"},
+				}
+				Expect(cli.Create(ctx, fc)).NotTo(HaveOccurred())
+
+				r := &ReconcileIstio{Client: cli, scheme: scheme, provider: operatorv1.ProviderNone, status: mockStatus}
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				patched := &v3.FelixConfiguration{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, patched)).NotTo(HaveOccurred())
+				Expect(patched.Spec.PolicySyncPathPrefix).To(Equal("/var/run/customer"))
+			})
+
+			It("leaves policySyncPathPrefix set on Istio deletion when ApplicationLayer still needs it", func() {
+				// AL with logsCollection enabled — the symmetric coordination
+				// case the user called out: Istio deletion must not clear the
+				// field while AL is still actively using it.
+				enabled := operatorv1.L7LogCollectionEnabled
+				al := &operatorv1.ApplicationLayer{
+					ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+					Spec: operatorv1.ApplicationLayerSpec{
+						LogCollection: &operatorv1.LogCollectionSpec{CollectLogs: &enabled},
+					},
+				}
+				Expect(cli.Create(ctx, al)).NotTo(HaveOccurred())
+
+				fc := &v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+				Expect(cli.Create(ctx, fc)).NotTo(HaveOccurred())
+
+				r := &ReconcileIstio{Client: cli, scheme: scheme, provider: operatorv1.ProviderNone, status: mockStatus}
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Now delete the Istio CR and reconcile the finalizer cleanup.
+				updated := &operatorv1.Istio{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, updated)).NotTo(HaveOccurred())
+				Expect(cli.Delete(ctx, updated)).NotTo(HaveOccurred())
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cleaned := &v3.FelixConfiguration{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, cleaned)).NotTo(HaveOccurred())
+				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
+			})
+
+			It("clears policySyncPathPrefix on Istio deletion when ApplicationLayer features are all disabled", func() {
+				disabled := operatorv1.L7LogCollectionDisabled
+				al := &operatorv1.ApplicationLayer{
+					ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+					Spec: operatorv1.ApplicationLayerSpec{
+						LogCollection: &operatorv1.LogCollectionSpec{CollectLogs: &disabled},
+					},
+				}
+				Expect(cli.Create(ctx, al)).NotTo(HaveOccurred())
+
+				fc := &v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+				Expect(cli.Create(ctx, fc)).NotTo(HaveOccurred())
+
+				r := &ReconcileIstio{Client: cli, scheme: scheme, provider: operatorv1.ProviderNone, status: mockStatus}
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				updated := &operatorv1.Istio{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, updated)).NotTo(HaveOccurred())
+				Expect(cli.Delete(ctx, updated)).NotTo(HaveOccurred())
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cleaned := &v3.FelixConfiguration{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, cleaned)).NotTo(HaveOccurred())
+				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal(""))
+			})
+
+			It("clears policySyncPathPrefix on Istio deletion when ApplicationLayer is absent", func() {
+				fc := &v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+				Expect(cli.Create(ctx, fc)).NotTo(HaveOccurred())
+
+				r := &ReconcileIstio{Client: cli, scheme: scheme, provider: operatorv1.ProviderNone, status: mockStatus}
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				updated := &operatorv1.Istio{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, updated)).NotTo(HaveOccurred())
+				Expect(cli.Delete(ctx, updated)).NotTo(HaveOccurred())
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				cleaned := &v3.FelixConfiguration{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, cleaned)).NotTo(HaveOccurred())
+				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal(""))
+			})
+		})
+
 		It("should clear FelixConfiguration on deletion", func() {
 			// Create empty FelixConfiguration
 			fc := &v3.FelixConfiguration{
@@ -789,6 +913,8 @@ var _ = Describe("Istio controller tests", func() {
 						{Image: "tigera/istio-install-cni", Digest: "sha256:cni123"},
 						{Image: "tigera/istio-ztunnel", Digest: "sha256:ztunnel123"},
 						{Image: "tigera/istio-proxyv2", Digest: "sha256:proxyv2123"},
+						// Waypoint l7-collector runs from the combined calico image.
+						{Image: "tigera/calico", Digest: "sha256:calico123"},
 					},
 				},
 			}

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -574,7 +574,7 @@ var _ = Describe("Istio controller tests", func() {
 				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
 			})
 
-			It("clears policySyncPathPrefix on Istio deletion when ApplicationLayer features are all disabled", func() {
+			It("leaves policySyncPathPrefix set on Istio deletion when ApplicationLayer features are all disabled", func() {
 				disabled := operatorv1.L7LogCollectionDisabled
 				al := &operatorv1.ApplicationLayer{
 					ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
@@ -599,10 +599,13 @@ var _ = Describe("Istio controller tests", func() {
 
 				cleaned := &v3.FelixConfiguration{}
 				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, cleaned)).NotTo(HaveOccurred())
-				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal(""))
+				// Never clear a value we may not own: egressgateway and Gateway
+				// API share this default and never clear it, so Istio deletion
+				// preserves it rather than wiping it out from under them.
+				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
 			})
 
-			It("clears policySyncPathPrefix on Istio deletion when ApplicationLayer is absent", func() {
+			It("leaves policySyncPathPrefix set on Istio deletion when ApplicationLayer is absent", func() {
 				fc := &v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 				Expect(cli.Create(ctx, fc)).NotTo(HaveOccurred())
 
@@ -618,7 +621,10 @@ var _ = Describe("Istio controller tests", func() {
 
 				cleaned := &v3.FelixConfiguration{}
 				Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, cleaned)).NotTo(HaveOccurred())
-				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal(""))
+				// Never clear a value we may not own: egressgateway and Gateway
+				// API share this default and never clear it, so Istio deletion
+				// preserves it rather than wiping it out from under them.
+				Expect(cleaned.Spec.PolicySyncPathPrefix).To(Equal("/var/run/nodeagent"))
 			})
 		})
 

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Istio controller tests", func() {
 		Expect(rbacv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		Expect(admregv1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
 		Expect(autoscalingv2.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
-		istio.AddEnvoyFilterToScheme(scheme)
+		// EnvoyFilter is registered via apis.AddToScheme above.
 
 		ctx = context.Background()
 		objTrackerWithCalls = test.NewObjectTrackerWithCalls(scheme)

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -471,6 +471,28 @@ var _ = Describe("Istio controller tests", func() {
 			Expect(err.Error()).To(ContainSubstring("felixconfig IstioAmbientMode modified by user"))
 		})
 
+		It("initializes nil Annotations when writing the DSCP mark (no nil-map panic)", func() {
+			// configureIstioAmbientMode only initializes fc.Annotations when it
+			// writes the mode annotation and can return without doing so, so
+			// configureIstioDSCPMark must guard the nil map itself before
+			// writing the DSCP annotation.
+			dscp := numorstring.DSCPFromInt(23)
+			instance := &operatorv1.Istio{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       operatorv1.IstioSpec{DSCPMark: &dscp},
+			}
+			// FelixConfiguration with nil Annotations (zero value).
+			fc := &v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+			r := &ReconcileIstio{}
+			changed, err := r.configureIstioDSCPMark(instance, fc, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeTrue())
+			Expect(fc.Annotations).To(HaveKeyWithValue(istio.IstioOperatorAnnotationDSCP, "23"))
+			Expect(fc.Spec.IstioDSCPMark).NotTo(BeNil())
+			Expect(fc.Spec.IstioDSCPMark.ToUint8()).To(Equal(uint8(23)))
+		})
+
 		It("should detect user modification of IstioDSCPMark in FelixConfiguration", func() {
 			// Create FelixConfiguration with mismatched annotation and spec
 			userModifiedDSCP := numorstring.DSCPFromInt(50)

--- a/pkg/controller/utils/policy_sync.go
+++ b/pkg/controller/utils/policy_sync.go
@@ -68,16 +68,20 @@ func IstioRequiresPolicySync(istio *operatorv1.Istio, variant operatorv1.Product
 // policySyncPathPrefix should hold given the currently set value and
 // whether either the applicationlayer or istio controllers need it.
 //
-//   - A non-empty existing value that does not match the operator-managed
-//     default is treated as a customer override and preserved verbatim.
-//   - If either controller needs the field, the operator-managed default
-//     is returned.
-//   - Otherwise the field is cleared.
+//   - Any non-empty existing value is preserved. This covers both a customer
+//     override and the operator-managed default claimed by another controller
+//     that shares this field (egressgateway, Gateway API) and never clears it.
+//     Those controllers only ever set the default or leave it; clearing it here
+//     would break them, so the applicationlayer and istio controllers likewise
+//     never clear a value they may not own.
+//   - When the field is empty and either controller needs it, the
+//     operator-managed default is returned.
+//   - Otherwise the field stays empty.
 //
-// Both the applicationlayer and istio controllers call this from their
-// set and cleanup paths to keep coordination explicit and symmetric.
+// Both the applicationlayer and istio controllers call this from their set and
+// cleanup paths to keep coordination explicit and symmetric.
 func DesiredPolicySyncPathPrefix(existing string, alNeeds, istioNeeds bool) string {
-	if existing != "" && existing != DefaultPolicySyncPrefix {
+	if existing != "" {
 		return existing
 	}
 	if alNeeds || istioNeeds {

--- a/pkg/controller/utils/policy_sync.go
+++ b/pkg/controller/utils/policy_sync.go
@@ -56,10 +56,12 @@ func ApplicationLayerRequiresPolicySync(al *operatorv1.ApplicationLayer) bool {
 // IstioRequiresPolicySync reports whether an Istio CR is active in a way
 // that requires policySyncPathPrefix to be set. The L7 ambient waypoint
 // resources (l7-collector sidecar + EnvoyFilter) are rendered when the
-// installation variant is Enterprise; this predicate mirrors that gate so
-// the FelixConfiguration field tracks the renderer.
+// installation variant is Enterprise and waypoint logging is enabled; this
+// predicate mirrors that gate (via the shared WaypointLoggingEnabled helper)
+// so the FelixConfiguration field tracks the renderer — including when
+// waypoint logging is explicitly Disabled.
 func IstioRequiresPolicySync(istio *operatorv1.Istio, variant operatorv1.ProductVariant) bool {
-	return istio != nil && variant.IsEnterprise()
+	return istio != nil && variant.IsEnterprise() && istio.WaypointLoggingEnabled()
 }
 
 // DesiredPolicySyncPathPrefix returns the value FelixConfiguration's

--- a/pkg/controller/utils/policy_sync.go
+++ b/pkg/controller/utils/policy_sync.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	operatorv1 "github.com/tigera/operator/api/v1"
+)
+
+// DefaultPolicySyncPrefix is the operator-managed value for
+// FelixConfiguration.policySyncPathPrefix. The applicationlayer and istio
+// controllers both write this value when their respective features need a
+// running policy-sync gRPC server on the host (Dikastes sidecar, Istio
+// ambient waypoint l7-collector, EGW).
+const DefaultPolicySyncPrefix = "/var/run/nodeagent"
+
+// ApplicationLayerRequiresPolicySync reports whether the given
+// ApplicationLayer CR has any feature enabled that requires
+// policySyncPathPrefix to be set on FelixConfiguration. A nil receiver
+// returns false (the AL CR is absent or being deleted).
+func ApplicationLayerRequiresPolicySync(al *operatorv1.ApplicationLayer) bool {
+	if al == nil {
+		return false
+	}
+	spec := &al.Spec
+	if spec.LogCollection != nil && spec.LogCollection.CollectLogs != nil &&
+		*spec.LogCollection.CollectLogs == operatorv1.L7LogCollectionEnabled {
+		return true
+	}
+	if spec.WebApplicationFirewall != nil &&
+		*spec.WebApplicationFirewall == operatorv1.WAFEnabled {
+		return true
+	}
+	if spec.ApplicationLayerPolicy != nil &&
+		*spec.ApplicationLayerPolicy == operatorv1.ApplicationLayerPolicyEnabled {
+		return true
+	}
+	if spec.SidecarInjection != nil &&
+		*spec.SidecarInjection == operatorv1.SidecarEnabled {
+		return true
+	}
+	return false
+}
+
+// IstioRequiresPolicySync reports whether an Istio CR is active in a way
+// that requires policySyncPathPrefix to be set. The L7 ambient waypoint
+// resources (l7-collector sidecar + EnvoyFilter) are rendered when the
+// installation variant is Enterprise; this predicate mirrors that gate so
+// the FelixConfiguration field tracks the renderer.
+func IstioRequiresPolicySync(istio *operatorv1.Istio, variant operatorv1.ProductVariant) bool {
+	return istio != nil && variant.IsEnterprise()
+}
+
+// DesiredPolicySyncPathPrefix returns the value FelixConfiguration's
+// policySyncPathPrefix should hold given the currently set value and
+// whether either the applicationlayer or istio controllers need it.
+//
+//   - A non-empty existing value that does not match the operator-managed
+//     default is treated as a customer override and preserved verbatim.
+//   - If either controller needs the field, the operator-managed default
+//     is returned.
+//   - Otherwise the field is cleared.
+//
+// Both the applicationlayer and istio controllers call this from their
+// set and cleanup paths to keep coordination explicit and symmetric.
+func DesiredPolicySyncPathPrefix(existing string, alNeeds, istioNeeds bool) string {
+	if existing != "" && existing != DefaultPolicySyncPrefix {
+		return existing
+	}
+	if alNeeds || istioNeeds {
+		return DefaultPolicySyncPrefix
+	}
+	return ""
+}

--- a/pkg/controller/utils/policy_sync_test.go
+++ b/pkg/controller/utils/policy_sync_test.go
@@ -73,8 +73,22 @@ var _ = Describe("policySyncPathPrefix coordination predicates", func() {
 			Expect(utils.IstioRequiresPolicySync(&operatorv1.Istio{}, operatorv1.Calico)).To(BeFalse())
 		})
 
-		It("returns true when an Istio CR is present on Enterprise", func() {
+		It("returns true when an Istio CR is present on Enterprise with WaypointLogging unset (default)", func() {
 			Expect(utils.IstioRequiresPolicySync(&operatorv1.Istio{}, operatorv1.CalicoEnterprise)).To(BeTrue())
+		})
+
+		It("returns true when WaypointLogging is explicitly Enabled", func() {
+			enabled := operatorv1.L7LogCollectionEnabled
+			Expect(utils.IstioRequiresPolicySync(&operatorv1.Istio{
+				Spec: operatorv1.IstioSpec{WaypointLogging: &enabled},
+			}, operatorv1.CalicoEnterprise)).To(BeTrue())
+		})
+
+		It("returns false when WaypointLogging is explicitly Disabled", func() {
+			disabled := operatorv1.L7LogCollectionDisabled
+			Expect(utils.IstioRequiresPolicySync(&operatorv1.Istio{
+				Spec: operatorv1.IstioSpec{WaypointLogging: &disabled},
+			}, operatorv1.CalicoEnterprise)).To(BeFalse())
 		})
 	})
 

--- a/pkg/controller/utils/policy_sync_test.go
+++ b/pkg/controller/utils/policy_sync_test.go
@@ -103,11 +103,15 @@ var _ = Describe("policySyncPathPrefix coordination predicates", func() {
 			Expect(utils.DesiredPolicySyncPathPrefix("", false, true)).To(Equal("/var/run/nodeagent"))
 		})
 
-		It("clears when neither side needs it and there is no override", func() {
+		It("leaves the field empty when nothing is set and neither side needs it", func() {
 			Expect(utils.DesiredPolicySyncPathPrefix("", false, false)).To(Equal(""))
-			// The operator-managed default is treated as operator-owned, not
-			// as a customer override — so it gets cleared in this case.
-			Expect(utils.DesiredPolicySyncPathPrefix("/var/run/nodeagent", false, false)).To(Equal(""))
+		})
+
+		It("preserves the operator default even when neither side needs it", func() {
+			// egressgateway and Gateway API set the same default and never clear
+			// it, so the applicationlayer/istio path must not clear a value it
+			// may not own.
+			Expect(utils.DesiredPolicySyncPathPrefix("/var/run/nodeagent", false, false)).To(Equal("/var/run/nodeagent"))
 		})
 	})
 })

--- a/pkg/controller/utils/policy_sync_test.go
+++ b/pkg/controller/utils/policy_sync_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/utils"
+)
+
+var _ = Describe("policySyncPathPrefix coordination predicates", func() {
+	Describe("ApplicationLayerRequiresPolicySync", func() {
+		It("returns false for a nil receiver", func() {
+			Expect(utils.ApplicationLayerRequiresPolicySync(nil)).To(BeFalse())
+		})
+
+		It("returns false when no feature is enabled", func() {
+			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{})).To(BeFalse())
+		})
+
+		It("returns true when LogCollection is enabled", func() {
+			enabled := operatorv1.L7LogCollectionEnabled
+			al := &operatorv1.ApplicationLayer{
+				Spec: operatorv1.ApplicationLayerSpec{
+					LogCollection: &operatorv1.LogCollectionSpec{CollectLogs: &enabled},
+				},
+			}
+			Expect(utils.ApplicationLayerRequiresPolicySync(al)).To(BeTrue())
+		})
+
+		It("returns true when WAF is enabled", func() {
+			enabled := operatorv1.WAFEnabled
+			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{
+				Spec: operatorv1.ApplicationLayerSpec{WebApplicationFirewall: &enabled},
+			})).To(BeTrue())
+		})
+
+		It("returns true when ApplicationLayerPolicy is enabled", func() {
+			enabled := operatorv1.ApplicationLayerPolicyEnabled
+			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{
+				Spec: operatorv1.ApplicationLayerSpec{ApplicationLayerPolicy: &enabled},
+			})).To(BeTrue())
+		})
+
+		It("returns true when SidecarInjection is enabled", func() {
+			enabled := operatorv1.SidecarEnabled
+			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{
+				Spec: operatorv1.ApplicationLayerSpec{SidecarInjection: &enabled},
+			})).To(BeTrue())
+		})
+	})
+
+	Describe("IstioRequiresPolicySync", func() {
+		It("returns false when the Istio CR is absent", func() {
+			Expect(utils.IstioRequiresPolicySync(nil, operatorv1.CalicoEnterprise)).To(BeFalse())
+		})
+
+		It("returns false on a non-Enterprise variant", func() {
+			Expect(utils.IstioRequiresPolicySync(&operatorv1.Istio{}, operatorv1.Calico)).To(BeFalse())
+		})
+
+		It("returns true when an Istio CR is present on Enterprise", func() {
+			Expect(utils.IstioRequiresPolicySync(&operatorv1.Istio{}, operatorv1.CalicoEnterprise)).To(BeTrue())
+		})
+	})
+
+	Describe("DesiredPolicySyncPathPrefix", func() {
+		It("preserves a customer override regardless of need flags", func() {
+			Expect(utils.DesiredPolicySyncPathPrefix("/var/run/customer", false, false)).To(Equal("/var/run/customer"))
+			Expect(utils.DesiredPolicySyncPathPrefix("/var/run/customer", true, true)).To(Equal("/var/run/customer"))
+		})
+
+		It("returns the operator default when either side needs it", func() {
+			Expect(utils.DesiredPolicySyncPathPrefix("", true, false)).To(Equal("/var/run/nodeagent"))
+			Expect(utils.DesiredPolicySyncPathPrefix("", false, true)).To(Equal("/var/run/nodeagent"))
+		})
+
+		It("clears when neither side needs it and there is no override", func() {
+			Expect(utils.DesiredPolicySyncPathPrefix("", false, false)).To(Equal(""))
+			// The operator-managed default is treated as operator-owned, not
+			// as a customer override — so it gets cleared in this case.
+			Expect(utils.DesiredPolicySyncPathPrefix("/var/run/nodeagent", false, false)).To(Equal(""))
+		})
+	})
+})

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -472,6 +472,21 @@ func GetApplicationLayer(ctx context.Context, c client.Client) (*operatorv1.Appl
 	return applicationLayer, nil
 }
 
+// Return the Istio CR if present. No error is returned if it was not found.
+func GetIstio(ctx context.Context, c client.Client) (*operatorv1.Istio, error) {
+	istio := &operatorv1.Istio{}
+
+	err := c.Get(ctx, DefaultInstanceKey, istio)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return istio, nil
+}
+
 // Return the ManagementCluster CR if present. No error is returned if it was not found.
 func GetManagementCluster(ctx context.Context, c client.Client) (*operatorv1.ManagementCluster, error) {
 	managementCluster := &operatorv1.ManagementCluster{}

--- a/pkg/imports/crds/operator/operator.tigera.io_istios.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_istios.yaml
@@ -2261,6 +2261,18 @@ spec:
                           type: object
                       type: object
                   type: object
+                waypointLogging:
+                  description: |-
+                    WaypointLogging controls whether L7 logging is enabled on every Gateway
+                    using the istio-waypoint GatewayClass. When Enabled (the default), the
+                    operator injects an l7-collector sidecar into each waypoint pod via
+                    class-level defaults. When Disabled, no sidecar is injected and the
+                    associated EnvoyFilters are not created. Allowed values are Enabled or
+                    Disabled.
+                  enum:
+                    - Enabled
+                    - Disabled
+                  type: string
                 ztunnel:
                   description:
                     ZTunnelDaemonset defines the resource requirements for

--- a/pkg/render/istio/envoyfilter.go
+++ b/pkg/render/istio/envoyfilter.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// envoyFilterGV is the GroupVersion for Istio EnvoyFilter resources.
+var envoyFilterGV = schema.GroupVersion{Group: "networking.istio.io", Version: "v1alpha3"}
+
+// EnvoyFilter is a typed wrapper around Istio's networking.istio.io/v1alpha3
+// EnvoyFilter, used to avoid the full istio.io/client-go dependency while
+// still letting the operator's component handler treat it as a
+// metav1.ObjectMetaAccessor. Only the fields the operator needs to manage are
+// represented; the Spec is an opaque map so we do not have to mirror the full
+// EnvoyFilter schema.
+type EnvoyFilter struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              map[string]interface{} `json:"spec,omitempty"`
+}
+
+// DeepCopyObject implements runtime.Object.
+func (e *EnvoyFilter) DeepCopyObject() runtime.Object {
+	if e == nil {
+		return nil
+	}
+	out := &EnvoyFilter{
+		TypeMeta:   e.TypeMeta,
+		ObjectMeta: *e.DeepCopy(),
+	}
+	if e.Spec != nil {
+		out.Spec = runtime.DeepCopyJSON(e.Spec)
+	}
+	return out
+}
+
+// EnvoyFilterList is the list form of EnvoyFilter. Controller-runtime's
+// caching client requires the List kind to be registered alongside the item
+// kind for watches and List calls to work.
+type EnvoyFilterList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []EnvoyFilter `json:"items"`
+}
+
+// DeepCopyObject implements runtime.Object.
+func (l *EnvoyFilterList) DeepCopyObject() runtime.Object {
+	if l == nil {
+		return nil
+	}
+	out := &EnvoyFilterList{
+		TypeMeta: l.TypeMeta,
+		ListMeta: *l.DeepCopy(),
+	}
+	if l.Items != nil {
+		out.Items = make([]EnvoyFilter, len(l.Items))
+		for i := range l.Items {
+			l.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+	return out
+}
+
+// DeepCopyInto copies the EnvoyFilter fields into the provided destination.
+func (e *EnvoyFilter) DeepCopyInto(out *EnvoyFilter) {
+	out.TypeMeta = e.TypeMeta
+	e.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if e.Spec != nil {
+		out.Spec = runtime.DeepCopyJSON(e.Spec)
+	}
+}
+
+// AddEnvoyFilterToScheme registers the EnvoyFilter type with the given
+// runtime.Scheme so the operator's client can create, update, and delete it.
+// Callers (controller setup and tests) must invoke this before using the
+// waypoint L7 render output.
+func AddEnvoyFilterToScheme(s *runtime.Scheme) {
+	s.AddKnownTypeWithName(envoyFilterGV.WithKind("EnvoyFilter"), &EnvoyFilter{})
+	s.AddKnownTypeWithName(envoyFilterGV.WithKind("EnvoyFilterList"), &EnvoyFilterList{})
+	metav1.AddToGroupVersion(s, envoyFilterGV)
+}

--- a/pkg/render/istio/envoyfilter.go
+++ b/pkg/render/istio/envoyfilter.go
@@ -88,10 +88,12 @@ func (e *EnvoyFilter) DeepCopyInto(out *EnvoyFilter) {
 
 // AddEnvoyFilterToScheme registers the EnvoyFilter type with the given
 // runtime.Scheme so the operator's client can create, update, and delete it.
-// Callers (controller setup and tests) must invoke this before using the
-// waypoint L7 render output.
-func AddEnvoyFilterToScheme(s *runtime.Scheme) {
+// It is wired into pkg/apis' AddToSchemes alongside the other third-party
+// types, so the manager scheme learns the type centrally; it returns error to
+// satisfy runtime.SchemeBuilder.
+func AddEnvoyFilterToScheme(s *runtime.Scheme) error {
 	s.AddKnownTypeWithName(envoyFilterGV.WithKind("EnvoyFilter"), &EnvoyFilter{})
 	s.AddKnownTypeWithName(envoyFilterGV.WithKind("EnvoyFilterList"), &EnvoyFilterList{})
 	metav1.AddToGroupVersion(s, envoyFilterGV)
+	return nil
 }

--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -321,9 +321,11 @@ func (c *IstioComponent) Objects() ([]client.Object, []client.Object) {
 	objs = append(objs, res.CNI...)
 	objs = append(objs, res.ZTunnel...)
 
-	// Waypoint L7 logging is Enterprise-only. The three resources live in the
-	// Istio system namespace so Istio's deployment controller applies them as
-	// class defaults to every Gateway using the istio-waypoint GatewayClass.
+	// Waypoint L7 logging is Enterprise-only. The five resources (the
+	// l7-collector defaults ConfigMap, the EnvoyFilter-writer Role and
+	// RoleBinding, and the two EnvoyFilters) live in the Istio system namespace
+	// so Istio's deployment controller applies them as class defaults to every
+	// Gateway using the istio-waypoint GatewayClass.
 	if c.cfg.Installation.Variant.IsEnterprise() {
 		if c.waypointLoggingEnabled() {
 			objs = append(objs, L7WaypointObjects(c.cfg.IstioNamespace, c.L7CollectorImage)...)

--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -52,6 +52,7 @@ type IstioComponent struct {
 	IstioInstallCNIImage string
 	IstioZTunnelImage    string
 	IstioProxyv2Image    string
+	L7CollectorImage     string
 
 	resources *IstioResources
 }
@@ -211,6 +212,18 @@ func (c *IstioComponent) ResolveImages(is *operatorv1.ImageSet) error {
 		if err != nil {
 			return err
 		}
+		if c.waypointLoggingEnabled() {
+			// The waypoint l7-collector runs as the "l7-collector" subcommand of
+			// the combined calico binary, so it reuses the calico/calico image
+			// that calico-node already pulls onto every node. Paired with
+			// imagePullPolicy: IfNotPresent on the sidecar, waypoint pods in user
+			// namespaces resolve the image from the node cache and never need an
+			// image-pull secret copied into their namespace.
+			c.L7CollectorImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+			if err != nil {
+				return err
+			}
+		}
 	} else {
 		c.IstioPilotImage, err = components.GetReference(components.ComponentCalicoIstioPilot, reg, path, prefix, is)
 		if err != nil {
@@ -308,7 +321,25 @@ func (c *IstioComponent) Objects() ([]client.Object, []client.Object) {
 	objs = append(objs, res.CNI...)
 	objs = append(objs, res.ZTunnel...)
 
+	// Waypoint L7 logging is Enterprise-only. The three resources live in the
+	// Istio system namespace so Istio's deployment controller applies them as
+	// class defaults to every Gateway using the istio-waypoint GatewayClass.
+	if c.cfg.Installation.Variant.IsEnterprise() {
+		if c.waypointLoggingEnabled() {
+			objs = append(objs, L7WaypointObjects(c.cfg.IstioNamespace, c.L7CollectorImage)...)
+		} else {
+			toDelete = append(toDelete, L7WaypointObjects(c.cfg.IstioNamespace, "")...)
+		}
+	}
+
 	return objs, toDelete
+}
+
+// waypointLoggingEnabled reports whether L7 logging should be rendered for
+// waypoint proxies. Defaults to true when the field is unset.
+func (c *IstioComponent) waypointLoggingEnabled() bool {
+	wl := c.cfg.Istio.Spec.WaypointLogging
+	return wl == nil || *wl != operatorv1.L7LogCollectionDisabled
 }
 
 func (c *IstioComponent) Ready() bool {

--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -16,6 +16,7 @@ package istio
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -330,7 +331,10 @@ func (c *IstioComponent) Objects() ([]client.Object, []client.Object) {
 		if c.waypointLoggingEnabled() {
 			objs = append(objs, L7WaypointObjects(c.cfg.IstioNamespace, c.L7CollectorImage)...)
 		} else {
-			toDelete = append(toDelete, L7WaypointObjects(c.cfg.IstioNamespace, "")...)
+			// Delete in the reverse of the create order so the EnvoyFilters can be deleted.
+			del := L7WaypointObjects(c.cfg.IstioNamespace, "")
+			slices.Reverse(del)
+			toDelete = append(toDelete, del...)
 		}
 	}
 

--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -336,10 +336,10 @@ func (c *IstioComponent) Objects() ([]client.Object, []client.Object) {
 }
 
 // waypointLoggingEnabled reports whether L7 logging should be rendered for
-// waypoint proxies. Defaults to true when the field is unset.
+// waypoint proxies. Defaults to true when the field is unset. Delegates to the
+// shared api helper so the renderer and the policy-sync predicate stay aligned.
 func (c *IstioComponent) waypointLoggingEnabled() bool {
-	wl := c.cfg.Istio.Spec.WaypointLogging
-	return wl == nil || *wl != operatorv1.L7LogCollectionDisabled
+	return c.cfg.Istio.WaypointLoggingEnabled()
 }
 
 func (c *IstioComponent) Ready() bool {

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -961,6 +961,32 @@ var _ = Describe("Istio Component Rendering", func() {
 			Expect(deleteNames).To(HaveKey(istio.L7WaypointDefaultsConfigMapName))
 			Expect(deleteNames).To(HaveKey(istio.L7WaypointALSFilterName))
 			Expect(deleteNames).To(HaveKey(istio.L7WaypointSrcPortFilterName))
+
+			// Delete the EnvoyFilters BEFORE the Role/RoleBinding otherwise the grant is
+			// removed first and the EnvoyFilter deletes fail with Forbidden,
+			// orphaning them.
+			idxOf := func(kind, name string) int {
+				for i, o := range objsToDelete {
+					if o.GetObjectKind().GroupVersionKind().Kind == kind &&
+						o.GetName() == name && o.GetNamespace() == istio.IstioNamespace {
+						return i
+					}
+				}
+				return -1
+			}
+			alsIdx := idxOf("EnvoyFilter", istio.L7WaypointALSFilterName)
+			srcIdx := idxOf("EnvoyFilter", istio.L7WaypointSrcPortFilterName)
+			roleIdx := idxOf("Role", istio.L7WaypointEnvoyFilterRoleName)
+			bindingIdx := idxOf("RoleBinding", istio.L7WaypointEnvoyFilterRoleName)
+			Expect(alsIdx).To(BeNumerically(">=", 0))
+			Expect(srcIdx).To(BeNumerically(">=", 0))
+			Expect(roleIdx).To(BeNumerically(">=", 0))
+			Expect(bindingIdx).To(BeNumerically(">=", 0))
+			// Both EnvoyFilters precede both the writer Role and RoleBinding.
+			Expect(alsIdx).To(BeNumerically("<", roleIdx))
+			Expect(alsIdx).To(BeNumerically("<", bindingIdx))
+			Expect(srcIdx).To(BeNumerically("<", roleIdx))
+			Expect(srcIdx).To(BeNumerically("<", bindingIdx))
 		})
 	})
 

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -866,9 +866,11 @@ var _ = Describe("Istio Component Rendering", func() {
 		})
 
 		It("should emit waypoint L7 logging resources only for Enterprise variant", func() {
-			// Enterprise: all three L7 waypoint resources must appear in the
-			// Istio root namespace, with the l7-collector image resolved onto
-			// the defaults ConfigMap.
+			// Enterprise: the five L7 waypoint resources (defaults ConfigMap,
+			// the EnvoyFilter-writer Role and RoleBinding, and two EnvoyFilters)
+			// are rendered into the Istio root namespace. This test asserts the
+			// ConfigMap (with the l7-collector image resolved onto it) and the
+			// two EnvoyFilters.
 			cfg.Installation.Variant = operatorv1.CalicoEnterprise
 			_, component, err := istio.Istio(cfg)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -894,7 +896,7 @@ var _ = Describe("Istio Component Rendering", func() {
 				objsToCreate, istio.L7WaypointSrcPortFilterName, istio.IstioNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			// Calico (OSS) variant: none of the three resources should appear,
+			// Calico (OSS) variant: none of the five resources should appear,
 			// regardless of image resolution outcome.
 			cfg.Installation.Variant = operatorv1.Calico
 			_, component, err = istio.Istio(cfg)

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -950,7 +950,7 @@ var _ = Describe("Istio Component Rendering", func() {
 				Expect(o.GetName()).NotTo(Equal(istio.L7WaypointSrcPortFilterName))
 			}
 
-			// The three L7 resources must be enqueued for deletion so that
+			// The five L7 resources must be enqueued for deletion so that
 			// flipping Enabled→Disabled removes any previously-created copies.
 			deleteNames := map[string]string{}
 			for _, o := range objsToDelete {

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -66,6 +66,24 @@ func getEnterpriseTestImageSet() *operatorv1.ImageSet {
 				{Image: "tigera/istio-install-cni", Digest: "sha256:test-cni-digest"},
 				{Image: "tigera/istio-ztunnel", Digest: "sha256:test-ztunnel-digest"},
 				{Image: "tigera/istio-proxyv2", Digest: "sha256:test-proxyv2-digest"},
+				// The waypoint l7-collector runs from the combined calico image.
+				{Image: "tigera/calico", Digest: "sha256:test-calico-digest"},
+			},
+		},
+	}
+}
+
+// getEnterpriseTestImageSetWithoutL7Collector returns an Enterprise imageSet
+// that omits the combined calico image, used to verify that disabling
+// WaypointLogging makes the L7 collector image unnecessary.
+func getEnterpriseTestImageSetWithoutL7Collector() *operatorv1.ImageSet {
+	return &operatorv1.ImageSet{
+		Spec: operatorv1.ImageSetSpec{
+			Images: []operatorv1.Image{
+				{Image: "tigera/istio-pilot", Digest: "sha256:test-pilot-digest"},
+				{Image: "tigera/istio-install-cni", Digest: "sha256:test-cni-digest"},
+				{Image: "tigera/istio-ztunnel", Digest: "sha256:test-ztunnel-digest"},
+				{Image: "tigera/istio-proxyv2", Digest: "sha256:test-proxyv2-digest"},
 			},
 		},
 	}
@@ -845,6 +863,102 @@ var _ = Describe("Istio Component Rendering", func() {
 			for _, data := range configMap.Data {
 				Expect(data).NotTo(ContainSubstring("fake.io/fakeimg/proxyv2:faketag"))
 			}
+		})
+
+		It("should emit waypoint L7 logging resources only for Enterprise variant", func() {
+			// Enterprise: all three L7 waypoint resources must appear in the
+			// Istio root namespace, with the l7-collector image resolved onto
+			// the defaults ConfigMap.
+			cfg.Installation.Variant = operatorv1.CalicoEnterprise
+			_, component, err := istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(component.ResolveImages(getEnterpriseTestImageSet())).To(Succeed())
+
+			objsToCreate, _ := component.Objects()
+
+			defaults, err := rtest.GetResourceOfType[*corev1.ConfigMap](
+				objsToCreate, istio.L7WaypointDefaultsConfigMapName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(defaults.Labels).To(HaveKeyWithValue(
+				"gateway.istio.io/defaults-for-class", istio.IstioWaypointGatewayClass))
+			expectedImage, _ := components.GetReference(components.CombinedCalicoImage(cfg.Installation),
+				cfg.Installation.Registry, cfg.Installation.ImagePath, cfg.Installation.ImagePrefix,
+				getEnterpriseTestImageSet())
+			Expect(defaults.Data["deployment"]).To(ContainSubstring(expectedImage))
+			Expect(defaults.Data["deployment"]).To(ContainSubstring("--mode=waypoint"))
+
+			_, err = rtest.GetResourceOfType[*istio.EnvoyFilter](
+				objsToCreate, istio.L7WaypointALSFilterName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = rtest.GetResourceOfType[*istio.EnvoyFilter](
+				objsToCreate, istio.L7WaypointSrcPortFilterName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Calico (OSS) variant: none of the three resources should appear,
+			// regardless of image resolution outcome.
+			cfg.Installation.Variant = operatorv1.Calico
+			_, component, err = istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(component.ResolveImages(getCalicoTestImageSet())).To(Succeed())
+
+			objsToCreate, _ = component.Objects()
+			for _, o := range objsToCreate {
+				Expect(o.GetName()).NotTo(Equal(istio.L7WaypointDefaultsConfigMapName))
+				Expect(o.GetName()).NotTo(Equal(istio.L7WaypointALSFilterName))
+				Expect(o.GetName()).NotTo(Equal(istio.L7WaypointSrcPortFilterName))
+			}
+		})
+
+		It("should render waypoint L7 logging resources when WaypointLogging is explicitly Enabled", func() {
+			cfg.Installation.Variant = operatorv1.CalicoEnterprise
+			enabled := operatorv1.L7LogCollectionEnabled
+			cfg.Istio.Spec.WaypointLogging = &enabled
+
+			_, component, err := istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(component.ResolveImages(getEnterpriseTestImageSet())).To(Succeed())
+
+			objsToCreate, _ := component.Objects()
+			_, err = rtest.GetResourceOfType[*corev1.ConfigMap](
+				objsToCreate, istio.L7WaypointDefaultsConfigMapName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = rtest.GetResourceOfType[*istio.EnvoyFilter](
+				objsToCreate, istio.L7WaypointALSFilterName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = rtest.GetResourceOfType[*istio.EnvoyFilter](
+				objsToCreate, istio.L7WaypointSrcPortFilterName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should omit waypoint L7 logging resources when WaypointLogging is Disabled", func() {
+			cfg.Installation.Variant = operatorv1.CalicoEnterprise
+			disabled := operatorv1.L7LogCollectionDisabled
+			cfg.Istio.Spec.WaypointLogging = &disabled
+
+			_, component, err := istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+			// L7CollectorImage is not required when disabled — pass an ImageSet
+			// that omits it to verify ResolveImages doesn't fail.
+			Expect(component.ResolveImages(getEnterpriseTestImageSetWithoutL7Collector())).To(Succeed())
+
+			objsToCreate, objsToDelete := component.Objects()
+			for _, o := range objsToCreate {
+				Expect(o.GetName()).NotTo(Equal(istio.L7WaypointDefaultsConfigMapName))
+				Expect(o.GetName()).NotTo(Equal(istio.L7WaypointALSFilterName))
+				Expect(o.GetName()).NotTo(Equal(istio.L7WaypointSrcPortFilterName))
+			}
+
+			// The three L7 resources must be enqueued for deletion so that
+			// flipping Enabled→Disabled removes any previously-created copies.
+			deleteNames := map[string]string{}
+			for _, o := range objsToDelete {
+				if o.GetNamespace() == istio.IstioNamespace {
+					deleteNames[o.GetName()] = o.GetObjectKind().GroupVersionKind().Kind
+				}
+			}
+			Expect(deleteNames).To(HaveKey(istio.L7WaypointDefaultsConfigMapName))
+			Expect(deleteNames).To(HaveKey(istio.L7WaypointALSFilterName))
+			Expect(deleteNames).To(HaveKey(istio.L7WaypointSrcPortFilterName))
 		})
 	})
 

--- a/pkg/render/istio/l7waypoint.go
+++ b/pkg/render/istio/l7waypoint.go
@@ -21,7 +21,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -75,11 +74,6 @@ const (
 	socketVolumeName = "l7-collector-socket"
 	felixVolumeName  = "felix-sync"
 )
-
-// EnvoyFilterGVK returns the GroupVersionKind for Istio EnvoyFilter resources.
-func EnvoyFilterGVK() schema.GroupVersionKind {
-	return envoyFilterGV.WithKind("EnvoyFilter")
-}
 
 // L7WaypointObjects returns the resources the operator manages to enable
 // L7 logging on every Gateway using the istio-waypoint GatewayClass:

--- a/pkg/render/istio/l7waypoint.go
+++ b/pkg/render/istio/l7waypoint.go
@@ -1,0 +1,345 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/render/common/securitycontext"
+)
+
+const (
+	// L7WaypointDefaultsConfigMapName is the class-level defaults ConfigMap that
+	// Istio's deployment controller applies to every Gateway using the
+	// istio-waypoint GatewayClass.
+	L7WaypointDefaultsConfigMapName = "tigera-waypoint-l7-defaults"
+
+	// L7WaypointALSFilterName is the EnvoyFilter that enables gRPC ALS access
+	// logging on the waypoint's main_internal listener.
+	L7WaypointALSFilterName = "tigera-waypoint-l7-als"
+
+	// L7WaypointSrcPortFilterName is the EnvoyFilter that captures the original
+	// client IP from the Forwarded header on the connect_terminate listener and
+	// propagates it as filter state to main_internal.
+	L7WaypointSrcPortFilterName = "tigera-waypoint-l7-srcport"
+
+	// IstioWaypointGatewayClass is the standard Istio-provided GatewayClass for
+	// waypoint proxies. Every Gateway using this class automatically receives
+	// L7 logging via the class-level defaults ConfigMap.
+	IstioWaypointGatewayClass = "istio-waypoint"
+
+	// gatewayClassDefaultsLabel is the label Istio's deployment controller uses
+	// to find class-level defaults ConfigMaps for a given GatewayClass.
+	gatewayClassDefaultsLabel = "gateway.istio.io/defaults-for-class"
+
+	// forwardedFilterStateKey is the filter state key used to propagate the
+	// original client IP from connect_terminate to main_internal.
+	forwardedFilterStateKey = "io.tigera.forwarded_header"
+
+	l7CollectorSocketMountPath = "/var/run/l7-collector"
+	l7CollectorSocketURI       = "unix:///var/run/l7-collector/l7-collector.sock"
+	felixSyncMountPath         = "/var/run/felix"
+	felixDialTarget            = "/var/run/felix/nodeagent/socket"
+
+	socketVolumeName = "l7-collector-socket"
+	felixVolumeName  = "felix-sync"
+)
+
+// EnvoyFilterGVK returns the GroupVersionKind for Istio EnvoyFilter resources.
+func EnvoyFilterGVK() schema.GroupVersionKind {
+	return envoyFilterGV.WithKind("EnvoyFilter")
+}
+
+// L7WaypointObjects returns the three resources the operator manages to enable
+// L7 logging on every Gateway using the istio-waypoint GatewayClass:
+//
+//   - A defaults ConfigMap (gateway.istio.io/defaults-for-class=istio-waypoint)
+//     that Istio applies as a strategic merge patch to every waypoint
+//     Deployment, injecting the l7-collector sidecar and its shared volumes.
+//   - An EnvoyFilter enabling gRPC ALS on main_internal.
+//   - An EnvoyFilter capturing the Forwarded header on connect_terminate and
+//     propagating it as filter state to main_internal.
+//
+// All three are created in the Istio system namespace (the root namespace
+// Istiod reads class-level defaults and mesh-wide EnvoyFilters from).
+func L7WaypointObjects(namespace, l7CollectorImage string) []client.Object {
+	return []client.Object{
+		renderL7DefaultsConfigMap(namespace, l7CollectorImage),
+		renderALSEnvoyFilter(namespace),
+		renderSrcPortEnvoyFilter(namespace),
+	}
+}
+
+// renderL7DefaultsConfigMap builds the class-level defaults ConfigMap. Istio's
+// deployment controller reads the `deployment` key as a strategic merge patch
+// onto every waypoint Deployment's PodSpec.
+func renderL7DefaultsConfigMap(namespace, image string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      L7WaypointDefaultsConfigMapName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				gatewayClassDefaultsLabel: IstioWaypointGatewayClass,
+			},
+		},
+		Data: map[string]string{
+			"deployment": waypointDeploymentOverlay(image),
+		},
+	}
+}
+
+// waypointDeploymentOverlay produces the YAML strategic merge patch that gets
+// applied to every waypoint Deployment, injecting the l7-collector sidecar,
+// the shared unix socket volume, and the Felix CSI volume. An additional
+// volumeMount is applied to the existing istio-proxy container so it can write
+// access logs to the shared socket.
+func waypointDeploymentOverlay(image string) string {
+	sc := securitycontext.NewNonRootContext()
+	sc.ReadOnlyRootFilesystem = ptr.To(true)
+
+	sidecar := corev1.Container{
+		Name:  "l7-collector",
+		Image: image,
+		// image is the combined calico/calico image (already present on every
+		// node via calico-node), so IfNotPresent avoids any pull from the user
+		// namespace and removes the need for an image-pull secret there.
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         []string{components.CalicoBinaryPath, "component", "l7-collector", "--mode=waypoint"},
+		Env: []corev1.EnvVar{
+			{Name: "FELIX_DIAL_TARGET", Value: felixDialTarget},
+			{Name: "LOG_LEVEL", Value: "Info"},
+			{Name: "OWNING_GATEWAY_NAME", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.labels['gateway.networking.k8s.io/gateway-name']",
+				},
+			}},
+			{Name: "OWNING_GATEWAY_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			}},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: socketVolumeName, MountPath: l7CollectorSocketMountPath},
+			{Name: felixVolumeName, MountPath: felixSyncMountPath},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		SecurityContext: sc,
+	}
+
+	// Only specify the istio-proxy container's new volumeMount; strategic merge
+	// on containers is keyed by name, so existing fields are preserved.
+	istioProxyPatch := corev1.Container{
+		Name: "istio-proxy",
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: socketVolumeName, MountPath: l7CollectorSocketMountPath},
+		},
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name:         socketVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+		{
+			Name: felixVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{Driver: "csi.tigera.io"},
+			},
+		},
+	}
+
+	overlay := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"volumes":    volumes,
+					"containers": []corev1.Container{istioProxyPatch, sidecar},
+				},
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(overlay)
+	if err != nil {
+		// yaml.Marshal on well-formed core types is not expected to fail.
+		panic(fmt.Errorf("failed to marshal waypoint deployment overlay: %w", err))
+	}
+	return string(out)
+}
+
+// renderALSEnvoyFilter builds the EnvoyFilter that enables gRPC ALS access
+// logging on the waypoint proxy's main_internal listener, streaming logs to
+// the l7-collector sidecar via the shared unix socket.
+func renderALSEnvoyFilter(namespace string) *EnvoyFilter {
+	return &EnvoyFilter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: envoyFilterGV.String(),
+			Kind:       "EnvoyFilter",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      L7WaypointALSFilterName,
+			Namespace: namespace,
+		},
+		Spec: map[string]interface{}{
+			// Attach mesh-wide to all waypoints. Istio's policy attachment
+			// (pilot/pkg/model/policyattachment.go) only matches waypoint
+			// proxies when the EnvoyFilter lives in the root namespace and
+			// carries a targetRef of kind GatewayClass with name
+			// "istio-waypoint". workloadSelector with the class-name label
+			// is silently ignored for waypoint internal listeners.
+			"targetRefs": []interface{}{
+				map[string]interface{}{
+					"kind":  "GatewayClass",
+					"group": "gateway.networking.k8s.io",
+					"name":  IstioWaypointGatewayClass,
+				},
+			},
+			"configPatches": []interface{}{
+				map[string]interface{}{
+					"applyTo": "NETWORK_FILTER",
+					"match": map[string]interface{}{
+						"listener": map[string]interface{}{
+							"name": "main_internal",
+							"filterChain": map[string]interface{}{
+								"filter": map[string]interface{}{
+									"name": "envoy.filters.network.http_connection_manager",
+								},
+							},
+						},
+					},
+					"patch": map[string]interface{}{
+						"operation": "MERGE",
+						"value": map[string]interface{}{
+							"typed_config": map[string]interface{}{
+								"@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+								"access_log": []interface{}{
+									map[string]interface{}{
+										"name": "envoy.access_loggers.http_grpc",
+										"typed_config": map[string]interface{}{
+											"@type": "type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig",
+											"common_config": map[string]interface{}{
+												"log_name": "tigera_l7",
+												"grpc_service": map[string]interface{}{
+													"google_grpc": map[string]interface{}{
+														"target_uri":  l7CollectorSocketURI,
+														"stat_prefix": "l7_waypoint_als",
+													},
+												},
+												"transport_api_version": "V3",
+												"filter_state_objects_to_log": []interface{}{
+													forwardedFilterStateKey,
+												},
+											},
+											"additional_request_headers_to_log": []interface{}{
+												"x-forwarded-for",
+												"x-envoy-external-address",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// renderSrcPortEnvoyFilter builds the EnvoyFilter that captures the original
+// client IP from the Forwarded header (set by ztunnel on the HBONE CONNECT
+// request) on the connect_terminate listener and propagates it as filter
+// state to main_internal.
+func renderSrcPortEnvoyFilter(namespace string) *EnvoyFilter {
+	return &EnvoyFilter{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: envoyFilterGV.String(),
+			Kind:       "EnvoyFilter",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      L7WaypointSrcPortFilterName,
+			Namespace: namespace,
+		},
+		Spec: map[string]interface{}{
+			// See renderALSEnvoyFilter — waypoints require a targetRef of
+			// kind GatewayClass in the root namespace; workloadSelector does
+			// not reach the waypoint's connect_terminate listener.
+			"targetRefs": []interface{}{
+				map[string]interface{}{
+					"kind":  "GatewayClass",
+					"group": "gateway.networking.k8s.io",
+					"name":  IstioWaypointGatewayClass,
+				},
+			},
+			"configPatches": []interface{}{
+				map[string]interface{}{
+					"applyTo": "HTTP_FILTER",
+					"match": map[string]interface{}{
+						"listener": map[string]interface{}{
+							"name": "connect_terminate",
+							"filterChain": map[string]interface{}{
+								"filter": map[string]interface{}{
+									"name": "envoy.filters.network.http_connection_manager",
+									"subFilter": map[string]interface{}{
+										"name": "connect_authority",
+									},
+								},
+							},
+						},
+					},
+					"patch": map[string]interface{}{
+						"operation": "INSERT_AFTER",
+						"value": map[string]interface{}{
+							"name": "tigera.forwarded_header",
+							"typed_config": map[string]interface{}{
+								"@type": "type.googleapis.com/envoy.extensions.filters.http.set_filter_state.v3.Config",
+								"on_request_headers": []interface{}{
+									map[string]interface{}{
+										"object_key": forwardedFilterStateKey,
+										"format_string": map[string]interface{}{
+											"text_format_source": map[string]interface{}{
+												"inline_string": "%REQ(forwarded)%",
+											},
+										},
+										"shared_with_upstream": "ONCE",
+										"factory_key":          "envoy.string",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/render/istio/l7waypoint.go
+++ b/pkg/render/istio/l7waypoint.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 )
@@ -43,6 +45,14 @@ const (
 	// client IP from the Forwarded header on the connect_terminate listener and
 	// propagates it as filter state to main_internal.
 	L7WaypointSrcPortFilterName = "tigera-waypoint-l7-srcport"
+
+	// L7WaypointEnvoyFilterRoleName is the Role/RoleBinding (in the Istio system
+	// namespace) that grants the operator create/update/delete on the waypoint
+	// EnvoyFilters. The operator's cluster-wide ClusterRole holds only
+	// get/list/watch on envoyfilters (the controller-runtime cache lists and
+	// watches them cluster-wide), so the namespace-scoped write verbs live here,
+	// confining the operator's EnvoyFilter mutations to this one namespace.
+	L7WaypointEnvoyFilterRoleName = "tigera-waypoint-l7-envoyfilters"
 
 	// IstioWaypointGatewayClass is the standard Istio-provided GatewayClass for
 	// waypoint proxies. Every Gateway using this class automatically receives
@@ -71,23 +81,80 @@ func EnvoyFilterGVK() schema.GroupVersionKind {
 	return envoyFilterGV.WithKind("EnvoyFilter")
 }
 
-// L7WaypointObjects returns the three resources the operator manages to enable
+// L7WaypointObjects returns the resources the operator manages to enable
 // L7 logging on every Gateway using the istio-waypoint GatewayClass:
 //
 //   - A defaults ConfigMap (gateway.istio.io/defaults-for-class=istio-waypoint)
 //     that Istio applies as a strategic merge patch to every waypoint
 //     Deployment, injecting the l7-collector sidecar and its shared volumes.
+//   - A Role + RoleBinding granting the operator create/update/delete on
+//     EnvoyFilters in this namespace (see renderEnvoyFilterWriterRole).
 //   - An EnvoyFilter enabling gRPC ALS on main_internal.
 //   - An EnvoyFilter capturing the Forwarded header on connect_terminate and
 //     propagating it as filter state to main_internal.
 //
-// All three are created in the Istio system namespace (the root namespace
-// Istiod reads class-level defaults and mesh-wide EnvoyFilters from).
+// All are created in the Istio system namespace (the root namespace Istiod
+// reads class-level defaults and mesh-wide EnvoyFilters from). The Role and
+// RoleBinding are ordered before the EnvoyFilters so the write grant exists
+// first; on a fresh install the controller re-reconciles to absorb any RBAC
+// propagation lag.
 func L7WaypointObjects(namespace, l7CollectorImage string) []client.Object {
 	return []client.Object{
 		renderL7DefaultsConfigMap(namespace, l7CollectorImage),
+		renderEnvoyFilterWriterRole(namespace),
+		renderEnvoyFilterWriterRoleBinding(namespace),
 		renderALSEnvoyFilter(namespace),
 		renderSrcPortEnvoyFilter(namespace),
+	}
+}
+
+// renderEnvoyFilterWriterRole grants the operator create/update/delete on
+// EnvoyFilters in the Istio system namespace. The operator's ClusterRole holds
+// only get/list/watch on envoyfilters — the controller-runtime cache lists and
+// watches them cluster-wide — so the write verbs are scoped here, to the only
+// namespace the operator ever creates waypoint EnvoyFilters in. This is
+// rendered by the operator (rather than the Helm chart) because the Istio
+// system namespace does not exist at chart-install time; creating a Role with
+// verbs the operator's ClusterRole no longer carries relies on the operator's
+// `escalate` RBAC verb, and the RoleBinding on its `bind` verb.
+func renderEnvoyFilterWriterRole(namespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      L7WaypointEnvoyFilterRoleName,
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{envoyFilterGV.Group},
+				Resources: []string{"envoyfilters"},
+				Verbs:     []string{"create", "update", "delete"},
+			},
+		},
+	}
+}
+
+// renderEnvoyFilterWriterRoleBinding binds the EnvoyFilter writer Role to the
+// operator's ServiceAccount.
+func renderEnvoyFilterWriterRoleBinding(namespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      L7WaypointEnvoyFilterRoleName,
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     L7WaypointEnvoyFilterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      common.OperatorServiceAccount(),
+				Namespace: common.OperatorNamespace(),
+			},
+		},
 	}
 }
 

--- a/pkg/render/istio/l7waypoint_test.go
+++ b/pkg/render/istio/l7waypoint_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/tigera/operator/pkg/components"
@@ -39,23 +40,40 @@ var _ = Describe("L7 Waypoint render", func() {
 	})
 
 	Context("L7WaypointObjects", func() {
-		It("returns exactly three resources in the requested namespace", func() {
+		It("returns exactly five resources in the requested namespace", func() {
 			objs := istio.L7WaypointObjects(ns, image)
-			Expect(objs).To(HaveLen(3))
+			Expect(objs).To(HaveLen(5))
 			for _, o := range objs {
 				Expect(o.GetNamespace()).To(Equal(ns), "object %s/%s in wrong namespace", o.GetObjectKind().GroupVersionKind().Kind, o.GetName())
 			}
 		})
 
-		It("returns the three expected resource names", func() {
+		It("returns the expected resource names", func() {
 			objs := istio.L7WaypointObjects(ns, image)
 			names := map[string]bool{}
 			for _, o := range objs {
 				names[o.GetName()] = true
 			}
 			Expect(names).To(HaveKey(istio.L7WaypointDefaultsConfigMapName))
+			Expect(names).To(HaveKey(istio.L7WaypointEnvoyFilterRoleName))
 			Expect(names).To(HaveKey(istio.L7WaypointALSFilterName))
 			Expect(names).To(HaveKey(istio.L7WaypointSrcPortFilterName))
+		})
+
+		It("grants the operator namespace-scoped EnvoyFilter writes", func() {
+			objs := istio.L7WaypointObjects(ns, image)
+			role, ok := objs[1].(*rbacv1.Role)
+			Expect(ok).To(BeTrue(), "second object should be the EnvoyFilter writer Role")
+			Expect(role.Rules).To(HaveLen(1))
+			Expect(role.Rules[0].APIGroups).To(ConsistOf("networking.istio.io"))
+			Expect(role.Rules[0].Resources).To(ConsistOf("envoyfilters"))
+			Expect(role.Rules[0].Verbs).To(ConsistOf("create", "update", "delete"))
+
+			rb, ok := objs[2].(*rbacv1.RoleBinding)
+			Expect(ok).To(BeTrue(), "third object should be the EnvoyFilter writer RoleBinding")
+			Expect(rb.RoleRef.Name).To(Equal(istio.L7WaypointEnvoyFilterRoleName))
+			Expect(rb.Subjects).To(HaveLen(1))
+			Expect(rb.Subjects[0].Kind).To(Equal("ServiceAccount"))
 		})
 	})
 
@@ -149,7 +167,7 @@ var _ = Describe("L7 Waypoint render", func() {
 		BeforeEach(func() {
 			objs := istio.L7WaypointObjects(ns, image)
 			var ok bool
-			ef, ok = objs[1].(*istio.EnvoyFilter)
+			ef, ok = objs[3].(*istio.EnvoyFilter)
 			Expect(ok).To(BeTrue())
 			Expect(ef.Kind).To(Equal("EnvoyFilter"))
 			Expect(ef.Name).To(Equal(istio.L7WaypointALSFilterName))
@@ -186,7 +204,7 @@ var _ = Describe("L7 Waypoint render", func() {
 		BeforeEach(func() {
 			objs := istio.L7WaypointObjects(ns, image)
 			var ok bool
-			ef, ok = objs[2].(*istio.EnvoyFilter)
+			ef, ok = objs[4].(*istio.EnvoyFilter)
 			Expect(ok).To(BeTrue())
 			Expect(ef.Kind).To(Equal("EnvoyFilter"))
 			Expect(ef.Name).To(Equal(istio.L7WaypointSrcPortFilterName))

--- a/pkg/render/istio/l7waypoint_test.go
+++ b/pkg/render/istio/l7waypoint_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/render/istio"
+)
+
+var _ = Describe("L7 Waypoint render", func() {
+	const (
+		ns    = "calico-system"
+		image = "my-registry.example.com/tigera/calico:v0.0.0"
+	)
+
+	It("EnvoyFilterGVK returns networking.istio.io/v1alpha3", func() {
+		gvk := istio.EnvoyFilterGVK()
+		Expect(gvk.Group).To(Equal("networking.istio.io"))
+		Expect(gvk.Version).To(Equal("v1alpha3"))
+		Expect(gvk.Kind).To(Equal("EnvoyFilter"))
+	})
+
+	Context("L7WaypointObjects", func() {
+		It("returns exactly three resources in the requested namespace", func() {
+			objs := istio.L7WaypointObjects(ns, image)
+			Expect(objs).To(HaveLen(3))
+			for _, o := range objs {
+				Expect(o.GetNamespace()).To(Equal(ns), "object %s/%s in wrong namespace", o.GetObjectKind().GroupVersionKind().Kind, o.GetName())
+			}
+		})
+
+		It("returns the three expected resource names", func() {
+			objs := istio.L7WaypointObjects(ns, image)
+			names := map[string]bool{}
+			for _, o := range objs {
+				names[o.GetName()] = true
+			}
+			Expect(names).To(HaveKey(istio.L7WaypointDefaultsConfigMapName))
+			Expect(names).To(HaveKey(istio.L7WaypointALSFilterName))
+			Expect(names).To(HaveKey(istio.L7WaypointSrcPortFilterName))
+		})
+	})
+
+	Context("defaults ConfigMap", func() {
+		var cm *corev1.ConfigMap
+		BeforeEach(func() {
+			objs := istio.L7WaypointObjects(ns, image)
+			var ok bool
+			cm, ok = objs[0].(*corev1.ConfigMap)
+			Expect(ok).To(BeTrue(), "first object should be the defaults ConfigMap")
+		})
+
+		It("is labelled for the istio-waypoint GatewayClass", func() {
+			Expect(cm.Labels).To(HaveKeyWithValue(
+				"gateway.istio.io/defaults-for-class", istio.IstioWaypointGatewayClass))
+		})
+
+		It("runs the combined calico binary in waypoint mode with IfNotPresent pull policy", func() {
+			raw, ok := cm.Data["deployment"]
+			Expect(ok).To(BeTrue(), "ConfigMap must contain a `deployment` key")
+
+			var overlay map[string]interface{}
+			Expect(yaml.Unmarshal([]byte(raw), &overlay)).To(Succeed())
+
+			containers := diveContainers(overlay)
+			var found bool
+			for _, c := range containers {
+				m := c.(map[string]interface{})
+				if m["name"] == "l7-collector" {
+					found = true
+					Expect(m["image"]).To(Equal(image))
+					// The sidecar reuses the combined calico image already on the
+					// node, so it must invoke the calico binary's l7-collector
+					// subcommand and never pull from the user namespace.
+					Expect(m["imagePullPolicy"]).To(Equal("IfNotPresent"))
+					cmd := m["command"].([]interface{})
+					Expect(cmd).To(Equal([]interface{}{
+						components.CalicoBinaryPath, "component", "l7-collector", "--mode=waypoint",
+					}))
+				}
+			}
+			Expect(found).To(BeTrue(), "overlay must contain an l7-collector sidecar container")
+		})
+
+		It("adds the shared socket volumeMount to the istio-proxy container", func() {
+			var overlay map[string]interface{}
+			Expect(yaml.Unmarshal([]byte(cm.Data["deployment"]), &overlay)).To(Succeed())
+			containers := diveContainers(overlay)
+
+			var found bool
+			for _, c := range containers {
+				m := c.(map[string]interface{})
+				if m["name"] != "istio-proxy" {
+					continue
+				}
+				found = true
+				mounts := m["volumeMounts"].([]interface{})
+				Expect(mounts).To(HaveLen(1))
+				mount := mounts[0].(map[string]interface{})
+				Expect(mount["name"]).To(Equal("l7-collector-socket"))
+				Expect(mount["mountPath"]).To(Equal("/var/run/l7-collector"))
+			}
+			Expect(found).To(BeTrue(), "overlay must patch the istio-proxy container")
+		})
+
+		It("declares the emptyDir and Felix CSI volumes", func() {
+			var overlay map[string]interface{}
+			Expect(yaml.Unmarshal([]byte(cm.Data["deployment"]), &overlay)).To(Succeed())
+			volumes := diveVolumes(overlay)
+
+			var hasSocket, hasFelix bool
+			for _, v := range volumes {
+				m := v.(map[string]interface{})
+				switch m["name"] {
+				case "l7-collector-socket":
+					hasSocket = true
+					Expect(m).To(HaveKey("emptyDir"))
+				case "felix-sync":
+					hasFelix = true
+					csi := m["csi"].(map[string]interface{})
+					Expect(csi["driver"]).To(Equal("csi.tigera.io"))
+				}
+			}
+			Expect(hasSocket).To(BeTrue(), "overlay must declare the l7-collector-socket emptyDir volume")
+			Expect(hasFelix).To(BeTrue(), "overlay must declare the felix-sync CSI volume")
+		})
+	})
+
+	Context("ALS EnvoyFilter", func() {
+		var ef *istio.EnvoyFilter
+		BeforeEach(func() {
+			objs := istio.L7WaypointObjects(ns, image)
+			var ok bool
+			ef, ok = objs[1].(*istio.EnvoyFilter)
+			Expect(ok).To(BeTrue())
+			Expect(ef.Kind).To(Equal("EnvoyFilter"))
+			Expect(ef.Name).To(Equal(istio.L7WaypointALSFilterName))
+		})
+
+		It("attaches to the istio-waypoint GatewayClass", func() {
+			refs := ef.Spec["targetRefs"].([]interface{})
+			Expect(refs).To(HaveLen(1))
+			ref := refs[0].(map[string]interface{})
+			Expect(ref).To(HaveKeyWithValue("kind", "GatewayClass"))
+			Expect(ref).To(HaveKeyWithValue("group", "gateway.networking.k8s.io"))
+			Expect(ref).To(HaveKeyWithValue("name", istio.IstioWaypointGatewayClass))
+		})
+
+		It("patches the main_internal listener", func() {
+			patch := firstConfigPatch(ef)
+			listener := patch["match"].(map[string]interface{})["listener"].(map[string]interface{})
+			Expect(listener["name"]).To(Equal("main_internal"))
+		})
+
+		It("configures the l7-collector unix socket as gRPC ALS target", func() {
+			patch := firstConfigPatch(ef)
+			value := patch["patch"].(map[string]interface{})["value"].(map[string]interface{})
+			typedConfig := value["typed_config"].(map[string]interface{})
+			accessLog := typedConfig["access_log"].([]interface{})[0].(map[string]interface{})
+			common := accessLog["typed_config"].(map[string]interface{})["common_config"].(map[string]interface{})
+			grpc := common["grpc_service"].(map[string]interface{})["google_grpc"].(map[string]interface{})
+			Expect(grpc["target_uri"]).To(Equal("unix:///var/run/l7-collector/l7-collector.sock"))
+		})
+	})
+
+	Context("SrcPort EnvoyFilter", func() {
+		var ef *istio.EnvoyFilter
+		BeforeEach(func() {
+			objs := istio.L7WaypointObjects(ns, image)
+			var ok bool
+			ef, ok = objs[2].(*istio.EnvoyFilter)
+			Expect(ok).To(BeTrue())
+			Expect(ef.Kind).To(Equal("EnvoyFilter"))
+			Expect(ef.Name).To(Equal(istio.L7WaypointSrcPortFilterName))
+		})
+
+		It("attaches to the istio-waypoint GatewayClass", func() {
+			refs := ef.Spec["targetRefs"].([]interface{})
+			Expect(refs).To(HaveLen(1))
+			ref := refs[0].(map[string]interface{})
+			Expect(ref).To(HaveKeyWithValue("kind", "GatewayClass"))
+			Expect(ref).To(HaveKeyWithValue("group", "gateway.networking.k8s.io"))
+			Expect(ref).To(HaveKeyWithValue("name", istio.IstioWaypointGatewayClass))
+		})
+
+		It("inserts after connect_authority on the connect_terminate listener", func() {
+			patch := firstConfigPatch(ef)
+			listener := patch["match"].(map[string]interface{})["listener"].(map[string]interface{})
+			Expect(listener["name"]).To(Equal("connect_terminate"))
+			subFilter := listener["filterChain"].(map[string]interface{})["filter"].(map[string]interface{})["subFilter"].(map[string]interface{})
+			Expect(subFilter["name"]).To(Equal("connect_authority"))
+			Expect(patch["patch"].(map[string]interface{})["operation"]).To(Equal("INSERT_AFTER"))
+		})
+
+		It("propagates io.tigera.forwarded_header to upstream", func() {
+			patch := firstConfigPatch(ef)
+			value := patch["patch"].(map[string]interface{})["value"].(map[string]interface{})
+			typedConfig := value["typed_config"].(map[string]interface{})
+			onReq := typedConfig["on_request_headers"].([]interface{})[0].(map[string]interface{})
+			Expect(onReq["object_key"]).To(Equal("io.tigera.forwarded_header"))
+			Expect(onReq["shared_with_upstream"]).To(Equal("ONCE"))
+		})
+	})
+})
+
+// diveContainers returns the containers slice from a strategic merge overlay
+// shaped like {spec: {template: {spec: {containers: [...]}}}}.
+func diveContainers(overlay map[string]interface{}) []interface{} {
+	return overlay["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})
+}
+
+// diveVolumes returns the volumes slice from the same overlay shape.
+func diveVolumes(overlay map[string]interface{}) []interface{} {
+	return overlay["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["volumes"].([]interface{})
+}
+
+// firstConfigPatch returns the first entry in spec.configPatches of an
+// EnvoyFilter.
+func firstConfigPatch(ef *istio.EnvoyFilter) map[string]interface{} {
+	patches := ef.Spec["configPatches"].([]interface{})
+	Expect(patches).NotTo(BeEmpty())
+	return patches[0].(map[string]interface{})
+}

--- a/pkg/render/istio/l7waypoint_test.go
+++ b/pkg/render/istio/l7waypoint_test.go
@@ -32,13 +32,6 @@ var _ = Describe("L7 Waypoint render", func() {
 		image = "my-registry.example.com/tigera/calico:v0.0.0"
 	)
 
-	It("EnvoyFilterGVK returns networking.istio.io/v1alpha3", func() {
-		gvk := istio.EnvoyFilterGVK()
-		Expect(gvk.Group).To(Equal("networking.istio.io"))
-		Expect(gvk.Version).To(Equal("v1alpha3"))
-		Expect(gvk.Kind).To(Equal("EnvoyFilter"))
-	})
-
 	Context("L7WaypointObjects", func() {
 		It("returns exactly five resources in the requested namespace", func() {
 			objs := istio.L7WaypointObjects(ns, image)


### PR DESCRIPTION
Adds L7 logging for every Gateway that uses the istio-waypoint GatewayClass. The istio controller now creates five static resources in the Istio root namespace (calico-system) and Istio's deployment controller applies the class-default ones to all waypoints cluster-wide:

- tigera-waypoint-l7-defaults ConfigMap injects the l7-collector sidecar (with --mode=waypoint on the existing ComponentL7Collector image) and the shared emptyDir + Felix CSI volumes into every waypoint pod.
- tigera-waypoint-l7-als EnvoyFilter enables gRPC ALS on main_internal.
- tigera-waypoint-l7-srcport EnvoyFilter captures the Forwarded header on connect_terminate and propagates the client IP as filter state.
- tigera-waypoint-l7-envoyfilters Role and RoleBinding grant the operator ServiceAccount namespaced create/update/delete on EnvoyFilters in calico-system. The operator self-renders this writer grant (via escalate/bind) so the cluster-wide operator ClusterRole keeps only get/list/watch on EnvoyFilters.

A small typed EnvoyFilter struct is introduced so the component handler (which casts to metav1.ObjectMetaAccessor) can manage the resources without taking on the networking.istio.io client-go dependency.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Add L7 log collection for Istio ambient mode waypoint proxies.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

