### PR TITLE
fix(kibana): bump ECK Elasticsearch/Kibana version to 8.19.15

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -47,13 +47,13 @@ components:
     version: release-calient-v3.23
   # eck-kibana holds the version of Kibana built for tigera/kibana
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.15
   kibana:
     image: kibana
     version: release-calient-v3.23
   # eck-elasticsearch holds the version of Elasticsearch built for tigera/elasticsearch
   eck-elasticsearch:
-    version: 8.19.10
+    version: 8.19.15
   elasticsearch:
     image: elasticsearch
     version: release-calient-v3.23

--- a/hack/release/prep_test.go
+++ b/hack/release/prep_test.go
@@ -57,7 +57,7 @@ components:
   cni:
     version: master
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.15
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
@@ -88,7 +88,7 @@ components:
   cni:
     version: v1.32.4
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.15
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -85,12 +85,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version: "8.19.10",
+		Version: "8.19.15",
 		variant: enterpriseVariant,
 	}
 
 	ComponentEckKibana = Component{
-		Version: "8.19.10",
+		Version: "8.19.15",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
## Description

Bump bundled ECK Kibana/Elasticsearch version constants from `8.19.10` → `8.19.15` to match the actual binary in the `tigera/kibana` image on `release-calient-v3.23` (per `calico-private/kibana/docker-image/Dockerfile`, which pulls from `kibana-ubi:v8.19.15`).

No behavior change — the same image was already shipping. This just aligns the operator-declared version with reality, so the value ECK stamps onto the Kibana CR `spec.version` matches what's running.

## Release note

```release-note
Bump bundled ECK Kibana/Elasticsearch version constant to 8.19.15.
```
