### PR TITLE
guardian: probe paths follow shared health aggregator

### DIFF
--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -504,7 +504,7 @@ func (c *GuardianComponent) container() []corev1.Container {
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/health",
+						Path: "/liveness",
 						Port: intstr.FromInt(9080),
 					},
 				},
@@ -513,7 +513,7 @@ func (c *GuardianComponent) container() []corev1.Container {
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/health",
+						Path: "/readiness",
 						Port: intstr.FromInt(9080),
 					},
 				},


### PR DESCRIPTION
## Description

Companion to https://github.com/tigera/calico-private/pull/11872. Voltronguardian moved off its bespoke `/health` stub to the shared `libcalico-go/lib/health` aggregator, which serves `/liveness` and `/readiness` instead. Update the deployment probes to match.

## Release Note

```release-note
None
```