### PR TITLE
Add RBAC for the new ui-apis ManagedCluster / ClusterInformation handlers

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -994,7 +994,7 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				Verbs: []string{"list"},
 			},
 			{
-				// ui-apis needs broad read access to UISettings and UISettingsGroups to serve
+				// ui-apis needs read access to UISettings and UISettingsGroups to serve
 				// requests on behalf of users. It performs SubjectAccessReviews to enforce
 				// per-group RBAC before returning results.
 				APIGroups: []string{"projectcalico.org"},
@@ -1004,6 +1004,24 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 					"uisettingsgroups/data",
 				},
 				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				// Delete is granted on the leaf UISettings resource (the ui-apis DELETE
+				// handler issues this call with its own SA token after the cloud security
+				// fix moved writes off user impersonation). The aggregated apiserver
+				// gates leaf writes on the uisettingsgroups/data subresource RBAC, so
+				// delete is granted there too. The bare uisettingsgroups resource is
+				// intentionally omitted — ui-apis never deletes groups themselves.
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"uisettings", "uisettingsgroups/data"},
+				Verbs:     []string{"delete"},
+			},
+			{
+				// ClusterInformation read: surfaces the management-cluster version in the UI.
+				// Served by the ui-apis ClusterInformation handler using its own SA token.
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"clusterinformations"},
+				Verbs:     []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -1027,11 +1045,14 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				},
 				Verbs: []string{"list"},
 			},
-			// Allow Enterprise Custom Dashboards to access managed clusters
+			// Allow Enterprise Custom Dashboards to access managed clusters. Create/delete
+			// were added when the ui-apis ManagedCluster handler took over CRUD with its
+			// own SA token (replacing the impersonated /apis/.../managedclusters proxy).
+			// Update is granted separately via managedClustersUpdateRBAC().
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -358,6 +358,16 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"uisettings", "uisettingsgroups/data"},
+				Verbs:     []string{"delete"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"clusterinformations"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"stagednetworkpolicies",
 					"tier.stagednetworkpolicies",
@@ -381,7 +391,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
@@ -695,6 +705,16 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"uisettings", "uisettingsgroups/data"},
+				Verbs:     []string{"delete"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"clusterinformations"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"stagednetworkpolicies",
 					"tier.stagednetworkpolicies",
@@ -718,7 +738,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"managedclusters"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list", "watch", "create", "delete"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},


### PR DESCRIPTION
## Description

The cloud security fix in calico-private (PR #11546) moves UISettings delete, ManagedCluster CRUD, and ClusterInformation reads off the user-impersonated /apis/projectcalico.org/v3 proxy path and onto ui-apis handlers that call the Calico API with their own service-account token. The tigera-manager pod SA therefore needs new grants on these resources.

Changes to managerClusterRole (pkg/render/manager.go):
- uisettings / uisettingsgroups / uisettingsgroups/data — add "delete" (previously only get/list/watch).
- managedclusters — add "create" and "delete" verbs (previously only get/list/watch). "update" continues to live in managedClustersUpdateRBAC().
- clusterinformations — new rule with "get" and "list" so the UI can surface the management cluster version through ui-apis.

manager_test.go updated at both assertion sites to match.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
