### PR TITLE
fix(kibana): bump ECK Elasticsearch/Kibana version to 8.19.15

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.21.7
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.15
   kibana:
     image: tigera/kibana
     version: v3.21.7
   eck-elasticsearch:
-    version: 8.19.10
+    version: 8.19.15
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.21.7

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.19.10",
+		Version:  "8.19.15",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.19.10",
+		Version:  "8.19.15",
 		Registry: "",
 	}
 


### PR DESCRIPTION
## Summary

The actual Kibana binary bundled in `quay.io/tigera/kibana:v3.21.7` is **8.19.15**, not the `8.19.10` declared by `ComponentEckKibana` / `ComponentEckElasticsearch` in this branch.

Kibana validates `migrations.discardUnknownObjects` against its own internal version. With the version mismatch it silently ignores the flag and logs:

```
The flag `migrations.discardUnknownObjects` is defined but does not match the current kibana version; unknown objects will NOT be discarded.
```

Result: customers upgrading CE 3.20 → 3.21 crashloop Kibana on the orphan `ingest_manager_settings` document left over from Fleet 7.17 (Fleet was disabled in v1.38). The `discardUnknownObjects` line landed in v1.38 with #4654, but the constant it references was stale, so the fix never actually took effect.

## What this changes

- `pkg/components/enterprise.go`: bump `ComponentEckElasticsearch.Version` and `ComponentEckKibana.Version` from `8.19.10` → `8.19.15`
- `config/enterprise_versions.yml`: mirror the bump (kept in sync per the file header comment)

## How it was verified

Read `/usr/share/kibana/package.json` from inside a running `v3.21.7` pod:

```
$ kubectl debug -n tigera-kibana pod/<crashing-kb-pod> \
    --copy-to=kbinspect --container=kibana \
    --image=quay.io/tigera/kibana:v3.21.7 \
    -- /bin/bash -c 'while true; do : ; done'

$ kubectl exec -n tigera-kibana kbinspect -c kibana -- \
    /bin/bash -c 'grep -E "\"version\"" /usr/share/kibana/package.json'
  "version": "8.19.15",
```

After applying this change, the orphan `ingest_manager_settings` document is discarded, Kibana migration completes, and the pod reaches Ready.

## Release Note

```release-note
Sync bundled Kibana's version to 8.19.15.
```