### PR TITLE
[release-v1.42] Grant calico-kube-controllers RBAC for ipamconfigs CRD

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -332,7 +332,7 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration) []rbacv1.
 		},
 		{
 			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
-			Resources: []string{"blockaffinities", "ipamblocks", "ipamhandles", "networksets", "ipamconfigurations"},
+			Resources: []string{"blockaffinities", "ipamblocks", "ipamhandles", "networksets", "ipamconfigurations", "ipamconfigs"},
 			Verbs:     []string{"get", "list", "create", "update", "delete", "watch"},
 		},
 		{


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/4775 to release-v1.42.

kube-controllers fails to read its IPAM config with a 403:

> ipamconfigs.crd.projectcalico.org \"default\" is forbidden: User \"system:serviceaccount:calico-system:calico-kube-controllers\" cannot get resource \"ipamconfigs\" in API group \"crd.projectcalico.org\" at the cluster scope

The IPAM client in kube-controllers reads the v1 `IPAMConfig` CRD directly, whose plural under `crd.projectcalico.org` is `ipamconfigs`. The RBAC rule was switched to only list `ipamconfigurations` (the v3 plural under `projectcalico.org`) in https://github.com/tigera/operator/pull/4092, so requests to the v1 CRD got denied.

```release-note
Fixes a permissions error in calico-kube-controllers that prevented it from reading IPAM configuration.
```