### PR TITLE
fix(gatewayapi): grant waf-http-filter SA RBAC to read v3.projectcalico.org APIService

### DIFF
--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -1193,6 +1193,12 @@ func (pr *gatewayAPIImplementationComponent) wafHttpFilterClusterRole() *rbacv1.
 				Verbs:     []string{"get", "watch"},
 			},
 			{
+				APIGroups:     []string{"apiregistration.k8s.io"},
+				Resources:     []string{"apiservices"},
+				ResourceNames: []string{"v3.projectcalico.org"},
+				Verbs:         []string{"get"},
+			},
+			{
 				APIGroups: []string{"authentication.k8s.io"},
 				Resources: []string{"tokenreviews"},
 				Verbs:     []string{"create"},

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1438,13 +1438,21 @@ value:
 		Expect(clusterRole.Name).To(Equal("waf-http-filter"))
 
 		// Verify the ClusterRole has the correct rules
-		Expect(clusterRole.Rules).To(HaveLen(3))
+		Expect(clusterRole.Rules).To(HaveLen(4))
 
 		// Check license key access for WAF
 		Expect(clusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
 			APIGroups: []string{"crd.projectcalico.org", "projectcalico.org"},
 			Resources: []string{"licensekeys"},
 			Verbs:     []string{"get", "watch"},
+		}))
+
+		// Check APIService read access (needed for v3 CRD discovery in no-api-server mode)
+		Expect(clusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups:     []string{"apiregistration.k8s.io"},
+			Resources:     []string{"apiservices"},
+			ResourceNames: []string{"v3.projectcalico.org"},
+			Verbs:         []string{"get"},
 		}))
 
 		// Check token review permissions for WAF


### PR DESCRIPTION
## Description

Bug fix for EV-6620 (no-api-server mode: l7-collector sees empty CIG/WAF dashboards due to failed license check).

**Why:** In no-api-server mode, `UsingV3CRDs()` in libcalico-go calls
`GET /apis/apiregistration.k8s.io/v1/apiservices/v3.projectcalico.org`
to determine whether the `projectcalico.org/v3` API group is served by a local CRD
(no-api-server) or an aggregated API server. The `waf-http-filter` ServiceAccount
lacked RBAC for that resource, so the check failed with error "unknown" and fell
back to `crd.projectcalico.org/v1`. The licensekey lives in `projectcalico.org/v3`
in no-api-server mode, so `IsLicensed()` returned false — causing l7-collector
to drop all log lines and leaving CIG/WAF dashboards empty.

**What changed:** Added a RBAC rule to `wafHttpFilterClusterRole()` granting
`apiregistration.k8s.io/apiservices` GET, scoped to resourceName `v3.projectcalico.org`.

**Testing:** Unit test updated (HaveLen 3→4 + ContainElement assertion for new rule).
End-to-end verified on cluster `seth-ez-82a4` (no-api-server mode) with a dev image
carrying the calico-private discovery fix — confirmed `v3isAggregated=false`,
`projectcalico.org/v3` selected, `IsLicensed()=true`.

**Components affected:** operator render/gatewayapi (ClusterRole for waf-http-filter SA).

**This is part of a three-part fix for EV-6620:**
1. calico-private#11986 — discovery logic: detect no-api-server when both v1+v3 groups present; `Accept: application/json` header fix
2. tigera/operator#4808 — licensekey RBAC for both `crd.projectcalico.org` and `projectcalico.org` groups (merged)
3. **This PR** — apiservice GET RBAC for `v3.projectcalico.org`

## Release Note

```release-note
Fixed a bug in no-api-server mode where the l7-collector (waf-http-filter) ServiceAccount
lacked permission to read the v3.projectcalico.org APIService, causing license detection
to fail and leaving CIG and WAF dashboards empty.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`