### PR TITLE
fix(apiserver): two MCM fixes for queryserver policy-activity path

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -52,6 +52,7 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/common/authentication"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/render/webhooks"
@@ -128,6 +129,10 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 					return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
 				}
 			}
+		}
+
+		if err = utils.AddSecretsWatch(c, relasticsearch.PublicCertSecret, common.OperatorNamespace()); err != nil {
+			return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
 		}
 
 		// Watch for changes to authentication
@@ -392,6 +397,16 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			return reconcile.Result{}, err
 		} else if prometheusCertificate != nil {
 			trustedBundle.AddCertificates(prometheusCertificate)
+		}
+
+		if managementClusterConnection != nil {
+			esGatewayCertificate, err := certificateManager.GetCertificate(r.client, relasticsearch.PublicCertSecret, common.OperatorNamespace())
+			if err != nil {
+				r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve %s", relasticsearch.PublicCertSecret), err, reqLogger)
+				return reconcile.Result{}, err
+			} else if esGatewayCertificate != nil {
+				trustedBundle.AddCertificates(esGatewayCertificate)
+			}
 		}
 
 		var authenticationCR *operatorv1.Authentication

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1277,7 +1277,6 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		env = append(env, c.cfg.KeyValidatorConfig.RequiredEnv("")...)
 	}
 
-	// Linseed client configuration for policy activity enrichment.
 	linseedURL := fmt.Sprintf("https://tigera-linseed.%s.svc", ElasticsearchNamespace)
 	if c.cfg.ManagementClusterConnection != nil {
 		linseedURL = "https://guardian.calico-system.svc"
@@ -1287,6 +1286,9 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: fmt.Sprintf("/%s/tls.crt", tlsSecret.GetName())},
 		corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: fmt.Sprintf("/%s/tls.key", tlsSecret.GetName())},
 	)
+	if c.cfg.ManagementClusterConnection != nil {
+		env = append(env, corev1.EnvVar{Name: "CLUSTER_ID", Value: ""})
+	}
 	if c.cfg.TrustedBundle != nil {
 		env = append(env, corev1.EnvVar{Name: "LINSEED_CA", Value: c.cfg.TrustedBundle.MountPath()})
 	}


### PR DESCRIPTION
## What

Two fixes on the managed-cluster apiserver controller path so the queryserver's policy-activity enrichment can reach Linseed:

1. Add the management cluster's CA chain to `apiserver-ca-bundle` (via `tigera-secure-es-gateway-http-certs-public`) so the queryserver can verify guardian's TLS cert. Watch that secret in the apiserver controller so changes trigger a reconcile.
2. Set `CLUSTER_ID=""` on the queryserver container when `ManagementClusterConnection` is present, so its linseed client sends an empty `x-cluster-id` header that voltron rewrites to the managed cluster name.

## Why

On a managed cluster the queryserver sidecar is configured with `LINSEED_URL=https://guardian.calico-system.svc` and verifies guardian's TLS cert against the bundle mounted from `apiserver-ca-bundle`.

**Bug 1 — TLS verification:** Guardian terminates the TLS using voltron's tunnel cert (`Subject CN=tigera-secure-es-gateway-http`) signed by the **management** cluster's `tigera-operator-signer`. The bundle previously only contained the **local** cluster's `tigera-operator-signer`. Both signers share the Subject DN `CN=tigera-operator-signer`, so Go's x509 verifier picks the local one as the candidate parent and fails with:

```
x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "tigera-operator-signer")
```

**Bug 2 — Cluster ID rejection:** With TLS unblocked, voltron's `inner_handler` rejected the request because the queryserver sent `x-cluster-id: cluster` (the literal env-var default):

```
WARNING voltron/inner_handler.go: Unexpected cluster ID url=/api/v1/policy_activity x-cluster-id="cluster"
```

Both manifest as 500s on the manager UI's policy list page when fetching managed-cluster policies (queryserver returns `failed to get policy activity from linseed: error connecting linseed API`).

## Behavior changes

- On managed clusters, `apiserver-ca-bundle` now contains the management cluster's `tigera-operator-signer` CA in addition to the local signer (cert count 1 → 3).
- The apiserver controller reconciles when `tigera-secure-es-gateway-http-certs-public` changes in the operator namespace.
- On managed clusters the queryserver gets `CLUSTER_ID=""`, so the linseed client sends an empty `x-cluster-id` header and voltron rewrites it to the managed cluster name.
- The queryserver's TLS handshake to `guardian.calico-system.svc` now succeeds and policy_activity enrichment proceeds (subject to a separate voltron-side fix for token injection on the tunnel-inbound linseed path).
- No change on management clusters or standalone clusters — both code paths are gated on `ManagementClusterConnection != nil`.

## Release Note

```release-note
Fix 500 errors on the policy list page for managed clusters by extending the calico-apiserver trusted bundle with the management cluster's CA and clearing the queryserver's CLUSTER_ID env var so voltron rewrites the x-cluster-id header correctly.
```