### PR TITLE
EV-6586: reload metrics ClientCAs per connection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -289,9 +289,13 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 				// is created by the operator after pod start, so an eager one-shot
 				// load would leave the trust pool permanently empty.
 				cfg.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+					pool, err := loadClientCAFromFile(metricsTLSCAFile())
+					if err != nil {
+						return nil, err
+					}
 					c := cfg.Clone()
 					c.ClientAuth = clientAuth
-					c.ClientCAs = loadClientCAFromFile(metricsTLSCAFile())
+					c.ClientCAs = pool
 					return c, nil
 				}
 			},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -283,8 +283,17 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 			func(cfg *tls.Config) {
 				cfg.GetCertificate = getCert
 				cfg.ClientAuth = clientAuth
-				cfg.ClientCAs = loadClientCAFromFile(metricsTLSCAFile())
 				cfg.MinVersion = minVersion
+				// Re-read ClientCAs per connection so kubelet volume updates and CA
+				// rotations are picked up without an operator restart. The CA Secret
+				// is created by the operator after pod start, so an eager one-shot
+				// load would leave the trust pool permanently empty.
+				cfg.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+					c := cfg.Clone()
+					c.ClientAuth = clientAuth
+					c.ClientCAs = loadClientCAFromFile(metricsTLSCAFile())
+					return c, nil
+				}
 			},
 		}
 	}

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cloudflare/cfssl/log"
+
 	"github.com/tigera/operator/pkg/common"
 )
 
@@ -91,13 +93,17 @@ func getCertificateFromFile(certFile, keyFile string) func(*tls.ClientHelloInfo)
 }
 
 // loadClientCAFromFile reads a PEM CA certificate file and returns an x509.CertPool.
-// Returns an empty pool if the file doesn't exist yet (optional volume mount).
+// Returns an empty pool if the file doesn't exist yet (optional volume mount) or
+// can't be parsed; the error is logged so the failure mode isn't silent.
 func loadClientCAFromFile(caFile string) *x509.CertPool {
 	pool := x509.NewCertPool()
 	caPEM, err := os.ReadFile(caFile)
 	if err != nil {
+		log.Errorf("failed to read metrics client CA from %s: %s", caFile, err)
 		return pool
 	}
-	pool.AppendCertsFromPEM(caPEM)
+	if !pool.AppendCertsFromPEM(caPEM) {
+		log.Errorf("metrics client CA file %s contained no valid PEM certificates", caFile)
+	}
 	return pool
 }

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cloudflare/cfssl/log"
-
 	"github.com/tigera/operator/pkg/common"
 )
 
@@ -93,17 +91,16 @@ func getCertificateFromFile(certFile, keyFile string) func(*tls.ClientHelloInfo)
 }
 
 // loadClientCAFromFile reads a PEM CA certificate file and returns an x509.CertPool.
-// Returns an empty pool if the file doesn't exist yet (optional volume mount) or
-// can't be parsed; the error is logged so the failure mode isn't silent.
-func loadClientCAFromFile(caFile string) *x509.CertPool {
-	pool := x509.NewCertPool()
+// Returns an error if the file can't be read or contains no valid PEM certificates;
+// callers should propagate the error so the failure mode isn't silent.
+func loadClientCAFromFile(caFile string) (*x509.CertPool, error) {
 	caPEM, err := os.ReadFile(caFile)
 	if err != nil {
-		log.Errorf("failed to read metrics client CA from %s: %s", caFile, err)
-		return pool
+		return nil, fmt.Errorf("failed to read metrics client CA from %s: %w", caFile, err)
 	}
+	pool := x509.NewCertPool()
 	if !pool.AppendCertsFromPEM(caPEM) {
-		log.Errorf("metrics client CA file %s contained no valid PEM certificates", caFile)
+		return nil, fmt.Errorf("metrics client CA file %s contained no valid PEM certificates", caFile)
 	}
-	return pool
+	return pool, nil
 }


### PR DESCRIPTION
## Summary
- The operator metrics server loaded its mTLS client-CA pool once at startup. The CA Secret is created by the operator *after* the pod starts, so `loadClientCAFromFile` read a non-existent file, silently returned an empty `CertPool`, and the trust pool stayed empty for the life of the process — every Prometheus scrape then failed `tls: unknown certificate authority` until the operator was restarted.
- Move `ClientCAs` into `tls.Config.GetConfigForClient` so it is re-loaded per connection, symmetric with how `GetCertificate` already reloads the serving keypair. Volume updates and CA rotations are now picked up without a restart.
- Log the read / parse failure in `loadClientCAFromFile` so a missing or malformed CA file is no longer silent.

Bug: https://tigera.atlassian.net/browse/EV-6586
Regressed in: #4558

## Test plan
- [ ] Install Calico Enterprise master-stream on a fresh cluster; confirm `kubectl logs -n tigera-operator deploy/tigera-operator` shows no `TLS handshake error` entries after install completes.
- [ ] `kubectl exec -n tigera-prometheus prometheus-calico-node-prometheus-0 -- ...` shows the `tigera-operator-metrics` target as `health: up`.
- [ ] Delete and recreate `tigera-ca-private` to simulate rotation; confirm scrapes recover without restarting the operator pod.

```release-note
Fix operator metrics server starting with an empty client-CA trust pool when the CA Secret is created after the operator pod, which previously broke Prometheus scraping until a restart.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)