### PR TITLE
fix(kibana): bump ECK Elasticsearch/Kibana version to 8.19.15

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.22.4
   eck-kibana:
-    version: 8.19.12
+    version: 8.19.15
   kibana:
     image: tigera/kibana
     version: v3.22.4
   eck-elasticsearch:
-    version: 8.19.12
+    version: 8.19.15
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.22.4

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.19.12",
+		Version:  "8.19.15",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.19.12",
+		Version:  "8.19.15",
 		Registry: "",
 	}
 


### PR DESCRIPTION
## Description

Bump bundled ECK Kibana/Elasticsearch version constants from `8.19.12` → `8.19.15` to match the actual binary in the `tigera/kibana` image on `release-calient-v3.22` (per `calico-private/kibana/docker-image/Dockerfile`, which pulls from `kibana-ubi:v8.19.15`).

No behavior change — the same image was already shipping. This just aligns the operator-declared version with reality, so the value ECK stamps onto the Kibana CR `spec.version` matches what's running.

## Release note

```release-note
Bump bundled ECK Kibana/Elasticsearch version constant to 8.19.15.
```
