### PR TITLE
Grant calico-kube-controllers RBAC for ipamconfigs CRD

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -329,7 +329,7 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration) []rbacv1.
 		},
 		{
 			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
-			Resources: []string{"blockaffinities", "ipamblocks", "ipamhandles", "networksets", "ipamconfigurations"},
+			Resources: []string{"blockaffinities", "ipamblocks", "ipamhandles", "networksets", "ipamconfigurations", "ipamconfigs"},
 			Verbs:     []string{"get", "list", "create", "update", "delete", "watch"},
 		},
 		{


### PR DESCRIPTION
kube-controllers fails to read its IPAM config with a 403:

> ipamconfigs.crd.projectcalico.org \"default\" is forbidden: User \"system:serviceaccount:calico-system:calico-kube-controllers\" cannot get resource \"ipamconfigs\" in API group \"crd.projectcalico.org\" at the cluster scope

The IPAM client in kube-controllers reads the v1 `IPAMConfig` CRD directly, whose plural under `crd.projectcalico.org` is `ipamconfigs`. The RBAC rule was switched to only list `ipamconfigurations` (the v3 plural under `projectcalico.org`) in https://github.com/tigera/operator/pull/4092, so requests to the v1 CRD got denied. `pkg/render/node.go` and `pkg/render/apiserver.go` already list both plurals - this brings kube-controllers in line.

```release-note
Fixes a permissions error in calico-kube-controllers that prevented it from reading IPAM configuration.
```