### PR TITLE
fix(apiserver): wire queryserver to Linseed via tigera-linseed service in MCM

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -130,6 +130,10 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 			}
 		}
 
+		if err = utils.AddSecretsWatch(c, render.VoltronLinseedPublicCert, common.OperatorNamespace()); err != nil {
+			return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
+		}
+
 		// Watch for changes to authentication
 		err = c.WatchObject(&operatorv1.Authentication{}, &handler.EnqueueRequestForObject{})
 		if err != nil {
@@ -394,6 +398,16 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			trustedBundle.AddCertificates(prometheusCertificate)
 		}
 
+		if managementClusterConnection != nil {
+			voltronLinseedCert, err := certificateManager.GetCertificate(r.client, render.VoltronLinseedPublicCert, common.OperatorNamespace())
+			if err != nil {
+				r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve %s", render.VoltronLinseedPublicCert), err, reqLogger)
+				return reconcile.Result{}, err
+			} else if voltronLinseedCert != nil {
+				trustedBundle.AddCertificates(voltronLinseedCert)
+			}
+		}
+
 		var authenticationCR *operatorv1.Authentication
 		// Fetch the Authentication spec. If present, we use it to configure user authentication.
 		authenticationCR, err = utils.GetAuthentication(ctx, r.client)
@@ -480,6 +494,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		MultiTenant:                  r.opts.MultiTenant,
 		KeyValidatorConfig:           keyValidatorConfig,
 		KubernetesVersion:            r.opts.KubernetesVersion,
+		ClusterDomain:                r.opts.ClusterDomain,
 		RequiresAggregationServer:    !r.opts.UseV3CRDs,
 		QueryServerTLSKeyPairCertificateManagementOnly: queryServerTLSSecretCertificateManagementOnly,
 	}

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -403,7 +403,8 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 			if err != nil {
 				r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve %s", render.VoltronLinseedPublicCert), err, reqLogger)
 				return reconcile.Result{}, err
-			} else if voltronLinseedCert != nil {
+			}
+			if voltronLinseedCert != nil {
 				trustedBundle.AddCertificates(voltronLinseedCert)
 			}
 		}

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1405,12 +1405,15 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 	}
 
 	if c.cfg.ManagementClusterConnection != nil {
+		// Optional: the Secret is delivered over the Guardian tunnel, which can't be
+		// established until calico-apiserver is Ready.
 		volumes = append(volumes, corev1.Volume{
 			Name: LinseedTokenVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: fmt.Sprintf(LinseedTokenSecret, "calico-apiserver"),
 					Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
+					Optional:   ptr.To(true),
 				},
 			},
 		})

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -140,6 +140,7 @@ type APIServerConfiguration struct {
 	MultiTenant                  bool
 	KeyValidatorConfig           authentication.KeyValidatorConfig
 	KubernetesVersion            *common.VersionInfo
+	ClusterDomain                string
 
 	// Whether or not we should run the aggregation API server for projectcalico.org/v3 APIs
 	// as part of this component.
@@ -321,6 +322,12 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		namespacedEnterpriseObjects = append(namespacedEnterpriseObjects, c.sidecarMutatingWebhookConfig())
 	} else {
 		objsToDelete = append(objsToDelete, &admregv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: common.SidecarMutatingWebhookConfigName}})
+	}
+	if c.cfg.ManagementClusterConnection != nil {
+		namespacedEnterpriseObjects = append(namespacedEnterpriseObjects,
+			c.externalLinseedService(),
+			c.externalLinseedRoleBinding(),
+		)
 	}
 
 	// Compile the final arrays based on the variant.
