### PR TITLE
Grant /status RBAC for ManagedCluster and PacketCapture

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -469,6 +469,11 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 			Resources: []string{"packetcaptures"},
 			Verbs:     []string{"get", "list", "update"},
 		},
+		{
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"packetcaptures/status"},
+			Verbs:     []string{"update"},
+		},
 	}
 
 	if cfg.ManagementClusterConnection != nil {

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -271,7 +271,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(27), "cluster role should have 27 rules")
+		Expect(clusterRole.Rules).To(HaveLen(28), "cluster role should have 28 rules")
 
 		ms := rtest.GetResource(resources, kubecontrollers.KubeControllerMetrics, common.CalicoNamespace, "", "v1", "Service").(*corev1.Service)
 		Expect(ms.Spec.ClusterIP).To(Equal("None"), "metrics service should be headless")
@@ -358,7 +358,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(25), "cluster role should have 25 rules")
+		Expect(clusterRole.Rules).To(HaveLen(26), "cluster role should have 26 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},
@@ -569,7 +569,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/calico:" + components.ComponentTigeraCalico.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(25), "cluster role should have 25 rules")
+		Expect(clusterRole.Rules).To(HaveLen(26), "cluster role should have 26 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -900,7 +900,7 @@ func (c *managerComponent) managedClustersUpdateRBAC() []client.Object {
 				Rules: []rbacv1.PolicyRule{
 					{
 						APIGroups: []string{"projectcalico.org"},
-						Resources: []string{"managedclusters"},
+						Resources: []string{"managedclusters", "managedclusters/status"},
 						Verbs:     []string{"update"},
 					},
 				},
@@ -931,7 +931,7 @@ func (c *managerComponent) managedClustersUpdateRBAC() []client.Object {
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"managedclusters"},
+					Resources: []string{"managedclusters", "managedclusters/status"},
 					Verbs:     []string{"update"},
 				},
 			},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(roleUpdateManagedClusters.Rules).To(ConsistOf([]rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
+				Resources: []string{"managedclusters", "managedclusters/status"},
 				Verbs:     []string{"update"},
 			},
 		}))


### PR DESCRIPTION
calico-private https://github.com/tigera/calico-private/pull/11977 routes voltron's ManagedCluster status writes and kube-controllers' PacketCapture status writes through the `/status` subresource. Without matching RBAC, both clients get 403'd and end up in a tight retry loop. Confirmed on the bleeding-edge cluster:

```
managedclusters.projectcalico.org "<name>" is forbidden:
User "system:serviceaccount:calico-system:calico-manager" cannot
update resource "managedclusters/status" in API group "projectcalico.org"
at the cluster scope
```

This change:
- Adds `managedclusters/status` (update) to the calico-manager update role (both ClusterRole and per-tenant Role variants).
- Adds `packetcaptures/status` (update) to the calico-kube-controllers ClusterRole.

The other resources from https://github.com/tigera/calico-private/pull/11961 (GlobalAlert, GlobalReport, AlertException, SecurityEventWebhook) either already have `/status` grants or have no current `UpdateStatus` callers, so they're unchanged here.

## Test plan
- [x] Verified live on bleeding-edge mgmt cluster that voltron status writes succeed once the calico-manager role is updated.
- [x] `pkg/render` + `pkg/render/kubecontrollers` unit tests pass (rule-count assertions updated).