### PR TITLE
[release-v1.42] Grant /status RBAC for ManagedCluster and PacketCapture

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -472,6 +472,11 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 			Resources: []string{"packetcaptures"},
 			Verbs:     []string{"get", "list", "update"},
 		},
+		{
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"packetcaptures/status"},
+			Verbs:     []string{"update"},
+		},
 	}
 
 	if cfg.ManagementClusterConnection != nil {

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -266,7 +266,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(27), "cluster role should have 27 rules")
+		Expect(clusterRole.Rules).To(HaveLen(28), "cluster role should have 28 rules")
 
 		ms := rtest.GetResource(resources, kubecontrollers.KubeControllerMetrics, common.CalicoNamespace, "", "v1", "Service").(*corev1.Service)
 		Expect(ms.Spec.ClusterIP).To(Equal("None"), "metrics service should be headless")
@@ -353,7 +353,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(25), "cluster role should have 25 rules")
+		Expect(clusterRole.Rules).To(HaveLen(26), "cluster role should have 26 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},
@@ -564,7 +564,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/kube-controllers:" + components.ComponentTigeraKubeControllers.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(25), "cluster role should have 25 rules")
+		Expect(clusterRole.Rules).To(HaveLen(26), "cluster role should have 26 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -904,7 +904,7 @@ func (c *managerComponent) managedClustersUpdateRBAC() []client.Object {
 				Rules: []rbacv1.PolicyRule{
 					{
 						APIGroups: []string{"projectcalico.org"},
-						Resources: []string{"managedclusters"},
+						Resources: []string{"managedclusters", "managedclusters/status"},
 						Verbs:     []string{"update"},
 					},
 				},
@@ -935,7 +935,7 @@ func (c *managerComponent) managedClustersUpdateRBAC() []client.Object {
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"projectcalico.org"},
-					Resources: []string{"managedclusters"},
+					Resources: []string{"managedclusters", "managedclusters/status"},
 					Verbs:     []string{"update"},
 				},
 			},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		Expect(roleUpdateManagedClusters.Rules).To(ConsistOf([]rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
+				Resources: []string{"managedclusters", "managedclusters/status"},
 				Verbs:     []string{"update"},
 			},
 		}))


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/4823 to release-v1.42.

Pairs with the calico-private release-calient-v3.23 backport of https://github.com/tigera/calico-private/pull/11977 + https://github.com/tigera/calico-private/pull/11979.

## Test plan
- [x] Cherry-pick applied cleanly.
- [x] `pkg/render` + `pkg/render/kubecontrollers` unit tests pass.