@@ -1275,13 +1282,19 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 	// Linseed client configuration for policy activity enrichment.
 	linseedURL := fmt.Sprintf("https://tigera-linseed.%s.svc", ElasticsearchNamespace)
 	if c.cfg.ManagementClusterConnection != nil {
-		linseedURL = "https://guardian.calico-system.svc"
+		linseedURL = fmt.Sprintf("https://tigera-linseed.%s.svc.%s", APIServerNamespace, c.cfg.ClusterDomain)
 	}
 	env = append(env,
 		corev1.EnvVar{Name: "LINSEED_URL", Value: linseedURL},
 		corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: fmt.Sprintf("/%s/tls.crt", tlsSecret.GetName())},
 		corev1.EnvVar{Name: "LINSEED_CLIENT_KEY", Value: fmt.Sprintf("/%s/tls.key", tlsSecret.GetName())},
 	)
+	if c.cfg.ManagementClusterConnection != nil {
+		env = append(env,
+			corev1.EnvVar{Name: "CLUSTER_ID", Value: ""},
+			corev1.EnvVar{Name: "LINSEED_TOKEN", Value: GetLinseedTokenPath(true)},
+		)
+	}
 	if c.cfg.TrustedBundle != nil {
 		env = append(env, corev1.EnvVar{Name: "LINSEED_CA", Value: c.cfg.TrustedBundle.MountPath()})
 	}
@@ -1301,6 +1314,12 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 	}
 	if c.cfg.TrustedBundle != nil {
 		volumeMounts = append(volumeMounts, c.cfg.TrustedBundle.VolumeMounts(c.SupportedOSType())...)
+	}
+	if c.cfg.ManagementClusterConnection != nil {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      LinseedTokenVolumeName,
+			MountPath: LinseedVolumeMountPath,
+		})
 	}
 
 	container := corev1.Container{
@@ -1322,6 +1341,42 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		VolumeMounts:    volumeMounts,
 	}
 	return container
+}
+
+func (c *apiServerComponent) externalLinseedService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tigera-linseed",
+			Namespace: APIServerNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: fmt.Sprintf("%s.%s.svc.%s", GuardianServiceName, GuardianNamespace, c.cfg.ClusterDomain),
+		},
+	}
+}
+
+func (c *apiServerComponent) externalLinseedRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tigera-linseed",
+			Namespace: APIServerNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     TigeraLinseedSecretsClusterRole,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      GuardianServiceAccountName,
+				Namespace: GuardianNamespace,
+			},
+		},
+	}
 }
 
 // apiServerVolumes creates the volumes used by the API server deployment.
@@ -1365,6 +1420,18 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 
 	if c.cfg.Installation.Variant.IsEnterprise() && c.cfg.TrustedBundle != nil {
 		volumes = append(volumes, c.cfg.TrustedBundle.Volume())
+	}
+
+	if c.cfg.ManagementClusterConnection != nil {
+		volumes = append(volumes, corev1.Volume{
+			Name: LinseedTokenVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: fmt.Sprintf(LinseedTokenSecret, "calico-apiserver"),
+					Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
+				},
+			},
+		})
 	}
 
 	return volumes

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/render/common/authentication"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/podaffinity"
@@ -325,7 +326,6 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	}
 	if c.cfg.ManagementClusterConnection != nil {
 		namespacedEnterpriseObjects = append(namespacedEnterpriseObjects,
-			c.externalLinseedService(),
 			c.externalLinseedRoleBinding(),
 		)
 	}
@@ -1279,11 +1279,7 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		env = append(env, c.cfg.KeyValidatorConfig.RequiredEnv("")...)
 	}
 
