### PR TITLE
EV-6558: [CVE] Bump Go to 1.25.10 / GO_BUILD_VER on release-v1.42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.25.9-llvm18.1.8-k8s1.35.4
+GO_BUILD_VER?=1.25.10-llvm18.1.8-k8s1.35.4
 CALICO_BASE_VER ?= ubi9-1771532994
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator/api
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary

Picks up Go 1.25.10 on `release-v1.42` to address CVE-2026-27143 (critical) and five high-severity stdlib CVEs flagged in the v3.23 hashrelease scans of the operator image. Companion to the calico-private release-calient-v3.23 bump merged as tigera/calico-private#11858 — the matching `calico/go-build:1.25.10-llvm18.1.8-k8s1.35.4` image was published to Docker Hub via projectcalico/toolchain#824.

## What changed

- `Makefile`: `GO_BUILD_VER?=1.25.9-llvm18.1.8-k8s1.35.4` → `1.25.10-...-k8s1.35.4` (LLVM and k8s unchanged).
- `go.mod` and `api/go.mod`: `go 1.25.9` → `go 1.25.10`.

Three-line diff. No transitive dependency changes, no generated-file regen needed.

## Release Note

```release-note
Bump Go toolchain to 1.25.10 to patch CVE-2026-27143 (critical) and five additional stdlib CVEs flagged on the operator image.
```

## Test plan

- [ ] CI builds pass for the operator image on the new go-build image
- [ ] Re-scan of the next v3.23 hashrelease no longer flags `stdlib:go1.25.9` for CVE-2026-27143 et al. on the operator image

🤖 Generated with [Claude Code](https://claude.com/claude-code)