### PR TITLE
[release-v1.38] CI-1933: enable OpenShift Ingress→Route for the manager

### DIFF
--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -376,16 +376,17 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	hlr := utils.NewComponentHandler(log, r.client, r.scheme, authentication)
 
 	dexComponentCfg := &render.DexComponentConfiguration{
-		PullSecrets:    pullSecrets,
-		OpenShift:      r.provider.IsOpenShift(),
-		Installation:   install,
-		DexConfig:      dexCfg,
-		ClusterDomain:  r.clusterDomain,
-		DeleteDex:      !enableDex,
-		TLSKeyPair:     tlsKeyPair,
-		TrustedBundle:  trustedBundle,
-		Authentication: authentication,
-		PodProxies:     r.resolvedPodProxies,
+		PullSecrets:     pullSecrets,
+		OpenShift:       r.provider.IsOpenShift(),
+		Installation:    install,
+		DexConfig:       dexCfg,
+		ClusterDomain:   r.clusterDomain,
+		DeleteDex:       !enableDex,
+		TLSKeyPair:      tlsKeyPair,
+		TrustedBundle:   trustedBundle,
+		TigeraCAKeyPair: certificateManager.KeyPair(),
+		Authentication:  authentication,
+		PodProxies:      r.resolvedPodProxies,
 	}
 
 	// Render the desired objects from the CRD and create or update them.

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -54,9 +54,9 @@ const (
 	DexPolicyName    = networkpolicy.TigeraComponentPolicyPrefix + "allow-tigera-dex"
 
 	// TigeraCAPublicSecretName holds a copy of the operator's CA certificate (from tigera-ca-private)
-	// in calico-system. It exists so that an OpenShift Ingress fronting the manager can reference it
-	// via the destination-CA-certificate annotation on a reencrypt route. Only rendered when the
-	// Authentication CR is configured to use the OpenShift IDP.
+	// in the manager namespace. It exists so that an OpenShift Ingress fronting the manager can
+	// reference it via the destination-CA-certificate annotation on a reencrypt route. Only rendered
+	// when the Authentication CR is configured to use the OpenShift IDP.
 	TigeraCAPublicSecretName = "tigera-ca-public"
 )
 
@@ -168,7 +168,7 @@ func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 	} else {
 		objectsToDelete = append(objectsToDelete, &corev1.Secret{
 			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
-			ObjectMeta: metav1.ObjectMeta{Name: TigeraCAPublicSecretName, Namespace: common.CalicoNamespace},
+			ObjectMeta: metav1.ObjectMeta{Name: TigeraCAPublicSecretName, Namespace: ManagerNamespace},
 		})
 	}
 
@@ -178,18 +178,19 @@ func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 	return objs, objectsToDelete
 }
 
-// tigeraCAPublicSecret returns an Opaque Secret in calico-system with the operator's CA certificate
-// under the tls.crt key. The customer points an Ingress at it via the
+// tigeraCAPublicSecret returns an Opaque Secret in the manager namespace with the operator's CA
+// certificate under the tls.crt key. The customer points an Ingress at it via the
 // route.openshift.io/destination-ca-certificate-secret annotation, and OpenShift's
 // ingress-to-route controller copies this into the generated reencrypt Route's destinationCACertificate.
-// Both the Ingress and this Secret must live in calico-system (same-namespace lookup in the upstream
-// controller). Type Opaque (not kubernetes.io/tls) because we have no private key to pair with the cert.
+// Both the Ingress and this Secret must live in the same namespace as the manager Service
+// (same-namespace lookup in the upstream controller). Type Opaque (not kubernetes.io/tls) because we
+// have no private key to pair with the cert.
 func (c *dexComponent) tigeraCAPublicSecret() *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      TigeraCAPublicSecretName,
-			Namespace: common.CalicoNamespace,
+			Namespace: ManagerNamespace,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -52,6 +52,12 @@ const (
 	DexTLSSecretName = "tigera-dex-tls"
 	DexClientId      = "tigera-manager"
 	DexPolicyName    = networkpolicy.TigeraComponentPolicyPrefix + "allow-tigera-dex"
+
+	// TigeraCAPublicSecretName holds a copy of the operator's CA certificate (from tigera-ca-private)
+	// in calico-system. It exists so that an OpenShift Ingress fronting the manager can reference it
+	// via the destination-CA-certificate annotation on a reencrypt route. Only rendered when the
+	// Authentication CR is configured to use the OpenShift IDP.
+	TigeraCAPublicSecretName = "tigera-ca-public"
 )
 
 var DexEntityRule = networkpolicy.CreateEntityRule(DexNamespace, DexObjectName, DexPort)
