### PR TITLE
fix(kibana): bump ECK Elasticsearch/Kibana version to 8.19.15

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -26,13 +26,13 @@ components:
     version: master
   # eck-kibana holds the version of Kibana built for tigera/kibana
   eck-kibana:
-    version: 8.19.10
+    version: 8.19.15
   kibana:
     image: kibana
     version: master
   # eck-elasticsearch holds the version of Elasticsearch built for tigera/elasticsearch
   eck-elasticsearch:
-    version: 8.19.10
+    version: 8.19.15
   elasticsearch:
     image: elasticsearch
     version: master

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -45,12 +45,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version: "8.19.10",
+		Version: "8.19.15",
 		variant: enterpriseVariant,
 	}
 
 	ComponentEckKibana = Component{
-		Version: "8.19.10",
+		Version: "8.19.15",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
## Description

Bump bundled ECK Kibana/Elasticsearch version constants from `8.19.10` → `8.19.15` to match the actual binary in the `tigera/kibana` image on master (per `calico-private/kibana/docker-image/Dockerfile`, which pulls from `kibana-ubi:v8.19.15`).

No behavior change — the same image was already shipping. This just aligns the operator-declared version with reality, so the value ECK stamps onto the Kibana CR `spec.version` matches what's running.

## Release note

```release-note
Bump bundled ECK Kibana/Elasticsearch version constant to 8.19.15.
```
