### PR TITLE
Respect node cordoning for Typha and host-networked Deployments

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1422,7 +1422,7 @@ func (c *apiServerComponent) apiServerVolumes() []corev1.Volume {
 // tolerations creates the tolerations used by the API server deployment.
 func (c *apiServerComponent) tolerations() []corev1.Toleration {
 	if c.hostNetwork() {
-		return rmeta.TolerateAll
+		return rmeta.TolerateBootstrap
 	}
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {

--- a/pkg/render/common/meta/meta.go
+++ b/pkg/render/common/meta/meta.go
@@ -68,6 +68,42 @@ var (
 		Effect:   corev1.TaintEffectNoSchedule,
 	}
 
+	// TolerateBootstrap is the toleration set used by host-networked Deployments
+	// that must be schedulable during cluster bootstrap (before the CNI is up and
+	// before the cloud provider has initialized the node), but which should
+	// otherwise respect node cordoning. Unlike TolerateAll, this set deliberately
+	// omits a blanket NoSchedule toleration so that the Kubernetes-added
+	// node.kubernetes.io/unschedulable taint applied by `kubectl cordon` takes
+	// effect.
+	TolerateBootstrap = []corev1.Toleration{
+		TolerateCriticalAddonsOnly,
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/not-ready",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/network-unavailable",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.cloudprovider.kubernetes.io/uninitialized",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+
 	// TolerateAll returns tolerations to tolerate all taints. When used, it is not necessary
 	// to include the user's custom tolerations because we already tolerate everything.
 	TolerateAll = []corev1.Toleration{

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -411,8 +411,11 @@ func (c *typhaComponent) typhaDeployment() []client.Object {
 		annotations["prometheus.io/port"] = fmt.Sprintf("%d", *c.cfg.Installation.TyphaMetricsPort)
 	}
 
-	// Allow tolerations to be overwritten by the end-user.
-	tolerations := rmeta.TolerateAll
+	// Allow tolerations to be overwritten by the end-user. By default Typha uses
+	// the bootstrap toleration set: broad enough to schedule on otherwise tainted
+	// nodes during install (before the CNI / cloud provider are ready), but narrow
+	// enough that cordoned nodes are still avoided.
+	tolerations := rmeta.TolerateBootstrap
 	if len(c.cfg.Installation.ControlPlaneTolerations) != 0 {
 		tolerations = c.cfg.Installation.ControlPlaneTolerations
 	}

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -84,6 +84,24 @@ var _ = Describe("Typha rendering tests", func() {
 		}
 	})
 
+	It("should default to bootstrap tolerations that respect cordoning", func() {
+		component := render.Typha(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		deploy := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(deploy).ToNot(BeNil())
+		Expect(deploy.Spec.Template.Spec.Tolerations).To(Equal(rmeta.TolerateBootstrap))
+
+		// Cordoned nodes get a node.kubernetes.io/unschedulable:NoSchedule taint;
+		// Typha must not tolerate it, otherwise replicas pile up on drained nodes.
+		for _, t := range deploy.Spec.Template.Spec.Tolerations {
+			Expect(t.Key).ToNot(Equal("node.kubernetes.io/unschedulable"))
+			Expect(t.Operator == corev1.TolerationOpExists && t.Key == "").To(BeFalse(),
+				"unbounded toleration would defeat node cordoning")
+		}
+	})
+
 	It("should render toleration on GKE", func() {
 		cfg.Installation.KubernetesProvider = operatorv1.ProviderGKE
 		component := render.Typha(&cfg)

--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -621,7 +621,7 @@ func (c *component) Ready() bool {
 // tolerations creates the tolerations used by the webhooks deployment.
 func (c *component) tolerations() []corev1.Toleration {
 	if render.HostNetworkRequired(c.cfg.Installation) {
-		return rmeta.TolerateAll
+		return rmeta.TolerateBootstrap
 	}
 	tolerations := append(c.cfg.Installation.ControlPlaneTolerations, rmeta.TolerateControlPlane...)
 	if c.cfg.Installation.KubernetesProvider.IsGKE() {


### PR DESCRIPTION
Typha (and the host-networked variants of the apiserver and webhooks Deployments) defaulted to a toleration set that includes a blanket `Effect: NoSchedule, Operator: Exists`. That tolerates the `node.kubernetes.io/unschedulable:NoSchedule` taint Kubernetes adds during `kubectl cordon`, so replicas happily land on cordoned nodes and pile up there as the cluster drains.

This PR introduces a narrower `TolerateBootstrap` set covering the taints these Deployments actually need to schedule through (`not-ready`, `network-unavailable`, `cloudprovider.kubernetes.io/uninitialized`, plus control-plane and `CriticalAddonsOnly`) and switches Typha and the host-networked apiserver / webhooks branches to use it. DaemonSets like calico-node still use `TolerateAll` since they need to run on every node by design.

Fixes https://github.com/projectcalico/calico/issues/8371

```release-note
Calico Typha no longer schedules on cordoned nodes. The apiserver and admission webhook Deployments also respect node cordoning when running in host-network mode.
```