### PR TITLE
Load mono calico image in FV harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,84 +377,28 @@ cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 
 FV_IMAGE_REGISTRY := docker.io
 VERSION_TAG := master
+CALICO_IMAGE := calico/calico
 NODE_IMAGE := calico/node
-APISERVER_IMAGE := calico/apiserver
-CNI_IMAGE := calico/cni
-FLEXVOL_IMAGE := calico/pod2daemon-flexvol
-KUBECONTROLLERS_IMAGE := calico/kube-controllers
-TYPHA_IMAGE := calico/typha
-CSI_IMAGE := calico/csi
-NODE_DRIVER_REGISTRAR_IMAGE := calico/node-driver-registrar
-GOLDMANE_IMAGE := calico/goldmane
 WHISKER_IMAGE := calico/whisker
-WHISKER_BACKEND_IMAGE := calico/whisker-backend
+
+.PHONY: calico-calico.tar
+calico-calico.tar:
+	docker pull $(FV_IMAGE_REGISTRY)/$(CALICO_IMAGE):$(VERSION_TAG)
+	docker save --output $@ $(CALICO_IMAGE):$(VERSION_TAG)
 
 .PHONY: calico-node.tar
 calico-node.tar:
 	docker pull $(FV_IMAGE_REGISTRY)/$(NODE_IMAGE):$(VERSION_TAG)
 	docker save --output $@ $(NODE_IMAGE):$(VERSION_TAG)
 
-.PHONY: calico-apiserver.tar
-calico-apiserver.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(APISERVER_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(APISERVER_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-cni.tar
-calico-cni.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(CNI_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(CNI_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-pod2daemon-flexvol.tar
-calico-pod2daemon-flexvol.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(FLEXVOL_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(FLEXVOL_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-kube-controllers.tar
-calico-kube-controllers.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(KUBECONTROLLERS_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(KUBECONTROLLERS_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-typha.tar
-calico-typha.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(TYPHA_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(TYPHA_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-csi.tar
-calico-csi.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(CSI_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(CSI_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-node-driver-registrar.tar
-calico-node-driver-registrar.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(NODE_DRIVER_REGISTRAR_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(NODE_DRIVER_REGISTRAR_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-goldmane.tar
-calico-goldmane.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(GOLDMANE_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(GOLDMANE_IMAGE):$(VERSION_TAG)
-
-.PHONY: calico-goldmane.tar
+.PHONY: calico-whisker.tar
 calico-whisker.tar:
 	docker pull $(FV_IMAGE_REGISTRY)/$(WHISKER_IMAGE):$(VERSION_TAG)
 	docker save --output $@ $(WHISKER_IMAGE):$(VERSION_TAG)
 
-.PHONY: calico-goldmane.tar
-calico-whisker-backend.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(WHISKER_BACKEND_IMAGE):$(VERSION_TAG)
-	docker save --output $@ $(WHISKER_BACKEND_IMAGE):$(VERSION_TAG)
-
-IMAGE_TARS := calico-node.tar \
-	calico-apiserver.tar \
-	calico-cni.tar \
-	calico-pod2daemon-flexvol.tar \
-	calico-kube-controllers.tar \
-	calico-typha.tar \
-	calico-csi.tar \
-	calico-node-driver-registrar.tar \
-	calico-goldmane.tar \
-	calico-whisker.tar \
-	calico-whisker-backend.tar
+IMAGE_TARS := calico-calico.tar \
+	calico-node.tar \
+	calico-whisker.tar
 
 load-container-images: ./test/load_images_on_kind_cluster.sh $(IMAGE_TARS)
 	# Load the latest tar files onto the currently running kind cluster.


### PR DESCRIPTION
The FV harness loads per-component image tars onto the kind cluster but doesn't load the `calico/calico` mono image. After #4608 and #4758, the operator deploys cni, flexvol, typha, kube-controllers, csi, csi-registrar, apiserver, goldmane, and whisker-backend from `calico/calico:master`, so kind has been pulling that image at runtime from the registry on every FV run. Works, but it's a network dependency we don't need.

This PR adds a `calico-calico.tar` target and trims `IMAGE_TARS` to the three images that still ship as their own builds: `calico/calico` (mono), `calico/node`, and `calico/whisker`. The other per-component tars are redundant since their contents now live inside `calico/calico`.

(Note: this isn't the fix for the master FV failure that started after #4758 - that was a build-ordering race where the new probe commands in node.go assume `/usr/bin/calico` is in `calico/node:master`, and the published image hadn't caught up yet. That's already self-healed.)

```release-note
None
```