### PR TITLE
fix(apiserver): mark linseed-token mount Optional to unblock MCM bootstrap

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1410,12 +1410,15 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 	}
 
 	if c.cfg.ManagementClusterConnection != nil {
+		// Optional: the Secret is delivered over the Guardian tunnel, which can't be
+		// established until calico-apiserver is Ready.
 		volumes = append(volumes, corev1.Volume{
 			Name: LinseedTokenVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: fmt.Sprintf(LinseedTokenSecret, "calico-apiserver"),
 					Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
+					Optional:   ptr.To(true),
 				},
 			},
 		})


### PR DESCRIPTION
## What

On managed clusters, mark the `calico-apiserver-tigera-linseed-token` Secret volume on the `calico-apiserver` Deployment as `Optional: true`.

```go
volumes = append(volumes, corev1.Volume{
    Name: LinseedTokenVolumeName,
    VolumeSource: corev1.VolumeSource{
        Secret: &corev1.SecretVolumeSource{
            SecretName: fmt.Sprintf(LinseedTokenSecret, "calico-apiserver"),
            Items:      []corev1.KeyToPath{{Key: LinseedTokenKey, Path: LinseedTokenSubPath}},
            Optional:   ptr.To(true),
        },
    },
})
```

Master sync: #4786.

## Why

#4780 added the non-optional `linseed-token` Secret volume to the managed-cluster calico-apiserver. On a fresh managed cluster this creates a bootstrap deadlock:

1. The Secret is only written by the management-cluster Linseed token controller, which writes it over the Guardian tunnel.
2. Guardian is deployed by the operator's `clusterconnection-controller`, which gates on the v3 (`projectcalico.org`) API being available.
3. The v3 API is served by `calico-apiserver`.
4. `calico-apiserver` won't start until kubelet can mount the Secret in (1).

So no Guardian → no token → no calico-apiserver → no v3 API → no Guardian. `ManagedCluster.status.ManagedClusterConnected` stays `False` forever; manager UI shows no data for the managed cluster.

Reproduced on a fresh `release-calient-v3.23` managed cluster paired with a `release-v1.42` operator: `calico-apiserver` pods stuck `ContainerCreating` with `MountVolume.SetUp failed for volume "linseed-token" : secret "calico-apiserver-tigera-linseed-token" not found`; `APIService v3.projectcalico.org` `False (MissingEndpoints)`; `ManagementClusterConnection` Degraded `Waiting for clusterInfoWatchReady watch to be established`; `tigera-guardian` Deployment never rendered.

After this change, kubelet projects an empty directory at the mount path so calico-apiserver starts immediately, the v3 API comes up, the operator deploys Guardian, the tunnel establishes, the token controller writes the Secret, and kubelet refreshes the projection on its standard sync interval. Policy activity (the only consumer of the token) is operational seconds later.

## Behavior changes

Managed clusters only — gated on `ManagementClusterConnection != nil`. No change on management or standalone clusters. No change at steady state once Guardian is up.

## Release Note

```release-note
Fix a bootstrap deadlock on fresh managed clusters that prevented calico-apiserver from starting and the Guardian tunnel from being established when the management cluster had not yet pushed the calico-apiserver linseed token.
```