@@ -73,6 +79,10 @@ type DexComponentConfiguration struct {
 	DeleteDex     bool
 	TLSKeyPair    certificatemanagement.KeyPairInterface
 	TrustedBundle certificatemanagement.TrustedBundle
+
+	// TigeraCAKeyPair is the operator CA keypair (backed by tigera-ca-private). Its certificate is
+	// copied into the tigera-ca-public Secret when the OpenShift IDP is configured.
+	TigeraCAKeyPair certificatemanagement.KeyPairInterface
 
 	Authentication *operatorv1.Authentication
 
@@ -153,10 +163,39 @@ func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 		objs = append(objs, certificatemanagement.CSRClusterRoleBinding(DexObjectName, DexNamespace))
 	}
 
+	if c.cfg.Authentication != nil && c.cfg.Authentication.Spec.Openshift != nil {
+		objs = append(objs, c.tigeraCAPublicSecret())
+	} else {
+		objectsToDelete = append(objectsToDelete, &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: TigeraCAPublicSecretName, Namespace: common.CalicoNamespace},
+		})
+	}
+
 	if c.cfg.DeleteDex {
 		return nil, append(objs, objectsToDelete...)
 	}
 	return objs, objectsToDelete
+}
+
+// tigeraCAPublicSecret returns an Opaque Secret in calico-system with the operator's CA certificate
+// under the tls.crt key. The customer points an Ingress at it via the
+// route.openshift.io/destination-ca-certificate-secret annotation, and OpenShift's
+// ingress-to-route controller copies this into the generated reencrypt Route's destinationCACertificate.
+// Both the Ingress and this Secret must live in calico-system (same-namespace lookup in the upstream
+// controller). Type Opaque (not kubernetes.io/tls) because we have no private key to pair with the cert.
+func (c *dexComponent) tigeraCAPublicSecret() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TigeraCAPublicSecretName,
+			Namespace: common.CalicoNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			corev1.TLSCertKey: c.cfg.TigeraCAKeyPair.GetCertificatePEM(),
+		},
+	}
 }
 
 func (c *dexComponent) Ready() bool {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -67,6 +67,7 @@ const (
 	ManagerTLSSecretName         = "manager-tls"
 	ManagerInternalTLSSecretName = "internal-manager-tls"
 	ManagerPolicyName            = networkpolicy.TigeraComponentPolicyPrefix + "manager-access"
+	ManagerPortName              = "https"
 
 	// The name of the TLS certificate used by Voltron to authenticate connections from managed
 	// cluster clients talking to Linseed.
@@ -688,6 +689,8 @@ func (c *managerComponent) managerService() *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
+					// OpenShift's Ingress→Route conversion requires a named target port.
+					Name:       ManagerPortName,
 					Port:       managerPort,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: intstr.FromInt(managerTargetPort),


### PR DESCRIPTION
Backport of #4763 to release-v1.38.

## Summary
- Name the manager Service's 9443 port `https`. OpenShift's ingress-to-route conversion needs a named target port.
- When the Authentication CR uses the OpenShift IDP, render an Opaque Secret `tigera-ca-public` in `calico-system` containing `tls.crt` from the operator CA (`tigera-ca-private`). Cleaned up automatically when the IDP changes or the Authentication CR is removed.

## Conflict resolution
- `authentication_controller.go`: kept `install` variable name (master used `installationSpec`); added new `TigeraCAKeyPair` field; reformatted alignment.
- `manager.go`: kept v1.38's `TigeraComponentPolicyPrefix` and lowercase `managerPort` (master used `CalicoComponentPolicyPrefix` and exported `ManagerPort`); added the new `ManagerPortName` constant and `Name` on the Service port.
- `dex.go`: kept `TigeraComponentPolicyPrefix + "allow-tigera-dex"` (master used `CalicoComponentPolicyPrefix + "dex"`); added new `TigeraCAPublicSecretName` constant. Rest of the patch (config field, Objects() branch, helper method) applied cleanly.

```release-note
Add a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a tigera-ca-public Secret in calico-system so OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.
```