-	// Linseed client configuration for policy activity enrichment.
-	linseedURL := fmt.Sprintf("https://tigera-linseed.%s.svc", ElasticsearchNamespace)
-	if c.cfg.ManagementClusterConnection != nil {
-		linseedURL = fmt.Sprintf("https://tigera-linseed.%s.svc.%s", APIServerNamespace, c.cfg.ClusterDomain)
-	}
+	linseedURL := relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, ElasticsearchNamespace, c.cfg.ManagementClusterConnection != nil, false)
 	env = append(env,
 		corev1.EnvVar{Name: "LINSEED_URL", Value: linseedURL},
 		corev1.EnvVar{Name: "LINSEED_CLIENT_CERT", Value: fmt.Sprintf("/%s/tls.crt", tlsSecret.GetName())},
@@ -1341,20 +1337,6 @@ func (c *apiServerComponent) queryServerContainer() corev1.Container {
 		VolumeMounts:    volumeMounts,
 	}
 	return container
-}
-
-func (c *apiServerComponent) externalLinseedService() *corev1.Service {
-	return &corev1.Service{
-		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tigera-linseed",
-			Namespace: APIServerNamespace,
-		},
-		Spec: corev1.ServiceSpec{
-			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: fmt.Sprintf("%s.%s.svc.%s", GuardianServiceName, GuardianNamespace, c.cfg.ClusterDomain),
-		},
-	}
 }
 
 func (c *apiServerComponent) externalLinseedRoleBinding() *rbacv1.RoleBinding {

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1079,6 +1079,56 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		Expect(deploy.Spec.Template.Spec.Affinity).To(Equal(podaffinity.NewPodAntiAffinity("calico-apiserver", []string{"calico-system", "tigera-system", "calico-apiserver"})))
 	})
 
+	It("should render Linseed routing for the queryserver when ManagementClusterConnection is set", func() {
+		cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{}
+		cfg.ClusterDomain = "cluster.local"
+
+		component, err := render.APIServer(cfg)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		resources, _ := component.Objects()
+
+		svc, ok := rtest.GetResource(resources, "tigera-linseed", "calico-system", "", "v1", "Service").(*corev1.Service)
+		Expect(ok).To(BeTrue(), "expected tigera-linseed Service in calico-system")
+		Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeExternalName))
+		Expect(svc.Spec.ExternalName).To(Equal("guardian.calico-system.svc.cluster.local"))
+
+		rb, ok := rtest.GetResource(resources, "tigera-linseed", "calico-system", "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
+		Expect(ok).To(BeTrue(), "expected tigera-linseed RoleBinding in calico-system")
+		Expect(rb.RoleRef.Name).To(Equal("tigera-linseed-secrets"))
+		Expect(rb.Subjects).To(ConsistOf(rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      render.GuardianServiceAccountName,
+			Namespace: render.GuardianNamespace,
+		}))
+
+		deploy, ok := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(ok).To(BeTrue())
+		var qs *corev1.Container
+		for i := range deploy.Spec.Template.Spec.Containers {
+			if deploy.Spec.Template.Spec.Containers[i].Name == "tigera-queryserver" {
+				qs = &deploy.Spec.Template.Spec.Containers[i]
+			}
+		}
+		Expect(qs).NotTo(BeNil())
+		Expect(qs.Env).To(ContainElement(corev1.EnvVar{Name: "LINSEED_URL", Value: "https://tigera-linseed.calico-system.svc.cluster.local"}))
+		Expect(qs.Env).To(ContainElement(corev1.EnvVar{Name: "CLUSTER_ID", Value: ""}))
+		Expect(qs.Env).To(ContainElement(corev1.EnvVar{Name: "LINSEED_TOKEN", Value: "/var/run/secrets/tigera.io/linseed/token"}))
+		Expect(qs.VolumeMounts).To(ContainElement(corev1.VolumeMount{
+			Name:      render.LinseedTokenVolumeName,
+			MountPath: render.LinseedVolumeMountPath,
+		}))
+
+		var tokenVol *corev1.Volume
+		for i := range deploy.Spec.Template.Spec.Volumes {
+			if deploy.Spec.Template.Spec.Volumes[i].Name == render.LinseedTokenVolumeName {
+				tokenVol = &deploy.Spec.Template.Spec.Volumes[i]
+			}
+		}
+		Expect(tokenVol).NotTo(BeNil())
+		Expect(tokenVol.Secret).NotTo(BeNil())
+		Expect(tokenVol.Secret.SecretName).To(Equal("calico-apiserver-tigera-linseed-token"))
+	})
+
 	Context("calico-system rendering", func() {
 		policyName := types.NamespacedName{Name: "calico-system.apiserver-access", Namespace: "calico-system"}
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1087,11 +1087,6 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
 		resources, _ := component.Objects()
 
-		svc, ok := rtest.GetResource(resources, "tigera-linseed", "calico-system", "", "v1", "Service").(*corev1.Service)
-		Expect(ok).To(BeTrue(), "expected tigera-linseed Service in calico-system")
-		Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeExternalName))
-		Expect(svc.Spec.ExternalName).To(Equal("guardian.calico-system.svc.cluster.local"))
-
 		rb, ok := rtest.GetResource(resources, "tigera-linseed", "calico-system", "rbac.authorization.k8s.io", "v1", "RoleBinding").(*rbacv1.RoleBinding)
 		Expect(ok).To(BeTrue(), "expected tigera-linseed RoleBinding in calico-system")
 		Expect(rb.RoleRef.Name).To(Equal("tigera-linseed-secrets"))
