### PR TITLE
fix(gatewayapi): inject CALICO_API_GROUP into waf-http-filter and l7-log-collector

### DIFF
--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -23,6 +23,7 @@ import (
 
 	envoyapi "github.com/envoyproxy/gateway/api/v1alpha1"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apigroup"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
@@ -843,17 +844,20 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 						MountPath: "/var/log/calico",
 					},
 				},
-				Env: []corev1.EnvVar{
+				// apigroup.EnvVars() injects CALICO_API_GROUP so libcalico-go skips
+				// auto-discovery. Required because these sidecars are templated into
+				// an EnvoyProxy CR and bypass the operator's componentHandler path.
+				Env: append([]corev1.EnvVar{
 					GatewayNameEnvVar,
 					GatewayNamespaceEnvVar,
-				},
+				}, apigroup.EnvVars()...),
 				SecurityContext: securitycontext.NewRootContext(true),
 			}
 			// need to make changes to the envoy container to mount the socket
 			l7LogCollector := corev1.Container{
 				Name:  "l7-log-collector",
 				Image: pr.L7LogCollectorImage,
-				Env: []corev1.EnvVar{
+				Env: append([]corev1.EnvVar{
 					{
 						Name:  "LOG_LEVEL",
 						Value: "info",
@@ -869,7 +873,7 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className string, 
 					// Owning Gateway info from pod labels (set by EnvoyProxy)
 					OwningGatewayNameEnvVar,
 					OwningGatewayNamespaceEnvVar,
-				},
+				}, apigroup.EnvVars()...),
 				RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 				VolumeMounts: []corev1.VolumeMount{
 					{

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -22,6 +22,7 @@ import (
 
 	envoyapi "github.com/envoyproxy/gateway/api/v1alpha1"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apigroup"
 	"github.com/tigera/operator/pkg/components"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -1077,6 +1078,78 @@ value:
 		}))
 
 		Expect(proxy.Spec.Telemetry.AccessLog.Settings).To(Equal(AccessLogSettings))
+	})
+
+	It("should inject CALICO_API_GROUP into waf-http-filter and l7-log-collector when v3 CRDs are in use", func() {
+		// EV-6620: these init containers are templated into an EnvoyProxy CR and
+		// bypass the componentHandler that normally injects CALICO_API_GROUP.
+		// Without the env var libcalico-go's auto-discovery picks the wrong group
+		// in no-api-server clusters where both v1 and v3 CRDs are present.
+		apigroup.Set(apigroup.V3)
+		DeferCleanup(func() { apigroup.Set(apigroup.Unknown) })
+
+		installation := &operatorv1.InstallationSpec{
+			Variant: operatorv1.CalicoEnterprise,
+		}
+		gatewayAPI := &operatorv1.GatewayAPI{
+			Spec: operatorv1.GatewayAPISpec{
+				GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}},
+			},
+		}
+		gatewayComp := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
+			Installation: installation,
+			GatewayAPI:   gatewayAPI,
+		})
+
+		objsToCreate, _ := gatewayComp.Objects()
+		proxy, err := rtest.GetResourceOfType[*envoyapi.EnvoyProxy](objsToCreate, "tigera-gateway-class", "tigera-gateway")
+		Expect(err).NotTo(HaveOccurred())
+
+		envoyDeployment := proxy.Spec.Provider.Kubernetes.EnvoyDeployment
+		Expect(envoyDeployment).ToNot(BeNil())
+
+		expectedEnvVar := corev1.EnvVar{Name: "CALICO_API_GROUP", Value: "projectcalico.org/v3"}
+
+		var wafFilter, l7Collector *corev1.Container
+		for i := range envoyDeployment.InitContainers {
+			switch envoyDeployment.InitContainers[i].Name {
+			case "waf-http-filter":
+				wafFilter = &envoyDeployment.InitContainers[i]
+			case "l7-log-collector":
+				l7Collector = &envoyDeployment.InitContainers[i]
+			}
+		}
+		Expect(wafFilter).ToNot(BeNil(), "waf-http-filter init container should exist")
+		Expect(l7Collector).ToNot(BeNil(), "l7-log-collector init container should exist")
+		Expect(wafFilter.Env).To(ContainElement(expectedEnvVar))
+		Expect(l7Collector.Env).To(ContainElement(expectedEnvVar))
+	})
+
+	It("should not inject CALICO_API_GROUP when v3 CRDs are not in use", func() {
+		apigroup.Set(apigroup.Unknown)
+
+		installation := &operatorv1.InstallationSpec{
+			Variant: operatorv1.CalicoEnterprise,
+		}
+		gatewayAPI := &operatorv1.GatewayAPI{
+			Spec: operatorv1.GatewayAPISpec{
+				GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}},
+			},
+		}
+		gatewayComp := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
+			Installation: installation,
+			GatewayAPI:   gatewayAPI,
+		})
+
+		objsToCreate, _ := gatewayComp.Objects()
+		proxy, err := rtest.GetResourceOfType[*envoyapi.EnvoyProxy](objsToCreate, "tigera-gateway-class", "tigera-gateway")
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, c := range proxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers {
+			for _, e := range c.Env {
+				Expect(e.Name).ToNot(Equal("CALICO_API_GROUP"))
+			}
+		}
 	})
 
 	It("should deploy waf-http-filter for Enterprise when using a custom proxy", func() {


### PR DESCRIPTION
## Description

Bug fix for **EV-6620** (no-api-server mode: empty CIG/WAF dashboards because the l7-log-collector's license check fails).

**Why:** the `waf-http-filter` and `l7-log-collector` containers are templated into an `EnvoyProxy` CR (rendered at `pkg/render/gatewayapi/gateway_api.go:889`) rather than created as a Deployment/DaemonSet directly. The operator's `componentHandler.injectAPIGroupEnv` walks `Deployment/DaemonSet/StatefulSet/Job/CronJob` — it never recurses into `EnvoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers`. So these two sidecars never get `CALICO_API_GROUP` stamped on them and fall through to libcalico-go's auto-discovery in `clientv3.NewFromEnv()`.

In **no-api-server mode** the operator installs both `crd.projectcalico.org/v1` and `projectcalico.org/v3` CRD groups. `UsingV3CRDs()` sees both groups present and (per its old `v3present && !v1present` heuristic) picks v1. But `kubectl apply` writes `LicenseKey` to the newer group → v3. The license lookup then 404s in v1 and `IsLicensed()` returns `false`. l7-log-collector silently drops every log line; waf-http-filter silently routes through the unlicensed request processor.

**What changed:** append `apigroup.EnvVars()` (which yields `CALICO_API_GROUP=projectcalico.org/v3` when the operator already determined v3 mode at startup, otherwise nil) to the `Env` slice of each init container at render time. Discovery is bypassed entirely on both sidecars — no extra RBAC, no extra API roundtrips, deterministic.

**Components affected:** `pkg/render/gatewayapi` only.

**Testing:**
- New unit specs in `gateway_api_test.go`: `should inject CALICO_API_GROUP …` and `should not inject CALICO_API_GROUP when v3 CRDs are not in use`. Both pass alongside the existing 20 specs.
- Verified on cluster `seth-ez-82a4` (no-api-server, both v1+v3 groups present, APIServer CR absent) that the existing pods lack the env var and exhibit the bug. After this fix, fresh pods will receive `CALICO_API_GROUP=projectcalico.org/v3` and skip the buggy discovery path.

### Related but out of scope

- `pkg/apis/version.go:78` has the **same** `v3present && !v1present` heuristic. In EV-6620 clusters the operator only avoids returning `false` because `checkDatastoreMigration` short-circuits when a `DatastoreMigration` CR is in `PhaseConverged`/`PhaseComplete`. Fresh `USE_API_SERVER=false` installs without a migration CR would hit the same bug; worth a follow-up.
- calico-private libcalico-go discovery fix (#11986) is defense-in-depth for any libcalico-go client that doesn't get an injected env var (calicoctl, third-party tooling). Not needed for the gateway path once this lands.

## Release Note

```release-note
Fixed empty CIG and WAF dashboards in no-api-server clusters by injecting CALICO_API_GROUP into the waf-http-filter and l7-log-collector init containers, so libcalico-go skips the auto-discovery path that picks the wrong Calico CRD group when both v1 and v3 groups are installed.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files` — N/A
- [ ] If changing versions, run `make gen-versions` — N/A