### PR TITLE
feat(gatewayapi): mount operator trust bundle on envoy-gateway and envoy-proxy

### DIFF
--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -40,6 +40,8 @@ import (
 	envoyapi "github.com/envoyproxy/gateway/api/v1alpha1"
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -274,12 +276,28 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	// Build a trust bundle containing public CA roots (extracted from the operator's
+	// UBI base image) plus the Calico operator CA. Envoy-gateway pulls wasm OCI
+	// images and envoy-proxy may originate TLS to public upstreams, JWT/OIDC
+	// providers, and tracing exporters -- none of which work without public CAs.
+	certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.clusterDomain, common.OperatorNamespace(), certificatemanager.WithLogger(reqLogger))
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+	trustedBundle, err := certificateManager.CreateTrustedBundleWithSystemRootCertificates()
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create gateway trust bundle", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	gatewayConfig := &gatewayapi.GatewayAPIImplementationConfig{
 		Installation:          installationSpec,
 		PullSecrets:           pullSecrets,
 		GatewayAPI:            gatewayAPI,
 		CustomEnvoyProxies:    make(map[string]*envoyapi.EnvoyProxy),
 		CurrentGatewayClasses: set.New[string](),
+		TrustedBundle:         trustedBundle,
 	}
 
 	if gatewayAPI.Spec.EnvoyGatewayConfigRef != nil {

--- a/pkg/controller/gatewayapi/gatewayapi_controller_test.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller_test.go
@@ -39,9 +39,12 @@ import (
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/gatewayapi"
 )
@@ -67,6 +70,14 @@ var _ = Describe("Gateway API controller tests", func() {
 		// Create a client that will have a CRUD interface of k8s objects.
 		c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 		ctx = context.Background()
+
+		// Seed the operator CA secret in the fake client so that certificatemanager.Create
+		// (called by ReconcileGatewayAPI.Reconcile to build the trusted bundle) does not
+		// fail with "CA secret does not exist".
+		certificateManager, err := certificatemanager.Create(c, nil, dns.DefaultClusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, certificateManager.KeyPair().Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+
 		installation = &operatorv1.Installation{
 			ObjectMeta: metav1.ObjectMeta{Name: "default"},
 			Spec: operatorv1.InstallationSpec{

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -797,12 +797,12 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 		bundleMounts := pr.cfg.TrustedBundle.VolumeMounts(pr.SupportedOSType())
 		if envoyProxy.Spec.Provider.Kubernetes.EnvoyDaemonSet != nil {
 			ds := envoyProxy.Spec.Provider.Kubernetes.EnvoyDaemonSet
-			ds.Pod.Volumes = appendVolumeIfMissing(ds.Pod.Volumes, bundleVolume)
-			ds.Container.VolumeMounts = appendVolumeMountsIfMissing(ds.Container.VolumeMounts, bundleMounts)
+			ds.Pod.Volumes = append(ds.Pod.Volumes, bundleVolume)
+			ds.Container.VolumeMounts = append(ds.Container.VolumeMounts, bundleMounts...)
 		} else {
 			dep := envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment
-			dep.Pod.Volumes = appendVolumeIfMissing(dep.Pod.Volumes, bundleVolume)
-			dep.Container.VolumeMounts = appendVolumeMountsIfMissing(dep.Container.VolumeMounts, bundleMounts)
+			dep.Pod.Volumes = append(dep.Pod.Volumes, bundleVolume)
+			dep.Container.VolumeMounts = append(dep.Container.VolumeMounts, bundleMounts...)
 		}
 	}
 
@@ -1126,28 +1126,6 @@ type GatewayAPIImplementationConfigInterface interface {
 
 func (pr *gatewayAPIImplementationComponent) GetConfig() *GatewayAPIImplementationConfig {
 	return pr.cfg
-}
-
-func appendVolumeIfMissing(volumes []corev1.Volume, v corev1.Volume) []corev1.Volume {
-	for _, existing := range volumes {
-		if existing.Name == v.Name {
-			return volumes
-		}
-	}
-	return append(volumes, v)
-}
-
-func appendVolumeMountsIfMissing(mounts []corev1.VolumeMount, toAdd []corev1.VolumeMount) []corev1.VolumeMount {
-	existing := make(map[string]struct{}, len(mounts))
-	for _, m := range mounts {
-		existing[m.Name+":"+m.MountPath] = struct{}{}
-	}
-	for _, m := range toAdd {
-		if _, ok := existing[m.Name+":"+m.MountPath]; !ok {
-			mounts = append(mounts, m)
-		}
-	}
-	return mounts
 }
 
 // applyEnvoyProxyServiceOverrides applies the overrides to the given EnvoyProxy.

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -30,6 +30,7 @@ import (
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -407,6 +408,11 @@ type GatewayAPIImplementationConfig struct {
 	CustomEnvoyGateway    *envoyapi.EnvoyGateway
 	CustomEnvoyProxies    map[string]*envoyapi.EnvoyProxy
 	CurrentGatewayClasses set.Set[string]
+	// TrustedBundle carries the public CA bundle (extracted from the operator's UBI
+	// base image) plus Calico's internal CA. Mounted on the envoy-gateway controller
+	// and on every provisioned envoy-proxy pod so outbound TLS (OCI wasm fetch,
+	// JWT/OIDC providers, public upstreams, tracing exporters) can validate peers.
+	TrustedBundle certificatemanagement.TrustedBundle
 }
 
 type gatewayAPIImplementationComponent struct {
@@ -600,6 +606,13 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 
 	objs = append(objs, envoyGatewayConfigMap)
 
+	// Ship the operator's trust bundle (public CAs + Calico CA) into the gateway
+	// namespace as a ConfigMap so it can be mounted on both the envoy-gateway
+	// controller and every provisioned envoy-proxy pod.
+	if pr.cfg.TrustedBundle != nil {
+		objs = append(objs, pr.cfg.TrustedBundle.ConfigMap(resources.namespace.Name))
+	}
+
 	// Deep copy the controller deployment,
 	controllerDeployment := resources.controllerDeployment.DeepCopyObject().(*appsv1.Deployment)
 
@@ -613,6 +626,29 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 
 	// Add a k8s-app label that we can use to provide API access for the controller.
 	controllerDeployment.Spec.Template.Labels["k8s-app"] = GatewayControllerLabel
+
+	// Mount the trust bundle on the envoy-gateway controller. The controller pulls
+	// wasm OCI images and may call out to JWT/OIDC providers, both of which need
+	// public CA roots to validate TLS.
+	if pr.cfg.TrustedBundle != nil {
+		controllerDeployment.Spec.Template.Spec.Volumes = append(
+			controllerDeployment.Spec.Template.Spec.Volumes,
+			pr.cfg.TrustedBundle.Volume(),
+		)
+		bundleMounts := pr.cfg.TrustedBundle.VolumeMounts(pr.SupportedOSType())
+		for i := range controllerDeployment.Spec.Template.Spec.Containers {
+			controllerDeployment.Spec.Template.Spec.Containers[i].VolumeMounts = append(
+				controllerDeployment.Spec.Template.Spec.Containers[i].VolumeMounts,
+				bundleMounts...,
+			)
+		}
+		if controllerDeployment.Spec.Template.Annotations == nil {
+			controllerDeployment.Spec.Template.Annotations = map[string]string{}
+		}
+		for k, v := range pr.cfg.TrustedBundle.HashAnnotations() {
+			controllerDeployment.Spec.Template.Annotations[k] = v
+		}
+	}
 
 	// Apply customizations from the GatewayControllerDeployment field of the GatewayAPI CR.
 	rcomp.ApplyDeploymentOverrides(controllerDeployment, pr.cfg.GatewayAPI.Spec.GatewayControllerDeployment)
@@ -750,6 +786,24 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 			envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container = &envoyapi.KubernetesContainerSpec{}
 		}
 		envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.Image = &pr.envoyProxyImage
+	}
+
+	// Mount the operator's trust bundle on the data-plane envoy-proxy pod so that
+	// outbound TLS (wasm OCI fetch, JWT/OIDC, HTTPS upstreams, tracing exporters)
+	// can validate public CAs. The bundle is the same ConfigMap mounted on the
+	// envoy-gateway controller, in the same namespace as the proxy.
+	if pr.cfg.TrustedBundle != nil {
+		bundleVolume := pr.cfg.TrustedBundle.Volume()
+		bundleMounts := pr.cfg.TrustedBundle.VolumeMounts(pr.SupportedOSType())
+		if envoyProxy.Spec.Provider.Kubernetes.EnvoyDaemonSet != nil {
+			ds := envoyProxy.Spec.Provider.Kubernetes.EnvoyDaemonSet
+			ds.Pod.Volumes = appendVolumeIfMissing(ds.Pod.Volumes, bundleVolume)
+			ds.Container.VolumeMounts = appendVolumeMountsIfMissing(ds.Container.VolumeMounts, bundleMounts)
+		} else {
+			dep := envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment
+			dep.Pod.Volumes = appendVolumeIfMissing(dep.Pod.Volumes, bundleVolume)
+			dep.Container.VolumeMounts = appendVolumeMountsIfMissing(dep.Container.VolumeMounts, bundleMounts)
+		}
 	}
 
 	// Apply overrides.
@@ -1072,6 +1126,28 @@ type GatewayAPIImplementationConfigInterface interface {
 
 func (pr *gatewayAPIImplementationComponent) GetConfig() *GatewayAPIImplementationConfig {
 	return pr.cfg
+}
+
+func appendVolumeIfMissing(volumes []corev1.Volume, v corev1.Volume) []corev1.Volume {
+	for _, existing := range volumes {
+		if existing.Name == v.Name {
+			return volumes
+		}
+	}
+	return append(volumes, v)
+}
+
+func appendVolumeMountsIfMissing(mounts []corev1.VolumeMount, toAdd []corev1.VolumeMount) []corev1.VolumeMount {
+	existing := make(map[string]struct{}, len(mounts))
+	for _, m := range mounts {
+		existing[m.Name+":"+m.MountPath] = struct{}{}
+	}
+	for _, m := range toAdd {
+		if _, ok := existing[m.Name+":"+m.MountPath]; !ok {
+			mounts = append(mounts, m)
+		}
+	}
+	return mounts
 }
 
 // applyEnvoyProxyServiceOverrides applies the overrides to the given EnvoyProxy.

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -24,6 +24,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -924,6 +925,61 @@ value:
 		Expect(ep.Spec.Provider.Kubernetes).NotTo(BeNil())
 		Expect(ep.Spec.Provider.Kubernetes.EnvoyService).NotTo(BeNil())
 		Expect(ep.Spec.Provider.Kubernetes.EnvoyService.Patch).To(Equal(patch))
+	})
+
+	It("mounts the trust bundle on envoy-gateway and envoy-proxy when provided", func() {
+		installation := &operatorv1.InstallationSpec{
+			Variant: operatorv1.Calico,
+		}
+		gatewayAPI := &operatorv1.GatewayAPI{
+			Spec: operatorv1.GatewayAPISpec{
+				GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}},
+			},
+		}
+		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
+		Expect(err).NotTo(HaveOccurred())
+		gatewayComp := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
+			Installation:  installation,
+			GatewayAPI:    gatewayAPI,
+			TrustedBundle: bundle,
+		})
+
+		objsToCreate, _ := gatewayComp.Objects()
+
+		// The bundle ConfigMap is materialised in the gateway namespace.
+		bundleCM, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, certificatemanagement.TrustedCertConfigMapName, "tigera-gateway")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bundleCM.Data).To(HaveKey(certificatemanagement.TrustedCertConfigMapKeyName))
+
+		// The envoy-gateway controller mounts the bundle.
+		controller, err := rtest.GetResourceOfType[*appsv1.Deployment](objsToCreate, "envoy-gateway", "tigera-gateway")
+		Expect(err).NotTo(HaveOccurred())
+		volNames := []string{}
+		for _, v := range controller.Spec.Template.Spec.Volumes {
+			volNames = append(volNames, v.Name)
+		}
+		Expect(volNames).To(ContainElement(certificatemanagement.TrustedCertConfigMapName))
+		mountPaths := []string{}
+		for _, m := range controller.Spec.Template.Spec.Containers[0].VolumeMounts {
+			mountPaths = append(mountPaths, m.MountPath)
+		}
+		Expect(mountPaths).To(ContainElement("/etc/pki/tls/certs"))
+
+		// The envoy-proxy data plane (patched via EnvoyProxy) mounts the bundle.
+		proxy, err := rtest.GetResourceOfType[*envoyapi.EnvoyProxy](objsToCreate, "tigera-gateway-class", "tigera-gateway")
+		Expect(err).NotTo(HaveOccurred())
+		dep := proxy.Spec.Provider.Kubernetes.EnvoyDeployment
+		Expect(dep).NotTo(BeNil())
+		proxyVolNames := []string{}
+		for _, v := range dep.Pod.Volumes {
+			proxyVolNames = append(proxyVolNames, v.Name)
+		}
+		Expect(proxyVolNames).To(ContainElement(certificatemanagement.TrustedCertConfigMapName))
+		proxyMountPaths := []string{}
+		for _, m := range dep.Container.VolumeMounts {
+			proxyMountPaths = append(proxyMountPaths, m.MountPath)
+		}
+		Expect(proxyMountPaths).To(ContainElement("/etc/pki/tls/certs"))
 	})
 
 	It("should not deploy waf-http-filter or l7-log-collector for open-source", func() {

--- a/test/gatewayapi_test.go
+++ b/test/gatewayapi_test.go
@@ -36,8 +36,11 @@ import (
 	envoyapi "github.com/envoyproxy/gateway/api/v1alpha1"
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/internal/controller"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/dns"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	gapi "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml" // gopkg.in/yaml.v2 didn't parse all the fields but this package did
@@ -84,6 +87,14 @@ var _ = Describe("GatewayAPI tests", func() {
 			Spec:       corev1.NamespaceSpec{},
 		}
 		err = c.Create(context.Background(), ns)
+		if err != nil && !kerror.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By("Seeding the operator CA secret (normally created by the core controller, which is not running in this FV suite)")
+		certificateManager, err := certificatemanager.Create(c, nil, dns.DefaultClusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
+		Expect(err).NotTo(HaveOccurred())
+		err = c.Create(context.Background(), certificateManager.KeyPair().Secret(common.OperatorNamespace()))
 		if err != nil && !kerror.IsAlreadyExists(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}


### PR DESCRIPTION
## Description

Adds public-CA roots (extracted from operator's UBI base) + Calico CA to a `tigera-ca-bundle` ConfigMap in the `tigera-gateway` namespace, mounts it on the envoy-gateway controller Deployment and on every provisioned envoy-proxy pod (Deployment + DaemonSet variants) at `/etc/pki/tls/certs`. Uses the existing `certificatemanager.CreateTrustedBundleWithSystemRootCertificates()` pattern already consumed by intrusion-detection, log-collector, authentication, and core.

**Type:** bug fix / enhancement (gateway-api render path)
**Components affected:** `pkg/render/gatewayapi`, `pkg/controller/gatewayapi`

### Why

Envoy-gateway pulls wasm OCI images and may originate TLS to public upstreams (JWT/OIDC providers, tracing exporters, HTTPS clusters), but calico/base ships no public CA roots. Result: `x509: certificate signed by unknown authority` on every outbound TLS handshake from envoy-gateway / envoy-proxy.

Per @hjiawei in Slack:
> The public root ca certs are mounted by tigera operator as needed. Normally, we don't bake them in the component image.

Confirmed: `build/Dockerfile:17,23` copies `/etc/pki` from `ubi9/ubi-minimal` into the operator image, and `pkg/tls/certificatemanagement/certificatebundle.go:249-273` reads it at runtime via `getSystemCertificates()` and packages it for downstream components. The gateway-api render path was the only major component not consuming this.

### What this replaces

Supersedes the image-side workaround in tigera/calico-private#11876 (baking CA roots into envoy-gateway + envoy-proxy images directly). With this operator change, the image change is no longer needed. Same logic applies to the Istio sibling PR tigera/calico-private#11878.

### Test plan

- [x] `go build ./...` (excluding pre-existing istio embed failure)
- [x] `go vet ./...`
- [x] `go test ./pkg/render/gatewayapi/...` — 20/20 specs (new positive test asserts ConfigMap + mount paths on both controller and proxy)
- [x] `go test ./pkg/controller/gatewayapi/...` — green (BeforeEach now seeds the operator CA secret, mirroring the compliance controller test pattern)
- [ ] Manual verify on a Kind/OrbStack cluster: install operator with this branch, apply GatewayAPI CR, confirm `tigera-ca-bundle` exists in `tigera-gateway`, envoy-gateway and envoy-proxy pods have the volume mounted at `/etc/pki/tls/certs`, outbound TLS from envoy-gateway (wasm OCI fetch) succeeds without `x509: unknown authority`

## Release Note

```release-note
Mount the operator-managed trusted CA bundle (public roots + Calico CA) on envoy-gateway and provisioned envoy-proxy pods so outbound TLS to public upstreams (e.g. wasm OCI registries, OIDC providers) succeeds without `x509: certificate signed by unknown authority`.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