@@ -1110,7 +1105,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			}
 		}
 		Expect(qs).NotTo(BeNil())
-		Expect(qs.Env).To(ContainElement(corev1.EnvVar{Name: "LINSEED_URL", Value: "https://tigera-linseed.calico-system.svc.cluster.local"}))
+		Expect(qs.Env).To(ContainElement(corev1.EnvVar{Name: "LINSEED_URL", Value: "https://guardian.calico-system.svc"}))
 		Expect(qs.Env).To(ContainElement(corev1.EnvVar{Name: "CLUSTER_ID", Value: ""}))
 		Expect(qs.Env).To(ContainElement(corev1.EnvVar{Name: "LINSEED_TOKEN", Value: "/var/run/secrets/tigera.io/linseed/token"}))
 		Expect(qs.VolumeMounts).To(ContainElement(corev1.VolumeMount{


### PR DESCRIPTION
## What

Master sync of https://github.com/tigera/operator/pull/4780 (release-v1.42 → master). On managed clusters, render the queryserver to talk to Linseed through the same signed-token / Linseed CA path as fluentd:

- Add `VoltronLinseedPublicCert` to `apiserver-ca-bundle` and watch it.
- Render `RoleBinding/tigera-linseed` (guardian SA → `tigera-linseed-secrets`) in `calico-system` so the Linseed token controller can write the per-SA Secret in this namespace.
- On the queryserver: build `LINSEED_URL` via `relasticsearch.LinseedEndpoint(...)`, set `CLUSTER_ID=""`, mount `calico-apiserver-tigera-linseed-token`, set `LINSEED_TOKEN`.

Pairs with https://github.com/tigera/calico-private/pull/11857

## Why

Manager UI policy list returns 500 on managed clusters — queryserver's `enrichPoliciesWithActivity` fails. Three gaps on the path queryserver → guardian → voltron tunnel → Linseed:

1. **Trust bundle** missed the management cluster's `tigera-operator-signer`; both signers share Subject DN, so x509 matched the wrong CA (`crypto/rsa: verification error`).
2. **Auth** — no `LINSEED_TOKEN` was set, so the queryserver sent its managed-cluster SA token which Linseed cannot validate → 401. And `CLUSTER_ID` defaulted to the literal `"cluster"`, which voltron's `inner_handler` rejected.
3. **No RoleBinding** in `calico-system` for guardian SA, so the Linseed token controller couldn't write the per-SA Secret in this namespace.

## Behavior changes

Managed clusters only — every change gated on `ManagementClusterConnection != nil`. New `RoleBinding` in `calico-system`, new env vars + token volume on the queryserver, and `apiserver-ca-bundle` extended with the management cluster's CA. No-op on management/standalone.

## Release Note

```release-note
Fix 500 errors on the policy list page for managed clusters by trusting the management cluster CA on the calico-apiserver bundle, attaching a Linseed-issued bearer token to the queryserver, and clearing x-cluster-id so voltron rewrites it.
```