### PR TITLE
feat(gatewayapi): bump bundled Envoy Gateway helm chart to v1.7.2 [release-v1.40]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ $(ISTIO_RESOURCES_DIR)/%.tgz:
 # To update the Envoy Gateway version, see "Updating the bundled version of
 # Envoy Gateway" in docs/common_tasks.md.
 ENVOY_GATEWAY_HELM_CHART ?= oci://docker.io/envoyproxy/gateway-helm
-ENVOY_GATEWAY_VERSION ?= v1.5.9
+ENVOY_GATEWAY_VERSION ?= v1.7.2
 ENVOY_GATEWAY_PREFIX ?= tigera-gateway-api
 ENVOY_GATEWAY_NAMESPACE ?= tigera-gateway
 ENVOY_GATEWAY_RESOURCES = pkg/render/gatewayapi/gateway_api_resources.yaml

--- a/pkg/render/gatewayapi/gateway_api_resources.yaml
+++ b/pkg/render/gatewayapi/gateway_api_resources.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: tigera-gateway
 ---
-# Source: crds/gatewayapi-crds.yaml
+# Source: gateway-helm/crds/gatewayapi-crds.yaml
 # Copyright 2025 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,9 +31,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   labels:
     gateway.networking.k8s.io/policy: Direct
   name: backendtlspolicies.gateway.networking.k8s.io
@@ -54,7 +53,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha3
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-
@@ -121,6 +120,28 @@ spec:
                     be unique across all targetRef entries in the BackendTLSPolicy.
                   * They select different sectionNames in the same target.
 
+                  When more than one BackendTLSPolicy selects the same target and
+                  sectionName, implementations MUST determine precedence using the
+                  following criteria, continuing on ties:
+
+                  * The older policy by creation timestamp takes precedence. For
+                    example, a policy with a creation timestamp of "2021-07-15
+                    01:02:03" MUST be given precedence over a policy with a
+                    creation timestamp of "2021-07-15 01:02:04".
+                  * The policy appearing first in alphabetical order by {name}.
+                    For example, a policy named `bar` is given precedence over a
+                    policy named `baz`.
+
+                  For any BackendTLSPolicy that does not take precedence, the
+                  implementation MUST ensure the `Accepted` Condition is set to
+                  `status: False`, with Reason `Conflicted`.
+
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
                   Support: Extended for Kubernetes Service
 
                   Support: Implementation-specific for any other resource
@@ -177,6 +198,7 @@ spec:
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName must be specified when targetRefs includes
                     2 or more references to the same target
@@ -205,8 +227,31 @@ spec:
                       not both. If CACertificateRefs is empty or unspecified, the configuration for
                       WellKnownCACertificates MUST be honored instead if supported by the implementation.
 
-                      References to a resource in a different namespace are invalid for the
-                      moment, although we will revisit this in the future.
+                      A CACertificateRef is invalid if:
+
+                      * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                        does not exist) or is misconfigured (e.g., a ConfigMap does not contain a key
+                        named `ca.crt`). In this case, the Reason must be set to `InvalidCACertificateRef`
+                        and the Message of the Condition must indicate which reference is invalid and why.
+
+                      * It refers to an unknown or unsupported kind of resource. In this case, the Reason
+                        must be set to `InvalidKind` and the Message of the Condition must explain which
+                        kind of resource is unknown or unsupported.
+
+                      * It refers to a resource in another namespace. This may change in future
+                        spec updates.
+
+                      Implementations MAY choose to perform further validation of the certificate
+                      content (e.g., checking expiry or enforcing specific formats). In such cases,
+                      an implementation-specific Reason and Message must be set for the invalid reference.
+
+                      In all cases, the implementation MUST ensure the `ResolvedRefs` Condition on
+                      the BackendTLSPolicy is set to `status: False`, with a Reason and Message
+                      that indicate the cause of the error. Connections using an invalid
+                      CACertificateRef MUST fail, and the client MUST receive an HTTP 5xx error
+                      response. If ALL CACertificateRefs are invalid, the implementation MUST also
+                      ensure the `Accepted` Condition on the BackendTLSPolicy is set to
+                      `status: False`, with a Reason `NoValidCACertificate`.
 
                       A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
                       Implementations MAY choose to support attaching multiple certificates to
@@ -215,8 +260,8 @@ spec:
                       Support: Core - An optional single reference to a Kubernetes ConfigMap,
                       with the CA certificate in a key named `ca.crt`.
 
-                      Support: Implementation-specific (More than one reference, or other kinds
-                      of resources).
+                      Support: Implementation-specific - More than one reference, other kinds
+                      of resources, or a single reference that includes multiple certificates.
                     items:
                       description: |-
                         LocalObjectReference identifies an API object within the namespace of the
@@ -254,15 +299,18 @@ spec:
                       type: object
                     maxItems: 8
                     type: array
+                    x-kubernetes-list-type: atomic
                   hostname:
                     description: |-
                       Hostname is used for two purposes in the connection between Gateways and
                       backends:
 
                       1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
-                      2. Hostname MUST be used for authentication and MUST match the certificate served by the matching backend, unless SubjectAltNames is specified.
-                         authentication and MUST match the certificate served by the matching
-                         backend.
+                      2. Hostname MUST be used for authentication and MUST match the certificate
+                         served by the matching backend, unless SubjectAltNames is specified.
+                      3. If SubjectAltNames are specified, Hostname can be used for certificate selection
+                         but MUST NOT be used for authentication. If you want to use the value
+                         of the Hostname field for authentication, you MUST add it to the SubjectAltNames list.
 
                       Support: Core
                     maxLength: 253
@@ -332,6 +380,7 @@ spec:
                           "")'
                     maxItems: 5
                     type: array
+                    x-kubernetes-list-type: atomic
                   wellKnownCACertificates:
                     description: |-
                       WellKnownCACertificates specifies whether system CA certificates may be used in
@@ -339,10 +388,11 @@ spec:
 
                       If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
                       must be specified with at least one entry for a valid configuration. Only one of
-                      CACertificateRefs or WellKnownCACertificates may be specified, not both. If an
-                      implementation does not support the WellKnownCACertificates field or the value
-                      supplied is not supported, the Status Conditions on the Policy MUST be
-                      updated to include an Accepted: False Condition with Reason: Invalid.
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both.
+                      If an implementation does not support the WellKnownCACertificates field, or
+                      the supplied value is not recognized, the implementation MUST ensure the
+                      `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with
+                      a Reason `Invalid`.
 
                       Support: Implementation-specific
                     enum:
@@ -653,10 +703,12 @@ spec:
                       type: string
                   required:
                   - ancestorRef
+                  - conditions
                   - controllerName
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - ancestors
             type: object
@@ -665,6 +717,675 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: The v1alpha3 version of BackendTLSPolicy has been deprecated
+      and will be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendTLSPolicy provides a way to configure how a Gateway
+          connects to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              options:
+                additionalProperties:
+                  description: |-
+                    AnnotationValue is the value of an annotation in Gateway API. This is used
+                    for validation of maps such as TLS options. This roughly matches Kubernetes
+                    annotation validation, although the length validation in that case is based
+                    on the entire size of the annotations struct.
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: |-
+                  Options are a list of key/value pairs to enable extended TLS
+                  configuration for each implementation. For example, configuring the
+                  minimum TLS version or supported cipher suites.
+
+                  A set of common keys MAY be defined by the API in the future. To avoid
+                  any ambiguity, implementation-specific definitions MUST use
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+                  Un-prefixed names are reserved for key names defined by Gateway API.
+
+                  Support: Implementation-specific
+                maxProperties: 16
+                type: object
+              targetRefs:
+                description: |-
+                  TargetRefs identifies an API object to apply the policy to.
+                  Only Services have Extended support. Implementations MAY support
+                  additional objects, with Implementation Specific support.
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+
+                  TargetRefs must be _distinct_. This means either that:
+
+                  * They select different targets. If this is the case, then targetRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, and `name` must
+                    be unique across all targetRef entries in the BackendTLSPolicy.
+                  * They select different sectionNames in the same target.
+
+                  When more than one BackendTLSPolicy selects the same target and
+                  sectionName, implementations MUST determine precedence using the
+                  following criteria, continuing on ties:
+
+                  * The older policy by creation timestamp takes precedence. For
+                    example, a policy with a creation timestamp of "2021-07-15
+                    01:02:03" MUST be given precedence over a policy with a
+                    creation timestamp of "2021-07-15 01:02:04".
+                  * The policy appearing first in alphabetical order by {name}.
+                    For example, a policy named `bar` is given precedence over a
+                    policy named `baz`.
+
+                  For any BackendTLSPolicy that does not take precedence, the
+                  implementation MUST ensure the `Accepted` Condition is set to
+                  `status: False`, with Reason `Conflicted`.
+
+                  Implementations SHOULD NOT support more than one targetRef at this
+                  time. Although the API technically allows for this, the current guidance
+                  for conflict resolution and status handling is lacking. Until that can be
+                  clarified in a future release, the safest approach is to support a single
+                  targetRef.
+
+                  Support: Extended for Kubernetes Service
+
+                  Support: Implementation-specific for any other resource
+                items:
+                  description: |-
+                    LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                    direct policy to. This should be used as part of Policy resources that can
+                    target single resources. For more information on how this policy attachment
+                    mode works, and a sample Policy resource, refer to the policy attachment
+                    documentation for Gateway API.
+
+                    Note: This should only be used for direct policy attachment when references
+                    to SectionName are actually needed. In all other cases,
+                    LocalPolicyTargetReference should be used.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. When
+                        unspecified, this targetRef targets the entire resource. In the following
+                        resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name
+                        * HTTPRoute: HTTPRouteRule name
+                        * Service: Port name
+
+                        If a SectionName is specified, but does not exist on the targeted object,
+                        the Policy must fail to attach, and the policy implementation should record
+                        a `ResolvedRefs` or similar Condition in the Policy's status.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when targetRefs includes
+                    2 or more references to the same target
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name ? ((!has(p1.sectionName) || p1.sectionName
+                    == '''') == (!has(p2.sectionName) || p2.sectionName == ''''))
+                    : true))'
+                - message: sectionName must be unique when targetRefs includes 2 or
+                    more references to the same target
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.sectionName) ||
+                    p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: |-
+                      CACertificateRefs contains one or more references to Kubernetes objects that
+                      contain a PEM-encoded TLS CA certificate bundle, which is used to
+                      validate a TLS handshake between the Gateway and backend Pod.
+
+                      If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                      specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both. If CACertificateRefs is empty or unspecified, the configuration for
+                      WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+                      A CACertificateRef is invalid if:
+
+                      * It refers to a resource that cannot be resolved (e.g., the referenced resource
+                        does not exist) or is misconfigured (e.g., a ConfigMap does not contain a key
+                        named `ca.crt`). In this case, the Reason must be set to `InvalidCACertificateRef`
+                        and the Message of the Condition must indicate which reference is invalid and why.
+
+                      * It refers to an unknown or unsupported kind of resource. In this case, the Reason
+                        must be set to `InvalidKind` and the Message of the Condition must explain which
+                        kind of resource is unknown or unsupported.
+
+                      * It refers to a resource in another namespace. This may change in future
+                        spec updates.
+
+                      Implementations MAY choose to perform further validation of the certificate
+                      content (e.g., checking expiry or enforcing specific formats). In such cases,
+                      an implementation-specific Reason and Message must be set for the invalid reference.
+
+                      In all cases, the implementation MUST ensure the `ResolvedRefs` Condition on
+                      the BackendTLSPolicy is set to `status: False`, with a Reason and Message
+                      that indicate the cause of the error. Connections using an invalid
+                      CACertificateRef MUST fail, and the client MUST receive an HTTP 5xx error
+                      response. If ALL CACertificateRefs are invalid, the implementation MUST also
+                      ensure the `Accepted` Condition on the BackendTLSPolicy is set to
+                      `status: False`, with a Reason `NoValidCACertificate`.
+
+                      A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                      Implementations MAY choose to support attaching multiple certificates to
+                      a backend, but this behavior is implementation-specific.
+
+                      Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                      with the CA certificate in a key named `ca.crt`.
+
+                      Support: Implementation-specific - More than one reference, other kinds
+                      of resources, or a single reference that includes multiple certificates.
+                    items:
+                      description: |-
+                        LocalObjectReference identifies an API object within the namespace of the
+                        referrer.
+                        The API object must be valid in the cluster; the Group and Kind must
+                        be registered in the cluster for this reference to be valid.
+
+                        References to objects with invalid Group and Kind are not valid, and must
+                        be rejected by the implementation, with appropriate Conditions set
+                        on the containing object.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  hostname:
+                    description: |-
+                      Hostname is used for two purposes in the connection between Gateways and
+                      backends:
+
+                      1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                      2. Hostname MUST be used for authentication and MUST match the certificate
+                         served by the matching backend, unless SubjectAltNames is specified.
+                      3. If SubjectAltNames are specified, Hostname can be used for certificate selection
+                         but MUST NOT be used for authentication. If you want to use the value
+                         of the Hostname field for authentication, you MUST add it to the SubjectAltNames list.
+
+                      Support: Core
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  subjectAltNames:
+                    description: |-
+                      SubjectAltNames contains one or more Subject Alternative Names.
+                      When specified the certificate served from the backend MUST
+                      have at least one Subject Alternate Name matching one of the specified SubjectAltNames.
+
+                      Support: Extended
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname contains Subject Alternative Name specified in DNS name format.
+                            Required when Type is set to Hostname, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: |-
+                            Type determines the format of the Subject Alternative Name. Always required.
+
+                            Support: Core
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: |-
+                            URI contains Subject Alternative Name specified in a full URI format.
+                            It MUST include both a scheme (e.g., "http" or "ftp") and a scheme-specific-part.
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+                            Required when Type is set to URI, ignored otherwise.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  wellKnownCACertificates:
+                    description: |-
+                      WellKnownCACertificates specifies whether system CA certificates may be used in
+                      the TLS handshake between the gateway and backend pod.
+
+                      If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                      must be specified with at least one entry for a valid configuration. Only one of
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both.
+                      If an implementation does not support the WellKnownCACertificates field, or
+                      the supplied value is not recognized, the implementation MUST ensure the
+                      `Accepted` Condition on the BackendTLSPolicy is set to `status: False`, with
+                      a Reason `Invalid`.
+
+                      Support: Implementation-specific
+                    enum:
+                    - System
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - conditions
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
     subresources:
       status: {}
 status:
@@ -682,9 +1403,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -1202,9 +1922,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -1264,7 +1983,7 @@ spec:
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
-                  indicate this in the associated entry in GatewayStatus.Addresses.
+                  indicate this in an associated entry in GatewayStatus.Conditions.
 
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
@@ -1319,19 +2038,22 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-validations:
-                  - message: Hostname value must only contain valid characters (matching
-                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
-                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                  - message: Hostname value must be empty or contain only valid characters
+                      (matching ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? (!has(self.value) || self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$""")):
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: IPAddress values must be unique
-                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
                 - message: Hostname values must be unique
-                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
               allowedListeners:
                 description: |-
                   AllowedListeners defines which ListenerSets can be attached to this Gateway.
@@ -1413,70 +2135,29 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                 type: object
-              backendTLS:
+              defaultScope:
                 description: |-
-                  BackendTLS configures TLS settings for when this Gateway is connecting to
-                  backends with TLS.
+                  DefaultScope, when set, configures the Gateway as a default Gateway,
+                  meaning it will dynamically and implicitly have Routes (e.g. HTTPRoute)
+                  attached to it, according to the scope configured here.
 
-                  Support: Core
-                properties:
-                  clientCertificateRef:
-                    description: |-
-                      ClientCertificateRef is a reference to an object that contains a Client
-                      Certificate and the associated private key.
+                  If unset (the default) or set to None, the Gateway will not act as a
+                  default Gateway; if set, the Gateway will claim any Route with a
+                  matching scope set in its UseDefaultGateway field, subject to the usual
+                  rules about which routes the Gateway can attach to.
 
-                      References to a resource in different namespace are invalid UNLESS there
-                      is a ReferenceGrant in the target namespace that allows the certificate
-                      to be attached. If a ReferenceGrant does not allow this reference, the
-                      "ResolvedRefs" condition MUST be set to False for this listener with the
-                      "RefNotPermitted" reason.
-
-                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
-                      Secret, or implementation-specific custom resources.
-
-                      This setting can be overridden on the service level by use of BackendTLSPolicy.
-
-                      Support: Core
-                    properties:
-                      group:
-                        default: ""
-                        description: |-
-                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                          When unspecified or empty string, core API group is inferred.
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      kind:
-                        default: Secret
-                        description: Kind is kind of the referent. For example "Secret".
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                        type: string
-                      name:
-                        description: Name is the name of the referent.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace is the namespace of the referenced object. When unspecified, the local
-                          namespace is inferred.
-
-                          Note that when a namespace different than the local namespace is specified,
-                          a ReferenceGrant object is required in the referent namespace to allow that
-                          namespace's owner to accept the reference. See the ReferenceGrant
-                          documentation for details.
-
-                          Support: Core
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
+                  Think carefully before using this functionality! While the normal rules
+                  about which Route can apply are still enforced, it is simply easier for
+                  the wrong Route to be accidentally attached to this Gateway in this
+                  configuration. If the Gateway operator is not also the operator in
+                  control of the scope (e.g. namespace) with tight controls and checks on
+                  what kind of workloads and Routes get added in that scope, we strongly
+                  recommend not using this just because it seems convenient, and instead
+                  stick to direct Route attachment.
+                enum:
+                - All
+                - None
+                type: string
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -1832,6 +2513,7 @@ spec:
                             type: object
                           maxItems: 8
                           type: array
+                          x-kubernetes-list-type: atomic
                         namespaces:
                           default:
                             from: Same
@@ -1999,7 +2681,7 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
-                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        The association of SNIs to Certificate defined in ListenerTLSConfig is
                         defined based on the Hostname field for this listener.
 
                         The GatewayClass MUST use the longest matching SNI out of all
@@ -2086,93 +2768,7 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
-                        frontendValidation:
-                          description: |-
-                            FrontendValidation holds configuration information for validating the frontend (client).
-                            Setting this field will require clients to send a client certificate
-                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
-                            that requests a user to specify the client certificate.
-                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
-
-                            Support: Extended
-                          properties:
-                            caCertificateRefs:
-                              description: |-
-                                CACertificateRefs contains one or more references to
-                                Kubernetes objects that contain TLS certificates of
-                                the Certificate Authorities that can be used
-                                as a trust anchor to validate the certificates presented by the client.
-
-                                A single CA certificate reference to a Kubernetes ConfigMap
-                                has "Core" support.
-                                Implementations MAY choose to support attaching multiple CA certificates to
-                                a Listener, but this behavior is implementation-specific.
-
-                                Support: Core - A single reference to a Kubernetes ConfigMap
-                                with the CA certificate in a key named `ca.crt`.
-
-                                Support: Implementation-specific (More than one reference, or other kinds
-                                of resources).
-
-                                References to a resource in a different namespace are invalid UNLESS there
-                                is a ReferenceGrant in the target namespace that allows the certificate
-                                to be attached. If a ReferenceGrant does not allow this reference, the
-                                "ResolvedRefs" condition MUST be set to False for this listener with the
-                                "RefNotPermitted" reason.
-                              items:
-                                description: |-
-                                  ObjectReference identifies an API object including its namespace.
-
-                                  The API object must be valid in the cluster; the Group and Kind must
-                                  be registered in the cluster for this reference to be valid.
-
-                                  References to objects with invalid Group and Kind are not valid, and must
-                                  be rejected by the implementation, with appropriate Conditions set
-                                  on the containing object.
-                                properties:
-                                  group:
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When set to the empty string, core API group is inferred.
-                                    maxLength: 253
-                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                    type: string
-                                  kind:
-                                    description: Kind is kind of the referent. For
-                                      example "ConfigMap" or "Service".
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                    type: string
-                                  name:
-                                    description: Name is the name of the referent.
-                                    maxLength: 253
-                                    minLength: 1
-                                    type: string
-                                  namespace:
-                                    description: |-
-                                      Namespace is the namespace of the referenced object. When unspecified, the local
-                                      namespace is inferred.
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-                                      Support: Core
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                    type: string
-                                required:
-                                - group
-                                - kind
-                                - name
-                                type: object
-                              maxItems: 8
-                              minItems: 1
-                              type: array
-                          type: object
+                          x-kubernetes-list-type: atomic
                         mode:
                           default: Terminate
                           description: |-
@@ -2251,6 +2847,366 @@ spec:
                   rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
                     == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
                     == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+              tls:
+                description: |-
+                  TLS specifies frontend and backend tls configuration for entire gateway.
+
+                  Support: Extended
+                properties:
+                  backend:
+                    description: |-
+                      Backend describes TLS configuration for gateway when connecting
+                      to backends.
+
+                      Note that this contains only details for the Gateway as a TLS client,
+                      and does _not_ imply behavior about how to choose which backend should
+                      get a TLS connection. That is determined by the presence of a BackendTLSPolicy.
+
+                      Support: Core
+                    properties:
+                      clientCertificateRef:
+                        description: |-
+                          ClientCertificateRef is a reference to an object that contains a Client
+                          Certificate and the associated private key.
+
+                          References to a resource in different namespace are invalid UNLESS there
+                          is a ReferenceGrant in the target namespace that allows the certificate
+                          to be attached. If a ReferenceGrant does not allow this reference, the
+                          "ResolvedRefs" condition MUST be set to False for this listener with the
+                          "RefNotPermitted" reason.
+
+                          ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                          Secret, or implementation-specific custom resources.
+
+                          Support: Core
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Secret
+                            description: Kind is kind of the referent. For example
+                              "Secret".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referenced object. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  frontend:
+                    description: |-
+                      Frontend describes TLS config when client connects to Gateway.
+                      Support: Core
+                    properties:
+                      default:
+                        description: |-
+                          Default specifies the default client certificate validation configuration
+                          for all Listeners handling HTTPS traffic, unless a per-port configuration
+                          is defined.
+
+                          support: Core
+                        properties:
+                          validation:
+                            description: |-
+                              Validation holds configuration information for validating the frontend (client).
+                              Setting this field will result in mutual authentication when connecting to the gateway.
+                              In browsers this may result in a dialog appearing
+                              that requests a user to specify the client certificate.
+                              The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                              Support: Core
+                            properties:
+                              caCertificateRefs:
+                                description: |-
+                                  CACertificateRefs contains one or more references to
+                                  Kubernetes objects that contain TLS certificates of
+                                  the Certificate Authorities that can be used
+                                  as a trust anchor to validate the certificates presented by the client.
+
+                                  A single CA certificate reference to a Kubernetes ConfigMap
+                                  has "Core" support.
+                                  Implementations MAY choose to support attaching multiple CA certificates to
+                                  a Listener, but this behavior is implementation-specific.
+
+                                  Support: Core - A single reference to a Kubernetes ConfigMap
+                                  with the CA certificate in a key named `ca.crt`.
+
+                                  Support: Implementation-specific (More than one certificate in a ConfigMap
+                                  with different keys or more than one reference, or other kinds of resources).
+
+                                  References to a resource in a different namespace are invalid UNLESS there
+                                  is a ReferenceGrant in the target namespace that allows the certificate
+                                  to be attached. If a ReferenceGrant does not allow this reference, the
+                                  "ResolvedRefs" condition MUST be set to False for this listener with the
+                                  "RefNotPermitted" reason.
+                                items:
+                                  description: |-
+                                    ObjectReference identifies an API object including its namespace.
+
+                                    The API object must be valid in the cluster; the Group and Kind must
+                                    be registered in the cluster for this reference to be valid.
+
+                                    References to objects with invalid Group and Kind are not valid, and must
+                                    be rejected by the implementation, with appropriate Conditions set
+                                    on the containing object.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When set to the empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "ConfigMap" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of the referenced object. When unspecified, the local
+                                        namespace is inferred.
+
+                                        Note that when a namespace different than the local namespace is specified,
+                                        a ReferenceGrant object is required in the referent namespace to allow that
+                                        namespace's owner to accept the reference. See the ReferenceGrant
+                                        documentation for details.
+
+                                        Support: Core
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                maxItems: 8
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mode:
+                                default: AllowValidOnly
+                                description: |-
+                                  FrontendValidationMode defines the mode for validating the client certificate.
+                                  There are two possible modes:
+
+                                  - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                    the client presents a valid certificate. This certificate must successfully
+                                    pass validation against the CA certificates specified in `CACertificateRefs`.
+                                  - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                    even if the client certificate is not presented or fails verification.
+
+                                    This approach delegates client authorization to the backend and introduce
+                                    a significant security risk. It should be used in testing environments or
+                                    on a temporary basis in non-testing environments.
+
+                                  Defaults to AllowValidOnly.
+
+                                  Support: Core
+                                enum:
+                                - AllowValidOnly
+                                - AllowInsecureFallback
+                                type: string
+                            required:
+                            - caCertificateRefs
+                            type: object
+                        type: object
+                      perPort:
+                        description: |-
+                          PerPort specifies tls configuration assigned per port.
+                          Per port configuration is optional. Once set this configuration overrides
+                          the default configuration for all Listeners handling HTTPS traffic
+                          that match this port.
+                          Each override port requires a unique TLS configuration.
+
+                          support: Core
+                        items:
+                          properties:
+                            port:
+                              description: |-
+                                The Port indicates the Port Number to which the TLS configuration will be
+                                applied. This configuration will be applied to all Listeners handling HTTPS
+                                traffic that match this port.
+
+                                Support: Core
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            tls:
+                              description: |-
+                                TLS store the configuration that will be applied to all Listeners handling
+                                HTTPS traffic and matching given port.
+
+                                Support: Core
+                              properties:
+                                validation:
+                                  description: |-
+                                    Validation holds configuration information for validating the frontend (client).
+                                    Setting this field will result in mutual authentication when connecting to the gateway.
+                                    In browsers this may result in a dialog appearing
+                                    that requests a user to specify the client certificate.
+                                    The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                    Support: Core
+                                  properties:
+                                    caCertificateRefs:
+                                      description: |-
+                                        CACertificateRefs contains one or more references to
+                                        Kubernetes objects that contain TLS certificates of
+                                        the Certificate Authorities that can be used
+                                        as a trust anchor to validate the certificates presented by the client.
+
+                                        A single CA certificate reference to a Kubernetes ConfigMap
+                                        has "Core" support.
+                                        Implementations MAY choose to support attaching multiple CA certificates to
+                                        a Listener, but this behavior is implementation-specific.
+
+                                        Support: Core - A single reference to a Kubernetes ConfigMap
+                                        with the CA certificate in a key named `ca.crt`.
+
+                                        Support: Implementation-specific (More than one certificate in a ConfigMap
+                                        with different keys or more than one reference, or other kinds of resources).
+
+                                        References to a resource in a different namespace are invalid UNLESS there
+                                        is a ReferenceGrant in the target namespace that allows the certificate
+                                        to be attached. If a ReferenceGrant does not allow this reference, the
+                                        "ResolvedRefs" condition MUST be set to False for this listener with the
+                                        "RefNotPermitted" reason.
+                                      items:
+                                        description: |-
+                                          ObjectReference identifies an API object including its namespace.
+
+                                          The API object must be valid in the cluster; the Group and Kind must
+                                          be registered in the cluster for this reference to be valid.
+
+                                          References to objects with invalid Group and Kind are not valid, and must
+                                          be rejected by the implementation, with appropriate Conditions set
+                                          on the containing object.
+                                        properties:
+                                          group:
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When set to the empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            description: Kind is kind of the referent.
+                                              For example "ConfigMap" or "Service".
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the referenced object. When unspecified, the local
+                                              namespace is inferred.
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                        required:
+                                        - group
+                                        - kind
+                                        - name
+                                        type: object
+                                      maxItems: 8
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mode:
+                                      default: AllowValidOnly
+                                      description: |-
+                                        FrontendValidationMode defines the mode for validating the client certificate.
+                                        There are two possible modes:
+
+                                        - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                          the client presents a valid certificate. This certificate must successfully
+                                          pass validation against the CA certificates specified in `CACertificateRefs`.
+                                        - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                          even if the client certificate is not presented or fails verification.
+
+                                          This approach delegates client authorization to the backend and introduce
+                                          a significant security risk. It should be used in testing environments or
+                                          on a temporary basis in non-testing environments.
+
+                                        Defaults to AllowValidOnly.
+
+                                        Support: Core
+                                      enum:
+                                      - AllowValidOnly
+                                      - AllowInsecureFallback
+                                      type: string
+                                  required:
+                                  - caCertificateRefs
+                                  type: object
+                              type: object
+                          required:
+                          - port
+                          - tls
+                          type: object
+                        maxItems: 64
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Port for TLS configuration must be unique within
+                            the Gateway
+                          rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                    required:
+                    - default
+                    type: object
+                type: object
             required:
             - gatewayClassName
             - listeners
@@ -2325,6 +3281,7 @@ spec:
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
@@ -2538,6 +3495,7 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                   - attachedRoutes
                   - conditions
@@ -2602,7 +3560,7 @@ spec:
                   Addresses requested for this Gateway. This is optional and behavior can
                   depend on the implementation. If a value is set in the spec and the
                   requested address is invalid or unavailable, the implementation MUST
-                  indicate this in the associated entry in GatewayStatus.Addresses.
+                  indicate this in an associated entry in GatewayStatus.Conditions.
 
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
@@ -2657,19 +3615,22 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-validations:
-                  - message: Hostname value must only contain valid characters (matching
-                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
-                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                  - message: Hostname value must be empty or contain only valid characters
+                      (matching ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? (!has(self.value) || self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$""")):
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: IPAddress values must be unique
-                  rule: 'self.all(a1, a1.type == ''IPAddress'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
                 - message: Hostname values must be unique
-                  rule: 'self.all(a1, a1.type == ''Hostname'' ? self.exists_one(a2,
-                    a2.type == a1.type && a2.value == a1.value) : true )'
+                  rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
               allowedListeners:
                 description: |-
                   AllowedListeners defines which ListenerSets can be attached to this Gateway.
@@ -2751,70 +3712,29 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                 type: object
-              backendTLS:
+              defaultScope:
                 description: |-
-                  BackendTLS configures TLS settings for when this Gateway is connecting to
-                  backends with TLS.
+                  DefaultScope, when set, configures the Gateway as a default Gateway,
+                  meaning it will dynamically and implicitly have Routes (e.g. HTTPRoute)
+                  attached to it, according to the scope configured here.
 
-                  Support: Core
-                properties:
-                  clientCertificateRef:
-                    description: |-
-                      ClientCertificateRef is a reference to an object that contains a Client
-                      Certificate and the associated private key.
+                  If unset (the default) or set to None, the Gateway will not act as a
+                  default Gateway; if set, the Gateway will claim any Route with a
+                  matching scope set in its UseDefaultGateway field, subject to the usual
+                  rules about which routes the Gateway can attach to.
 
-                      References to a resource in different namespace are invalid UNLESS there
-                      is a ReferenceGrant in the target namespace that allows the certificate
-                      to be attached. If a ReferenceGrant does not allow this reference, the
-                      "ResolvedRefs" condition MUST be set to False for this listener with the
-                      "RefNotPermitted" reason.
-
-                      ClientCertificateRef can reference to standard Kubernetes resources, i.e.
-                      Secret, or implementation-specific custom resources.
-
-                      This setting can be overridden on the service level by use of BackendTLSPolicy.
-
-                      Support: Core
-                    properties:
-                      group:
-                        default: ""
-                        description: |-
-                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                          When unspecified or empty string, core API group is inferred.
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                        type: string
-                      kind:
-                        default: Secret
-                        description: Kind is kind of the referent. For example "Secret".
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                        type: string
-                      name:
-                        description: Name is the name of the referent.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace is the namespace of the referenced object. When unspecified, the local
-                          namespace is inferred.
-
-                          Note that when a namespace different than the local namespace is specified,
-                          a ReferenceGrant object is required in the referent namespace to allow that
-                          namespace's owner to accept the reference. See the ReferenceGrant
-                          documentation for details.
-
-                          Support: Core
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
+                  Think carefully before using this functionality! While the normal rules
+                  about which Route can apply are still enforced, it is simply easier for
+                  the wrong Route to be accidentally attached to this Gateway in this
+                  configuration. If the Gateway operator is not also the operator in
+                  control of the scope (e.g. namespace) with tight controls and checks on
+                  what kind of workloads and Routes get added in that scope, we strongly
+                  recommend not using this just because it seems convenient, and instead
+                  stick to direct Route attachment.
+                enum:
+                - All
+                - None
+                type: string
               gatewayClassName:
                 description: |-
                   GatewayClassName used for this Gateway. This is the name of a
@@ -3170,6 +4090,7 @@ spec:
                             type: object
                           maxItems: 8
                           type: array
+                          x-kubernetes-list-type: atomic
                         namespaces:
                           default:
                             from: Same
@@ -3337,7 +4258,7 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
-                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        The association of SNIs to Certificate defined in ListenerTLSConfig is
                         defined based on the Hostname field for this listener.
 
                         The GatewayClass MUST use the longest matching SNI out of all
@@ -3424,93 +4345,7 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
-                        frontendValidation:
-                          description: |-
-                            FrontendValidation holds configuration information for validating the frontend (client).
-                            Setting this field will require clients to send a client certificate
-                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
-                            that requests a user to specify the client certificate.
-                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
-
-                            Support: Extended
-                          properties:
-                            caCertificateRefs:
-                              description: |-
-                                CACertificateRefs contains one or more references to
-                                Kubernetes objects that contain TLS certificates of
-                                the Certificate Authorities that can be used
-                                as a trust anchor to validate the certificates presented by the client.
-
-                                A single CA certificate reference to a Kubernetes ConfigMap
-                                has "Core" support.
-                                Implementations MAY choose to support attaching multiple CA certificates to
-                                a Listener, but this behavior is implementation-specific.
-
-                                Support: Core - A single reference to a Kubernetes ConfigMap
-                                with the CA certificate in a key named `ca.crt`.
-
-                                Support: Implementation-specific (More than one reference, or other kinds
-                                of resources).
-
-                                References to a resource in a different namespace are invalid UNLESS there
-                                is a ReferenceGrant in the target namespace that allows the certificate
-                                to be attached. If a ReferenceGrant does not allow this reference, the
-                                "ResolvedRefs" condition MUST be set to False for this listener with the
-                                "RefNotPermitted" reason.
-                              items:
-                                description: |-
-                                  ObjectReference identifies an API object including its namespace.
-
-                                  The API object must be valid in the cluster; the Group and Kind must
-                                  be registered in the cluster for this reference to be valid.
-
-                                  References to objects with invalid Group and Kind are not valid, and must
-                                  be rejected by the implementation, with appropriate Conditions set
-                                  on the containing object.
-                                properties:
-                                  group:
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When set to the empty string, core API group is inferred.
-                                    maxLength: 253
-                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                    type: string
-                                  kind:
-                                    description: Kind is kind of the referent. For
-                                      example "ConfigMap" or "Service".
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                    type: string
-                                  name:
-                                    description: Name is the name of the referent.
-                                    maxLength: 253
-                                    minLength: 1
-                                    type: string
-                                  namespace:
-                                    description: |-
-                                      Namespace is the namespace of the referenced object. When unspecified, the local
-                                      namespace is inferred.
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-                                      Support: Core
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                    type: string
-                                required:
-                                - group
-                                - kind
-                                - name
-                                type: object
-                              maxItems: 8
-                              minItems: 1
-                              type: array
-                          type: object
+                          x-kubernetes-list-type: atomic
                         mode:
                           default: Terminate
                           description: |-
@@ -3589,6 +4424,366 @@ spec:
                   rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
                     == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
                     == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+              tls:
+                description: |-
+                  TLS specifies frontend and backend tls configuration for entire gateway.
+
+                  Support: Extended
+                properties:
+                  backend:
+                    description: |-
+                      Backend describes TLS configuration for gateway when connecting
+                      to backends.
+
+                      Note that this contains only details for the Gateway as a TLS client,
+                      and does _not_ imply behavior about how to choose which backend should
+                      get a TLS connection. That is determined by the presence of a BackendTLSPolicy.
+
+                      Support: Core
+                    properties:
+                      clientCertificateRef:
+                        description: |-
+                          ClientCertificateRef is a reference to an object that contains a Client
+                          Certificate and the associated private key.
+
+                          References to a resource in different namespace are invalid UNLESS there
+                          is a ReferenceGrant in the target namespace that allows the certificate
+                          to be attached. If a ReferenceGrant does not allow this reference, the
+                          "ResolvedRefs" condition MUST be set to False for this listener with the
+                          "RefNotPermitted" reason.
+
+                          ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                          Secret, or implementation-specific custom resources.
+
+                          Support: Core
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Secret
+                            description: Kind is kind of the referent. For example
+                              "Secret".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referenced object. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  frontend:
+                    description: |-
+                      Frontend describes TLS config when client connects to Gateway.
+                      Support: Core
+                    properties:
+                      default:
+                        description: |-
+                          Default specifies the default client certificate validation configuration
+                          for all Listeners handling HTTPS traffic, unless a per-port configuration
+                          is defined.
+
+                          support: Core
+                        properties:
+                          validation:
+                            description: |-
+                              Validation holds configuration information for validating the frontend (client).
+                              Setting this field will result in mutual authentication when connecting to the gateway.
+                              In browsers this may result in a dialog appearing
+                              that requests a user to specify the client certificate.
+                              The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                              Support: Core
+                            properties:
+                              caCertificateRefs:
+                                description: |-
+                                  CACertificateRefs contains one or more references to
+                                  Kubernetes objects that contain TLS certificates of
+                                  the Certificate Authorities that can be used
+                                  as a trust anchor to validate the certificates presented by the client.
+
+                                  A single CA certificate reference to a Kubernetes ConfigMap
+                                  has "Core" support.
+                                  Implementations MAY choose to support attaching multiple CA certificates to
+                                  a Listener, but this behavior is implementation-specific.
+
+                                  Support: Core - A single reference to a Kubernetes ConfigMap
+                                  with the CA certificate in a key named `ca.crt`.
+
+                                  Support: Implementation-specific (More than one certificate in a ConfigMap
+                                  with different keys or more than one reference, or other kinds of resources).
+
+                                  References to a resource in a different namespace are invalid UNLESS there
+                                  is a ReferenceGrant in the target namespace that allows the certificate
+                                  to be attached. If a ReferenceGrant does not allow this reference, the
+                                  "ResolvedRefs" condition MUST be set to False for this listener with the
+                                  "RefNotPermitted" reason.
+                                items:
+                                  description: |-
+                                    ObjectReference identifies an API object including its namespace.
+
+                                    The API object must be valid in the cluster; the Group and Kind must
+                                    be registered in the cluster for this reference to be valid.
+
+                                    References to objects with invalid Group and Kind are not valid, and must
+                                    be rejected by the implementation, with appropriate Conditions set
+                                    on the containing object.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When set to the empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "ConfigMap" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of the referenced object. When unspecified, the local
+                                        namespace is inferred.
+
+                                        Note that when a namespace different than the local namespace is specified,
+                                        a ReferenceGrant object is required in the referent namespace to allow that
+                                        namespace's owner to accept the reference. See the ReferenceGrant
+                                        documentation for details.
+
+                                        Support: Core
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                maxItems: 8
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mode:
+                                default: AllowValidOnly
+                                description: |-
+                                  FrontendValidationMode defines the mode for validating the client certificate.
+                                  There are two possible modes:
+
+                                  - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                    the client presents a valid certificate. This certificate must successfully
+                                    pass validation against the CA certificates specified in `CACertificateRefs`.
+                                  - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                    even if the client certificate is not presented or fails verification.
+
+                                    This approach delegates client authorization to the backend and introduce
+                                    a significant security risk. It should be used in testing environments or
+                                    on a temporary basis in non-testing environments.
+
+                                  Defaults to AllowValidOnly.
+
+                                  Support: Core
+                                enum:
+                                - AllowValidOnly
+                                - AllowInsecureFallback
+                                type: string
+                            required:
+                            - caCertificateRefs
+                            type: object
+                        type: object
+                      perPort:
+                        description: |-
+                          PerPort specifies tls configuration assigned per port.
+                          Per port configuration is optional. Once set this configuration overrides
+                          the default configuration for all Listeners handling HTTPS traffic
+                          that match this port.
+                          Each override port requires a unique TLS configuration.
+
+                          support: Core
+                        items:
+                          properties:
+                            port:
+                              description: |-
+                                The Port indicates the Port Number to which the TLS configuration will be
+                                applied. This configuration will be applied to all Listeners handling HTTPS
+                                traffic that match this port.
+
+                                Support: Core
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            tls:
+                              description: |-
+                                TLS store the configuration that will be applied to all Listeners handling
+                                HTTPS traffic and matching given port.
+
+                                Support: Core
+                              properties:
+                                validation:
+                                  description: |-
+                                    Validation holds configuration information for validating the frontend (client).
+                                    Setting this field will result in mutual authentication when connecting to the gateway.
+                                    In browsers this may result in a dialog appearing
+                                    that requests a user to specify the client certificate.
+                                    The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                    Support: Core
+                                  properties:
+                                    caCertificateRefs:
+                                      description: |-
+                                        CACertificateRefs contains one or more references to
+                                        Kubernetes objects that contain TLS certificates of
+                                        the Certificate Authorities that can be used
+                                        as a trust anchor to validate the certificates presented by the client.
+
+                                        A single CA certificate reference to a Kubernetes ConfigMap
+                                        has "Core" support.
+                                        Implementations MAY choose to support attaching multiple CA certificates to
+                                        a Listener, but this behavior is implementation-specific.
+
+                                        Support: Core - A single reference to a Kubernetes ConfigMap
+                                        with the CA certificate in a key named `ca.crt`.
+
+                                        Support: Implementation-specific (More than one certificate in a ConfigMap
+                                        with different keys or more than one reference, or other kinds of resources).
+
+                                        References to a resource in a different namespace are invalid UNLESS there
+                                        is a ReferenceGrant in the target namespace that allows the certificate
+                                        to be attached. If a ReferenceGrant does not allow this reference, the
+                                        "ResolvedRefs" condition MUST be set to False for this listener with the
+                                        "RefNotPermitted" reason.
+                                      items:
+                                        description: |-
+                                          ObjectReference identifies an API object including its namespace.
+
+                                          The API object must be valid in the cluster; the Group and Kind must
+                                          be registered in the cluster for this reference to be valid.
+
+                                          References to objects with invalid Group and Kind are not valid, and must
+                                          be rejected by the implementation, with appropriate Conditions set
+                                          on the containing object.
+                                        properties:
+                                          group:
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When set to the empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            description: Kind is kind of the referent.
+                                              For example "ConfigMap" or "Service".
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the referenced object. When unspecified, the local
+                                              namespace is inferred.
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                        required:
+                                        - group
+                                        - kind
+                                        - name
+                                        type: object
+                                      maxItems: 8
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mode:
+                                      default: AllowValidOnly
+                                      description: |-
+                                        FrontendValidationMode defines the mode for validating the client certificate.
+                                        There are two possible modes:
+
+                                        - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                          the client presents a valid certificate. This certificate must successfully
+                                          pass validation against the CA certificates specified in `CACertificateRefs`.
+                                        - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                          even if the client certificate is not presented or fails verification.
+
+                                          This approach delegates client authorization to the backend and introduce
+                                          a significant security risk. It should be used in testing environments or
+                                          on a temporary basis in non-testing environments.
+
+                                        Defaults to AllowValidOnly.
+
+                                        Support: Core
+                                      enum:
+                                      - AllowValidOnly
+                                      - AllowInsecureFallback
+                                      type: string
+                                  required:
+                                  - caCertificateRefs
+                                  type: object
+                              type: object
+                          required:
+                          - port
+                          - tls
+                          type: object
+                        maxItems: 64
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Port for TLS configuration must be unique within
+                            the Gateway
+                          rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                    required:
+                    - default
+                    type: object
+                type: object
             required:
             - gatewayClassName
             - listeners
@@ -3663,6 +4858,7 @@ spec:
                       true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
@@ -3876,6 +5072,7 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                   - attachedRoutes
                   - conditions
@@ -3910,9 +5107,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -4058,6 +5254,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -4270,6 +5467,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -4891,6 +6089,7 @@ spec:
                                 rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                             maxItems: 16
                             type: array
+                            x-kubernetes-list-type: atomic
                             x-kubernetes-validations:
                             - message: RequestHeaderModifier filter cannot be repeated
                               rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
@@ -4987,6 +6186,7 @@ spec:
                             ? has(self.port) : true'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                     filters:
                       description: |-
                         Filters define the filters that are applied to requests that match
@@ -5537,6 +6737,7 @@ spec:
                           rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                       - message: RequestHeaderModifier filter cannot be repeated
                         rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
@@ -5714,6 +6915,7 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
@@ -5815,6 +7017,7 @@ spec:
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: While 16 rules and 64 matches per rule are allowed, the
                     total number of matches across all rules in a route must be less
@@ -5839,6 +7042,24 @@ spec:
                 - message: Rule name must be unique within the route
                   rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
                     && l1.name == l2.name))
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
             type: object
           status:
             description: Status defines the current state of GRPCRoute.
@@ -6103,14 +7324,18 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -6131,9 +7356,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -6259,6 +7483,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -6471,6 +7696,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -6596,16 +7822,14 @@ spec:
                                         AllowCredentials indicates whether the actual cross-origin request allows
                                         to include credentials.
 
-                                        The only valid value for the `Access-Control-Allow-Credentials` response
-                                        header is true (case-sensitive).
+                                        When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                        response header with value true (case-sensitive).
 
-                                        If the credentials are not allowed in cross-origin requests, the gateway
-                                        will omit the header `Access-Control-Allow-Credentials` entirely rather
-                                        than setting its value to false.
+                                        When set to false or omitted the gateway will omit the header
+                                        `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                        behavior).
 
                                         Support: Extended
-                                      enum:
-                                      - true
                                       type: boolean
                                     allowHeaders:
                                       description: |-
@@ -6632,9 +7856,9 @@ spec:
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
                                         The `Access-Control-Allow-Headers` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is unspecified.
+                                        wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                        When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                        When the `AllowCredentials` field is true and `AllowHeaders` field
                                         specified with the `*` wildcard, the gateway must specify one or more
                                         HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                         header. The value of the header `Access-Control-Allow-Headers` is same as
@@ -6695,9 +7919,9 @@ spec:
                                         side.
 
                                         The `Access-Control-Allow-Methods` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is unspecified.
+                                        wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                        When the `AllowCredentials` field is specified and `AllowMethods` field
+                                        When the `AllowCredentials` field is true and `AllowMethods` field
                                         specified with the `*` wildcard, the gateway must specify one HTTP method
                                         in the value of the Access-Control-Allow-Methods response header. The
                                         value of the header `Access-Control-Allow-Methods` is same as the
@@ -6773,9 +7997,9 @@ spec:
                                         Therefore, the client doesn't attempt the actual cross-origin request.
 
                                         The `Access-Control-Allow-Origin` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is unspecified.
+                                        wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                        When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                        When the `AllowCredentials` field is true and `AllowOrigins` field
                                         specified with the `*` wildcard, the gateway must return a single origin
                                         in the value of the `Access-Control-Allow-Origin` response header,
                                         instead of specifying the `*` wildcard. The value of the header
@@ -6785,18 +8009,22 @@ spec:
                                         Support: Extended
                                       items:
                                         description: |-
-                                          The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                          encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                          include an authority MUST include a fully qualified domain name or
+                                          The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                          URIs that include an authority MUST include a fully qualified domain name or
                                           IP address as the host.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                        pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                         type: string
                                       maxItems: 64
                                       type: array
                                       x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
                                     exposeHeaders:
                                       description: |-
                                         ExposeHeaders indicates which HTTP response headers can be exposed
@@ -6826,8 +8054,7 @@ spec:
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
                                         to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the `AllowCredentials` field is
-                                        unspecified.
+                                        use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
 
                                         Support: Extended
                                       items:
@@ -6902,6 +8129,253 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                externalAuth:
+                                  description: |-
+                                    ExternalAuth configures settings related to sending request details
+                                    to an external auth service. The external service MUST authenticate
+                                    the request, and MAY authorize the request as well.
+
+                                    If there is any problem communicating with the external service,
+                                    this filter MUST fail closed.
+
+                                    Support: Extended
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef is a reference to a backend to send authorization
+                                        requests to.
+
+                                        The backend must speak the selected protocol (GRPC or HTTP) on the
+                                        referenced port.
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    forwardBody:
+                                      description: |-
+                                        ForwardBody controls if requests to the authorization server should include
+                                        the body of the client request; and if so, how big that body is allowed
+                                        to be.
+
+                                        It is expected that implementations will buffer the request body up to
+                                        `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                        4xx series error (413 or 403 are common examples), and fail processing
+                                        of the filter.
+
+                                        If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                        be forwarded.
+
+                                        Feature Name: HTTPRouteExternalAuthForwardBody
+                                      properties:
+                                        maxSize:
+                                          description: |-
+                                            MaxSize specifies how large in bytes the largest body that will be buffered
+                                            and sent to the authorization server. If the body size is larger than
+                                            `maxSize`, then the body sent to the authorization server must be
+                                            truncated to `maxSize` bytes.
+
+                                            Experimental note: This behavior needs to be checked against
+                                            various dataplanes; it may need to be changed.
+                                            See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                            for more.
+
+                                            If 0, the body will not be sent to the authorization server.
+                                          type: integer
+                                      type: object
+                                    grpc:
+                                      description: |-
+                                        GRPCAuthConfig contains configuration for communication with ext_authz
+                                        protocol-speaking backends.
+
+                                        If unset, implementations must assume the default behavior for each
+                                        included field is intended.
+                                      properties:
+                                        allowedHeaders:
+                                          description: |-
+                                            AllowedRequestHeaders specifies what headers from the client request
+                                            will be sent to the authorization server.
+
+                                            If this list is empty, then all headers must be sent.
+
+                                            If the list has entries, only those entries must be sent.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                      type: object
+                                    http:
+                                      description: |-
+                                        HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                        backends.
+
+                                        If unset, implementations must assume the default behavior for each
+                                        included field is intended.
+                                      properties:
+                                        allowedHeaders:
+                                          description: |-
+                                            AllowedRequestHeaders specifies what additional headers from the client request
+                                            will be sent to the authorization server.
+
+                                            The following headers must always be sent to the authorization server,
+                                            regardless of this setting:
+
+                                            * `Host`
+                                            * `Method`
+                                            * `Path`
+                                            * `Content-Length`
+                                            * `Authorization`
+
+                                            If this list is empty, then only those headers must be sent.
+
+                                            Note that `Content-Length` has a special behavior, in that the length
+                                            sent must be correct for the actual request to the external authorization
+                                            server - that is, it must reflect the actual number of bytes sent in the
+                                            body of the request to the authorization server.
+
+                                            So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                            to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                            to anything other than `0`, then the `Content-Length` of the authorization
+                                            request must be set to the actual number of bytes forwarded.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        allowedResponseHeaders:
+                                          description: |-
+                                            AllowedResponseHeaders specifies what headers from the authorization response
+                                            will be copied into the request to the backend.
+
+                                            If this list is empty, then all headers from the authorization server
+                                            except Authority or Host must be copied.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        path:
+                                          description: |-
+                                            Path sets the prefix that paths from the client request will have added
+                                            when forwarded to the authorization server.
+
+                                            When empty or unspecified, no prefix is added.
+
+                                            Valid values are the same as the "value" regex for path values in the `match`
+                                            stanza, and the validation regex will screen out invalid paths in the same way.
+                                            Even with the validation, implementations MUST sanitize this input before using it
+                                            directly.
+                                          maxLength: 1024
+                                          pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                          type: string
+                                      type: object
+                                    protocol:
+                                      description: |-
+                                        ExternalAuthProtocol describes which protocol to use when communicating with an
+                                        ext_authz authorization server.
+
+                                        When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                        on the port specified in `backendRefs`. Requests and responses are defined
+                                        in the protobufs explained at:
+                                        https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                        When this is set to HTTP, each backend must respond with a `200` status
+                                        code in on a successful authorization. Any other code is considered
+                                        an authorization failure.
+
+                                        Feature Names:
+                                        GRPC Support - HTTPRouteExternalAuthGRPC
+                                        HTTP Support - HTTPRouteExternalAuthHTTP
+                                      enum:
+                                      - HTTP
+                                      - GRPC
+                                      type: string
+                                  required:
+                                  - backendRef
+                                  - protocol
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: grpc must be specified when protocol
+                                      is set to 'GRPC'
+                                    rule: 'self.protocol == ''GRPC'' ? has(self.grpc)
+                                      : true'
+                                  - message: protocol must be 'GRPC' when grpc is
+                                      set
+                                    rule: 'has(self.grpc) ? self.protocol == ''GRPC''
+                                      : true'
+                                  - message: http must be specified when protocol
+                                      is set to 'HTTP'
+                                    rule: 'self.protocol == ''HTTP'' ? has(self.http)
+                                      : true'
+                                  - message: protocol must be 'HTTP' when http is
+                                      set
+                                    rule: 'has(self.http) ? self.protocol == ''HTTP''
+                                      : true'
                                 requestHeaderModifier:
                                   description: |-
                                     RequestHeaderModifier defines a schema for a filter that modifies request
@@ -7515,6 +8989,7 @@ spec:
                                   - URLRewrite
                                   - ExtensionRef
                                   - CORS
+                                  - ExternalAuth
                                   type: string
                                 urlRewrite:
                                   description: |-
@@ -7652,13 +9127,16 @@ spec:
                                 rule: '!(has(self.cors) && self.type != ''CORS'')'
                               - message: filter.cors must be specified for CORS filter.type
                                 rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                              - message: filter.externalAuth must be nil if the filter.type
+                                  is not ExternalAuth
+                                rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                              - message: filter.externalAuth must be specified for
+                                  ExternalAuth filter.type
+                                rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                             maxItems: 16
                             type: array
+                            x-kubernetes-list-type: atomic
                             x-kubernetes-validations:
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
                             - message: May specify either httpRouteFilterRequestRedirect
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')
@@ -7764,6 +9242,7 @@ spec:
                             ? has(self.port) : true'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                     filters:
                       description: |-
                         Filters define the filters that are applied to requests that match
@@ -7823,16 +9302,14 @@ spec:
                                   AllowCredentials indicates whether the actual cross-origin request allows
                                   to include credentials.
 
-                                  The only valid value for the `Access-Control-Allow-Credentials` response
-                                  header is true (case-sensitive).
+                                  When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                  response header with value true (case-sensitive).
 
-                                  If the credentials are not allowed in cross-origin requests, the gateway
-                                  will omit the header `Access-Control-Allow-Credentials` entirely rather
-                                  than setting its value to false.
+                                  When set to false or omitted the gateway will omit the header
+                                  `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                  behavior).
 
                                   Support: Extended
-                                enum:
-                                - true
                                 type: boolean
                               allowHeaders:
                                 description: |-
@@ -7859,9 +9336,9 @@ spec:
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
                                   The `Access-Control-Allow-Headers` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is unspecified.
+                                  wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                  When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                  When the `AllowCredentials` field is true and `AllowHeaders` field
                                   specified with the `*` wildcard, the gateway must specify one or more
                                   HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                   header. The value of the header `Access-Control-Allow-Headers` is same as
@@ -7922,9 +9399,9 @@ spec:
                                   side.
 
                                   The `Access-Control-Allow-Methods` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is unspecified.
+                                  wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                  When the `AllowCredentials` field is specified and `AllowMethods` field
+                                  When the `AllowCredentials` field is true and `AllowMethods` field
                                   specified with the `*` wildcard, the gateway must specify one HTTP method
                                   in the value of the Access-Control-Allow-Methods response header. The
                                   value of the header `Access-Control-Allow-Methods` is same as the
@@ -8000,9 +9477,9 @@ spec:
                                   Therefore, the client doesn't attempt the actual cross-origin request.
 
                                   The `Access-Control-Allow-Origin` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is unspecified.
+                                  wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                  When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                  When the `AllowCredentials` field is true and `AllowOrigins` field
                                   specified with the `*` wildcard, the gateway must return a single origin
                                   in the value of the `Access-Control-Allow-Origin` response header,
                                   instead of specifying the `*` wildcard. The value of the header
@@ -8012,18 +9489,22 @@ spec:
                                   Support: Extended
                                 items:
                                   description: |-
-                                    The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                    encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                    include an authority MUST include a fully qualified domain name or
+                                    The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                    URIs that include an authority MUST include a fully qualified domain name or
                                     IP address as the host.
                                   maxLength: 253
                                   minLength: 1
-                                  pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                  pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                   type: string
                                 maxItems: 64
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
                               exposeHeaders:
                                 description: |-
                                   ExposeHeaders indicates which HTTP response headers can be exposed
@@ -8053,8 +9534,7 @@ spec:
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
                                   to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the `AllowCredentials` field is
-                                  unspecified.
+                                  use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
 
                                   Support: Extended
                                 items:
@@ -8129,6 +9609,251 @@ spec:
                             - kind
                             - name
                             type: object
+                          externalAuth:
+                            description: |-
+                              ExternalAuth configures settings related to sending request details
+                              to an external auth service. The external service MUST authenticate
+                              the request, and MAY authorize the request as well.
+
+                              If there is any problem communicating with the external service,
+                              this filter MUST fail closed.
+
+                              Support: Extended
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef is a reference to a backend to send authorization
+                                  requests to.
+
+                                  The backend must speak the selected protocol (GRPC or HTTP) on the
+                                  referenced port.
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              forwardBody:
+                                description: |-
+                                  ForwardBody controls if requests to the authorization server should include
+                                  the body of the client request; and if so, how big that body is allowed
+                                  to be.
+
+                                  It is expected that implementations will buffer the request body up to
+                                  `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                  4xx series error (413 or 403 are common examples), and fail processing
+                                  of the filter.
+
+                                  If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                  be forwarded.
+
+                                  Feature Name: HTTPRouteExternalAuthForwardBody
+                                properties:
+                                  maxSize:
+                                    description: |-
+                                      MaxSize specifies how large in bytes the largest body that will be buffered
+                                      and sent to the authorization server. If the body size is larger than
+                                      `maxSize`, then the body sent to the authorization server must be
+                                      truncated to `maxSize` bytes.
+
+                                      Experimental note: This behavior needs to be checked against
+                                      various dataplanes; it may need to be changed.
+                                      See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                      for more.
+
+                                      If 0, the body will not be sent to the authorization server.
+                                    type: integer
+                                type: object
+                              grpc:
+                                description: |-
+                                  GRPCAuthConfig contains configuration for communication with ext_authz
+                                  protocol-speaking backends.
+
+                                  If unset, implementations must assume the default behavior for each
+                                  included field is intended.
+                                properties:
+                                  allowedHeaders:
+                                    description: |-
+                                      AllowedRequestHeaders specifies what headers from the client request
+                                      will be sent to the authorization server.
+
+                                      If this list is empty, then all headers must be sent.
+
+                                      If the list has entries, only those entries must be sent.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                type: object
+                              http:
+                                description: |-
+                                  HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                  backends.
+
+                                  If unset, implementations must assume the default behavior for each
+                                  included field is intended.
+                                properties:
+                                  allowedHeaders:
+                                    description: |-
+                                      AllowedRequestHeaders specifies what additional headers from the client request
+                                      will be sent to the authorization server.
+
+                                      The following headers must always be sent to the authorization server,
+                                      regardless of this setting:
+
+                                      * `Host`
+                                      * `Method`
+                                      * `Path`
+                                      * `Content-Length`
+                                      * `Authorization`
+
+                                      If this list is empty, then only those headers must be sent.
+
+                                      Note that `Content-Length` has a special behavior, in that the length
+                                      sent must be correct for the actual request to the external authorization
+                                      server - that is, it must reflect the actual number of bytes sent in the
+                                      body of the request to the authorization server.
+
+                                      So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                      to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                      to anything other than `0`, then the `Content-Length` of the authorization
+                                      request must be set to the actual number of bytes forwarded.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  allowedResponseHeaders:
+                                    description: |-
+                                      AllowedResponseHeaders specifies what headers from the authorization response
+                                      will be copied into the request to the backend.
+
+                                      If this list is empty, then all headers from the authorization server
+                                      except Authority or Host must be copied.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  path:
+                                    description: |-
+                                      Path sets the prefix that paths from the client request will have added
+                                      when forwarded to the authorization server.
+
+                                      When empty or unspecified, no prefix is added.
+
+                                      Valid values are the same as the "value" regex for path values in the `match`
+                                      stanza, and the validation regex will screen out invalid paths in the same way.
+                                      Even with the validation, implementations MUST sanitize this input before using it
+                                      directly.
+                                    maxLength: 1024
+                                    pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                    type: string
+                                type: object
+                              protocol:
+                                description: |-
+                                  ExternalAuthProtocol describes which protocol to use when communicating with an
+                                  ext_authz authorization server.
+
+                                  When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                  on the port specified in `backendRefs`. Requests and responses are defined
+                                  in the protobufs explained at:
+                                  https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                  When this is set to HTTP, each backend must respond with a `200` status
+                                  code in on a successful authorization. Any other code is considered
+                                  an authorization failure.
+
+                                  Feature Names:
+                                  GRPC Support - HTTPRouteExternalAuthGRPC
+                                  HTTP Support - HTTPRouteExternalAuthHTTP
+                                enum:
+                                - HTTP
+                                - GRPC
+                                type: string
+                            required:
+                            - backendRef
+                            - protocol
+                            type: object
+                            x-kubernetes-validations:
+                            - message: grpc must be specified when protocol is set
+                                to 'GRPC'
+                              rule: 'self.protocol == ''GRPC'' ? has(self.grpc) :
+                                true'
+                            - message: protocol must be 'GRPC' when grpc is set
+                              rule: 'has(self.grpc) ? self.protocol == ''GRPC'' :
+                                true'
+                            - message: http must be specified when protocol is set
+                                to 'HTTP'
+                              rule: 'self.protocol == ''HTTP'' ? has(self.http) :
+                                true'
+                            - message: protocol must be 'HTTP' when http is set
+                              rule: 'has(self.http) ? self.protocol == ''HTTP'' :
+                                true'
                           requestHeaderModifier:
                             description: |-
                               RequestHeaderModifier defines a schema for a filter that modifies request
@@ -8738,6 +10463,7 @@ spec:
                             - URLRewrite
                             - ExtensionRef
                             - CORS
+                            - ExternalAuth
                             type: string
                           urlRewrite:
                             description: |-
@@ -8872,8 +10598,15 @@ spec:
                           rule: '!(has(self.cors) && self.type != ''CORS'')'
                         - message: filter.cors must be specified for CORS filter.type
                           rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                        - message: filter.externalAuth must be nil if the filter.type
+                            is not ExternalAuth
+                          rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                        - message: filter.externalAuth must be specified for ExternalAuth
+                            filter.type
+                          rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                       - message: May specify either httpRouteFilterRequestRedirect
                           or httpRouteFilterRequestRewrite, but not both
@@ -9185,6 +10918,7 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
@@ -9280,6 +11014,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     sessionPersistence:
                       description: |-
@@ -9475,6 +11210,7 @@ spec:
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: While 16 rules and 64 matches per rule are allowed, the
                     total number of matches across all rules in a route must be less
@@ -9493,6 +11229,24 @@ spec:
                 - message: Rule name must be unique within the route
                   rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
                     && l1.name == l2.name))
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -9757,11 +11511,13 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
@@ -9885,6 +11641,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -10097,6 +11854,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -10222,16 +11980,14 @@ spec:
                                         AllowCredentials indicates whether the actual cross-origin request allows
                                         to include credentials.
 
-                                        The only valid value for the `Access-Control-Allow-Credentials` response
-                                        header is true (case-sensitive).
+                                        When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                        response header with value true (case-sensitive).
 
-                                        If the credentials are not allowed in cross-origin requests, the gateway
-                                        will omit the header `Access-Control-Allow-Credentials` entirely rather
-                                        than setting its value to false.
+                                        When set to false or omitted the gateway will omit the header
+                                        `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                        behavior).
 
                                         Support: Extended
-                                      enum:
-                                      - true
                                       type: boolean
                                     allowHeaders:
                                       description: |-
@@ -10258,9 +12014,9 @@ spec:
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
                                         The `Access-Control-Allow-Headers` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is unspecified.
+                                        wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                        When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                        When the `AllowCredentials` field is true and `AllowHeaders` field
                                         specified with the `*` wildcard, the gateway must specify one or more
                                         HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                         header. The value of the header `Access-Control-Allow-Headers` is same as
@@ -10321,9 +12077,9 @@ spec:
                                         side.
 
                                         The `Access-Control-Allow-Methods` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is unspecified.
+                                        wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                        When the `AllowCredentials` field is specified and `AllowMethods` field
+                                        When the `AllowCredentials` field is true and `AllowMethods` field
                                         specified with the `*` wildcard, the gateway must specify one HTTP method
                                         in the value of the Access-Control-Allow-Methods response header. The
                                         value of the header `Access-Control-Allow-Methods` is same as the
@@ -10399,9 +12155,9 @@ spec:
                                         Therefore, the client doesn't attempt the actual cross-origin request.
 
                                         The `Access-Control-Allow-Origin` response header can only use `*`
-                                        wildcard as value when the `AllowCredentials` field is unspecified.
+                                        wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                        When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                        When the `AllowCredentials` field is true and `AllowOrigins` field
                                         specified with the `*` wildcard, the gateway must return a single origin
                                         in the value of the `Access-Control-Allow-Origin` response header,
                                         instead of specifying the `*` wildcard. The value of the header
@@ -10411,18 +12167,22 @@ spec:
                                         Support: Extended
                                       items:
                                         description: |-
-                                          The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                          encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                          include an authority MUST include a fully qualified domain name or
+                                          The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                          encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                          scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                          URIs that include an authority MUST include a fully qualified domain name or
                                           IP address as the host.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                        pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                         type: string
                                       maxItems: 64
                                       type: array
                                       x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
                                     exposeHeaders:
                                       description: |-
                                         ExposeHeaders indicates which HTTP response headers can be exposed
@@ -10452,8 +12212,7 @@ spec:
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
                                         to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the `AllowCredentials` field is
-                                        unspecified.
+                                        use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
 
                                         Support: Extended
                                       items:
@@ -10528,6 +12287,253 @@ spec:
                                   - kind
                                   - name
                                   type: object
+                                externalAuth:
+                                  description: |-
+                                    ExternalAuth configures settings related to sending request details
+                                    to an external auth service. The external service MUST authenticate
+                                    the request, and MAY authorize the request as well.
+
+                                    If there is any problem communicating with the external service,
+                                    this filter MUST fail closed.
+
+                                    Support: Extended
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef is a reference to a backend to send authorization
+                                        requests to.
+
+                                        The backend must speak the selected protocol (GRPC or HTTP) on the
+                                        referenced port.
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+                                            Defaults to "Service" when not specified.
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    forwardBody:
+                                      description: |-
+                                        ForwardBody controls if requests to the authorization server should include
+                                        the body of the client request; and if so, how big that body is allowed
+                                        to be.
+
+                                        It is expected that implementations will buffer the request body up to
+                                        `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                        4xx series error (413 or 403 are common examples), and fail processing
+                                        of the filter.
+
+                                        If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                        be forwarded.
+
+                                        Feature Name: HTTPRouteExternalAuthForwardBody
+                                      properties:
+                                        maxSize:
+                                          description: |-
+                                            MaxSize specifies how large in bytes the largest body that will be buffered
+                                            and sent to the authorization server. If the body size is larger than
+                                            `maxSize`, then the body sent to the authorization server must be
+                                            truncated to `maxSize` bytes.
+
+                                            Experimental note: This behavior needs to be checked against
+                                            various dataplanes; it may need to be changed.
+                                            See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                            for more.
+
+                                            If 0, the body will not be sent to the authorization server.
+                                          type: integer
+                                      type: object
+                                    grpc:
+                                      description: |-
+                                        GRPCAuthConfig contains configuration for communication with ext_authz
+                                        protocol-speaking backends.
+
+                                        If unset, implementations must assume the default behavior for each
+                                        included field is intended.
+                                      properties:
+                                        allowedHeaders:
+                                          description: |-
+                                            AllowedRequestHeaders specifies what headers from the client request
+                                            will be sent to the authorization server.
+
+                                            If this list is empty, then all headers must be sent.
+
+                                            If the list has entries, only those entries must be sent.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                      type: object
+                                    http:
+                                      description: |-
+                                        HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                        backends.
+
+                                        If unset, implementations must assume the default behavior for each
+                                        included field is intended.
+                                      properties:
+                                        allowedHeaders:
+                                          description: |-
+                                            AllowedRequestHeaders specifies what additional headers from the client request
+                                            will be sent to the authorization server.
+
+                                            The following headers must always be sent to the authorization server,
+                                            regardless of this setting:
+
+                                            * `Host`
+                                            * `Method`
+                                            * `Path`
+                                            * `Content-Length`
+                                            * `Authorization`
+
+                                            If this list is empty, then only those headers must be sent.
+
+                                            Note that `Content-Length` has a special behavior, in that the length
+                                            sent must be correct for the actual request to the external authorization
+                                            server - that is, it must reflect the actual number of bytes sent in the
+                                            body of the request to the authorization server.
+
+                                            So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                            to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                            to anything other than `0`, then the `Content-Length` of the authorization
+                                            request must be set to the actual number of bytes forwarded.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        allowedResponseHeaders:
+                                          description: |-
+                                            AllowedResponseHeaders specifies what headers from the authorization response
+                                            will be copied into the request to the backend.
+
+                                            If this list is empty, then all headers from the authorization server
+                                            except Authority or Host must be copied.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        path:
+                                          description: |-
+                                            Path sets the prefix that paths from the client request will have added
+                                            when forwarded to the authorization server.
+
+                                            When empty or unspecified, no prefix is added.
+
+                                            Valid values are the same as the "value" regex for path values in the `match`
+                                            stanza, and the validation regex will screen out invalid paths in the same way.
+                                            Even with the validation, implementations MUST sanitize this input before using it
+                                            directly.
+                                          maxLength: 1024
+                                          pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                          type: string
+                                      type: object
+                                    protocol:
+                                      description: |-
+                                        ExternalAuthProtocol describes which protocol to use when communicating with an
+                                        ext_authz authorization server.
+
+                                        When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                        on the port specified in `backendRefs`. Requests and responses are defined
+                                        in the protobufs explained at:
+                                        https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                        When this is set to HTTP, each backend must respond with a `200` status
+                                        code in on a successful authorization. Any other code is considered
+                                        an authorization failure.
+
+                                        Feature Names:
+                                        GRPC Support - HTTPRouteExternalAuthGRPC
+                                        HTTP Support - HTTPRouteExternalAuthHTTP
+                                      enum:
+                                      - HTTP
+                                      - GRPC
+                                      type: string
+                                  required:
+                                  - backendRef
+                                  - protocol
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: grpc must be specified when protocol
+                                      is set to 'GRPC'
+                                    rule: 'self.protocol == ''GRPC'' ? has(self.grpc)
+                                      : true'
+                                  - message: protocol must be 'GRPC' when grpc is
+                                      set
+                                    rule: 'has(self.grpc) ? self.protocol == ''GRPC''
+                                      : true'
+                                  - message: http must be specified when protocol
+                                      is set to 'HTTP'
+                                    rule: 'self.protocol == ''HTTP'' ? has(self.http)
+                                      : true'
+                                  - message: protocol must be 'HTTP' when http is
+                                      set
+                                    rule: 'has(self.http) ? self.protocol == ''HTTP''
+                                      : true'
                                 requestHeaderModifier:
                                   description: |-
                                     RequestHeaderModifier defines a schema for a filter that modifies request
@@ -11141,6 +13147,7 @@ spec:
                                   - URLRewrite
                                   - ExtensionRef
                                   - CORS
+                                  - ExternalAuth
                                   type: string
                                 urlRewrite:
                                   description: |-
@@ -11278,13 +13285,16 @@ spec:
                                 rule: '!(has(self.cors) && self.type != ''CORS'')'
                               - message: filter.cors must be specified for CORS filter.type
                                 rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                              - message: filter.externalAuth must be nil if the filter.type
+                                  is not ExternalAuth
+                                rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                              - message: filter.externalAuth must be specified for
+                                  ExternalAuth filter.type
+                                rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                             maxItems: 16
                             type: array
+                            x-kubernetes-list-type: atomic
                             x-kubernetes-validations:
-                            - message: May specify either httpRouteFilterRequestRedirect
-                                or httpRouteFilterRequestRewrite, but not both
-                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
-                                && self.exists(f, f.type == ''URLRewrite''))'
                             - message: May specify either httpRouteFilterRequestRedirect
                                 or httpRouteFilterRequestRewrite, but not both
                               rule: '!(self.exists(f, f.type == ''RequestRedirect'')
@@ -11390,6 +13400,7 @@ spec:
                             ? has(self.port) : true'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                     filters:
                       description: |-
                         Filters define the filters that are applied to requests that match
@@ -11449,16 +13460,14 @@ spec:
                                   AllowCredentials indicates whether the actual cross-origin request allows
                                   to include credentials.
 
-                                  The only valid value for the `Access-Control-Allow-Credentials` response
-                                  header is true (case-sensitive).
+                                  When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                  response header with value true (case-sensitive).
 
-                                  If the credentials are not allowed in cross-origin requests, the gateway
-                                  will omit the header `Access-Control-Allow-Credentials` entirely rather
-                                  than setting its value to false.
+                                  When set to false or omitted the gateway will omit the header
+                                  `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                  behavior).
 
                                   Support: Extended
-                                enum:
-                                - true
                                 type: boolean
                               allowHeaders:
                                 description: |-
@@ -11485,9 +13494,9 @@ spec:
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
                                   The `Access-Control-Allow-Headers` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is unspecified.
+                                  wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                  When the `AllowCredentials` field is specified and `AllowHeaders` field
+                                  When the `AllowCredentials` field is true and `AllowHeaders` field
                                   specified with the `*` wildcard, the gateway must specify one or more
                                   HTTP headers in the value of the `Access-Control-Allow-Headers` response
                                   header. The value of the header `Access-Control-Allow-Headers` is same as
@@ -11548,9 +13557,9 @@ spec:
                                   side.
 
                                   The `Access-Control-Allow-Methods` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is unspecified.
+                                  wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                  When the `AllowCredentials` field is specified and `AllowMethods` field
+                                  When the `AllowCredentials` field is true and `AllowMethods` field
                                   specified with the `*` wildcard, the gateway must specify one HTTP method
                                   in the value of the Access-Control-Allow-Methods response header. The
                                   value of the header `Access-Control-Allow-Methods` is same as the
@@ -11626,9 +13635,9 @@ spec:
                                   Therefore, the client doesn't attempt the actual cross-origin request.
 
                                   The `Access-Control-Allow-Origin` response header can only use `*`
-                                  wildcard as value when the `AllowCredentials` field is unspecified.
+                                  wildcard as value when the `AllowCredentials` field is false or omitted.
 
-                                  When the `AllowCredentials` field is specified and `AllowOrigins` field
+                                  When the `AllowCredentials` field is true and `AllowOrigins` field
                                   specified with the `*` wildcard, the gateway must return a single origin
                                   in the value of the `Access-Control-Allow-Origin` response header,
                                   instead of specifying the `*` wildcard. The value of the header
@@ -11638,18 +13647,22 @@ spec:
                                   Support: Extended
                                 items:
                                   description: |-
-                                    The AbsoluteURI MUST NOT be a relative URI, and it MUST follow the URI syntax and
-                                    encoding rules specified in RFC3986.  The AbsoluteURI MUST include both a
-                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part.  URIs that
-                                    include an authority MUST include a fully qualified domain name or
+                                    The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                    encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                    scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                    URIs that include an authority MUST include a fully qualified domain name or
                                     IP address as the host.
                                   maxLength: 253
                                   minLength: 1
-                                  pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                                  pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
                                   type: string
                                 maxItems: 64
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
                               exposeHeaders:
                                 description: |-
                                   ExposeHeaders indicates which HTTP response headers can be exposed
@@ -11679,8 +13692,7 @@ spec:
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
                                   to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the `AllowCredentials` field is
-                                  unspecified.
+                                  use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
 
                                   Support: Extended
                                 items:
@@ -11755,6 +13767,251 @@ spec:
                             - kind
                             - name
                             type: object
+                          externalAuth:
+                            description: |-
+                              ExternalAuth configures settings related to sending request details
+                              to an external auth service. The external service MUST authenticate
+                              the request, and MAY authorize the request as well.
+
+                              If there is any problem communicating with the external service,
+                              this filter MUST fail closed.
+
+                              Support: Extended
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef is a reference to a backend to send authorization
+                                  requests to.
+
+                                  The backend must speak the selected protocol (GRPC or HTTP) on the
+                                  referenced port.
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+                                      Defaults to "Service" when not specified.
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              forwardBody:
+                                description: |-
+                                  ForwardBody controls if requests to the authorization server should include
+                                  the body of the client request; and if so, how big that body is allowed
+                                  to be.
+
+                                  It is expected that implementations will buffer the request body up to
+                                  `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                  4xx series error (413 or 403 are common examples), and fail processing
+                                  of the filter.
+
+                                  If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                  be forwarded.
+
+                                  Feature Name: HTTPRouteExternalAuthForwardBody
+                                properties:
+                                  maxSize:
+                                    description: |-
+                                      MaxSize specifies how large in bytes the largest body that will be buffered
+                                      and sent to the authorization server. If the body size is larger than
+                                      `maxSize`, then the body sent to the authorization server must be
+                                      truncated to `maxSize` bytes.
+
+                                      Experimental note: This behavior needs to be checked against
+                                      various dataplanes; it may need to be changed.
+                                      See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                      for more.
+
+                                      If 0, the body will not be sent to the authorization server.
+                                    type: integer
+                                type: object
+                              grpc:
+                                description: |-
+                                  GRPCAuthConfig contains configuration for communication with ext_authz
+                                  protocol-speaking backends.
+
+                                  If unset, implementations must assume the default behavior for each
+                                  included field is intended.
+                                properties:
+                                  allowedHeaders:
+                                    description: |-
+                                      AllowedRequestHeaders specifies what headers from the client request
+                                      will be sent to the authorization server.
+
+                                      If this list is empty, then all headers must be sent.
+
+                                      If the list has entries, only those entries must be sent.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                type: object
+                              http:
+                                description: |-
+                                  HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                  backends.
+
+                                  If unset, implementations must assume the default behavior for each
+                                  included field is intended.
+                                properties:
+                                  allowedHeaders:
+                                    description: |-
+                                      AllowedRequestHeaders specifies what additional headers from the client request
+                                      will be sent to the authorization server.
+
+                                      The following headers must always be sent to the authorization server,
+                                      regardless of this setting:
+
+                                      * `Host`
+                                      * `Method`
+                                      * `Path`
+                                      * `Content-Length`
+                                      * `Authorization`
+
+                                      If this list is empty, then only those headers must be sent.
+
+                                      Note that `Content-Length` has a special behavior, in that the length
+                                      sent must be correct for the actual request to the external authorization
+                                      server - that is, it must reflect the actual number of bytes sent in the
+                                      body of the request to the authorization server.
+
+                                      So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                      to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                      to anything other than `0`, then the `Content-Length` of the authorization
+                                      request must be set to the actual number of bytes forwarded.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  allowedResponseHeaders:
+                                    description: |-
+                                      AllowedResponseHeaders specifies what headers from the authorization response
+                                      will be copied into the request to the backend.
+
+                                      If this list is empty, then all headers from the authorization server
+                                      except Authority or Host must be copied.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  path:
+                                    description: |-
+                                      Path sets the prefix that paths from the client request will have added
+                                      when forwarded to the authorization server.
+
+                                      When empty or unspecified, no prefix is added.
+
+                                      Valid values are the same as the "value" regex for path values in the `match`
+                                      stanza, and the validation regex will screen out invalid paths in the same way.
+                                      Even with the validation, implementations MUST sanitize this input before using it
+                                      directly.
+                                    maxLength: 1024
+                                    pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                    type: string
+                                type: object
+                              protocol:
+                                description: |-
+                                  ExternalAuthProtocol describes which protocol to use when communicating with an
+                                  ext_authz authorization server.
+
+                                  When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                  on the port specified in `backendRefs`. Requests and responses are defined
+                                  in the protobufs explained at:
+                                  https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                  When this is set to HTTP, each backend must respond with a `200` status
+                                  code in on a successful authorization. Any other code is considered
+                                  an authorization failure.
+
+                                  Feature Names:
+                                  GRPC Support - HTTPRouteExternalAuthGRPC
+                                  HTTP Support - HTTPRouteExternalAuthHTTP
+                                enum:
+                                - HTTP
+                                - GRPC
+                                type: string
+                            required:
+                            - backendRef
+                            - protocol
+                            type: object
+                            x-kubernetes-validations:
+                            - message: grpc must be specified when protocol is set
+                                to 'GRPC'
+                              rule: 'self.protocol == ''GRPC'' ? has(self.grpc) :
+                                true'
+                            - message: protocol must be 'GRPC' when grpc is set
+                              rule: 'has(self.grpc) ? self.protocol == ''GRPC'' :
+                                true'
+                            - message: http must be specified when protocol is set
+                                to 'HTTP'
+                              rule: 'self.protocol == ''HTTP'' ? has(self.http) :
+                                true'
+                            - message: protocol must be 'HTTP' when http is set
+                              rule: 'has(self.http) ? self.protocol == ''HTTP'' :
+                                true'
                           requestHeaderModifier:
                             description: |-
                               RequestHeaderModifier defines a schema for a filter that modifies request
@@ -12364,6 +14621,7 @@ spec:
                             - URLRewrite
                             - ExtensionRef
                             - CORS
+                            - ExternalAuth
                             type: string
                           urlRewrite:
                             description: |-
@@ -12498,8 +14756,15 @@ spec:
                           rule: '!(has(self.cors) && self.type != ''CORS'')'
                         - message: filter.cors must be specified for CORS filter.type
                           rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                        - message: filter.externalAuth must be nil if the filter.type
+                            is not ExternalAuth
+                          rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                        - message: filter.externalAuth must be specified for ExternalAuth
+                            filter.type
+                          rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                       maxItems: 16
                       type: array
+                      x-kubernetes-list-type: atomic
                       x-kubernetes-validations:
                       - message: May specify either httpRouteFilterRequestRedirect
                           or httpRouteFilterRequestRewrite, but not both
@@ -12811,6 +15076,7 @@ spec:
                         type: object
                       maxItems: 64
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
@@ -12906,6 +15172,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     sessionPersistence:
                       description: |-
@@ -13101,6 +15368,7 @@ spec:
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: While 16 rules and 64 matches per rule are allowed, the
                     total number of matches across all rules in a route must be less
@@ -13119,6 +15387,24 @@ spec:
                 - message: Rule name must be unique within the route
                   rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
                     && l1.name == l2.name))
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -13383,11 +15669,13 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
@@ -13413,9 +15701,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -13534,6 +15821,7 @@ spec:
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               to:
                 description: |-
                   To describes the resources that may be referenced by the resources
@@ -13583,6 +15871,7 @@ spec:
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - from
             - to
@@ -13606,9 +15895,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: tcproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -13865,6 +16153,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -14029,6 +16318,7 @@ spec:
                       maxItems: 16
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
@@ -14038,14 +16328,35 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
+                  required:
+                  - backendRefs
                   type: object
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: Rule name must be unique within the route
                   rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
                     && l1.name == l2.name))
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
             required:
             - rules
             type: object
@@ -14312,11 +16623,13 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
@@ -14342,9 +16655,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: tlsroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -14449,6 +16761,7 @@ spec:
                   type: string
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
               parentRefs:
                 description: |-
                   ParentRefs references the resources (usually Gateways) that a Route wants
@@ -14661,6 +16974,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -14828,6 +17142,7 @@ spec:
                       maxItems: 16
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
@@ -14837,14 +17152,35 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
+                  required:
+                  - backendRefs
                   type: object
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: Rule name must be unique within the route
                   rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
                     && l1.name == l2.name))
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
             required:
             - rules
             type: object
@@ -15111,11 +17447,810 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+
+          If you need to forward traffic to a single target for a TLS listener, you
+          could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI hostnames that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                  1. IPs are not allowed in SNI hostnames per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+                  If a hostname is specified by both the Listener and TLSRoute, there
+                  must be at least one intersecting hostname for the TLSRoute to be
+                  attached to the Listener. For example:
+
+                  * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                    that have specified at least one of `test.example.com` or
+                    `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                    that have specified at least one hostname that matches the Listener
+                    hostname. For example, `test.example.com` and `*.example.com` would both
+                    match. On the other hand, `example.com` and `test.example.net` would not
+                    match.
+
+                  If both the Listener and TLSRoute have specified hostnames, any
+                  TLSRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+                  If both the Listener and TLSRoute have specified hostnames, and none
+                  match with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection or returning a 500 status code.
+                        Request rejections must respect weight; if an invalid backend is
+                        requested to have 80% of requests, then 80% of requests must be rejected
+                        instead.
+
+                        Support: Core for Kubernetes Service
+
+                        Support: Extended for Kubernetes ServiceImport
+
+                        Support: Implementation-specific for any other resource
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: |-
+                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                        Support: Extended
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - hostnames
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
@@ -15141,9 +18276,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: udproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -15400,6 +18534,7 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
@@ -15564,6 +18699,7 @@ spec:
                       maxItems: 16
                       minItems: 1
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: |-
                         Name is the name of the route rule. This name MUST be unique within a Route if it is set.
@@ -15573,14 +18709,35 @@ spec:
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
+                  required:
+                  - backendRefs
                   type: object
                 maxItems: 16
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: Rule name must be unique within the route
                   rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
                     && l1.name == l2.name))
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
             required:
             - rules
             type: object
@@ -15847,11 +19004,13 @@ spec:
                       - name
                       type: object
                   required:
+                  - conditions
                   - controllerName
                   - parentRef
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - parents
             type: object
@@ -15877,9 +19036,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   labels:
     gateway.networking.k8s.io/policy: Direct
   name: xbackendtrafficpolicies.gateway.networking.x-k8s.io
@@ -16457,10 +19615,12 @@ spec:
                       type: string
                   required:
                   - ancestorRef
+                  - conditions
                   - controllerName
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - ancestors
             type: object
@@ -16486,9 +19646,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.3.0
+    gateway.networking.k8s.io/bundle-version: v1.4.1
     gateway.networking.k8s.io/channel: experimental
-  creationTimestamp: null
   name: xlistenersets.gateway.networking.x-k8s.io
 spec:
   group: gateway.networking.x-k8s.io
@@ -16517,8 +19676,33 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          XListenerSet defines a set of additional listeners
-          to attach to an existing Gateway.
+          XListenerSet defines a set of additional listeners to attach to an existing Gateway.
+          This resource provides a mechanism to merge multiple listeners into a single Gateway.
+
+          The parent Gateway must explicitly allow ListenerSet attachment through its
+          AllowedListeners configuration. By default, Gateways do not allow ListenerSet
+          attachment.
+
+          Routes can attach to a ListenerSet by specifying it as a parentRef, and can
+          optionally target specific listeners using the sectionName field.
+
+          Policy Attachment:
+          - Policies that attach to a ListenerSet apply to all listeners defined in that resource
+          - Policies do not impact listeners in the parent Gateway
+          - Different ListenerSets attached to the same Gateway can have different policies
+          - If an implementation cannot apply a policy to specific listeners, it should reject the policy
+
+          ReferenceGrant Semantics:
+          - ReferenceGrants applied to a Gateway are not inherited by child ListenerSets
+          - ReferenceGrants applied to a ListenerSet do not grant permission to the parent Gateway's listeners
+          - A ListenerSet can reference secrets/backends in its own namespace without a ReferenceGrant
+
+          Gateway Integration:
+          - The parent Gateway's status will include an "AttachedListenerSets" condition
+          - This condition will be:
+            - True: when AllowedListeners is set and at least one child ListenerSet is attached
+            - False: when AllowedListeners is set but no valid listeners are attached, or when AllowedListeners is not set or false
+            - Unknown: when no AllowedListeners config is present
         properties:
           apiVersion:
             description: |-
@@ -16556,10 +19740,10 @@ spec:
 
                   1. "parent" Gateway
                   2. ListenerSet ordered by creation time (oldest first)
-                  3. ListenerSet ordered alphabetically by “{namespace}/{name}”.
+                  3. ListenerSet ordered alphabetically by "{namespace}/{name}".
 
                   An implementation MAY reject listeners by setting the ListenerEntryStatus
-                  `Accepted`` condition to False with the Reason `TooManyListeners`
+                  `Accepted` condition to False with the Reason `TooManyListeners`
 
                   If a listener has a conflict, this will be reported in the
                   Status.ListenerEntryStatus setting the `Conflicted` condition to True.
@@ -16632,6 +19816,7 @@ spec:
                             type: object
                           maxItems: 8
                           type: array
+                          x-kubernetes-list-type: atomic
                         namespaces:
                           default:
                             from: Same
@@ -16754,12 +19939,18 @@ spec:
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     port:
+                      default: 0
                       description: |-
                         Port is the network port. Multiple listeners may use the
                         same port, subject to the Listener compatibility rules.
+
+                        If the port is not set or specified as zero, the implementation will assign
+                        a unique port. If the implementation does not support dynamic port
+                        assignment, it MUST set `Accepted` condition to `False` with the
+                        `UnsupportedPort` reason.
                       format: int32
                       maximum: 65535
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     protocol:
                       description: Protocol specifies the network protocol this listener
@@ -16774,7 +19965,7 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
-                        The association of SNIs to Certificate defined in GatewayTLSConfig is
+                        The association of SNIs to Certificate defined in ListenerTLSConfig is
                         defined based on the Hostname field for this listener.
 
                         The GatewayClass MUST use the longest matching SNI out of all
@@ -16859,93 +20050,7 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
-                        frontendValidation:
-                          description: |-
-                            FrontendValidation holds configuration information for validating the frontend (client).
-                            Setting this field will require clients to send a client certificate
-                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
-                            that requests a user to specify the client certificate.
-                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
-
-                            Support: Extended
-                          properties:
-                            caCertificateRefs:
-                              description: |-
-                                CACertificateRefs contains one or more references to
-                                Kubernetes objects that contain TLS certificates of
-                                the Certificate Authorities that can be used
-                                as a trust anchor to validate the certificates presented by the client.
-
-                                A single CA certificate reference to a Kubernetes ConfigMap
-                                has "Core" support.
-                                Implementations MAY choose to support attaching multiple CA certificates to
-                                a Listener, but this behavior is implementation-specific.
-
-                                Support: Core - A single reference to a Kubernetes ConfigMap
-                                with the CA certificate in a key named `ca.crt`.
-
-                                Support: Implementation-specific (More than one reference, or other kinds
-                                of resources).
-
-                                References to a resource in a different namespace are invalid UNLESS there
-                                is a ReferenceGrant in the target namespace that allows the certificate
-                                to be attached. If a ReferenceGrant does not allow this reference, the
-                                "ResolvedRefs" condition MUST be set to False for this listener with the
-                                "RefNotPermitted" reason.
-                              items:
-                                description: |-
-                                  ObjectReference identifies an API object including its namespace.
-
-                                  The API object must be valid in the cluster; the Group and Kind must
-                                  be registered in the cluster for this reference to be valid.
-
-                                  References to objects with invalid Group and Kind are not valid, and must
-                                  be rejected by the implementation, with appropriate Conditions set
-                                  on the containing object.
-                                properties:
-                                  group:
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When set to the empty string, core API group is inferred.
-                                    maxLength: 253
-                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                    type: string
-                                  kind:
-                                    description: Kind is kind of the referent. For
-                                      example "ConfigMap" or "Service".
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                                    type: string
-                                  name:
-                                    description: Name is the name of the referent.
-                                    maxLength: 253
-                                    minLength: 1
-                                    type: string
-                                  namespace:
-                                    description: |-
-                                      Namespace is the namespace of the referenced object. When unspecified, the local
-                                      namespace is inferred.
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-                                      Support: Core
-                                    maxLength: 63
-                                    minLength: 1
-                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                                    type: string
-                                required:
-                                - group
-                                - kind
-                                - name
-                                type: object
-                              maxItems: 8
-                              minItems: 1
-                              type: array
-                          type: object
+                          x-kubernetes-list-type: atomic
                         mode:
                           default: Terminate
                           description: |-
@@ -16997,7 +20102,6 @@ spec:
                           > 0 || size(self.options) > 0 : true'
                   required:
                   - name
-                  - port
                   - protocol
                   type: object
                 maxItems: 64
@@ -17297,6 +20401,7 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                   - attachedRoutes
                   - conditions
@@ -17323,15 +20428,267 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: experimental
+  name: xmeshes.gateway.networking.x-k8s.io
+spec:
+  group: gateway.networking.x-k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: XMesh
+    listKind: XMeshList
+    plural: xmeshes
+    shortNames:
+    - mesh
+    singular: xmesh
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: XMesh defines mesh-wide characteristics of a GAMMA-compliant
+          service mesh.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of XMesh.
+            properties:
+              controllerName:
+                description: |-
+                  ControllerName is the name of a controller that is managing Gateway API
+                  resources for mesh traffic management. The value of this field MUST be a
+                  domain prefixed path.
+
+                  Example: "example.com/awesome-mesh".
+
+                  This field is not mutable and cannot be empty.
+
+                  Support: Core
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description optionally provides a human-readable description
+                  of a Mesh.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: |-
+                  ParametersRef is an optional reference to a resource that contains
+                  implementation-specific configuration for this Mesh. If no
+                  implementation-specific parameters are needed, this field MUST be
+                  omitted.
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e.
+                  ConfigMap, or an implementation-specific custom resource. The resource
+                  can be cluster-scoped or namespace-scoped.
+
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the Mesh MUST be rejected
+                  with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
+
+                  Support: Implementation-specific
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.
+                      This field is required when referring to a Namespace-scoped resource and
+                      MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of XMesh.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions is the current status from the controller for
+                  this Mesh.
+
+                  Controllers should prefer to publish conditions using values
+                  of MeshConditionType for the type of each Condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |-
+                  SupportedFeatures is the set of features the Mesh support.
+                  It MUST be sorted in ascending alphabetical order by the Name key.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        FeatureName is used to describe distinct features that are covered by
+                        conformance tests.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_backends.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: backends.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -17474,7 +20831,7 @@ spec:
                     rule: ((has(self.fqdn) && !(has(self.ip) || has(self.unix))) ||
                       (has(self.ip) && !(has(self.fqdn) || has(self.unix))) || (has(self.unix)
                       && !(has(self.ip) || has(self.fqdn))))
-                maxItems: 64
+                maxItems: 256
                 minItems: 1
                 type: array
                 x-kubernetes-validations:
@@ -17495,6 +20852,27 @@ spec:
                   be a merge of both configurations. In case of overlapping fields, the values defined in the BackendTLSPolicy will
                   take precedence.
                 properties:
+                  alpnProtocols:
+                    description: |-
+                      ALPNProtocols supplies the list of ALPN protocols that should be
+                      exposed by the listener or used by the proxy to connect to the backend.
+                      Defaults:
+                      1. HTTPS Routes: h2 and http/1.1 are enabled in listener context.
+                      2. Other Routes: ALPN is disabled.
+                      3. Backends: proxy uses the appropriate ALPN options for the backend protocol.
+                      When an empty list is provided, the ALPN TLS extension is disabled.
+
+                      Defaults to [h2, http/1.1] if not specified.
+
+                      Typical Supported values are:
+                      - http/1.0
+                      - http/1.1
+                      - h2
+                    items:
+                      description: ALPNProtocol specifies the protocol to be negotiated
+                        using ALPN
+                      type: string
+                    type: array
                   caCertificateRefs:
                     description: |-
                       CACertificateRefs contains one or more references to Kubernetes objects that
@@ -17544,12 +20922,128 @@ spec:
                       type: object
                     maxItems: 8
                     type: array
+                  ciphers:
+                    description: |-
+                      Ciphers specifies the set of cipher suites supported when
+                      negotiating TLS 1.0 - 1.2. This setting has no effect for TLS 1.3.
+                      In non-FIPS Envoy Proxy builds the default cipher list is:
+                      - [ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]
+                      - [ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                      In builds using BoringSSL FIPS the default cipher list is:
+                      - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES128-GCM-SHA256
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                    items:
+                      type: string
+                    type: array
+                  clientCertificateRef:
+                    description: |-
+                      ClientCertificateRef defines the reference to a Kubernetes Secret that contains
+                      the client certificate and private key for Envoy to use when connecting to
+                      backend services and external services, such as ExtAuth, ALS, OpenTelemetry, etc.
+                      This secret should be located within the same namespace as the Envoy proxy resource that references it.
+                    properties:
+                      group:
+                        default: ""
+                        description: |-
+                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                          When unspecified or empty string, core API group is inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Secret
+                        description: Kind is kind of the referent. For example "Secret".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referenced object. When unspecified, the local
+                          namespace is inferred.
+
+                          Note that when a namespace different than the local namespace is specified,
+                          a ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  ecdhCurves:
+                    description: |-
+                      ECDHCurves specifies the set of supported ECDH curves.
+                      In non-FIPS Envoy Proxy builds the default curves are:
+                      - X25519
+                      - P-256
+                      In builds using BoringSSL FIPS the default curve is:
+                      - P-256
+                    items:
+                      type: string
+                    type: array
                   insecureSkipVerify:
                     default: false
                     description: |-
                       InsecureSkipVerify indicates whether the upstream's certificate verification
                       should be skipped. Defaults to "false".
                     type: boolean
+                  maxVersion:
+                    description: |-
+                      Max specifies the maximal TLS protocol version to allow
+                      The default is TLS 1.3 if this is not specified.
+                    enum:
+                    - Auto
+                    - "1.0"
+                    - "1.1"
+                    - "1.2"
+                    - "1.3"
+                    type: string
+                  minVersion:
+                    description: |-
+                      Min specifies the minimal TLS protocol version to allow.
+                      The default is TLS 1.2 if this is not specified.
+                    enum:
+                    - Auto
+                    - "1.0"
+                    - "1.1"
+                    - "1.2"
+                    - "1.3"
+                    type: string
+                  signatureAlgorithms:
+                    description: |-
+                      SignatureAlgorithms specifies which signature algorithms the listener should
+                      support.
+                    items:
+                      type: string
+                    type: array
+                  sni:
+                    description: |-
+                      SNI is specifies the SNI value used when establishing an upstream TLS connection to the backend.
+
+                      Envoy Gateway will use the HTTP host header value for SNI, when all resources referenced in BackendRefs are:
+                      1. Backend resources that do not set SNI, or
+                      2. Service/ServiceImport resources that do not have a BackendTLSPolicy attached to them
+
+                      When a BackendTLSPolicy attaches to a Backend resource, the BackendTLSPolicy's Hostname value takes precedence
+                      over this value.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   wellKnownCACertificates:
                     description: |-
                       WellKnownCACertificates specifies whether system CA certificates may be used in
@@ -17573,6 +21067,15 @@ spec:
                     && ((has(self.caCertificateRefs) && size(self.caCertificateRefs)
                     > 0) || (has(self.wellKnownCACertificates) && self.wellKnownCACertificates
                     != "")))'
+                - message: setting ciphers has no effect if the minimum possible TLS
+                    version is 1.3
+                  rule: 'has(self.minVersion) && self.minVersion == ''1.3'' ? !has(self.ciphers)
+                    : true'
+                - message: minVersion must be smaller or equal to maxVersion
+                  rule: 'has(self.minVersion) && has(self.maxVersion) ? {"Auto":0,"1.0":1,"1.1":2,"1.2":3,"1.3":4}[self.minVersion]
+                    <= {"1.0":1,"1.1":2,"1.2":3,"1.3":4,"Auto":5}[self.maxVersion]
+                    : !has(self.minVersion) && has(self.maxVersion) ? 3 <= {"1.0":1,"1.1":2,"1.2":3,"1.3":4,"Auto":5}[self.maxVersion]
+                    : true'
               type:
                 default: Endpoints
                 description: Type defines the type of the backend. Defaults to "Endpoints"
@@ -17658,13 +21161,13 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: backendtrafficpolicies.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -17775,7 +21278,9 @@ spec:
                     type: object
                 type: object
               compression:
-                description: The compression config for the http streams.
+                description: |-
+                  The compression config for the http streams.
+                  Deprecated: Use Compressor instead.
                 items:
                   description: |-
                     Compression defines the config of enabling compression.
@@ -17787,13 +21292,76 @@ spec:
                     gzip:
                       description: The configuration for GZIP compressor.
                       type: object
+                    minContentLength:
+                      allOf:
+                      - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      - pattern: ^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        MinContentLength defines the minimum response size in bytes to apply compression.
+                        Responses smaller than this threshold will not be compressed.
+                        Must be at least 30 bytes as enforced by Envoy Proxy.
+                        Note that when the suffix is not provided, the value is interpreted as bytes.
+                        Default: 30 bytes
+                      x-kubernetes-int-or-string: true
                     type:
                       description: CompressorType defines the compressor type to use
                         for compression.
                       enum:
                       - Gzip
                       - Brotli
+                      - Zstd
                       type: string
+                    zstd:
+                      description: The configuration for Zstd compressor.
+                      type: object
+                  required:
+                  - type
+                  type: object
+                type: array
+              compressor:
+                description: |-
+                  The compressor config for the http streams.
+                  This provides more granular control over compression configuration.
+                  Order matters: The first compressor in the list is preferred when q-values in Accept-Encoding are equal.
+                items:
+                  description: |-
+                    Compression defines the config of enabling compression.
+                    This can help reduce the bandwidth at the expense of higher CPU.
+                  properties:
+                    brotli:
+                      description: The configuration for Brotli compressor.
+                      type: object
+                    gzip:
+                      description: The configuration for GZIP compressor.
+                      type: object
+                    minContentLength:
+                      allOf:
+                      - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      - pattern: ^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        MinContentLength defines the minimum response size in bytes to apply compression.
+                        Responses smaller than this threshold will not be compressed.
+                        Must be at least 30 bytes as enforced by Envoy Proxy.
+                        Note that when the suffix is not provided, the value is interpreted as bytes.
+                        Default: 30 bytes
+                      x-kubernetes-int-or-string: true
+                    type:
+                      description: CompressorType defines the compressor type to use
+                        for compression.
+                      enum:
+                      - Gzip
+                      - Brotli
+                      - Zstd
+                      type: string
+                    zstd:
+                      description: The configuration for Zstd compressor.
+                      type: object
                   required:
                   - type
                   type: object
@@ -17815,6 +21383,41 @@ spec:
                       For example, 20Mi, 1Gi, 256Ki etc.
                       Note: that when the suffix is not provided, the value is interpreted as bytes.
                     x-kubernetes-int-or-string: true
+                  preconnect:
+                    description: |-
+                      Preconnect configures proactive upstream connections to reduce latency by establishing
+                      connections before they’re needed and avoiding connection establishment overhead.
+
+                      If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                    properties:
+                      perEndpointPercent:
+                        description: |-
+                          PerEndpointPercent configures how many additional connections to maintain per
+                          upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                          percentage of the connections required by active streams
+                          (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                          Allowed value range is between 100-300. When both PerEndpointPercent and
+                          PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                        format: int32
+                        maximum: 300
+                        minimum: 100
+                        type: integer
+                      predictivePercent:
+                        description: |-
+                          PredictivePercent configures how many additional connections to maintain
+                          across the cluster by anticipating which upstream endpoint the load balancer
+                          will select next, useful for low-QPS services. Relies on deterministic
+                          loadbalancing and is only supported with Random or RoundRobin.
+                          Expressed as a percentage of the connections required by active streams
+                          (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                          Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                          set Envoy ensures both are satisfied per host (max of the two).
+                        format: int32
+                        minimum: 100
+                        type: integer
+                    type: object
                   socketBufferLimit:
                     allOf:
                     - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -18150,7 +21753,6 @@ spec:
                         format: int32
                         type: integer
                       consecutiveGatewayErrors:
-                        default: 0
                         description: ConsecutiveGatewayErrors sets the number of consecutive
                           gateway errors triggering ejection.
                         format: int32
@@ -18161,6 +21763,15 @@ spec:
                           ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                           Parameter takes effect only when split_external_local_origin_errors is set to true.
                         format: int32
+                        type: integer
+                      failurePercentageThreshold:
+                        description: |-
+                          FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                          If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                          Defaults to 85.
+                        format: int32
+                        maximum: 100
+                        minimum: 0
                         type: integer
                       interval:
                         default: 3s
@@ -18291,8 +21902,10 @@ spec:
                         - name
                         type: object
                       header:
-                        description: Header configures the header hash policy when
-                          the consistent hash type is set to Header.
+                        description: |-
+                          Header configures the header hash policy when the consistent hash type is set to Header.
+
+                          Deprecated: use Headers instead
                         properties:
                           name:
                             description: Name of the header to hash.
@@ -18300,6 +21913,36 @@ spec:
                         required:
                         - name
                         type: object
+                      headers:
+                        description: Headers configures the header hash policy for
+                          each header, when the consistent hash type is set to Headers.
+                        items:
+                          description: |-
+                            Header defines the header hashing configuration for consistent hash based
+                            load balancing.
+                          properties:
+                            name:
+                              description: Name of the header to hash.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      queryParams:
+                        description: QueryParams configures the query parameter hash
+                          policy when the consistent hash type is set to QueryParams.
+                        items:
+                          description: |-
+                            QueryParam defines the query parameter name hashing configuration for consistent hash based
+                            load balancing.
+                          properties:
+                            name:
+                              description: Name of the query param to hash.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
                       tableSize:
                         default: 65537
                         description: The table size for consistent hashing, must be
@@ -18313,11 +21956,15 @@ spec:
                           ConsistentHashType defines the type of input to hash on. Valid Type values are
                           "SourceIP",
                           "Header",
+                          "Headers",
                           "Cookie".
+                          "QueryParams".
                         enum:
                         - SourceIP
                         - Header
+                        - Headers
                         - Cookie
+                        - QueryParams
                         type: string
                     required:
                     - type
@@ -18326,9 +21973,16 @@ spec:
                     - message: If consistent hash type is header, the header field
                         must be set.
                       rule: 'self.type == ''Header'' ? has(self.header) : !has(self.header)'
+                    - message: If consistent hash type is headers, the headers field
+                        must be set.
+                      rule: 'self.type == ''Headers'' ? has(self.headers) : !has(self.headers)'
                     - message: If consistent hash type is cookie, the cookie field
                         must be set.
                       rule: 'self.type == ''Cookie'' ? has(self.cookie) : !has(self.cookie)'
+                    - message: If consistent hash type is queryParams, the queryParams
+                        field must be set.
+                      rule: 'self.type == ''QueryParams'' ? has(self.queryParams)
+                        : !has(self.queryParams)'
                   endpointOverride:
                     description: |-
                       EndpointOverride defines the configuration for endpoint override.
@@ -18413,6 +22067,14 @@ spec:
                               of total upstream endpoints across all zones required
                               to enable zone-aware routing.
                             format: int64
+                            type: integer
+                          percentageEnabled:
+                            description: Configures percentage of requests that will
+                              be considered for zone aware routing if zone aware routing
+                              is configured. If not specified, Envoy defaults to 100%.
+                            format: int32
+                            maximum: 100
+                            minimum: 0
                             type: integer
                         type: object
                     type: object
@@ -18499,12 +22161,12 @@ spec:
                                   RateLimitSelectCondition specifies the attributes within the traffic flow that can
                                   be used to select a subset of clients to be ratelimited.
                                   All the individual conditions must hold True for the overall condition to hold True.
+                                  And, at least one of headers or methods or path or sourceCIDR or queryParams condition must be specified.
                                 properties:
                                   headers:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-                                      At least one of headers or sourceCIDR condition must be specified.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -18545,10 +22207,108 @@ spec:
                                       type: object
                                     maxItems: 16
                                     type: array
-                                  sourceCIDR:
+                                  methods:
                                     description: |-
-                                      SourceCIDR is the client IP Address range to match on.
-                                      At least one of headers or sourceCIDR condition must be specified.
+                                      Methods is a list of request methods to match. Multiple method values are ORed together,
+                                      meaning, a request can match any one of the specified methods. If not specified, it matches all methods.
+                                    items:
+                                      description: MethodMatch defines the matching
+                                        criteria for the HTTP method of a request.
+                                      properties:
+                                        invert:
+                                          default: false
+                                          description: Invert specifies whether the
+                                            value match result will be inverted.
+                                          type: boolean
+                                        value:
+                                          description: Value specifies the HTTP method.
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                      required:
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: |-
+                                      Path is the request path to match.
+                                      Support Exact, PathPrefix and RegularExpression match types.
+                                    properties:
+                                      invert:
+                                        default: false
+                                        description: Invert specifies whether the
+                                          value match result will be inverted.
+                                        type: boolean
+                                      type:
+                                        default: PathPrefix
+                                        description: Type specifies how to match against
+                                          the value of the path.
+                                        enum:
+                                        - Exact
+                                        - PathPrefix
+                                        - RegularExpression
+                                        type: string
+                                      value:
+                                        default: /
+                                        description: Value specifies the HTTP path.
+                                        maxLength: 1024
+                                        type: string
+                                    required:
+                                    - value
+                                    type: object
+                                  queryParams:
+                                    description: |-
+                                      QueryParams is a list of query parameters to match. Multiple query parameter values are ANDed together,
+                                      meaning, a request MUST match all the specified query parameters.
+                                    items:
+                                      description: QueryParamMatch defines the match
+                                        attributes within the query parameters of
+                                        the request.
+                                      properties:
+                                        invert:
+                                          default: false
+                                          description: |-
+                                            Invert specifies whether the value match result will be inverted.
+                                            Do not set this field when Type="Distinct", implying matching on any/all unique
+                                            values within the query parameter.
+                                          type: boolean
+                                        name:
+                                          description: Name of the query parameter.
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        type:
+                                          default: Exact
+                                          description: Type specifies how to match
+                                            against the value of the query parameter.
+                                          enum:
+                                          - Exact
+                                          - RegularExpression
+                                          - Distinct
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Value of the query parameter.
+                                            Do not set this field when Type="Distinct", implying matching on any/all unique
+                                            values within the query parameter.
+                                          maxLength: 1024
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    maxItems: 16
+                                    type: array
+                                  sourceCIDR:
+                                    description: SourceCIDR is the client IP Address
+                                      range to match on.
                                     properties:
                                       type:
                                         default: Exact
@@ -18568,6 +22328,11 @@ spec:
                                     - value
                                     type: object
                                 type: object
+                                x-kubernetes-validations:
+                                - message: at least one of headers, methods, path,
+                                    sourceCIDR or queryParams must be specified
+                                  rule: has(self.headers) || has(self.methods) ||
+                                    has(self.path) || has(self.sourceCIDR) || has(self.queryParams)
                               maxItems: 8
                               type: array
                             cost:
@@ -18703,6 +22468,15 @@ spec:
                               - requests
                               - unit
                               type: object
+                            shadowMode:
+                              description: |-
+                                ShadowMode indicates whether this rate-limit rule runs in shadow mode.
+                                When enabled, all rate-limiting operations are performed (cache lookups,
+                                counter updates, telemetry generation), but the outcome is never enforced.
+                                The request always succeeds, even if the configured limit is exceeded.
+
+                                Only supported for Global Rate Limits.
+                              type: boolean
                             shared:
                               description: |-
                                 Shared determines whether this rate limit rule applies across all the policy targets.
@@ -18712,7 +22486,7 @@ spec:
                           required:
                           - limit
                           type: object
-                        maxItems: 64
+                        maxItems: 128
                         type: array
                     required:
                     - rules
@@ -18750,12 +22524,12 @@ spec:
                                   RateLimitSelectCondition specifies the attributes within the traffic flow that can
                                   be used to select a subset of clients to be ratelimited.
                                   All the individual conditions must hold True for the overall condition to hold True.
+                                  And, at least one of headers or methods or path or sourceCIDR or queryParams condition must be specified.
                                 properties:
                                   headers:
                                     description: |-
                                       Headers is a list of request headers to match. Multiple header values are ANDed together,
                                       meaning, a request MUST match all the specified headers.
-                                      At least one of headers or sourceCIDR condition must be specified.
                                     items:
                                       description: HeaderMatch defines the match attributes
                                         within the HTTP Headers of the request.
@@ -18796,10 +22570,108 @@ spec:
                                       type: object
                                     maxItems: 16
                                     type: array
-                                  sourceCIDR:
+                                  methods:
                                     description: |-
-                                      SourceCIDR is the client IP Address range to match on.
-                                      At least one of headers or sourceCIDR condition must be specified.
+                                      Methods is a list of request methods to match. Multiple method values are ORed together,
+                                      meaning, a request can match any one of the specified methods. If not specified, it matches all methods.
+                                    items:
+                                      description: MethodMatch defines the matching
+                                        criteria for the HTTP method of a request.
+                                      properties:
+                                        invert:
+                                          default: false
+                                          description: Invert specifies whether the
+                                            value match result will be inverted.
+                                          type: boolean
+                                        value:
+                                          description: Value specifies the HTTP method.
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                      required:
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: |-
+                                      Path is the request path to match.
+                                      Support Exact, PathPrefix and RegularExpression match types.
+                                    properties:
+                                      invert:
+                                        default: false
+                                        description: Invert specifies whether the
+                                          value match result will be inverted.
+                                        type: boolean
+                                      type:
+                                        default: PathPrefix
+                                        description: Type specifies how to match against
+                                          the value of the path.
+                                        enum:
+                                        - Exact
+                                        - PathPrefix
+                                        - RegularExpression
+                                        type: string
+                                      value:
+                                        default: /
+                                        description: Value specifies the HTTP path.
+                                        maxLength: 1024
+                                        type: string
+                                    required:
+                                    - value
+                                    type: object
+                                  queryParams:
+                                    description: |-
+                                      QueryParams is a list of query parameters to match. Multiple query parameter values are ANDed together,
+                                      meaning, a request MUST match all the specified query parameters.
+                                    items:
+                                      description: QueryParamMatch defines the match
+                                        attributes within the query parameters of
+                                        the request.
+                                      properties:
+                                        invert:
+                                          default: false
+                                          description: |-
+                                            Invert specifies whether the value match result will be inverted.
+                                            Do not set this field when Type="Distinct", implying matching on any/all unique
+                                            values within the query parameter.
+                                          type: boolean
+                                        name:
+                                          description: Name of the query parameter.
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        type:
+                                          default: Exact
+                                          description: Type specifies how to match
+                                            against the value of the query parameter.
+                                          enum:
+                                          - Exact
+                                          - RegularExpression
+                                          - Distinct
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Value of the query parameter.
+                                            Do not set this field when Type="Distinct", implying matching on any/all unique
+                                            values within the query parameter.
+                                          maxLength: 1024
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    maxItems: 16
+                                    type: array
+                                  sourceCIDR:
+                                    description: SourceCIDR is the client IP Address
+                                      range to match on.
                                     properties:
                                       type:
                                         default: Exact
@@ -18819,6 +22691,11 @@ spec:
                                     - value
                                     type: object
                                 type: object
+                                x-kubernetes-validations:
+                                - message: at least one of headers, methods, path,
+                                    sourceCIDR or queryParams must be specified
+                                  rule: has(self.headers) || has(self.methods) ||
+                                    has(self.path) || has(self.sourceCIDR) || has(self.queryParams)
                               maxItems: 8
                               type: array
                             cost:
@@ -18954,6 +22831,15 @@ spec:
                               - requests
                               - unit
                               type: object
+                            shadowMode:
+                              description: |-
+                                ShadowMode indicates whether this rate-limit rule runs in shadow mode.
+                                When enabled, all rate-limiting operations are performed (cache lookups,
+                                counter updates, telemetry generation), but the outcome is never enforced.
+                                The request always succeeds, even if the configured limit is exceeded.
+
+                                Only supported for Global Rate Limits.
+                              type: boolean
                             shared:
                               description: |-
                                 Shared determines whether this rate limit rule applies across all the policy targets.
@@ -18968,17 +22854,19 @@ spec:
                         x-kubernetes-validations:
                         - message: response cost is not supported for Local Rate Limits
                           rule: self.all(foo, !has(foo.cost) || !has(foo.cost.response))
+                        - message: shadow mode is not supported for Local Rate Limits
+                          rule: self.all(foo, !has(foo.shadowMode))
                     type: object
                   type:
                     description: |-
                       Type decides the scope for the RateLimits.
                       Valid RateLimitType values are "Global" or "Local".
+
+                      Deprecated: Use Global and/or Local fields directly instead. Both can be specified simultaneously for combined rate limiting.
                     enum:
                     - Global
                     - Local
                     type: string
-                required:
-                - type
                 type: object
               requestBuffer:
                 description: |-
@@ -19168,8 +23056,6 @@ spec:
                             Port will not be added in the 'Location' header if scheme is HTTP and port is 80
                             or scheme is HTTPS and port is 443.
                           format: int32
-                          maximum: 65535
-                          minimum: 1
                           type: integer
                         scheme:
                           description: |-
@@ -19263,6 +23149,142 @@ spec:
                           description: Content Type of the response. This will be
                             set in the Content-Type header.
                           type: string
+                        header:
+                          description: |-
+                            Header defines headers to add, set or remove from the response.
+                            This allows the response policy to append, add or override headers
+                            of the final response before it is sent to a downstream client.
+                            Note: Header removal is not supported for responseOverride.
+                          properties:
+                            add:
+                              description: |-
+                                Add adds the given header(s) (name, value) to the request
+                                before the action. It appends to any existing values associated
+                                with the header name.
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+                                Config:
+                                  add:
+                                  - name: "my-header"
+                                    value: "bar,baz"
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo,bar,baz
+                              items:
+                                description: HTTPHeader represents an HTTP Header
+                                  name and value as defined by RFC 7230.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  value:
+                                    description: Value is the value of HTTP Header
+                                      to be matched.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              maxItems: 16
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            remove:
+                              description: |-
+                                Remove the given header(s) from the HTTP request before the action. The
+                                value of Remove is a list of HTTP header names. Note that the header
+                                names are case-insensitive (see
+                                https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header1: foo
+                                  my-header2: bar
+                                  my-header3: baz
+
+                                Config:
+                                  remove: ["my-header1", "my-header3"]
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header2: bar
+                              items:
+                                type: string
+                              maxItems: 16
+                              type: array
+                              x-kubernetes-list-type: set
+                            set:
+                              description: |-
+                                Set overwrites the request with the given header (name, value)
+                                before the action.
+
+                                Input:
+                                  GET /foo HTTP/1.1
+                                  my-header: foo
+
+                                Config:
+                                  set:
+                                  - name: "my-header"
+                                    value: "bar"
+
+                                Output:
+                                  GET /foo HTTP/1.1
+                                  my-header: bar
+                              items:
+                                description: HTTPHeader represents an HTTP Header
+                                  name and value as defined by RFC 7230.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                      case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                      If multiple entries specify equivalent header names, the first entry with
+                                      an equivalent name MUST be considered for a match. Subsequent entries
+                                      with an equivalent header name MUST be ignored. Due to the
+                                      case-insensitivity of header names, "foo" and "Foo" are considered
+                                      equivalent.
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  value:
+                                    description: Value is the value of HTTP Header
+                                      to be matched.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              maxItems: 16
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                          type: object
+                          x-kubernetes-validations:
+                          - message: Remove is not supported for header in CustomResponse
+                            rule: '!has(self.remove) || size(self.remove) == 0'
                         statusCode:
                           description: |-
                             Status Code of the Custom Response
@@ -19362,6 +23384,13 @@ spec:
                         type: array
                     type: object
                 type: object
+              routingType:
+                description: |-
+                  RoutingType can be set to "Service" to use the Service Cluster IP for routing to the backend,
+                  or it can be set to "Endpoint" to use Endpoint routing.
+                  When specified, this overrides the EnvoyProxy-level setting for the relevant targeRefs.
+                  If not specified, the EnvoyProxy-level setting is used.
+                type: string
               targetRef:
                 description: |-
                   TargetRef is the name of the resource this policy is being attached to.
@@ -19560,9 +23589,27 @@ spec:
                   Telemetry configures the telemetry settings for the policy target (Gateway or xRoute).
                   This will override the telemetry settings in the EnvoyProxy resource.
                 properties:
+                  metrics:
+                    description: Metrics defines metrics configuration for the backend
+                      or Route.
+                    properties:
+                      routeStatName:
+                        description: |-
+                          RouteStatName defines the value of the Route stat_prefix, determining how the route stats are named.
+                          For more details, see envoy docs: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-route
+                          The supported operators for this pattern are:
+                          %ROUTE_NAME%: name of Gateway API xRoute resource
+                          %ROUTE_NAMESPACE%: namespace of Gateway API xRoute resource
+                          %ROUTE_KIND%: kind of Gateway API xRoute resource
+                          Example: %ROUTE_KIND%/%ROUTE_NAMESPACE%/%ROUTE_NAME% => httproute/my-ns/my-route
+                          Disabled by default.
+                        type: string
+                    type: object
                   tracing:
-                    description: Tracing configures the tracing settings for the backend
-                      or HTTPRoute.
+                    description: |-
+                      Tracing configures the tracing settings for the backend or HTTPRoute.
+
+                      This takes precedence over EnvoyProxy tracing when set.
                     properties:
                       customTags:
                         additionalProperties:
@@ -19625,13 +23672,13 @@ spec:
                         description: |-
                           CustomTags defines the custom tags to add to each span.
                           If provider is kubernetes, pod name and namespace are added by default.
+
+                          Deprecated: Use Tags instead.
                         type: object
                       samplingFraction:
                         description: |-
                           SamplingFraction represents the fraction of requests that should be
                           selected for tracing if no prior sampling decision has been made.
-
-                          This will take precedence over sampling fraction on EnvoyProxy if set.
                         properties:
                           denominator:
                             default: 100
@@ -19648,6 +23695,39 @@ spec:
                         x-kubernetes-validations:
                         - message: numerator must be less than or equal to denominator
                           rule: self.numerator <= self.denominator
+                      spanName:
+                        description: |-
+                          SpanName defines the name of the span which will be used for tracing.
+                          Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the value.
+                          The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information.
+
+                          If not set, the span name is provider specific.
+                          e.g. Datadog use `ingress` as the default client span name,
+                          and `router <UPSTREAM_CLUSTER> egress` as the server span name.
+                        properties:
+                          client:
+                            description: Client defines operation name of the span
+                              which will be used for tracing.
+                            type: string
+                          server:
+                            description: Server defines the operation name of the
+                              upstream span which will be used for tracing.
+                            type: string
+                        required:
+                        - client
+                        - server
+                        type: object
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags defines the custom tags to add to each span.
+                          Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the value.
+                          The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information.
+                          If provider is kubernetes, pod name and namespace are added by default.
+
+                          Same keys take precedence over CustomTags.
+                        type: object
                     type: object
                 type: object
               timeout:
@@ -19666,6 +23746,14 @@ spec:
                         description: |-
                           The maximum duration of an HTTP connection.
                           Default: unlimited.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                      maxStreamDuration:
+                        description: |-
+                          MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                          from when the request is sent until the response stream is fully consumed and does not apply to
+                          non-streaming requests.
+                          When set to "0s", no max duration is applied and streams can run indefinitely.
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                       requestTimeout:
@@ -19703,8 +23791,6 @@ spec:
             - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
               rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
                 ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''] : true'
-            - message: this policy does not yet support the sectionName field
-              rule: 'has(self.targetRef) ? !has(self.targetRef.sectionName) : true'
             - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group ==
                 ''gateway.networking.k8s.io'') : true '
@@ -19712,9 +23798,14 @@ spec:
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
                 ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
                 : true '
-            - message: this policy does not yet support the sectionName field
-              rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, !has(ref.sectionName))
-                : true'
+            - message: either compression or compressor can be set, not both
+              rule: '!has(self.compression) || !has(self.compressor)'
+            - message: predictivePercent in preconnect policy only works with RoundRobin
+                or Random load balancers
+              rule: '!((has(self.connection) && has(self.connection.preconnect) &&
+                has(self.connection.preconnect.predictivePercent)) && !(has(self.loadBalancer)
+                && has(self.loadBalancer.type) && self.loadBalancer.type in [''Random'',
+                ''RoundRobin'']))'
           status:
             description: status defines the current status of BackendTrafficPolicy.
             properties:
@@ -19920,8 +24011,38 @@ spec:
                       - name
                       type: object
                     conditions:
-                      description: Conditions describes the status of the Policy with
-                        respect to the given Ancestor.
+                      description: |-
+                        Conditions describes the status of the Policy with respect to the given Ancestor.
+
+                        <gateway:util:excludeFromCRD>
+
+                        Notes for implementors:
+
+                        Conditions are a listType `map`, which means that they function like a
+                        map with a key of the `type` field _in the k8s apiserver_.
+
+                        This means that implementations must obey some rules when updating this
+                        section.
+
+                        * Implementations MUST perform a read-modify-write cycle on this field
+                          before modifying it. That is, when modifying this field, implementations
+                          must be confident they have fetched the most recent version of this field,
+                          and ensure that changes they make are on that recent version.
+                        * Implementations MUST NOT remove or reorder Conditions that they are not
+                          directly responsible for. For example, if an implementation sees a Condition
+                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
+                          Condition.
+                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
+                          rather than creating more than one Condition of the same Type.
+                        * Implementations MUST always update the `observedGeneration` field of the
+                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
+                        * If the `observedGeneration` of a Condition is _greater than_ the value the
+                          implementation knows about, then it MUST NOT perform the update on that Condition,
+                          but must wait for a future reconciliation and status update. (The assumption is that
+                          the implementation's copy of the object is stale and an update will be re-triggered
+                          if relevant.)
+
+                        </gateway:util:excludeFromCRD>
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -20004,10 +24125,12 @@ spec:
                       type: string
                   required:
                   - ancestorRef
+                  - conditions
                   - controllerName
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - ancestors
             type: object
@@ -20020,13 +24143,13 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: clienttrafficpolicies.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -20106,9 +24229,18 @@ spec:
                     properties:
                       numTrustedHops:
                         description: |-
-                          NumTrustedHops controls the number of additional ingress proxy hops from the right side of XFF HTTP
-                          headers to trust when determining the origin client's IP address.
-                          Only one of NumTrustedHops and TrustedCIDRs must be set.
+                          NumTrustedHops specifies how many trusted hops to count from the rightmost side of
+                          the X-Forwarded-For (XFF) header when determining the original client’s IP address.
+
+                          If NumTrustedHops is set to N, the client IP is taken from the Nth address from the
+                          right end of the XFF header.
+
+                          Example:
+                            XFF = "203.0.113.128, 203.0.113.10, 203.0.113.1"
+                            NumTrustedHops = 2
+                            → Trusted client address = 203.0.113.10
+
+                          Only one of NumTrustedHops or TrustedCIDRs should be configured.
                         format: int32
                         type: integer
                       trustedCIDRs:
@@ -20165,6 +24297,25 @@ spec:
                           Default: none.
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
+                      maxConnectionDuration:
+                        description: |-
+                          MaxConnectionDuration is the maximum amount of time a connection can remain established
+                          (usually via TCP/HTTP Keepalive packets) before being drained and/or closed.
+                          If not specified, there is no limit.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                      maxRequestsPerConnection:
+                        description: |-
+                          MaxRequestsPerConnection defines the maximum number of requests allowed over a single connection.
+                          If not specified, there is no limit. Setting this parameter to 1 will effectively disable keep alive.
+                        format: int32
+                        type: integer
+                      maxStreamDuration:
+                        description: |-
+                          MaxStreamDuration is the maximum amount of time to keep alive an http stream. When the limit is reached
+                          the stream will be reset independent of any other timeouts. If not specified, no value is set.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
                       value:
                         description: |-
                           Value of the maximum concurrent connections limit.
@@ -20172,9 +24323,10 @@ spec:
                         format: int64
                         minimum: 1
                         type: integer
-                    required:
-                    - value
                     type: object
+                    x-kubernetes-validations:
+                    - message: closeDelay can only be configured when value is set
+                      rule: '!has(self.closeDelay) || has(self.value)'
                   maxAcceptPerSocketEvent:
                     default: 1
                     description: |-
@@ -20267,6 +24419,59 @@ spec:
                           - value
                           type: object
                         maxItems: 64
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      addIfAbsent:
+                        description: |-
+                          AddIfAbsent adds the given header(s) (name, value) to the request/response
+                          only if the header does not already exist. Unlike Add which appends to
+                          existing values, this is a no-op if the header is already present.
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+
+                          Config:
+                            addIfAbsent:
+                            - name: "my-header"
+                              value: "bar"
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                If multiple entries specify equivalent header names, the first entry with
+                                an equivalent name MUST be considered for a match. Subsequent entries
+                                with an equivalent header name MUST be ignored. Due to the
+                                case-insensitivity of header names, "foo" and "Foo" are considered
+                                equivalent.
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -20293,8 +24498,40 @@ spec:
                         items:
                           type: string
                         maxItems: 64
+                        minItems: 1
                         type: array
                         x-kubernetes-list-type: set
+                      removeOnMatch:
+                        description: |-
+                          RemoveOnMatch removes headers whose names match the specified string matchers.
+                          Matching is performed on the header name (case-insensitive).
+                        items:
+                          description: |-
+                            StringMatch defines how to match any strings.
+                            This is a general purpose match condition that can be used by other EG APIs
+                            that need to match against a string.
+                          properties:
+                            type:
+                              default: Exact
+                              description: Type specifies how to match against a string.
+                              enum:
+                              - Exact
+                              - Prefix
+                              - Suffix
+                              - RegularExpression
+                              type: string
+                            value:
+                              description: Value specifies the string value that the
+                                match must have.
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                          required:
+                          - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
                       set:
                         description: |-
                           Set overwrites the request with the given header (name, value)
@@ -20341,6 +24578,7 @@ spec:
                           - value
                           type: object
                         maxItems: 64
+                        minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -20351,17 +24589,234 @@ spec:
                       EnableEnvoyHeaders configures Envoy Proxy to add the "X-Envoy-" headers to requests
                       and responses.
                     type: boolean
+                  lateResponseHeaders:
+                    description: LateResponseHeaders defines settings for global response
+                      header modification.
+                    properties:
+                      add:
+                        description: |-
+                          Add adds the given header(s) (name, value) to the request
+                          before the action. It appends to any existing values associated
+                          with the header name.
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+
+                          Config:
+                            add:
+                            - name: "my-header"
+                              value: "bar,baz"
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header: foo,bar,baz
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                If multiple entries specify equivalent header names, the first entry with
+                                an equivalent name MUST be considered for a match. Subsequent entries
+                                with an equivalent header name MUST be ignored. Due to the
+                                case-insensitivity of header names, "foo" and "Foo" are considered
+                                equivalent.
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      addIfAbsent:
+                        description: |-
+                          AddIfAbsent adds the given header(s) (name, value) to the request/response
+                          only if the header does not already exist. Unlike Add which appends to
+                          existing values, this is a no-op if the header is already present.
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+
+                          Config:
+                            addIfAbsent:
+                            - name: "my-header"
+                              value: "bar"
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                If multiple entries specify equivalent header names, the first entry with
+                                an equivalent name MUST be considered for a match. Subsequent entries
+                                with an equivalent header name MUST be ignored. Due to the
+                                case-insensitivity of header names, "foo" and "Foo" are considered
+                                equivalent.
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      remove:
+                        description: |-
+                          Remove the given header(s) from the HTTP request before the action. The
+                          value of Remove is a list of HTTP header names. Note that the header
+                          names are case-insensitive (see
+                          https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header1: foo
+                            my-header2: bar
+                            my-header3: baz
+
+                          Config:
+                            remove: ["my-header1", "my-header3"]
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header2: bar
+                        items:
+                          type: string
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: set
+                      removeOnMatch:
+                        description: |-
+                          RemoveOnMatch removes headers whose names match the specified string matchers.
+                          Matching is performed on the header name (case-insensitive).
+                        items:
+                          description: |-
+                            StringMatch defines how to match any strings.
+                            This is a general purpose match condition that can be used by other EG APIs
+                            that need to match against a string.
+                          properties:
+                            type:
+                              default: Exact
+                              description: Type specifies how to match against a string.
+                              enum:
+                              - Exact
+                              - Prefix
+                              - Suffix
+                              - RegularExpression
+                              type: string
+                            value:
+                              description: Value specifies the string value that the
+                                match must have.
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                          required:
+                          - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                      set:
+                        description: |-
+                          Set overwrites the request with the given header (name, value)
+                          before the action.
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+
+                          Config:
+                            set:
+                            - name: "my-header"
+                              value: "bar"
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header: bar
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                If multiple entries specify equivalent header names, the first entry with
+                                an equivalent name MUST be considered for a match. Subsequent entries
+                                with an equivalent header name MUST be ignored. Due to the
+                                case-insensitivity of header names, "foo" and "Foo" are considered
+                                equivalent.
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
                   preserveXRequestID:
                     description: |-
                       PreserveXRequestID configures Envoy to keep the X-Request-ID header if passed for a request that is edge
                       (Edge request is the request from external clients to front Envoy) and not reset it, which is the current Envoy behaviour.
                       Defaults to false and cannot be combined with RequestID.
-                      Deprecated: use RequestID=Preserve instead
+                      Deprecated: use RequestID=PreserveOrGenerate instead
                     type: boolean
                   requestID:
                     description: |-
                       RequestID configures Envoy's behavior for handling the `X-Request-ID` header.
-                      Defaults to `Generate` and builds the `X-Request-ID` for every request and ignores pre-existing values from the edge.
+                      When omitted default behavior is `Generate` which builds the `X-Request-ID` for every request
+                       and ignores pre-existing values from the edge.
                       (An "edge request" refers to a request from an external client to the Envoy entrypoint.)
                     enum:
                     - PreserveOrGenerate
@@ -20449,6 +24904,14 @@ spec:
               http1:
                 description: HTTP1 provides HTTP/1 configuration on the listener.
                 properties:
+                  disableSafeMaxConnectionDuration:
+                    description: |-
+                      DisableSafeMaxConnectionDuration controls the close behavior for HTTP/1 connections.
+                      By default, connection closure is delayed until the next request arrives after maxConnectionDuration is exceeded.
+                      It then adds a Connection: close header and gracefully closes the connection after the response completes.
+                      When set to true (disabled), Envoy uses its default drain behavior, closing the connection shortly after maxConnectionDuration elapses.
+                      Has no effect unless maxConnectionDuration is set.
+                    type: boolean
                   enableTrailers:
                     description: EnableTrailers defines if HTTP/1 trailers should
                       be proxied by Envoy.
@@ -20459,11 +24922,18 @@ spec:
                     properties:
                       useDefaultHost:
                         description: |-
-                          UseDefaultHost defines if the HTTP/1.0 request is missing the Host header,
-                          then the hostname associated with the listener should be injected into the
-                          request.
-                          If this is not set and an HTTP/1.0 request arrives without a host, then
-                          it will be rejected.
+                          UseDefaultHost specifies whether a default Host header should be injected
+                          into HTTP/1.0 requests that do not include one.
+
+                          When set to true, Envoy Gateway injects the hostname associated with the
+                          listener or route into the request, in the following order:
+
+                            1. If the targeted listener has a non-wildcard hostname, use that hostname.
+                            2. If there is exactly one HTTPRoute with a non-wildcard hostname under
+                               the targeted listener, use that hostname.
+
+                           Note: Setting this field to true without a non-wildcard hostname makes the
+                          ClientTrafficPolicy invalid.
                         type: boolean
                     type: object
                   preserveHeaderCase:
@@ -20556,6 +25026,21 @@ spec:
                       For more information on security implications, see haproxy.org/download/2.1/doc/proxy-protocol.txt
                     type: boolean
                 type: object
+              scheme:
+                description: |-
+                  Scheme configures how the :scheme pseudo-header is set for requests forwarded to backends.
+
+                  - Preserve (default): Preserves the :scheme from the original client request.
+                    Use this when backends need to know the original client scheme for URL generation or redirects.
+
+                  - MatchBackend: Sets the :scheme to match the backend transport protocol.
+                    If the backend uses TLS, the scheme is "https", otherwise "http".
+                    Use this when backends require the scheme to match the actual transport protocol,
+                    such as strictly HTTPS services that validate the :scheme header.
+                enum:
+                - Preserve
+                - MatchBackend
+                type: string
               targetRef:
                 description: |-
                   TargetRef is the name of the resource this policy is being attached to.
@@ -20800,17 +25285,16 @@ spec:
                       2. Other Routes: ALPN is disabled.
                       3. Backends: proxy uses the appropriate ALPN options for the backend protocol.
                       When an empty list is provided, the ALPN TLS extension is disabled.
-                      Supported values are:
+
+                      Defaults to [h2, http/1.1] if not specified.
+
+                      Typical Supported values are:
                       - http/1.0
                       - http/1.1
                       - h2
                     items:
                       description: ALPNProtocol specifies the protocol to be negotiated
                         using ALPN
-                      enum:
-                      - http/1.0
-                      - http/1.1
-                      - h2
                       type: string
                     type: array
                   ciphers:
@@ -20909,6 +25393,81 @@ spec:
                         items:
                           type: string
                         type: array
+                      crl:
+                        description: Crl specifies the crl configuration that can
+                          be used to validate the client initiating the TLS connection
+                        properties:
+                          onlyVerifyLeafCertificate:
+                            description: |-
+                              If this option is set to true,  Envoy will only verify the certificate at the end of the certificate chain against the CRL.
+                              Defaults to false, which will verify the entire certificate chain against the CRL.
+                            type: boolean
+                          refs:
+                            description: |-
+                              Refs contains one or more references to a Kubernetes ConfigMap or a Kubernetes Secret,
+                              containing the certificate revocation list in PEM format
+                              Expects the content in a key named `ca.crl`.
+
+                              References to a resource in different namespace are invalid UNLESS there
+                              is a ReferenceGrant in the target namespace that allows the crl
+                              to be attached.
+                            items:
+                              description: |-
+                                SecretObjectReference identifies an API object including its namespace,
+                                defaulting to Secret.
+
+                                The API object must be valid in the cluster; the Group and Kind must
+                                be registered in the cluster for this reference to be valid.
+
+                                References to objects with invalid Group and Kind are not valid, and must
+                                be rejected by the implementation, with appropriate Conditions set
+                                on the containing object.
+                              properties:
+                                group:
+                                  default: ""
+                                  description: |-
+                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                    When unspecified or empty string, core API group is inferred.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  default: Secret
+                                  description: Kind is kind of the referent. For example
+                                    "Secret".
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                                name:
+                                  description: Name is the name of the referent.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of the referenced object. When unspecified, the local
+                                    namespace is inferred.
+
+                                    Note that when a namespace different than the local namespace is specified,
+                                    a ReferenceGrant object is required in the referent namespace to allow that
+                                    namespace's owner to accept the reference. See the ReferenceGrant
+                                    documentation for details.
+
+                                    Support: Core
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            maxItems: 8
+                            minItems: 1
+                            type: array
+                        required:
+                        - refs
+                        type: object
                       optional:
                         description: |-
                           Optional set to true accepts connections even when a client doesn't present a certificate.
@@ -21364,8 +25923,38 @@ spec:
                       - name
                       type: object
                     conditions:
-                      description: Conditions describes the status of the Policy with
-                        respect to the given Ancestor.
+                      description: |-
+                        Conditions describes the status of the Policy with respect to the given Ancestor.
+
+                        <gateway:util:excludeFromCRD>
+
+                        Notes for implementors:
+
+                        Conditions are a listType `map`, which means that they function like a
+                        map with a key of the `type` field _in the k8s apiserver_.
+
+                        This means that implementations must obey some rules when updating this
+                        section.
+
+                        * Implementations MUST perform a read-modify-write cycle on this field
+                          before modifying it. That is, when modifying this field, implementations
+                          must be confident they have fetched the most recent version of this field,
+                          and ensure that changes they make are on that recent version.
+                        * Implementations MUST NOT remove or reorder Conditions that they are not
+                          directly responsible for. For example, if an implementation sees a Condition
+                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
+                          Condition.
+                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
+                          rather than creating more than one Condition of the same Type.
+                        * Implementations MUST always update the `observedGeneration` field of the
+                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
+                        * If the `observedGeneration` of a Condition is _greater than_ the value the
+                          implementation knows about, then it MUST NOT perform the update on that Condition,
+                          but must wait for a future reconciliation and status update. (The assumption is that
+                          the implementation's copy of the object is stale and an update will be re-triggered
+                          if relevant.)
+
+                        </gateway:util:excludeFromCRD>
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -21448,10 +26037,12 @@ spec:
                       type: string
                   required:
                   - ancestorRef
+                  - conditions
                   - controllerName
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - ancestors
             type: object
@@ -21464,13 +26055,13 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: envoyextensionpolicies.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -21672,6 +26263,26 @@ spec:
                             maximum: 65535
                             minimum: 1
                             type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
                         required:
                         - name
                         type: object
@@ -21768,6 +26379,41 @@ spec:
                                 For example, 20Mi, 1Gi, 256Ki etc.
                                 Note: that when the suffix is not provided, the value is interpreted as bytes.
                               x-kubernetes-int-or-string: true
+                            preconnect:
+                              description: |-
+                                Preconnect configures proactive upstream connections to reduce latency by establishing
+                                connections before they’re needed and avoiding connection establishment overhead.
+
+                                If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                              properties:
+                                perEndpointPercent:
+                                  description: |-
+                                    PerEndpointPercent configures how many additional connections to maintain per
+                                    upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                    percentage of the connections required by active streams
+                                    (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                    Allowed value range is between 100-300. When both PerEndpointPercent and
+                                    PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                  format: int32
+                                  maximum: 300
+                                  minimum: 100
+                                  type: integer
+                                predictivePercent:
+                                  description: |-
+                                    PredictivePercent configures how many additional connections to maintain
+                                    across the cluster by anticipating which upstream endpoint the load balancer
+                                    will select next, useful for low-QPS services. Relies on deterministic
+                                    loadbalancing and is only supported with Random or RoundRobin.
+                                    Expressed as a percentage of the connections required by active streams
+                                    (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                    Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                    set Envoy ensures both are satisfied per host (max of the two).
+                                  format: int32
+                                  minimum: 100
+                                  type: integer
+                              type: object
                             socketBufferLimit:
                               allOf:
                               - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -22060,7 +26706,6 @@ spec:
                                   format: int32
                                   type: integer
                                 consecutiveGatewayErrors:
-                                  default: 0
                                   description: ConsecutiveGatewayErrors sets the number
                                     of consecutive gateway errors triggering ejection.
                                   format: int32
@@ -22071,6 +26716,15 @@ spec:
                                     ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                     Parameter takes effect only when split_external_local_origin_errors is set to true.
                                   format: int32
+                                  type: integer
+                                failurePercentageThreshold:
+                                  description: |-
+                                    FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                    If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                    Defaults to 85.
+                                  format: int32
+                                  maximum: 100
+                                  minimum: 0
                                   type: integer
                                 interval:
                                   default: 3s
@@ -22172,8 +26826,10 @@ spec:
                                   - name
                                   type: object
                                 header:
-                                  description: Header configures the header hash policy
-                                    when the consistent hash type is set to Header.
+                                  description: |-
+                                    Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                    Deprecated: use Headers instead
                                   properties:
                                     name:
                                       description: Name of the header to hash.
@@ -22181,6 +26837,38 @@ spec:
                                   required:
                                   - name
                                   type: object
+                                headers:
+                                  description: Headers configures the header hash
+                                    policy for each header, when the consistent hash
+                                    type is set to Headers.
+                                  items:
+                                    description: |-
+                                      Header defines the header hashing configuration for consistent hash based
+                                      load balancing.
+                                    properties:
+                                      name:
+                                        description: Name of the header to hash.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                queryParams:
+                                  description: QueryParams configures the query parameter
+                                    hash policy when the consistent hash type is set
+                                    to QueryParams.
+                                  items:
+                                    description: |-
+                                      QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                      load balancing.
+                                    properties:
+                                      name:
+                                        description: Name of the query param to hash.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
                                 tableSize:
                                   default: 65537
                                   description: The table size for consistent hashing,
@@ -22194,11 +26882,15 @@ spec:
                                     ConsistentHashType defines the type of input to hash on. Valid Type values are
                                     "SourceIP",
                                     "Header",
+                                    "Headers",
                                     "Cookie".
+                                    "QueryParams".
                                   enum:
                                   - SourceIP
                                   - Header
+                                  - Headers
                                   - Cookie
+                                  - QueryParams
                                   type: string
                               required:
                               - type
@@ -22208,10 +26900,18 @@ spec:
                                   field must be set.
                                 rule: 'self.type == ''Header'' ? has(self.header)
                                   : !has(self.header)'
+                              - message: If consistent hash type is headers, the headers
+                                  field must be set.
+                                rule: 'self.type == ''Headers'' ? has(self.headers)
+                                  : !has(self.headers)'
                               - message: If consistent hash type is cookie, the cookie
                                   field must be set.
                                 rule: 'self.type == ''Cookie'' ? has(self.cookie)
                                   : !has(self.cookie)'
+                              - message: If consistent hash type is queryParams, the
+                                  queryParams field must be set.
+                                rule: 'self.type == ''QueryParams'' ? has(self.queryParams)
+                                  : !has(self.queryParams)'
                             endpointOverride:
                               description: |-
                                 EndpointOverride defines the configuration for endpoint override.
@@ -22298,6 +26998,15 @@ spec:
                                         number of total upstream endpoints across
                                         all zones required to enable zone-aware routing.
                                       format: int64
+                                      type: integer
+                                    percentageEnabled:
+                                      description: Configures percentage of requests
+                                        that will be considered for zone aware routing
+                                        if zone aware routing is configured. If not
+                                        specified, Envoy defaults to 100%.
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
                                       type: integer
                                   type: object
                               type: object
@@ -22466,6 +27175,14 @@ spec:
                                     Default: unlimited.
                                   pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                   type: string
+                                maxStreamDuration:
+                                  description: |-
+                                    MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                    from when the request is sent until the response stream is fully consumed and does not apply to
+                                    non-streaming requests.
+                                    When set to "0s", no max duration is applied and streams can run indefinitely.
+                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                  type: string
                                 requestTimeout:
                                   description: RequestTimeout is the time until which
                                     entire response is received from the upstream.
@@ -22484,6 +27201,13 @@ spec:
                               type: object
                           type: object
                       type: object
+                      x-kubernetes-validations:
+                      - message: predictivePercent in preconnect policy only works
+                          with RoundRobin or Random load balancers
+                        rule: '!((has(self.connection) && has(self.connection.preconnect)
+                          && has(self.connection.preconnect.predictivePercent)) &&
+                          !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                          && self.loadBalancer.type in [''Random'', ''RoundRobin'']))'
                     failOpen:
                       default: false
                       description: |-
@@ -23157,8 +27881,6 @@ spec:
             - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
               rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
                 ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''] : true'
-            - message: this policy does not yet support the sectionName field
-              rule: 'has(self.targetRef) ? !has(self.targetRef.sectionName) : true'
             - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group ==
                 ''gateway.networking.k8s.io'') : true '
@@ -23166,9 +27888,6 @@ spec:
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
                 ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
                 : true '
-            - message: this policy does not yet support the sectionName field
-              rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, !has(ref.sectionName))
-                : true'
           status:
             description: Status defines the current status of EnvoyExtensionPolicy.
             properties:
@@ -23374,8 +28093,38 @@ spec:
                       - name
                       type: object
                     conditions:
-                      description: Conditions describes the status of the Policy with
-                        respect to the given Ancestor.
+                      description: |-
+                        Conditions describes the status of the Policy with respect to the given Ancestor.
+
+                        <gateway:util:excludeFromCRD>
+
+                        Notes for implementors:
+
+                        Conditions are a listType `map`, which means that they function like a
+                        map with a key of the `type` field _in the k8s apiserver_.
+
+                        This means that implementations must obey some rules when updating this
+                        section.
+
+                        * Implementations MUST perform a read-modify-write cycle on this field
+                          before modifying it. That is, when modifying this field, implementations
+                          must be confident they have fetched the most recent version of this field,
+                          and ensure that changes they make are on that recent version.
+                        * Implementations MUST NOT remove or reorder Conditions that they are not
+                          directly responsible for. For example, if an implementation sees a Condition
+                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
+                          Condition.
+                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
+                          rather than creating more than one Condition of the same Type.
+                        * Implementations MUST always update the `observedGeneration` field of the
+                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
+                        * If the `observedGeneration` of a Condition is _greater than_ the value the
+                          implementation knows about, then it MUST NOT perform the update on that Condition,
+                          but must wait for a future reconciliation and status update. (The assumption is that
+                          the implementation's copy of the object is stale and an update will be re-triggered
+                          if relevant.)
+
+                        </gateway:util:excludeFromCRD>
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -23458,10 +28207,12 @@ spec:
                       type: string
                   required:
                   - ancestorRef
+                  - conditions
                   - controllerName
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - ancestors
             type: object
@@ -23474,13 +28225,13 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_envoypatchpolicies.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_envoypatchpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: envoypatchpolicies.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -23496,8 +28247,11 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Programmed")].reason
-      name: Status
+    - jsonPath: .status.ancestors[0].conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .status.ancestors[0].conditions[?(@.type=="Programmed")].status
+      name: Programmed
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -23852,8 +28606,38 @@ spec:
                       - name
                       type: object
                     conditions:
-                      description: Conditions describes the status of the Policy with
-                        respect to the given Ancestor.
+                      description: |-
+                        Conditions describes the status of the Policy with respect to the given Ancestor.
+
+                        <gateway:util:excludeFromCRD>
+
+                        Notes for implementors:
+
+                        Conditions are a listType `map`, which means that they function like a
+                        map with a key of the `type` field _in the k8s apiserver_.
+
+                        This means that implementations must obey some rules when updating this
+                        section.
+
+                        * Implementations MUST perform a read-modify-write cycle on this field
+                          before modifying it. That is, when modifying this field, implementations
+                          must be confident they have fetched the most recent version of this field,
+                          and ensure that changes they make are on that recent version.
+                        * Implementations MUST NOT remove or reorder Conditions that they are not
+                          directly responsible for. For example, if an implementation sees a Condition
+                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
+                          Condition.
+                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
+                          rather than creating more than one Condition of the same Type.
+                        * Implementations MUST always update the `observedGeneration` field of the
+                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
+                        * If the `observedGeneration` of a Condition is _greater than_ the value the
+                          implementation knows about, then it MUST NOT perform the update on that Condition,
+                          but must wait for a future reconciliation and status update. (The assumption is that
+                          the implementation's copy of the object is stale and an update will be re-triggered
+                          if relevant.)
+
+                        </gateway:util:excludeFromCRD>
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -23936,10 +28720,12 @@ spec:
                       type: string
                   required:
                   - ancestorRef
+                  - conditions
                   - controllerName
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - ancestors
             type: object
@@ -23952,13 +28738,13 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: envoyproxies.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -24012,17 +28798,16 @@ spec:
                       2. Other Routes: ALPN is disabled.
                       3. Backends: proxy uses the appropriate ALPN options for the backend protocol.
                       When an empty list is provided, the ALPN TLS extension is disabled.
-                      Supported values are:
+
+                      Defaults to [h2, http/1.1] if not specified.
+
+                      Typical Supported values are:
                       - http/1.0
                       - http/1.1
                       - h2
                     items:
                       description: ALPNProtocol specifies the protocol to be negotiated
                         using ALPN
-                      enum:
-                      - http/1.0
-                      - http/1.1
-                      - h2
                       type: string
                     type: array
                   ciphers:
@@ -24251,6 +29036,8 @@ spec:
 
                   - envoy.filters.http.ext_authz
 
+                  - envoy.filters.http.api_key_auth
+
                   - envoy.filters.http.basic_auth
 
                   - envoy.filters.http.oauth2
@@ -24258,6 +29045,8 @@ spec:
                   - envoy.filters.http.jwt_authn
 
                   - envoy.filters.http.stateful_session
+
+                  - envoy.filters.http.buffer
 
                   - envoy.filters.http.lua
 
@@ -24440,7 +29229,7 @@ spec:
               preserveRouteOrder:
                 description: |-
                   PreserveRouteOrder determines if the order of matching for HTTPRoutes is determined by Gateway-API
-                  specification (https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteRule)
+                  specification (https://gateway-api.sigs.k8s.io/reference/1.4/spec/#httprouterule)
                   or preserves the order defined by users in the HTTPRoute's HTTPRouteRule list.
                   Default: False
                 type: boolean
@@ -24450,6 +29239,19 @@ spec:
                   If unspecified, the "Kubernetes" resource provider is used with default configuration
                   parameters.
                 properties:
+                  host:
+                    description: |-
+                      Host provides runtime deployment of the data plane as a child process on the
+                      host environment.
+                      If unspecified and type is "Host", default settings for the custom provider
+                      are applied.
+                    properties:
+                      envoyVersion:
+                        description: |-
+                          EnvoyVersion is the version of Envoy to use. If unspecified, the version
+                          against which Envoy Gateway is built will be used.
+                        type: string
+                    type: object
                   kubernetes:
                     description: |-
                       Kubernetes defines the desired state of the Kubernetes resource provider.
@@ -24474,8 +29276,9 @@ spec:
                                     present in a Container.
                                   properties:
                                     name:
-                                      description: Name of the environment variable.
-                                        Must be a C_IDENTIFIER.
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
                                       type: string
                                     value:
                                       description: |-
@@ -24532,6 +29335,43 @@ spec:
                                               type: string
                                           required:
                                           - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fileKeyRef:
+                                          description: |-
+                                            FileKeyRef selects a key of the env file.
+                                            Requires the EnvFiles feature gate to be enabled.
+                                          properties:
+                                            key:
+                                              description: |-
+                                                The key within the env file. An invalid key will prevent the pod from starting.
+                                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                              type: string
+                                            optional:
+                                              default: false
+                                              description: |-
+                                                Specify whether the file or its key must be defined. If the file or key
+                                                does not exist, then the env var is not published.
+                                                If optional is set to true and the specified key does not exist,
+                                                the environment variable will not be set in the Pod's containers.
+
+                                                If optional is set to false and the specified key does not exist,
+                                                an error will be returned during Pod creation.
+                                              type: boolean
+                                            path:
+                                              description: |-
+                                                The path within the volume from which to select the file.
+                                                Must be relative and may not contain the '..' path or start with '..'.
+                                              type: string
+                                            volumeName:
+                                              description: The name of the volume
+                                                mount containing the env file.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          - volumeName
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
@@ -24620,7 +29460,7 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-                                      This is an alpha field and requires enabling the
+                                      This field depends on the
                                       DynamicResourceAllocation feature gate.
 
                                       This field is immutable. It can only be set for containers.
@@ -25548,8 +30388,8 @@ spec:
                                           most preferred is the one with the greatest sum of weights, i.e.
                                           for each node that meets all of the scheduling requirements (resource
                                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                          compute a sum by iterating through the elements of this field and adding
-                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          compute a sum by iterating through the elements of this field and subtracting
+                                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                           node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
@@ -25946,6 +30786,12 @@ spec:
                                   Selector which must match a node's labels for the pod to be scheduled on that node.
                                   More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                 type: object
+                              priorityClassName:
+                                description: |-
+                                  PriorityClassName indicates the importance of a Pod relative to other Pods.
+                                  If a PriorityClassName is not specified, the pod priority will be default or zero if there is no default.
+                                  More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+                                type: string
                               securityContext:
                                 description: |-
                                   SecurityContext holds pod-level security attributes and common container settings.
@@ -26201,9 +31047,10 @@ spec:
                                     operator:
                                       description: |-
                                         Operator represents a key's relationship to the value.
-                                        Valid operators are Exists and Equal. Defaults to Equal.
+                                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                         Exists is equivalent to wildcard for value, so that a pod can
                                         tolerate all taints of a particular category.
+                                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                       type: string
                                     tolerationSeconds:
                                       description: |-
@@ -27003,7 +31850,7 @@ spec:
                                                 resources:
                                                   description: |-
                                                     resources represents the minimum resources the volume should have.
-                                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                    Users are allowed to specify resource requirements
                                                     that are lower than previous value but must still be higher than capacity recorded in the
                                                     status field of the claim.
                                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -27094,15 +31941,13 @@ spec:
                                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                                    will be set by the persistentvolume controller if it exists.
+                                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                                    this field can be reset to its previous value (including nil) to cancel the modification.
                                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                                     exists.
                                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                                   type: string
                                                 volumeMode:
                                                   description: |-
@@ -27287,12 +32132,10 @@ spec:
                                       description: |-
                                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                       properties:
                                         endpoints:
-                                          description: |-
-                                            endpoints is the endpoint name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                          description: endpoints is the endpoint name
+                                            that details Glusterfs topology.
                                           type: string
                                         path:
                                           description: |-
@@ -27371,7 +32214,7 @@ spec:
                                       description: |-
                                         iscsi represents an ISCSI Disk resource that is attached to a
                                         kubelet's host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                                       properties:
                                         chapAuthDiscovery:
                                           description: chapAuthDiscovery defines whether
@@ -27815,6 +32658,130 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 type: object
+                                              podCertificate:
+                                                description: |-
+                                                  Projects an auto-rotating credential bundle (private key and certificate
+                                                  chain) that the pod can use either as a TLS client or server.
+
+                                                  Kubelet generates a private key and uses it to send a
+                                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                                  request and issues a certificate chain, Kubelet writes the key and
+                                                  certificate chain to the pod filesystem.  The pod does not start until
+                                                  certificates have been issued for each podCertificate projected volume
+                                                  source in its spec.
+
+                                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                                  timestamp.
+
+                                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                                  field, or separate files, indicated by the keyPath and
+                                                  certificateChainPath fields.
+
+                                                  The credential bundle is a single file in PEM format.  The first PEM
+                                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                                  entries are the certificate chain issued by the signer (typically,
+                                                  signers will return their certificate chain in leaf-to-root order).
+
+                                                  Prefer using the credential bundle format, since your application code
+                                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                                  your application must make two separate file reads. If these coincide
+                                                  with a certificate rotation, it is possible that the private key and leaf
+                                                  certificate you read may not correspond to each other.  Your application
+                                                  will need to check for this condition, and re-read until they are
+                                                  consistent.
+
+                                                  The named signer controls chooses the format of the certificate it
+                                                  issues; consult the signer implementation's documentation to learn how to
+                                                  use the certificates it issues.
+                                                properties:
+                                                  certificateChainPath:
+                                                    description: |-
+                                                      Write the certificate chain at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    description: |-
+                                                      Write the credential bundle at this path in the projected volume.
+
+                                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                      key.
+
+                                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                      certificate chain from the signer (leaf and any intermediates).
+
+                                                      Using credentialBundlePath lets your Pod's application code make a single
+                                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                                      project them to separate files, your application code will need to
+                                                      additionally check that the leaf certificate was issued to the key.
+                                                    type: string
+                                                  keyPath:
+                                                    description: |-
+                                                      Write the key at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  keyType:
+                                                    description: |-
+                                                      The type of keypair Kubelet will generate for the pod.
+
+                                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                      "ECDSAP521", and "ED25519".
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    description: |-
+                                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                                      certificate.
+
+                                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                      generates for this projection.
+
+                                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                      value is 7862400 (91 days).
+
+                                                      The signer implementation is then free to issue a certificate with any
+                                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                                      longer than 24 hours.
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    description: Kubelet's generated
+                                                      CSRs will be addressed to this
+                                                      signer.
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      userAnnotations allow pod authors to pass additional information to
+                                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                                      metadata in any way.
+
+                                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                                      Entries are subject to the same validation as object metadata annotations,
+                                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                                      are placed on values, except an overall size limitation on the entire field.
+
+                                                      Signers should document the keys and values they support. Signers should
+                                                      deny requests that contain keys they do not recognize.
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
                                               secret:
                                                 description: secret information about
                                                   the secret data to project
@@ -27952,7 +32919,6 @@ spec:
                                       description: |-
                                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md
                                       properties:
                                         fsType:
                                           description: |-
@@ -28268,7 +33234,7 @@ spec:
                                       pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
                                       on that node is marked deleted. If the old pod becomes unavailable for any
                                       reason (Ready transitions to false, is evicted, or is drained) an updated
-                                      pod is immediatedly created on that node without considering surge limits.
+                                      pod is immediately created on that node without considering surge limits.
                                       Allowing surge implies the possibility that the resources consumed by the
                                       daemonset on any given node can double if the readiness check fails, and
                                       so resource intensive daemonsets should take into account that they may
@@ -28319,8 +33285,9 @@ spec:
                                     present in a Container.
                                   properties:
                                     name:
-                                      description: Name of the environment variable.
-                                        Must be a C_IDENTIFIER.
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
                                       type: string
                                     value:
                                       description: |-
@@ -28377,6 +33344,43 @@ spec:
                                               type: string
                                           required:
                                           - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fileKeyRef:
+                                          description: |-
+                                            FileKeyRef selects a key of the env file.
+                                            Requires the EnvFiles feature gate to be enabled.
+                                          properties:
+                                            key:
+                                              description: |-
+                                                The key within the env file. An invalid key will prevent the pod from starting.
+                                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                              type: string
+                                            optional:
+                                              default: false
+                                              description: |-
+                                                Specify whether the file or its key must be defined. If the file or key
+                                                does not exist, then the env var is not published.
+                                                If optional is set to true and the specified key does not exist,
+                                                the environment variable will not be set in the Pod's containers.
+
+                                                If optional is set to false and the specified key does not exist,
+                                                an error will be returned during Pod creation.
+                                              type: boolean
+                                            path:
+                                              description: |-
+                                                The path within the volume from which to select the file.
+                                                Must be relative and may not contain the '..' path or start with '..'.
+                                              type: string
+                                            volumeName:
+                                              description: The name of the volume
+                                                mount containing the env file.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          - volumeName
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
@@ -28465,7 +33469,7 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-                                      This is an alpha field and requires enabling the
+                                      This field depends on the
                                       DynamicResourceAllocation feature gate.
 
                                       This field is immutable. It can only be set for containers.
@@ -28827,8 +33831,9 @@ spec:
                                       variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
                                         type: string
                                       value:
                                         description: |-
@@ -28885,6 +33890,43 @@ spec:
                                                 type: string
                                             required:
                                             - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
@@ -28950,8 +33992,8 @@ spec:
                                 envFrom:
                                   description: |-
                                     List of sources to populate environment variables in the container.
-                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container is starting. When a key exists in multiple
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    When a key exists in multiple
                                     sources, the value associated with the last source will take precedence.
                                     Values defined by an Env with a duplicate key will take precedence.
                                     Cannot be updated.
@@ -28978,9 +34020,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: Optional text to prepend to the
-                                          name of each environment variable. Must
-                                          be a C_IDENTIFIER.
+                                        description: |-
+                                          Optional text to prepend to the name of each environment variable.
+                                          May consist of any printable ASCII characters except '='.
                                         type: string
                                       secretRef:
                                         description: The Secret to select from
@@ -29635,7 +34677,9 @@ spec:
                                       type: integer
                                   type: object
                                 resizePolicy:
-                                  description: Resources resize policy for the container.
+                                  description: |-
+                                    Resources resize policy for the container.
+                                    This field cannot be set on ephemeral containers.
                                   items:
                                     description: ContainerResizePolicy represents
                                       resource resize policy for the container.
@@ -29667,7 +34711,7 @@ spec:
                                         Claims lists the names of resources, defined in spec.resourceClaims,
                                         that are used by this container.
 
-                                        This is an alpha field and requires enabling the
+                                        This field depends on the
                                         DynamicResourceAllocation feature gate.
 
                                         This field is immutable. It can only be set for containers.
@@ -29722,10 +34766,10 @@ spec:
                                 restartPolicy:
                                   description: |-
                                     RestartPolicy defines the restart behavior of individual containers in a pod.
-                                    This field may only be set for init containers, and the only allowed value is "Always".
-                                    For non-init containers or when this field is not specified,
+                                    This overrides the pod-level restart policy. When this field is not specified,
                                     the restart behavior is defined by the Pod's restart policy and the container type.
-                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                    Additionally, setting the RestartPolicy as "Always" for the init container will
+                                    have the following effect:
                                     this init container will be continually restarted on
                                     exit until all regular containers have terminated. Once all regular
                                     containers have completed, all init containers with restartPolicy "Always"
@@ -29737,6 +34781,59 @@ spec:
                                     init container is started, or after any startupProbe has successfully
                                     completed.
                                   type: string
+                                restartPolicyRules:
+                                  description: |-
+                                    Represents a list of rules to be checked to determine if the
+                                    container should be restarted on exit. The rules are evaluated in
+                                    order. Once a rule matches a container exit condition, the remaining
+                                    rules are ignored. If no rule matches the container exit condition,
+                                    the Container-level restart policy determines the whether the container
+                                    is restarted or not. Constraints on the rules:
+                                    - At most 20 rules are allowed.
+                                    - Rules can have the same action.
+                                    - Identical rules are not forbidden in validations.
+                                    When rules are specified, container MUST set RestartPolicy explicitly
+                                    even it if matches the Pod's RestartPolicy.
+                                  items:
+                                    description: ContainerRestartRule describes how
+                                      a container exit is handled.
+                                    properties:
+                                      action:
+                                        description: |-
+                                          Specifies the action taken on a container exit if the requirements
+                                          are satisfied. The only possible value is "Restart" to restart the
+                                          container.
+                                        type: string
+                                      exitCodes:
+                                        description: Represents the exit codes to
+                                          check on container exits.
+                                        properties:
+                                          operator:
+                                            description: |-
+                                              Represents the relationship between the container exit code(s) and the
+                                              specified values. Possible values are:
+                                              - In: the requirement is satisfied if the container exit code is in the
+                                                set of specified values.
+                                              - NotIn: the requirement is satisfied if the container exit code is
+                                                not in the set of specified values.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              Specifies the set of values to check for container exit codes.
+                                              At most 255 elements are allowed.
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 securityContext:
                                   description: |-
                                     SecurityContext defines the security options the container should be run with.
@@ -30851,8 +35948,8 @@ spec:
                                           most preferred is the one with the greatest sum of weights, i.e.
                                           for each node that meets all of the scheduling requirements (resource
                                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                          compute a sum by iterating through the elements of this field and adding
-                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          compute a sum by iterating through the elements of this field and subtracting
+                                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                           node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
@@ -31249,6 +36346,12 @@ spec:
                                   Selector which must match a node's labels for the pod to be scheduled on that node.
                                   More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                 type: object
+                              priorityClassName:
+                                description: |-
+                                  PriorityClassName indicates the importance of a Pod relative to other Pods.
+                                  If a PriorityClassName is not specified, the pod priority will be default or zero if there is no default.
+                                  More info: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+                                type: string
                               securityContext:
                                 description: |-
                                   SecurityContext holds pod-level security attributes and common container settings.
@@ -31504,9 +36607,10 @@ spec:
                                     operator:
                                       description: |-
                                         Operator represents a key's relationship to the value.
-                                        Valid operators are Exists and Equal. Defaults to Equal.
+                                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                         Exists is equivalent to wildcard for value, so that a pod can
                                         tolerate all taints of a particular category.
+                                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                       type: string
                                     tolerationSeconds:
                                       description: |-
@@ -32306,7 +37410,7 @@ spec:
                                                 resources:
                                                   description: |-
                                                     resources represents the minimum resources the volume should have.
-                                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                    Users are allowed to specify resource requirements
                                                     that are lower than previous value but must still be higher than capacity recorded in the
                                                     status field of the claim.
                                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -32397,15 +37501,13 @@ spec:
                                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                                    will be set by the persistentvolume controller if it exists.
+                                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                                    this field can be reset to its previous value (including nil) to cancel the modification.
                                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                                     exists.
                                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                                   type: string
                                                 volumeMode:
                                                   description: |-
@@ -32590,12 +37692,10 @@ spec:
                                       description: |-
                                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                       properties:
                                         endpoints:
-                                          description: |-
-                                            endpoints is the endpoint name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                          description: endpoints is the endpoint name
+                                            that details Glusterfs topology.
                                           type: string
                                         path:
                                           description: |-
@@ -32674,7 +37774,7 @@ spec:
                                       description: |-
                                         iscsi represents an ISCSI Disk resource that is attached to a
                                         kubelet's host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
                                       properties:
                                         chapAuthDiscovery:
                                           description: chapAuthDiscovery defines whether
@@ -33118,6 +38218,130 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 type: object
+                                              podCertificate:
+                                                description: |-
+                                                  Projects an auto-rotating credential bundle (private key and certificate
+                                                  chain) that the pod can use either as a TLS client or server.
+
+                                                  Kubelet generates a private key and uses it to send a
+                                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                                  request and issues a certificate chain, Kubelet writes the key and
+                                                  certificate chain to the pod filesystem.  The pod does not start until
+                                                  certificates have been issued for each podCertificate projected volume
+                                                  source in its spec.
+
+                                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                                  timestamp.
+
+                                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                                  field, or separate files, indicated by the keyPath and
+                                                  certificateChainPath fields.
+
+                                                  The credential bundle is a single file in PEM format.  The first PEM
+                                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                                  entries are the certificate chain issued by the signer (typically,
+                                                  signers will return their certificate chain in leaf-to-root order).
+
+                                                  Prefer using the credential bundle format, since your application code
+                                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                                  your application must make two separate file reads. If these coincide
+                                                  with a certificate rotation, it is possible that the private key and leaf
+                                                  certificate you read may not correspond to each other.  Your application
+                                                  will need to check for this condition, and re-read until they are
+                                                  consistent.
+
+                                                  The named signer controls chooses the format of the certificate it
+                                                  issues; consult the signer implementation's documentation to learn how to
+                                                  use the certificates it issues.
+                                                properties:
+                                                  certificateChainPath:
+                                                    description: |-
+                                                      Write the certificate chain at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    description: |-
+                                                      Write the credential bundle at this path in the projected volume.
+
+                                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                      key.
+
+                                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                      certificate chain from the signer (leaf and any intermediates).
+
+                                                      Using credentialBundlePath lets your Pod's application code make a single
+                                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                                      project them to separate files, your application code will need to
+                                                      additionally check that the leaf certificate was issued to the key.
+                                                    type: string
+                                                  keyPath:
+                                                    description: |-
+                                                      Write the key at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  keyType:
+                                                    description: |-
+                                                      The type of keypair Kubelet will generate for the pod.
+
+                                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                      "ECDSAP521", and "ED25519".
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    description: |-
+                                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                                      certificate.
+
+                                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                      generates for this projection.
+
+                                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                      value is 7862400 (91 days).
+
+                                                      The signer implementation is then free to issue a certificate with any
+                                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                                      longer than 24 hours.
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    description: Kubelet's generated
+                                                      CSRs will be addressed to this
+                                                      signer.
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      userAnnotations allow pod authors to pass additional information to
+                                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                                      metadata in any way.
+
+                                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                                      Entries are subject to the same validation as object metadata annotations,
+                                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                                      are placed on values, except an overall size limitation on the entire field.
+
+                                                      Signers should document the keys and values they support. Signers should
+                                                      deny requests that contain keys they do not recognize.
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
                                               secret:
                                                 description: secret information about
                                                   the secret data to project
@@ -33255,7 +38479,6 @@ spec:
                                       description: |-
                                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md
                                       properties:
                                         fsType:
                                           description: |-
@@ -33680,8 +38903,8 @@ spec:
                                       and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
                                       triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
 
-                                      This is an alpha field and requires enabling the HPAConfigurableTolerance
-                                      feature gate.
+                                      This is an beta field and requires the HPAConfigurableTolerance feature
+                                      gate to be enabled.
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
@@ -33756,8 +38979,8 @@ spec:
                                       and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
                                       triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
 
-                                      This is an alpha field and requires enabling the HPAConfigurableTolerance
-                                      feature gate.
+                                      This is an beta field and requires the HPAConfigurableTolerance feature
+                                      gate to be enabled.
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
@@ -34480,10 +39703,10 @@ spec:
                     description: |-
                       Type is the type of resource provider to use. A resource provider provides
                       infrastructure resources for running the data plane, e.g. Envoy proxy, and
-                      optional auxiliary control planes. Supported types are "Kubernetes".
+                      optional auxiliary control planes. Supported types are "Kubernetes"and "Host".
                     enum:
                     - Kubernetes
-                    - Custom
+                    - Host
                     type: string
                 required:
                 - type
@@ -34550,8 +39773,9 @@ spec:
                                     The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information.
                                   type: string
                                 type:
-                                  description: Type defines the type of accesslog
-                                    format.
+                                  description: |-
+                                    Type defines the type of accesslog format.
+                                    When unset, both text and json can be specified.
                                   enum:
                                   - Text
                                   - JSON
@@ -34560,10 +39784,24 @@ spec:
                               x-kubernetes-validations:
                               - message: If AccessLogFormat type is Text, text field
                                   needs to be set.
-                                rule: 'self.type == ''Text'' ? has(self.text) : !has(self.text)'
+                                rule: 'has(self.type) && self.type == ''Text'' ? has(self.text)
+                                  : true'
+                              - message: If AccessLogFormat type is Text, json field
+                                  must not be set.
+                                rule: 'has(self.type) && self.type == ''Text'' ? !has(self.json)
+                                  : true'
                               - message: If AccessLogFormat type is JSON, json field
                                   needs to be set.
-                                rule: 'self.type == ''JSON'' ? has(self.json) : !has(self.json)'
+                                rule: 'has(self.type) && self.type == ''JSON'' ? has(self.json)
+                                  : true'
+                              - message: If AccessLogFormat type is JSON, text field
+                                  must not be set.
+                                rule: 'has(self.type) && self.type == ''JSON'' ? !has(self.text)
+                                  : true'
+                              - message: If AccessLogFormat type is unset, at least
+                                  one of text or json must be set.
+                                rule: '!has(self.type) ? (has(self.text) || has(self.json))
+                                  : true'
                             matches:
                               description: |-
                                 Matches defines the match conditions for accesslog in CEL expression.
@@ -34735,6 +39973,26 @@ spec:
                                               maximum: 65535
                                               minimum: 1
                                               type: integer
+                                            weight:
+                                              default: 1
+                                              description: |-
+                                                Weight specifies the proportion of requests forwarded to the referenced
+                                                backend. This is computed as weight/(sum of all weights in this
+                                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                                the exact proportion defined here depending on the precision an
+                                                implementation supports. Weight is not a percentage and the sum of
+                                                weights does not need to equal 100.
+
+                                                If only one backend is specified and it has a weight greater than 0, 100%
+                                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                                traffic should be forwarded for this entry. If unspecified, weight
+                                                defaults to 1.
+
+                                                Support for this field varies based on the context where used.
+                                              format: int32
+                                              maximum: 1000000
+                                              minimum: 0
+                                              type: integer
                                           required:
                                           - name
                                           type: object
@@ -34838,6 +40096,41 @@ spec:
                                                   For example, 20Mi, 1Gi, 256Ki etc.
                                                   Note: that when the suffix is not provided, the value is interpreted as bytes.
                                                 x-kubernetes-int-or-string: true
+                                              preconnect:
+                                                description: |-
+                                                  Preconnect configures proactive upstream connections to reduce latency by establishing
+                                                  connections before they’re needed and avoiding connection establishment overhead.
+
+                                                  If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                                properties:
+                                                  perEndpointPercent:
+                                                    description: |-
+                                                      PerEndpointPercent configures how many additional connections to maintain per
+                                                      upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                                      percentage of the connections required by active streams
+                                                      (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                                      Allowed value range is between 100-300. When both PerEndpointPercent and
+                                                      PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                                    format: int32
+                                                    maximum: 300
+                                                    minimum: 100
+                                                    type: integer
+                                                  predictivePercent:
+                                                    description: |-
+                                                      PredictivePercent configures how many additional connections to maintain
+                                                      across the cluster by anticipating which upstream endpoint the load balancer
+                                                      will select next, useful for low-QPS services. Relies on deterministic
+                                                      loadbalancing and is only supported with Random or RoundRobin.
+                                                      Expressed as a percentage of the connections required by active streams
+                                                      (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                                      Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                                      set Envoy ensures both are satisfied per host (max of the two).
+                                                    format: int32
+                                                    minimum: 100
+                                                    type: integer
+                                                type: object
                                               socketBufferLimit:
                                                 allOf:
                                                 - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -35163,7 +40456,6 @@ spec:
                                                     format: int32
                                                     type: integer
                                                   consecutiveGatewayErrors:
-                                                    default: 0
                                                     description: ConsecutiveGatewayErrors
                                                       sets the number of consecutive
                                                       gateway errors triggering ejection.
@@ -35175,6 +40467,15 @@ spec:
                                                       ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                                       Parameter takes effect only when split_external_local_origin_errors is set to true.
                                                     format: int32
+                                                    type: integer
+                                                  failurePercentageThreshold:
+                                                    description: |-
+                                                      FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                                      If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                                      Defaults to 85.
+                                                    format: int32
+                                                    maximum: 100
+                                                    minimum: 0
                                                     type: integer
                                                   interval:
                                                     default: 3s
@@ -35282,10 +40583,10 @@ spec:
                                                     - name
                                                     type: object
                                                   header:
-                                                    description: Header configures
-                                                      the header hash policy when
-                                                      the consistent hash type is
-                                                      set to Header.
+                                                    description: |-
+                                                      Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                                      Deprecated: use Headers instead
                                                     properties:
                                                       name:
                                                         description: Name of the header
@@ -35294,6 +40595,42 @@ spec:
                                                     required:
                                                     - name
                                                     type: object
+                                                  headers:
+                                                    description: Headers configures
+                                                      the header hash policy for each
+                                                      header, when the consistent
+                                                      hash type is set to Headers.
+                                                    items:
+                                                      description: |-
+                                                        Header defines the header hashing configuration for consistent hash based
+                                                        load balancing.
+                                                      properties:
+                                                        name:
+                                                          description: Name of the
+                                                            header to hash.
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                  queryParams:
+                                                    description: QueryParams configures
+                                                      the query parameter hash policy
+                                                      when the consistent hash type
+                                                      is set to QueryParams.
+                                                    items:
+                                                      description: |-
+                                                        QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                                        load balancing.
+                                                      properties:
+                                                        name:
+                                                          description: Name of the
+                                                            query param to hash.
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
                                                   tableSize:
                                                     default: 65537
                                                     description: The table size for
@@ -35308,11 +40645,15 @@ spec:
                                                       ConsistentHashType defines the type of input to hash on. Valid Type values are
                                                       "SourceIP",
                                                       "Header",
+                                                      "Headers",
                                                       "Cookie".
+                                                      "QueryParams".
                                                     enum:
                                                     - SourceIP
                                                     - Header
+                                                    - Headers
                                                     - Cookie
+                                                    - QueryParams
                                                     type: string
                                                 required:
                                                 - type
@@ -35324,10 +40665,20 @@ spec:
                                                   rule: 'self.type == ''Header'' ?
                                                     has(self.header) : !has(self.header)'
                                                 - message: If consistent hash type
+                                                    is headers, the headers field
+                                                    must be set.
+                                                  rule: 'self.type == ''Headers''
+                                                    ? has(self.headers) : !has(self.headers)'
+                                                - message: If consistent hash type
                                                     is cookie, the cookie field must
                                                     be set.
                                                   rule: 'self.type == ''Cookie'' ?
                                                     has(self.cookie) : !has(self.cookie)'
+                                                - message: If consistent hash type
+                                                    is queryParams, the queryParams
+                                                    field must be set.
+                                                  rule: 'self.type == ''QueryParams''
+                                                    ? has(self.queryParams) : !has(self.queryParams)'
                                               endpointOverride:
                                                 description: |-
                                                   EndpointOverride defines the configuration for endpoint override.
@@ -35420,6 +40771,17 @@ spec:
                                                           across all zones required
                                                           to enable zone-aware routing.
                                                         format: int64
+                                                        type: integer
+                                                      percentageEnabled:
+                                                        description: Configures percentage
+                                                          of requests that will be
+                                                          considered for zone aware
+                                                          routing if zone aware routing
+                                                          is configured. If not specified,
+                                                          Envoy defaults to 100%.
+                                                        format: int32
+                                                        maximum: 100
+                                                        minimum: 0
                                                         type: integer
                                                     type: object
                                                 type: object
@@ -35597,6 +40959,14 @@ spec:
                                                       Default: unlimited.
                                                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                     type: string
+                                                  maxStreamDuration:
+                                                    description: |-
+                                                      MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                                      from when the request is sent until the response stream is fully consumed and does not apply to
+                                                      non-streaming requests.
+                                                      When set to "0s", no max duration is applied and streams can run indefinitely.
+                                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                                    type: string
                                                   requestTimeout:
                                                     description: RequestTimeout is
                                                       the time until which entire
@@ -35618,6 +40988,15 @@ spec:
                                                 type: object
                                             type: object
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: predictivePercent in preconnect
+                                            policy only works with RoundRobin or Random
+                                            load balancers
+                                          rule: '!((has(self.connection) && has(self.connection.preconnect)
+                                            && has(self.connection.preconnect.predictivePercent))
+                                            && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                                            && self.loadBalancer.type in [''Random'',
+                                            ''RoundRobin'']))'
                                       http:
                                         description: HTTP defines additional configuration
                                           specific to HTTP access logs.
@@ -35846,6 +41225,26 @@ spec:
                                               maximum: 65535
                                               minimum: 1
                                               type: integer
+                                            weight:
+                                              default: 1
+                                              description: |-
+                                                Weight specifies the proportion of requests forwarded to the referenced
+                                                backend. This is computed as weight/(sum of all weights in this
+                                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                                the exact proportion defined here depending on the precision an
+                                                implementation supports. Weight is not a percentage and the sum of
+                                                weights does not need to equal 100.
+
+                                                If only one backend is specified and it has a weight greater than 0, 100%
+                                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                                traffic should be forwarded for this entry. If unspecified, weight
+                                                defaults to 1.
+
+                                                Support for this field varies based on the context where used.
+                                              format: int32
+                                              maximum: 1000000
+                                              minimum: 0
+                                              type: integer
                                           required:
                                           - name
                                           type: object
@@ -35949,6 +41348,41 @@ spec:
                                                   For example, 20Mi, 1Gi, 256Ki etc.
                                                   Note: that when the suffix is not provided, the value is interpreted as bytes.
                                                 x-kubernetes-int-or-string: true
+                                              preconnect:
+                                                description: |-
+                                                  Preconnect configures proactive upstream connections to reduce latency by establishing
+                                                  connections before they’re needed and avoiding connection establishment overhead.
+
+                                                  If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                                properties:
+                                                  perEndpointPercent:
+                                                    description: |-
+                                                      PerEndpointPercent configures how many additional connections to maintain per
+                                                      upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                                      percentage of the connections required by active streams
+                                                      (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                                      Allowed value range is between 100-300. When both PerEndpointPercent and
+                                                      PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                                    format: int32
+                                                    maximum: 300
+                                                    minimum: 100
+                                                    type: integer
+                                                  predictivePercent:
+                                                    description: |-
+                                                      PredictivePercent configures how many additional connections to maintain
+                                                      across the cluster by anticipating which upstream endpoint the load balancer
+                                                      will select next, useful for low-QPS services. Relies on deterministic
+                                                      loadbalancing and is only supported with Random or RoundRobin.
+                                                      Expressed as a percentage of the connections required by active streams
+                                                      (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                                      Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                                      set Envoy ensures both are satisfied per host (max of the two).
+                                                    format: int32
+                                                    minimum: 100
+                                                    type: integer
+                                                type: object
                                               socketBufferLimit:
                                                 allOf:
                                                 - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -36274,7 +41708,6 @@ spec:
                                                     format: int32
                                                     type: integer
                                                   consecutiveGatewayErrors:
-                                                    default: 0
                                                     description: ConsecutiveGatewayErrors
                                                       sets the number of consecutive
                                                       gateway errors triggering ejection.
@@ -36286,6 +41719,15 @@ spec:
                                                       ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                                       Parameter takes effect only when split_external_local_origin_errors is set to true.
                                                     format: int32
+                                                    type: integer
+                                                  failurePercentageThreshold:
+                                                    description: |-
+                                                      FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                                      If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                                      Defaults to 85.
+                                                    format: int32
+                                                    maximum: 100
+                                                    minimum: 0
                                                     type: integer
                                                   interval:
                                                     default: 3s
@@ -36393,10 +41835,10 @@ spec:
                                                     - name
                                                     type: object
                                                   header:
-                                                    description: Header configures
-                                                      the header hash policy when
-                                                      the consistent hash type is
-                                                      set to Header.
+                                                    description: |-
+                                                      Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                                      Deprecated: use Headers instead
                                                     properties:
                                                       name:
                                                         description: Name of the header
@@ -36405,6 +41847,42 @@ spec:
                                                     required:
                                                     - name
                                                     type: object
+                                                  headers:
+                                                    description: Headers configures
+                                                      the header hash policy for each
+                                                      header, when the consistent
+                                                      hash type is set to Headers.
+                                                    items:
+                                                      description: |-
+                                                        Header defines the header hashing configuration for consistent hash based
+                                                        load balancing.
+                                                      properties:
+                                                        name:
+                                                          description: Name of the
+                                                            header to hash.
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                  queryParams:
+                                                    description: QueryParams configures
+                                                      the query parameter hash policy
+                                                      when the consistent hash type
+                                                      is set to QueryParams.
+                                                    items:
+                                                      description: |-
+                                                        QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                                        load balancing.
+                                                      properties:
+                                                        name:
+                                                          description: Name of the
+                                                            query param to hash.
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
                                                   tableSize:
                                                     default: 65537
                                                     description: The table size for
@@ -36419,11 +41897,15 @@ spec:
                                                       ConsistentHashType defines the type of input to hash on. Valid Type values are
                                                       "SourceIP",
                                                       "Header",
+                                                      "Headers",
                                                       "Cookie".
+                                                      "QueryParams".
                                                     enum:
                                                     - SourceIP
                                                     - Header
+                                                    - Headers
                                                     - Cookie
+                                                    - QueryParams
                                                     type: string
                                                 required:
                                                 - type
@@ -36435,10 +41917,20 @@ spec:
                                                   rule: 'self.type == ''Header'' ?
                                                     has(self.header) : !has(self.header)'
                                                 - message: If consistent hash type
+                                                    is headers, the headers field
+                                                    must be set.
+                                                  rule: 'self.type == ''Headers''
+                                                    ? has(self.headers) : !has(self.headers)'
+                                                - message: If consistent hash type
                                                     is cookie, the cookie field must
                                                     be set.
                                                   rule: 'self.type == ''Cookie'' ?
                                                     has(self.cookie) : !has(self.cookie)'
+                                                - message: If consistent hash type
+                                                    is queryParams, the queryParams
+                                                    field must be set.
+                                                  rule: 'self.type == ''QueryParams''
+                                                    ? has(self.queryParams) : !has(self.queryParams)'
                                               endpointOverride:
                                                 description: |-
                                                   EndpointOverride defines the configuration for endpoint override.
@@ -36531,6 +42023,17 @@ spec:
                                                           across all zones required
                                                           to enable zone-aware routing.
                                                         format: int64
+                                                        type: integer
+                                                      percentageEnabled:
+                                                        description: Configures percentage
+                                                          of requests that will be
+                                                          considered for zone aware
+                                                          routing if zone aware routing
+                                                          is configured. If not specified,
+                                                          Envoy defaults to 100%.
+                                                        format: int32
+                                                        maximum: 100
+                                                        minimum: 0
                                                         type: integer
                                                     type: object
                                                 type: object
@@ -36708,6 +42211,14 @@ spec:
                                                       Default: unlimited.
                                                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                                     type: string
+                                                  maxStreamDuration:
+                                                    description: |-
+                                                      MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                                      from when the request is sent until the response stream is fully consumed and does not apply to
+                                                      non-streaming requests.
+                                                      When set to "0s", no max duration is applied and streams can run indefinitely.
+                                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                                    type: string
                                                   requestTimeout:
                                                     description: RequestTimeout is
                                                       the time until which entire
@@ -36729,6 +42240,51 @@ spec:
                                                 type: object
                                             type: object
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: predictivePercent in preconnect
+                                            policy only works with RoundRobin or Random
+                                            load balancers
+                                          rule: '!((has(self.connection) && has(self.connection.preconnect)
+                                            && has(self.connection.preconnect.predictivePercent))
+                                            && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                                            && self.loadBalancer.type in [''Random'',
+                                            ''RoundRobin'']))'
+                                      headers:
+                                        description: |-
+                                          Headers is a list of additional headers to send with OTLP export requests.
+                                          These headers are added as gRPC initial metadata for the OTLP gRPC service.
+                                        items:
+                                          description: HTTPHeader represents an HTTP
+                                            Header name and value as defined by RFC
+                                            7230.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                                If multiple entries specify equivalent header names, the first entry with
+                                                an equivalent name MUST be considered for a match. Subsequent entries
+                                                with an equivalent header name MUST be ignored. Due to the
+                                                case-insensitivity of header names, "foo" and "Foo" are considered
+                                                equivalent.
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                              type: string
+                                            value:
+                                              description: Value is the value of HTTP
+                                                Header to be matched.
+                                              maxLength: 4096
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        maxItems: 32
+                                        minItems: 1
+                                        type: array
                                       host:
                                         description: |-
                                           Host define the extension service hostname.
@@ -36742,12 +42298,21 @@ spec:
                                         format: int32
                                         minimum: 0
                                         type: integer
+                                      resourceAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          ResourceAttributes is a set of labels that describe the source of a log entry, including envoy node info.
+                                          It's recommended to follow [semantic conventions](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/).
+                                        type: object
                                       resources:
                                         additionalProperties:
                                           type: string
                                         description: |-
                                           Resources is a set of labels that describe the source of a log entry, including envoy node info.
                                           It's recommended to follow [semantic conventions](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/).
+
+                                          Deprecated: Use ResourceAttributes instead.
                                         type: object
                                     type: object
                                     x-kubernetes-validations:
@@ -36767,6 +42332,9 @@ spec:
                                       rule: 'has(self.backendRefs) ? (self.backendRefs.all(f,
                                         f.group == "" || f.group == ''gateway.envoyproxy.io''))
                                         : true'
+                                    - message: either resources or resourceAttributes
+                                        can be set, not both
+                                      rule: '!has(self.resources) || !has(self.resourceAttributes)'
                                   type:
                                     description: Type defines the type of accesslog
                                       sink.
@@ -36818,15 +42386,15 @@ spec:
                           ClusterStatName defines the value of cluster alt_stat_name, determining how cluster stats are named.
                           For more details, see envoy docs: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html
                           The supported operators for this pattern are:
-                          %ROUTE_NAME%: name of Gateway API xRoute resource
-                          %ROUTE_NAMESPACE%: namespace of Gateway API xRoute resource
-                          %ROUTE_KIND%: kind of Gateway API xRoute resource
-                          %ROUTE_RULE_NAME%: name of the Gateway API xRoute section
-                          %ROUTE_RULE_NUMBER%: name of the Gateway API xRoute section
-                          %BACKEND_REFS%: names of all backends referenced in <NAMESPACE>/<NAME>|<NAMESPACE>/<NAME>|... format
+                          `%ROUTE_NAME%`: name of Gateway API xRoute resource
+                          `%ROUTE_NAMESPACE%`: namespace of Gateway API xRoute resource
+                          `%ROUTE_KIND%`: kind of Gateway API xRoute resource
+                          `%ROUTE_RULE_NAME%`: name of the Gateway API xRoute section
+                          `%ROUTE_RULE_NUMBER%`: name of the Gateway API xRoute section
+                          `%BACKEND_REFS%`: names of all backends referenced in `<NAMESPACE>/<NAME>|<NAMESPACE>/<NAME>|...` format
                           Only xDS Clusters created for HTTPRoute and GRPCRoute are currently supported.
-                          Default: %ROUTE_KIND%/%ROUTE_NAMESPACE%/%ROUTE_NAME%/rule/%ROUTE_RULE_NUMBER%
-                          Example: httproute/my-ns/my-route/rule/0
+                          Default: `%ROUTE_KIND%/%ROUTE_NAMESPACE%/%ROUTE_NAME%/rule/%ROUTE_RULE_NUMBER%`
+                          Example: `httproute/my-ns/my-route/rule/0`
                         type: string
                       enablePerEndpointStats:
                         description: |-
@@ -36891,13 +42459,31 @@ spec:
                               gzip:
                                 description: The configuration for GZIP compressor.
                                 type: object
+                              minContentLength:
+                                allOf:
+                                - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                - pattern: ^[1-9]+[0-9]*([EPTGMK]i|[EPTGMk])?$
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  MinContentLength defines the minimum response size in bytes to apply compression.
+                                  Responses smaller than this threshold will not be compressed.
+                                  Must be at least 30 bytes as enforced by Envoy Proxy.
+                                  Note that when the suffix is not provided, the value is interpreted as bytes.
+                                  Default: 30 bytes
+                                x-kubernetes-int-or-string: true
                               type:
                                 description: CompressorType defines the compressor
                                   type to use for compression.
                                 enum:
                                 - Gzip
                                 - Brotli
+                                - Zstd
                                 type: string
+                              zstd:
+                                description: The configuration for Zstd compressor.
+                                type: object
                             required:
                             - type
                             type: object
@@ -37069,6 +42655,26 @@ spec:
                                         maximum: 65535
                                         minimum: 1
                                         type: integer
+                                      weight:
+                                        default: 1
+                                        description: |-
+                                          Weight specifies the proportion of requests forwarded to the referenced
+                                          backend. This is computed as weight/(sum of all weights in this
+                                          BackendRefs list). For non-zero values, there may be some epsilon from
+                                          the exact proportion defined here depending on the precision an
+                                          implementation supports. Weight is not a percentage and the sum of
+                                          weights does not need to equal 100.
+
+                                          If only one backend is specified and it has a weight greater than 0, 100%
+                                          of the traffic is forwarded to that backend. If weight is set to 0, no
+                                          traffic should be forwarded for this entry. If unspecified, weight
+                                          defaults to 1.
+
+                                          Support for this field varies based on the context where used.
+                                        format: int32
+                                        maximum: 1000000
+                                        minimum: 0
+                                        type: integer
                                     required:
                                     - name
                                     type: object
@@ -37169,6 +42775,41 @@ spec:
                                             For example, 20Mi, 1Gi, 256Ki etc.
                                             Note: that when the suffix is not provided, the value is interpreted as bytes.
                                           x-kubernetes-int-or-string: true
+                                        preconnect:
+                                          description: |-
+                                            Preconnect configures proactive upstream connections to reduce latency by establishing
+                                            connections before they’re needed and avoiding connection establishment overhead.
+
+                                            If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                          properties:
+                                            perEndpointPercent:
+                                              description: |-
+                                                PerEndpointPercent configures how many additional connections to maintain per
+                                                upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                                percentage of the connections required by active streams
+                                                (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                                Allowed value range is between 100-300. When both PerEndpointPercent and
+                                                PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                              format: int32
+                                              maximum: 300
+                                              minimum: 100
+                                              type: integer
+                                            predictivePercent:
+                                              description: |-
+                                                PredictivePercent configures how many additional connections to maintain
+                                                across the cluster by anticipating which upstream endpoint the load balancer
+                                                will select next, useful for low-QPS services. Relies on deterministic
+                                                loadbalancing and is only supported with Random or RoundRobin.
+                                                Expressed as a percentage of the connections required by active streams
+                                                (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                                Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                                set Envoy ensures both are satisfied per host (max of the two).
+                                              format: int32
+                                              minimum: 100
+                                              type: integer
+                                          type: object
                                         socketBufferLimit:
                                           allOf:
                                           - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -37477,7 +43118,6 @@ spec:
                                               format: int32
                                               type: integer
                                             consecutiveGatewayErrors:
-                                              default: 0
                                               description: ConsecutiveGatewayErrors
                                                 sets the number of consecutive gateway
                                                 errors triggering ejection.
@@ -37489,6 +43129,15 @@ spec:
                                                 ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                                 Parameter takes effect only when split_external_local_origin_errors is set to true.
                                               format: int32
+                                              type: integer
+                                            failurePercentageThreshold:
+                                              description: |-
+                                                FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                                If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                                Defaults to 85.
+                                              format: int32
+                                              maximum: 100
+                                              minimum: 0
                                               type: integer
                                             interval:
                                               default: 3s
@@ -37592,9 +43241,10 @@ spec:
                                               - name
                                               type: object
                                             header:
-                                              description: Header configures the header
-                                                hash policy when the consistent hash
-                                                type is set to Header.
+                                              description: |-
+                                                Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                                Deprecated: use Headers instead
                                               properties:
                                                 name:
                                                   description: Name of the header
@@ -37603,6 +43253,42 @@ spec:
                                               required:
                                               - name
                                               type: object
+                                            headers:
+                                              description: Headers configures the
+                                                header hash policy for each header,
+                                                when the consistent hash type is set
+                                                to Headers.
+                                              items:
+                                                description: |-
+                                                  Header defines the header hashing configuration for consistent hash based
+                                                  load balancing.
+                                                properties:
+                                                  name:
+                                                    description: Name of the header
+                                                      to hash.
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                            queryParams:
+                                              description: QueryParams configures
+                                                the query parameter hash policy when
+                                                the consistent hash type is set to
+                                                QueryParams.
+                                              items:
+                                                description: |-
+                                                  QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                                  load balancing.
+                                                properties:
+                                                  name:
+                                                    description: Name of the query
+                                                      param to hash.
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
                                             tableSize:
                                               default: 65537
                                               description: The table size for consistent
@@ -37617,11 +43303,15 @@ spec:
                                                 ConsistentHashType defines the type of input to hash on. Valid Type values are
                                                 "SourceIP",
                                                 "Header",
+                                                "Headers",
                                                 "Cookie".
+                                                "QueryParams".
                                               enum:
                                               - SourceIP
                                               - Header
+                                              - Headers
                                               - Cookie
+                                              - QueryParams
                                               type: string
                                           required:
                                           - type
@@ -37631,10 +43321,18 @@ spec:
                                               the header field must be set.
                                             rule: 'self.type == ''Header'' ? has(self.header)
                                               : !has(self.header)'
+                                          - message: If consistent hash type is headers,
+                                              the headers field must be set.
+                                            rule: 'self.type == ''Headers'' ? has(self.headers)
+                                              : !has(self.headers)'
                                           - message: If consistent hash type is cookie,
                                               the cookie field must be set.
                                             rule: 'self.type == ''Cookie'' ? has(self.cookie)
                                               : !has(self.cookie)'
+                                          - message: If consistent hash type is queryParams,
+                                              the queryParams field must be set.
+                                            rule: 'self.type == ''QueryParams'' ?
+                                              has(self.queryParams) : !has(self.queryParams)'
                                         endpointOverride:
                                           description: |-
                                             EndpointOverride defines the configuration for endpoint override.
@@ -37725,6 +43423,17 @@ spec:
                                                     zones required to enable zone-aware
                                                     routing.
                                                   format: int64
+                                                  type: integer
+                                                percentageEnabled:
+                                                  description: Configures percentage
+                                                    of requests that will be considered
+                                                    for zone aware routing if zone
+                                                    aware routing is configured. If
+                                                    not specified, Envoy defaults
+                                                    to 100%.
+                                                  format: int32
+                                                  maximum: 100
+                                                  minimum: 0
                                                   type: integer
                                               type: object
                                           type: object
@@ -37896,6 +43605,14 @@ spec:
                                                 Default: unlimited.
                                               pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                               type: string
+                                            maxStreamDuration:
+                                              description: |-
+                                                MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                                from when the request is sent until the response stream is fully consumed and does not apply to
+                                                non-streaming requests.
+                                                When set to "0s", no max duration is applied and streams can run indefinitely.
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                              type: string
                                             requestTimeout:
                                               description: RequestTimeout is the time
                                                 until which entire response is received
@@ -37915,6 +43632,48 @@ spec:
                                           type: object
                                       type: object
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: predictivePercent in preconnect policy
+                                      only works with RoundRobin or Random load balancers
+                                    rule: '!((has(self.connection) && has(self.connection.preconnect)
+                                      && has(self.connection.preconnect.predictivePercent))
+                                      && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                                      && self.loadBalancer.type in [''Random'', ''RoundRobin'']))'
+                                headers:
+                                  description: |-
+                                    Headers is a list of additional headers to send with OTLP export requests.
+                                    These headers are added as gRPC initial metadata for the OTLP gRPC service.
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header
+                                      name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                          case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                          If multiple entries specify equivalent header names, the first entry with
+                                          an equivalent name MUST be considered for a match. Subsequent entries
+                                          with an equivalent header name MUST be ignored. Due to the
+                                          case-insensitivity of header names, "foo" and "Foo" are considered
+                                          equivalent.
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header
+                                          to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 32
+                                  minItems: 1
+                                  type: array
                                 host:
                                   description: |-
                                     Host define the service hostname.
@@ -37929,6 +43688,24 @@ spec:
                                   maximum: 65535
                                   minimum: 0
                                   type: integer
+                                reportCountersAsDeltas:
+                                  description: |-
+                                    ReportCountersAsDeltas configures the OpenTelemetry sink to report
+                                    counters as delta temporality instead of cumulative.
+                                  type: boolean
+                                reportHistogramsAsDeltas:
+                                  description: |-
+                                    ReportHistogramsAsDeltas configures the OpenTelemetry sink to report
+                                    histograms as delta temporality instead of cumulative.
+                                    Required for backends like Elastic that drop cumulative histograms.
+                                  type: boolean
+                                resourceAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    ResourceAttributes is a set of labels that describe the source of metrics.
+                                    It's recommended to follow semantic conventions: https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/
+                                  type: object
                               type: object
                               x-kubernetes-validations:
                               - message: host or backendRefs needs to be set
@@ -37965,6 +43742,25 @@ spec:
                               : !has(self.openTelemetry)'
                         maxItems: 16
                         type: array
+                    type: object
+                  requestID:
+                    description: RequestID configures Envoy request ID behavior.
+                    properties:
+                      tracing:
+                        description: |-
+                          Tracing configures Envoy's behavior for the UUID request ID extension,
+                          including whether the trace sampling decision is packed into the UUID and
+                          whether `X-Request-ID` is used for trace sampling decisions.
+
+                          When omitted, the default behavior is `PackAndSample`, which alters the UUID
+                          to contain the trace sampling decision and uses `X-Request-ID` for stable
+                          trace sampling.
+                        enum:
+                        - PackAndSample
+                        - Sample
+                        - Pack
+                        - Disable
+                        type: string
                     type: object
                   tracing:
                     description: |-
@@ -38032,6 +43828,8 @@ spec:
                         description: |-
                           CustomTags defines the custom tags to add to each span.
                           If provider is kubernetes, pod name and namespace are added by default.
+
+                          Deprecated: Use Tags instead.
                         type: object
                       provider:
                         description: Provider defines the tracing provider.
@@ -38187,6 +43985,26 @@ spec:
                                   maximum: 65535
                                   minimum: 1
                                   type: integer
+                                weight:
+                                  default: 1
+                                  description: |-
+                                    Weight specifies the proportion of requests forwarded to the referenced
+                                    backend. This is computed as weight/(sum of all weights in this
+                                    BackendRefs list). For non-zero values, there may be some epsilon from
+                                    the exact proportion defined here depending on the precision an
+                                    implementation supports. Weight is not a percentage and the sum of
+                                    weights does not need to equal 100.
+
+                                    If only one backend is specified and it has a weight greater than 0, 100%
+                                    of the traffic is forwarded to that backend. If weight is set to 0, no
+                                    traffic should be forwarded for this entry. If unspecified, weight
+                                    defaults to 1.
+
+                                    Support for this field varies based on the context where used.
+                                  format: int32
+                                  maximum: 1000000
+                                  minimum: 0
+                                  type: integer
                               required:
                               - name
                               type: object
@@ -38285,6 +44103,41 @@ spec:
                                       For example, 20Mi, 1Gi, 256Ki etc.
                                       Note: that when the suffix is not provided, the value is interpreted as bytes.
                                     x-kubernetes-int-or-string: true
+                                  preconnect:
+                                    description: |-
+                                      Preconnect configures proactive upstream connections to reduce latency by establishing
+                                      connections before they’re needed and avoiding connection establishment overhead.
+
+                                      If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                    properties:
+                                      perEndpointPercent:
+                                        description: |-
+                                          PerEndpointPercent configures how many additional connections to maintain per
+                                          upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                          percentage of the connections required by active streams
+                                          (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                          Allowed value range is between 100-300. When both PerEndpointPercent and
+                                          PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                        format: int32
+                                        maximum: 300
+                                        minimum: 100
+                                        type: integer
+                                      predictivePercent:
+                                        description: |-
+                                          PredictivePercent configures how many additional connections to maintain
+                                          across the cluster by anticipating which upstream endpoint the load balancer
+                                          will select next, useful for low-QPS services. Relies on deterministic
+                                          loadbalancing and is only supported with Random or RoundRobin.
+                                          Expressed as a percentage of the connections required by active streams
+                                          (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                          Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                          set Envoy ensures both are satisfied per host (max of the two).
+                                        format: int32
+                                        minimum: 100
+                                        type: integer
+                                    type: object
                                   socketBufferLimit:
                                     allOf:
                                     - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -38591,7 +44444,6 @@ spec:
                                         format: int32
                                         type: integer
                                       consecutiveGatewayErrors:
-                                        default: 0
                                         description: ConsecutiveGatewayErrors sets
                                           the number of consecutive gateway errors
                                           triggering ejection.
@@ -38603,6 +44455,15 @@ spec:
                                           ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                           Parameter takes effect only when split_external_local_origin_errors is set to true.
                                         format: int32
+                                        type: integer
+                                      failurePercentageThreshold:
+                                        description: |-
+                                          FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                          If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                          Defaults to 85.
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
                                         type: integer
                                       interval:
                                         default: 3s
@@ -38706,9 +44567,10 @@ spec:
                                         - name
                                         type: object
                                       header:
-                                        description: Header configures the header
-                                          hash policy when the consistent hash type
-                                          is set to Header.
+                                        description: |-
+                                          Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                          Deprecated: use Headers instead
                                         properties:
                                           name:
                                             description: Name of the header to hash.
@@ -38716,6 +44578,39 @@ spec:
                                         required:
                                         - name
                                         type: object
+                                      headers:
+                                        description: Headers configures the header
+                                          hash policy for each header, when the consistent
+                                          hash type is set to Headers.
+                                        items:
+                                          description: |-
+                                            Header defines the header hashing configuration for consistent hash based
+                                            load balancing.
+                                          properties:
+                                            name:
+                                              description: Name of the header to hash.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                      queryParams:
+                                        description: QueryParams configures the query
+                                          parameter hash policy when the consistent
+                                          hash type is set to QueryParams.
+                                        items:
+                                          description: |-
+                                            QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                            load balancing.
+                                          properties:
+                                            name:
+                                              description: Name of the query param
+                                                to hash.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
                                       tableSize:
                                         default: 65537
                                         description: The table size for consistent
@@ -38730,11 +44625,15 @@ spec:
                                           ConsistentHashType defines the type of input to hash on. Valid Type values are
                                           "SourceIP",
                                           "Header",
+                                          "Headers",
                                           "Cookie".
+                                          "QueryParams".
                                         enum:
                                         - SourceIP
                                         - Header
+                                        - Headers
                                         - Cookie
+                                        - QueryParams
                                         type: string
                                     required:
                                     - type
@@ -38744,10 +44643,18 @@ spec:
                                         the header field must be set.
                                       rule: 'self.type == ''Header'' ? has(self.header)
                                         : !has(self.header)'
+                                    - message: If consistent hash type is headers,
+                                        the headers field must be set.
+                                      rule: 'self.type == ''Headers'' ? has(self.headers)
+                                        : !has(self.headers)'
                                     - message: If consistent hash type is cookie,
                                         the cookie field must be set.
                                       rule: 'self.type == ''Cookie'' ? has(self.cookie)
                                         : !has(self.cookie)'
+                                    - message: If consistent hash type is queryParams,
+                                        the queryParams field must be set.
+                                      rule: 'self.type == ''QueryParams'' ? has(self.queryParams)
+                                        : !has(self.queryParams)'
                                   endpointOverride:
                                     description: |-
                                       EndpointOverride defines the configuration for endpoint override.
@@ -38837,6 +44744,16 @@ spec:
                                               endpoints across all zones required
                                               to enable zone-aware routing.
                                             format: int64
+                                            type: integer
+                                          percentageEnabled:
+                                            description: Configures percentage of
+                                              requests that will be considered for
+                                              zone aware routing if zone aware routing
+                                              is configured. If not specified, Envoy
+                                              defaults to 100%.
+                                            format: int32
+                                            maximum: 100
+                                            minimum: 0
                                             type: integer
                                         type: object
                                     type: object
@@ -39006,6 +44923,14 @@ spec:
                                           Default: unlimited.
                                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                         type: string
+                                      maxStreamDuration:
+                                        description: |-
+                                          MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                          from when the request is sent until the response stream is fully consumed and does not apply to
+                                          non-streaming requests.
+                                          When set to "0s", no max duration is applied and streams can run indefinitely.
+                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                        type: string
                                       requestTimeout:
                                         description: RequestTimeout is the time until
                                           which entire response is received from the
@@ -39025,11 +44950,65 @@ spec:
                                     type: object
                                 type: object
                             type: object
+                            x-kubernetes-validations:
+                            - message: predictivePercent in preconnect policy only
+                                works with RoundRobin or Random load balancers
+                              rule: '!((has(self.connection) && has(self.connection.preconnect)
+                                && has(self.connection.preconnect.predictivePercent))
+                                && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                                && self.loadBalancer.type in [''Random'', ''RoundRobin'']))'
                           host:
                             description: |-
                               Host define the provider service hostname.
                               Deprecated: Use BackendRefs instead.
                             type: string
+                          openTelemetry:
+                            description: OpenTelemetry defines the OpenTelemetry tracing
+                              provider configuration
+                            properties:
+                              headers:
+                                description: |-
+                                  Headers is a list of additional headers to send with OTLP export requests.
+                                  These headers are added as gRPC initial metadata for the OTLP gRPC service.
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 32
+                                minItems: 1
+                                type: array
+                              resourceAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  ResourceAttributes is a set of labels that describe the source of traces.
+                                  It's recommended to follow semantic conventions: https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/
+                                type: object
+                            type: object
                           port:
                             default: 4317
                             description: |-
@@ -39090,13 +45069,13 @@ spec:
                           rule: 'has(self.backendRefs) ? (self.backendRefs.all(f,
                             f.group == "" || f.group == ''gateway.envoyproxy.io''))
                             : true'
+                        - message: openTelemetry can only be used with type OpenTelemetry
+                          rule: 'has(self.openTelemetry) ? self.type == ''OpenTelemetry''
+                            : true'
                       samplingFraction:
                         description: |-
                           SamplingFraction represents the fraction of requests that should be
                           selected for tracing if no prior sampling decision has been made.
-
-                          Only one of SamplingRate or SamplingFraction may be specified.
-                          If neither field is specified, all requests will be sampled.
                         properties:
                           denominator:
                             default: 100
@@ -39125,6 +45104,39 @@ spec:
                         maximum: 100
                         minimum: 0
                         type: integer
+                      spanName:
+                        description: |-
+                          SpanName defines the name of the span which will be used for tracing.
+                          Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the value.
+                          The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information.
+
+                          If not set, the span name is provider specific.
+                          e.g. Datadog use `ingress` as the default client span name,
+                          and `router <UPSTREAM_CLUSTER> egress` as the server span name.
+                        properties:
+                          client:
+                            description: Client defines operation name of the span
+                              which will be used for tracing.
+                            type: string
+                          server:
+                            description: Server defines the operation name of the
+                              upstream span which will be used for tracing.
+                            type: string
+                        required:
+                        - client
+                        - server
+                        type: object
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Tags defines the custom tags to add to each span.
+                          Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be used in the value.
+                          The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings) provides more information.
+                          If provider is kubernetes, pod name and namespace are added by default.
+
+                          Same keys take precedence over CustomTags.
+                        type: object
                     required:
                     - provider
                     type: object
@@ -39136,7 +45148,218 @@ spec:
             type: object
           status:
             description: EnvoyProxyStatus defines the actual state of EnvoyProxy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors represent the status information for all the GatewayClass or Gateway
+                  reference this EnvoyProxy with ParametersReference.
+                items:
+                  properties:
+                    ancestorRef:
+                      description: AncestorRef corresponds a GatewayClass or Gateway
+                        use this EnvoyProxy with ParametersReference.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            <gateway:experimental:description>
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+                            </gateway:experimental:description>
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            <gateway:experimental:description>
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+                            </gateway:experimental:description>
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                  required:
+                  - ancestorRef
+                  type: object
+                type: array
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -39144,13 +45367,13 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: httproutefilters.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -39275,7 +45498,7 @@ spec:
                   return a fixed response.
                 properties:
                   body:
-                    description: Body of the Response
+                    description: Body of the direct response.
                     properties:
                       inline:
                         description: Inline contains the value as an inline string.
@@ -39340,15 +45563,195 @@ spec:
                       rule: 'has(self.valueRef) ? self.valueRef.kind == ''ConfigMap''
                         : true'
                   contentType:
-                    description: Content Type of the response. This will be set in
-                      the Content-Type header.
+                    description: Content Type of the direct response. This will be
+                      set in the Content-Type header.
                     type: string
+                  header:
+                    description: Header defines the headers of the direct response.
+                    properties:
+                      add:
+                        description: |-
+                          Add adds the given header(s) (name, value) to the request
+                          before the action. It appends to any existing values associated
+                          with the header name.
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+
+                          Config:
+                            add:
+                            - name: "my-header"
+                              value: "bar,baz"
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header: foo,bar,baz
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                If multiple entries specify equivalent header names, the first entry with
+                                an equivalent name MUST be considered for a match. Subsequent entries
+                                with an equivalent header name MUST be ignored. Due to the
+                                case-insensitivity of header names, "foo" and "Foo" are considered
+                                equivalent.
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 16
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      remove:
+                        description: |-
+                          Remove the given header(s) from the HTTP request before the action. The
+                          value of Remove is a list of HTTP header names. Note that the header
+                          names are case-insensitive (see
+                          https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header1: foo
+                            my-header2: bar
+                            my-header3: baz
+
+                          Config:
+                            remove: ["my-header1", "my-header3"]
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header2: bar
+                        items:
+                          type: string
+                        maxItems: 16
+                        type: array
+                        x-kubernetes-list-type: set
+                      set:
+                        description: |-
+                          Set overwrites the request with the given header (name, value)
+                          before the action.
+
+                          Input:
+                            GET /foo HTTP/1.1
+                            my-header: foo
+
+                          Config:
+                            set:
+                            - name: "my-header"
+                              value: "bar"
+
+                          Output:
+                            GET /foo HTTP/1.1
+                            my-header: bar
+                        items:
+                          description: HTTPHeader represents an HTTP Header name and
+                            value as defined by RFC 7230.
+                          properties:
+                            name:
+                              description: |-
+                                Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+                                If multiple entries specify equivalent header names, the first entry with
+                                an equivalent name MUST be considered for a match. Subsequent entries
+                                with an equivalent header name MUST be ignored. Due to the
+                                case-insensitivity of header names, "foo" and "Foo" are considered
+                                equivalent.
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                              type: string
+                            value:
+                              description: Value is the value of HTTP Header to be
+                                matched.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        maxItems: 16
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                    x-kubernetes-validations:
+                    - message: header.remove is not supported for DirectResponse
+                      rule: '!has(self.remove) || size(self.remove) == 0'
                   statusCode:
                     description: |-
                       Status Code of the HTTP response
                       If unset, defaults to 200.
                     type: integer
                 type: object
+              matches:
+                description: |-
+                  Matches defines additional matching criteria for the HTTPRoute rule.
+                  As with HTTPRouteRule.Matches, the rule is matched if any one match applies.
+                  When both HTTPRouteRule.Matches and HTTPRouteFilter.Matches are set, the
+                  effective matching is the logical AND of the two sets.
+                items:
+                  description: |-
+                    HTTPRouteMatchFilter defines additional matching criteria for the HTTPRoute rule.
+                    At least one matcher must be specified.
+                  minProperties: 1
+                  properties:
+                    cookies:
+                      description: |-
+                        Cookies is a list of cookie matchers evaluated against the HTTP request.
+                        All specified matchers must match.
+                      items:
+                        description: HTTPCookieMatch defines how to match a single
+                          cookie.
+                        properties:
+                          name:
+                            description: Name is the cookie name to evaluate.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          type:
+                            default: Exact
+                            description: Type specifies how to match against the value
+                              of the cookie.
+                            enum:
+                            - Exact
+                            - RegularExpression
+                            type: string
+                          value:
+                            description: Value is the cookie value to be matched.
+                            maxLength: 4096
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 8
+                type: array
               urlRewrite:
                 description: HTTPURLRewriteFilter define rewrites of HTTP URL components
                   such as path and host
@@ -39441,13 +45844,13 @@ spec:
     subresources: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: securitypolicies.gateway.envoyproxy.io
 spec:
   group: gateway.envoyproxy.io
@@ -39698,6 +46101,15 @@ spec:
                                 or the proxy protocol.
                                 You can use the `ClientIPDetection` or the `ProxyProtocol` field in
                                 the `ClientTrafficPolicy` to configure how the client IP is detected.
+
+                                For TCPRoute targets (raw TCP connections), HTTP headers such as
+                                X-Forwarded-For are not available. The client IP is obtained from the
+                                TCP connection's peer address. If intermediaries (load balancers, NAT)
+                                terminate or proxy TCP, the original client IP will only be available
+                                if the intermediary preserves the source address (for example by
+                                enabling the PROXY protocol or avoiding SNAT). Ensure your L4 proxy is
+                                configured to preserve the source IP to enable correct client-IP
+                                matching for TCPRoute targets.
                               items:
                                 description: |-
                                   CIDR defines a CIDR Address range.
@@ -39783,7 +46195,7 @@ spec:
                                           If multiple values are specified, one of the values must match for the rule to match.
                                         items:
                                           type: string
-                                        maxItems: 16
+                                        maxItems: 128
                                         minItems: 1
                                         type: array
                                     required:
@@ -39805,8 +46217,8 @@ spec:
                                   description: |-
                                     Scopes are a special type of claim in a JWT token that represents the permissions of the client.
 
-                                    The value of the scopes field should be a space delimited string that is expected in the scope parameter,
-                                    as defined in RFC 6749: https://datatracker.ietf.org/doc/html/rfc6749#page-23.
+                                    The value of the scopes field should be a space delimited string that is expected in the
+                                    scope (or scp) claim, as defined in RFC 6749: https://datatracker.ietf.org/doc/html/rfc6749#page-23.
 
                                     If multiple scopes are specified, all scopes must match for the rule to match.
                                   items:
@@ -39823,6 +46235,29 @@ spec:
                               - message: at least one of claims or scopes must be
                                   specified
                                 rule: (has(self.claims) || has(self.scopes))
+                            sourceCIDRs:
+                              description: |-
+                                SourceCIDRs are the IP CIDR ranges of the source (L4 peer IP).
+                                Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+
+                                If multiple CIDR ranges are specified, one of the CIDR ranges must match
+                                the source IP for the rule to match.
+
+                                The source IP is the IP address of the peer that connected to Envoy.
+                                This IP is obtained from the TCP connection's peer address and is not
+                                affected by X-Forwarded-For or other IP detection headers.
+                                If intermediaries (load balancers, NAT) terminate or proxy TCP,
+                                the original client IP will only be available if the intermediary
+                                preserves the source address (for example by enabling the PROXY protocol
+                                or avoiding SNAT).
+                              items:
+                                description: |-
+                                  CIDR defines a CIDR Address range.
+                                  A CIDR can be an IPv4 address range such as "192.168.1.0/24" or an IPv6 address range such as "2001:0db8:11a3:09d7::/64".
+                                pattern: ((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]+))|((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/([0-9]+))
+                                type: string
+                              minItems: 1
+                              type: array
                           type: object
                           x-kubernetes-validations:
                           - message: at least one of clientCIDRs, jwt, or headers
@@ -39986,6 +46421,85 @@ spec:
                     required:
                     - maxRequestBytes
                     type: object
+                  contextExtensions:
+                    description: |-
+                      ContextExtensions are analogous to http_request.headers, however these
+                      contents will not be sent to the upstream server. This provides an
+                      extension mechanism for sending additional information to the auth server
+                      without modifying the proto definition. It maps to the internal opaque
+                      context in the filter chain.
+                    items:
+                      description: |-
+                        ContextExtension is analogous to http_request.headers, however these
+                        contents will not be sent to the upstream server. This provides an
+                        extension mechanism for sending additional information to the auth server
+                        without modifying the proto definition. It maps to the internal opaque
+                        context in the filter chain.
+                      properties:
+                        name:
+                          description: Name of the context extension.
+                          type: string
+                        type:
+                          default: Value
+                          description: |-
+                            Type is the type of method to use to read the ContextExtension value.
+                            Valid values are Value and ValueRef, default is Value.
+                          enum:
+                          - Value
+                          - ValueRef
+                          type: string
+                        value:
+                          description: Value of the context extension.
+                          type: string
+                        valueRef:
+                          description: ValueRef for the context extension's value.
+                          properties:
+                            group:
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            key:
+                              description: The key to select.
+                              type: string
+                            kind:
+                              description: Kind is kind of the referent. For example
+                                "HTTPRoute" or "Service".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - group
+                          - key
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-validations:
+                          - message: Only a reference to an object of kind ConfigMap
+                              or Secret belonging to default v1 API group is supported.
+                            rule: self.kind in ['ConfigMap', 'Secret'] && self.group
+                              in ['', 'v1']
+                      required:
+                      - name
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: Exactly one of value or valueRef must be set with
+                          correct type.
+                        rule: (self.type == 'Value' && has(self.value) && !has(self.valueRef))
+                          || (self.type == 'ValueRef' && !has(self.value) && has(self.valueRef))
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   failOpen:
                     default: false
                     description: |-
@@ -40154,6 +46668,26 @@ spec:
                               maximum: 65535
                               minimum: 1
                               type: integer
+                            weight:
+                              default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
                           required:
                           - name
                           type: object
@@ -40250,6 +46784,41 @@ spec:
                                   For example, 20Mi, 1Gi, 256Ki etc.
                                   Note: that when the suffix is not provided, the value is interpreted as bytes.
                                 x-kubernetes-int-or-string: true
+                              preconnect:
+                                description: |-
+                                  Preconnect configures proactive upstream connections to reduce latency by establishing
+                                  connections before they’re needed and avoiding connection establishment overhead.
+
+                                  If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                properties:
+                                  perEndpointPercent:
+                                    description: |-
+                                      PerEndpointPercent configures how many additional connections to maintain per
+                                      upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                      percentage of the connections required by active streams
+                                      (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                      Allowed value range is between 100-300. When both PerEndpointPercent and
+                                      PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                    format: int32
+                                    maximum: 300
+                                    minimum: 100
+                                    type: integer
+                                  predictivePercent:
+                                    description: |-
+                                      PredictivePercent configures how many additional connections to maintain
+                                      across the cluster by anticipating which upstream endpoint the load balancer
+                                      will select next, useful for low-QPS services. Relies on deterministic
+                                      loadbalancing and is only supported with Random or RoundRobin.
+                                      Expressed as a percentage of the connections required by active streams
+                                      (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                      Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                      set Envoy ensures both are satisfied per host (max of the two).
+                                    format: int32
+                                    minimum: 100
+                                    type: integer
+                                type: object
                               socketBufferLimit:
                                 allOf:
                                 - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -40544,7 +47113,6 @@ spec:
                                     format: int32
                                     type: integer
                                   consecutiveGatewayErrors:
-                                    default: 0
                                     description: ConsecutiveGatewayErrors sets the
                                       number of consecutive gateway errors triggering
                                       ejection.
@@ -40556,6 +47124,15 @@ spec:
                                       ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                       Parameter takes effect only when split_external_local_origin_errors is set to true.
                                     format: int32
+                                    type: integer
+                                  failurePercentageThreshold:
+                                    description: |-
+                                      FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                      If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                      Defaults to 85.
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
                                     type: integer
                                   interval:
                                     default: 3s
@@ -40659,9 +47236,10 @@ spec:
                                     - name
                                     type: object
                                   header:
-                                    description: Header configures the header hash
-                                      policy when the consistent hash type is set
-                                      to Header.
+                                    description: |-
+                                      Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                      Deprecated: use Headers instead
                                     properties:
                                       name:
                                         description: Name of the header to hash.
@@ -40669,6 +47247,39 @@ spec:
                                     required:
                                     - name
                                     type: object
+                                  headers:
+                                    description: Headers configures the header hash
+                                      policy for each header, when the consistent
+                                      hash type is set to Headers.
+                                    items:
+                                      description: |-
+                                        Header defines the header hashing configuration for consistent hash based
+                                        load balancing.
+                                      properties:
+                                        name:
+                                          description: Name of the header to hash.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  queryParams:
+                                    description: QueryParams configures the query
+                                      parameter hash policy when the consistent hash
+                                      type is set to QueryParams.
+                                    items:
+                                      description: |-
+                                        QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                        load balancing.
+                                      properties:
+                                        name:
+                                          description: Name of the query param to
+                                            hash.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
                                   tableSize:
                                     default: 65537
                                     description: The table size for consistent hashing,
@@ -40682,11 +47293,15 @@ spec:
                                       ConsistentHashType defines the type of input to hash on. Valid Type values are
                                       "SourceIP",
                                       "Header",
+                                      "Headers",
                                       "Cookie".
+                                      "QueryParams".
                                     enum:
                                     - SourceIP
                                     - Header
+                                    - Headers
                                     - Cookie
+                                    - QueryParams
                                     type: string
                                 required:
                                 - type
@@ -40696,10 +47311,18 @@ spec:
                                     header field must be set.
                                   rule: 'self.type == ''Header'' ? has(self.header)
                                     : !has(self.header)'
+                                - message: If consistent hash type is headers, the
+                                    headers field must be set.
+                                  rule: 'self.type == ''Headers'' ? has(self.headers)
+                                    : !has(self.headers)'
                                 - message: If consistent hash type is cookie, the
                                     cookie field must be set.
                                   rule: 'self.type == ''Cookie'' ? has(self.cookie)
                                     : !has(self.cookie)'
+                                - message: If consistent hash type is queryParams,
+                                    the queryParams field must be set.
+                                  rule: 'self.type == ''QueryParams'' ? has(self.queryParams)
+                                    : !has(self.queryParams)'
                               endpointOverride:
                                 description: |-
                                   EndpointOverride defines the configuration for endpoint override.
@@ -40788,6 +47411,15 @@ spec:
                                           across all zones required to enable zone-aware
                                           routing.
                                         format: int64
+                                        type: integer
+                                      percentageEnabled:
+                                        description: Configures percentage of requests
+                                          that will be considered for zone aware routing
+                                          if zone aware routing is configured. If
+                                          not specified, Envoy defaults to 100%.
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
                                         type: integer
                                     type: object
                                 type: object
@@ -40957,6 +47589,14 @@ spec:
                                       Default: unlimited.
                                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                  maxStreamDuration:
+                                    description: |-
+                                      MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                      from when the request is sent until the response stream is fully consumed and does not apply to
+                                      non-streaming requests.
+                                      When set to "0s", no max duration is applied and streams can run indefinitely.
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                    type: string
                                   requestTimeout:
                                     description: RequestTimeout is the time until
                                       which entire response is received from the upstream.
@@ -40975,6 +47615,13 @@ spec:
                                 type: object
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: predictivePercent in preconnect policy only works
+                            with RoundRobin or Random load balancers
+                          rule: '!((has(self.connection) && has(self.connection.preconnect)
+                            && has(self.connection.preconnect.predictivePercent))
+                            && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                            && self.loadBalancer.type in [''Random'', ''RoundRobin'']))'
                     type: object
                     x-kubernetes-validations:
                     - message: backendRef or backendRefs needs to be set
@@ -41161,6 +47808,26 @@ spec:
                               maximum: 65535
                               minimum: 1
                               type: integer
+                            weight:
+                              default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
                           required:
                           - name
                           type: object
@@ -41257,6 +47924,41 @@ spec:
                                   For example, 20Mi, 1Gi, 256Ki etc.
                                   Note: that when the suffix is not provided, the value is interpreted as bytes.
                                 x-kubernetes-int-or-string: true
+                              preconnect:
+                                description: |-
+                                  Preconnect configures proactive upstream connections to reduce latency by establishing
+                                  connections before they’re needed and avoiding connection establishment overhead.
+
+                                  If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                properties:
+                                  perEndpointPercent:
+                                    description: |-
+                                      PerEndpointPercent configures how many additional connections to maintain per
+                                      upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                      percentage of the connections required by active streams
+                                      (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                      Allowed value range is between 100-300. When both PerEndpointPercent and
+                                      PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                    format: int32
+                                    maximum: 300
+                                    minimum: 100
+                                    type: integer
+                                  predictivePercent:
+                                    description: |-
+                                      PredictivePercent configures how many additional connections to maintain
+                                      across the cluster by anticipating which upstream endpoint the load balancer
+                                      will select next, useful for low-QPS services. Relies on deterministic
+                                      loadbalancing and is only supported with Random or RoundRobin.
+                                      Expressed as a percentage of the connections required by active streams
+                                      (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                      Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                      set Envoy ensures both are satisfied per host (max of the two).
+                                    format: int32
+                                    minimum: 100
+                                    type: integer
+                                type: object
                               socketBufferLimit:
                                 allOf:
                                 - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -41551,7 +48253,6 @@ spec:
                                     format: int32
                                     type: integer
                                   consecutiveGatewayErrors:
-                                    default: 0
                                     description: ConsecutiveGatewayErrors sets the
                                       number of consecutive gateway errors triggering
                                       ejection.
@@ -41563,6 +48264,15 @@ spec:
                                       ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                       Parameter takes effect only when split_external_local_origin_errors is set to true.
                                     format: int32
+                                    type: integer
+                                  failurePercentageThreshold:
+                                    description: |-
+                                      FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                      If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                      Defaults to 85.
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
                                     type: integer
                                   interval:
                                     default: 3s
@@ -41666,9 +48376,10 @@ spec:
                                     - name
                                     type: object
                                   header:
-                                    description: Header configures the header hash
-                                      policy when the consistent hash type is set
-                                      to Header.
+                                    description: |-
+                                      Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                      Deprecated: use Headers instead
                                     properties:
                                       name:
                                         description: Name of the header to hash.
@@ -41676,6 +48387,39 @@ spec:
                                     required:
                                     - name
                                     type: object
+                                  headers:
+                                    description: Headers configures the header hash
+                                      policy for each header, when the consistent
+                                      hash type is set to Headers.
+                                    items:
+                                      description: |-
+                                        Header defines the header hashing configuration for consistent hash based
+                                        load balancing.
+                                      properties:
+                                        name:
+                                          description: Name of the header to hash.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  queryParams:
+                                    description: QueryParams configures the query
+                                      parameter hash policy when the consistent hash
+                                      type is set to QueryParams.
+                                    items:
+                                      description: |-
+                                        QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                        load balancing.
+                                      properties:
+                                        name:
+                                          description: Name of the query param to
+                                            hash.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
                                   tableSize:
                                     default: 65537
                                     description: The table size for consistent hashing,
@@ -41689,11 +48433,15 @@ spec:
                                       ConsistentHashType defines the type of input to hash on. Valid Type values are
                                       "SourceIP",
                                       "Header",
+                                      "Headers",
                                       "Cookie".
+                                      "QueryParams".
                                     enum:
                                     - SourceIP
                                     - Header
+                                    - Headers
                                     - Cookie
+                                    - QueryParams
                                     type: string
                                 required:
                                 - type
@@ -41703,10 +48451,18 @@ spec:
                                     header field must be set.
                                   rule: 'self.type == ''Header'' ? has(self.header)
                                     : !has(self.header)'
+                                - message: If consistent hash type is headers, the
+                                    headers field must be set.
+                                  rule: 'self.type == ''Headers'' ? has(self.headers)
+                                    : !has(self.headers)'
                                 - message: If consistent hash type is cookie, the
                                     cookie field must be set.
                                   rule: 'self.type == ''Cookie'' ? has(self.cookie)
                                     : !has(self.cookie)'
+                                - message: If consistent hash type is queryParams,
+                                    the queryParams field must be set.
+                                  rule: 'self.type == ''QueryParams'' ? has(self.queryParams)
+                                    : !has(self.queryParams)'
                               endpointOverride:
                                 description: |-
                                   EndpointOverride defines the configuration for endpoint override.
@@ -41795,6 +48551,15 @@ spec:
                                           across all zones required to enable zone-aware
                                           routing.
                                         format: int64
+                                        type: integer
+                                      percentageEnabled:
+                                        description: Configures percentage of requests
+                                          that will be considered for zone aware routing
+                                          if zone aware routing is configured. If
+                                          not specified, Envoy defaults to 100%.
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
                                         type: integer
                                     type: object
                                 type: object
@@ -41964,6 +48729,14 @@ spec:
                                       Default: unlimited.
                                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                  maxStreamDuration:
+                                    description: |-
+                                      MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                      from when the request is sent until the response stream is fully consumed and does not apply to
+                                      non-streaming requests.
+                                      When set to "0s", no max duration is applied and streams can run indefinitely.
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                    type: string
                                   requestTimeout:
                                     description: RequestTimeout is the time until
                                       which entire response is received from the upstream.
@@ -41982,6 +48755,13 @@ spec:
                                 type: object
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: predictivePercent in preconnect policy only works
+                            with RoundRobin or Random load balancers
+                          rule: '!((has(self.connection) && has(self.connection.preconnect)
+                            && has(self.connection.preconnect.predictivePercent))
+                            && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                            && self.loadBalancer.type in [''Random'', ''RoundRobin'']))'
                       headersToBackend:
                         description: |-
                           HeadersToBackend are the authorization response headers that will be added
@@ -42024,6 +48804,12 @@ spec:
                       route matching decisions. If the recomputation selects a new route, features targeting
                       the new matched route will be applied.
                     type: boolean
+                  timeout:
+                    description: |-
+                      Timeout defines the timeout for requests to the external authorization service.
+                      If not specified, defaults to 10 seconds.
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
                 type: object
                 x-kubernetes-validations:
                 - message: one of grpc or http must be specified
@@ -42358,6 +49144,26 @@ spec:
                                     maximum: 65535
                                     minimum: 1
                                     type: integer
+                                  weight:
+                                    default: 1
+                                    description: |-
+                                      Weight specifies the proportion of requests forwarded to the referenced
+                                      backend. This is computed as weight/(sum of all weights in this
+                                      BackendRefs list). For non-zero values, there may be some epsilon from
+                                      the exact proportion defined here depending on the precision an
+                                      implementation supports. Weight is not a percentage and the sum of
+                                      weights does not need to equal 100.
+
+                                      If only one backend is specified and it has a weight greater than 0, 100%
+                                      of the traffic is forwarded to that backend. If weight is set to 0, no
+                                      traffic should be forwarded for this entry. If unspecified, weight
+                                      defaults to 1.
+
+                                      Support for this field varies based on the context where used.
+                                    format: int32
+                                    maximum: 1000000
+                                    minimum: 0
+                                    type: integer
                                 required:
                                 - name
                                 type: object
@@ -42456,6 +49262,41 @@ spec:
                                         For example, 20Mi, 1Gi, 256Ki etc.
                                         Note: that when the suffix is not provided, the value is interpreted as bytes.
                                       x-kubernetes-int-or-string: true
+                                    preconnect:
+                                      description: |-
+                                        Preconnect configures proactive upstream connections to reduce latency by establishing
+                                        connections before they’re needed and avoiding connection establishment overhead.
+
+                                        If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                      properties:
+                                        perEndpointPercent:
+                                          description: |-
+                                            PerEndpointPercent configures how many additional connections to maintain per
+                                            upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                            percentage of the connections required by active streams
+                                            (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                            Allowed value range is between 100-300. When both PerEndpointPercent and
+                                            PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                          format: int32
+                                          maximum: 300
+                                          minimum: 100
+                                          type: integer
+                                        predictivePercent:
+                                          description: |-
+                                            PredictivePercent configures how many additional connections to maintain
+                                            across the cluster by anticipating which upstream endpoint the load balancer
+                                            will select next, useful for low-QPS services. Relies on deterministic
+                                            loadbalancing and is only supported with Random or RoundRobin.
+                                            Expressed as a percentage of the connections required by active streams
+                                            (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                            Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                            set Envoy ensures both are satisfied per host (max of the two).
+                                          format: int32
+                                          minimum: 100
+                                          type: integer
+                                      type: object
                                     socketBufferLimit:
                                       allOf:
                                       - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -42763,7 +49604,6 @@ spec:
                                           format: int32
                                           type: integer
                                         consecutiveGatewayErrors:
-                                          default: 0
                                           description: ConsecutiveGatewayErrors sets
                                             the number of consecutive gateway errors
                                             triggering ejection.
@@ -42775,6 +49615,15 @@ spec:
                                             ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                             Parameter takes effect only when split_external_local_origin_errors is set to true.
                                           format: int32
+                                          type: integer
+                                        failurePercentageThreshold:
+                                          description: |-
+                                            FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                            If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                            Defaults to 85.
+                                          format: int32
+                                          maximum: 100
+                                          minimum: 0
                                           type: integer
                                         interval:
                                           default: 3s
@@ -42878,9 +49727,10 @@ spec:
                                           - name
                                           type: object
                                         header:
-                                          description: Header configures the header
-                                            hash policy when the consistent hash type
-                                            is set to Header.
+                                          description: |-
+                                            Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                            Deprecated: use Headers instead
                                           properties:
                                             name:
                                               description: Name of the header to hash.
@@ -42888,6 +49738,40 @@ spec:
                                           required:
                                           - name
                                           type: object
+                                        headers:
+                                          description: Headers configures the header
+                                            hash policy for each header, when the
+                                            consistent hash type is set to Headers.
+                                          items:
+                                            description: |-
+                                              Header defines the header hashing configuration for consistent hash based
+                                              load balancing.
+                                            properties:
+                                              name:
+                                                description: Name of the header to
+                                                  hash.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        queryParams:
+                                          description: QueryParams configures the
+                                            query parameter hash policy when the consistent
+                                            hash type is set to QueryParams.
+                                          items:
+                                            description: |-
+                                              QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                              load balancing.
+                                            properties:
+                                              name:
+                                                description: Name of the query param
+                                                  to hash.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
                                         tableSize:
                                           default: 65537
                                           description: The table size for consistent
@@ -42902,11 +49786,15 @@ spec:
                                             ConsistentHashType defines the type of input to hash on. Valid Type values are
                                             "SourceIP",
                                             "Header",
+                                            "Headers",
                                             "Cookie".
+                                            "QueryParams".
                                           enum:
                                           - SourceIP
                                           - Header
+                                          - Headers
                                           - Cookie
+                                          - QueryParams
                                           type: string
                                       required:
                                       - type
@@ -42916,10 +49804,18 @@ spec:
                                           the header field must be set.
                                         rule: 'self.type == ''Header'' ? has(self.header)
                                           : !has(self.header)'
+                                      - message: If consistent hash type is headers,
+                                          the headers field must be set.
+                                        rule: 'self.type == ''Headers'' ? has(self.headers)
+                                          : !has(self.headers)'
                                       - message: If consistent hash type is cookie,
                                           the cookie field must be set.
                                         rule: 'self.type == ''Cookie'' ? has(self.cookie)
                                           : !has(self.cookie)'
+                                      - message: If consistent hash type is queryParams,
+                                          the queryParams field must be set.
+                                        rule: 'self.type == ''QueryParams'' ? has(self.queryParams)
+                                          : !has(self.queryParams)'
                                     endpointOverride:
                                       description: |-
                                         EndpointOverride defines the configuration for endpoint override.
@@ -43009,6 +49905,16 @@ spec:
                                                 endpoints across all zones required
                                                 to enable zone-aware routing.
                                               format: int64
+                                              type: integer
+                                            percentageEnabled:
+                                              description: Configures percentage of
+                                                requests that will be considered for
+                                                zone aware routing if zone aware routing
+                                                is configured. If not specified, Envoy
+                                                defaults to 100%.
+                                              format: int32
+                                              maximum: 100
+                                              minimum: 0
                                               type: integer
                                           type: object
                                       type: object
@@ -43179,6 +50085,14 @@ spec:
                                             Default: unlimited.
                                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                           type: string
+                                        maxStreamDuration:
+                                          description: |-
+                                            MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                            from when the request is sent until the response stream is fully consumed and does not apply to
+                                            non-streaming requests.
+                                            When set to "0s", no max duration is applied and streams can run indefinitely.
+                                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                          type: string
                                         requestTimeout:
                                           description: RequestTimeout is the time
                                             until which entire response is received
@@ -43198,6 +50112,20 @@ spec:
                                       type: object
                                   type: object
                               type: object
+                              x-kubernetes-validations:
+                              - message: predictivePercent in preconnect policy only
+                                  works with RoundRobin or Random load balancers
+                                rule: '!((has(self.connection) && has(self.connection.preconnect)
+                                  && has(self.connection.preconnect.predictivePercent))
+                                  && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                                  && self.loadBalancer.type in [''Random'', ''RoundRobin'']))'
+                            cacheDuration:
+                              default: 300s
+                              description: |-
+                                Duration is a string value representing a duration in time. The format is as specified
+                                in GEP-2257, a strict subset of the syntax parsed by Golang time.ParseDuration.
+                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                              type: string
                             uri:
                               description: |-
                                 URI is the HTTPS URI to fetch the JWKS. Envoy's system trust bundle is used to validate the server certificate.
@@ -43379,6 +50307,16 @@ spec:
                           If not specified, defaults to "IdToken-(randomly generated uid)"
                         type: string
                     type: object
+                  csrfTokenTTL:
+                    description: |-
+                      CSRFTokenTTL defines how long the CSRF token generated during the OAuth2 authorization flow remains valid.
+
+                      This duration determines the lifetime of the CSRF cookie, which is validated against the CSRF token
+                      in the "state" parameter when the provider redirects back to the callback endpoint.
+
+                      If omitted, Envoy Gateway defaults the token expiration to 10 minutes.
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
                   defaultRefreshTokenTTL:
                     description: |-
                       DefaultRefreshTokenTTL is the default lifetime of the refresh token.
@@ -43443,6 +50381,12 @@ spec:
                     required:
                     - headers
                     type: object
+                  disableTokenEncryption:
+                    description: |-
+                      Disable token encryption. When set to true, both the access token and the ID token will be stored in plain text.
+                      This option should only be used in secure environments where token encryption is not required.
+                      Default is false (tokens are encrypted).
+                    type: boolean
                   forwardAccessToken:
                     description: |-
                       ForwardAccessToken indicates whether the Envoy should forward the access token
@@ -43624,6 +50568,26 @@ spec:
                               maximum: 65535
                               minimum: 1
                               type: integer
+                            weight:
+                              default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
                           required:
                           - name
                           type: object
@@ -43720,6 +50684,41 @@ spec:
                                   For example, 20Mi, 1Gi, 256Ki etc.
                                   Note: that when the suffix is not provided, the value is interpreted as bytes.
                                 x-kubernetes-int-or-string: true
+                              preconnect:
+                                description: |-
+                                  Preconnect configures proactive upstream connections to reduce latency by establishing
+                                  connections before they’re needed and avoiding connection establishment overhead.
+
+                                  If unset, Envoy will fetch connections as needed to serve in-flight requests.
+                                properties:
+                                  perEndpointPercent:
+                                    description: |-
+                                      PerEndpointPercent configures how many additional connections to maintain per
+                                      upstream endpoint, useful for high-QPS or latency sensitive services. Expressed as a
+                                      percentage of the connections required by active streams
+                                      (e.g. 100 = preconnect disabled, 105 = 1.05x connections per-endpoint, 200 = 2.00×).
+
+                                      Allowed value range is between 100-300. When both PerEndpointPercent and
+                                      PredictivePercent are set, Envoy ensures both are satisfied (max of the two).
+                                    format: int32
+                                    maximum: 300
+                                    minimum: 100
+                                    type: integer
+                                  predictivePercent:
+                                    description: |-
+                                      PredictivePercent configures how many additional connections to maintain
+                                      across the cluster by anticipating which upstream endpoint the load balancer
+                                      will select next, useful for low-QPS services. Relies on deterministic
+                                      loadbalancing and is only supported with Random or RoundRobin.
+                                      Expressed as a percentage of the connections required by active streams
+                                      (e.g. 100 = 1.0 (no preconnect), 105 = 1.05× connections across the cluster, 200 = 2.00×).
+
+                                      Minimum allowed value is 100. When both PerEndpointPercent and PredictivePercent are
+                                      set Envoy ensures both are satisfied per host (max of the two).
+                                    format: int32
+                                    minimum: 100
+                                    type: integer
+                                type: object
                               socketBufferLimit:
                                 allOf:
                                 - pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -44014,7 +51013,6 @@ spec:
                                     format: int32
                                     type: integer
                                   consecutiveGatewayErrors:
-                                    default: 0
                                     description: ConsecutiveGatewayErrors sets the
                                       number of consecutive gateway errors triggering
                                       ejection.
@@ -44026,6 +51024,15 @@ spec:
                                       ConsecutiveLocalOriginFailures sets the number of consecutive local origin failures triggering ejection.
                                       Parameter takes effect only when split_external_local_origin_errors is set to true.
                                     format: int32
+                                    type: integer
+                                  failurePercentageThreshold:
+                                    description: |-
+                                      FailurePercentageThreshold sets the failure percentage threshold for outlier detection.
+                                      If the failure percentage of a given host is greater than or equal to this value, it will be ejected.
+                                      Defaults to 85.
+                                    format: int32
+                                    maximum: 100
+                                    minimum: 0
                                     type: integer
                                   interval:
                                     default: 3s
@@ -44129,9 +51136,10 @@ spec:
                                     - name
                                     type: object
                                   header:
-                                    description: Header configures the header hash
-                                      policy when the consistent hash type is set
-                                      to Header.
+                                    description: |-
+                                      Header configures the header hash policy when the consistent hash type is set to Header.
+
+                                      Deprecated: use Headers instead
                                     properties:
                                       name:
                                         description: Name of the header to hash.
@@ -44139,6 +51147,39 @@ spec:
                                     required:
                                     - name
                                     type: object
+                                  headers:
+                                    description: Headers configures the header hash
+                                      policy for each header, when the consistent
+                                      hash type is set to Headers.
+                                    items:
+                                      description: |-
+                                        Header defines the header hashing configuration for consistent hash based
+                                        load balancing.
+                                      properties:
+                                        name:
+                                          description: Name of the header to hash.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  queryParams:
+                                    description: QueryParams configures the query
+                                      parameter hash policy when the consistent hash
+                                      type is set to QueryParams.
+                                    items:
+                                      description: |-
+                                        QueryParam defines the query parameter name hashing configuration for consistent hash based
+                                        load balancing.
+                                      properties:
+                                        name:
+                                          description: Name of the query param to
+                                            hash.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
                                   tableSize:
                                     default: 65537
                                     description: The table size for consistent hashing,
@@ -44152,11 +51193,15 @@ spec:
                                       ConsistentHashType defines the type of input to hash on. Valid Type values are
                                       "SourceIP",
                                       "Header",
+                                      "Headers",
                                       "Cookie".
+                                      "QueryParams".
                                     enum:
                                     - SourceIP
                                     - Header
+                                    - Headers
                                     - Cookie
+                                    - QueryParams
                                     type: string
                                 required:
                                 - type
@@ -44166,10 +51211,18 @@ spec:
                                     header field must be set.
                                   rule: 'self.type == ''Header'' ? has(self.header)
                                     : !has(self.header)'
+                                - message: If consistent hash type is headers, the
+                                    headers field must be set.
+                                  rule: 'self.type == ''Headers'' ? has(self.headers)
+                                    : !has(self.headers)'
                                 - message: If consistent hash type is cookie, the
                                     cookie field must be set.
                                   rule: 'self.type == ''Cookie'' ? has(self.cookie)
                                     : !has(self.cookie)'
+                                - message: If consistent hash type is queryParams,
+                                    the queryParams field must be set.
+                                  rule: 'self.type == ''QueryParams'' ? has(self.queryParams)
+                                    : !has(self.queryParams)'
                               endpointOverride:
                                 description: |-
                                   EndpointOverride defines the configuration for endpoint override.
@@ -44258,6 +51311,15 @@ spec:
                                           across all zones required to enable zone-aware
                                           routing.
                                         format: int64
+                                        type: integer
+                                      percentageEnabled:
+                                        description: Configures percentage of requests
+                                          that will be considered for zone aware routing
+                                          if zone aware routing is configured. If
+                                          not specified, Envoy defaults to 100%.
+                                        format: int32
+                                        maximum: 100
+                                        minimum: 0
                                         type: integer
                                     type: object
                                 type: object
@@ -44427,6 +51489,14 @@ spec:
                                       Default: unlimited.
                                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                                     type: string
+                                  maxStreamDuration:
+                                    description: |-
+                                      MaxStreamDuration is the maximum duration for a stream to complete. This timeout measures the time
+                                      from when the request is sent until the response stream is fully consumed and does not apply to
+                                      non-streaming requests.
+                                      When set to "0s", no max duration is applied and streams can run indefinitely.
+                                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                    type: string
                                   requestTimeout:
                                     description: RequestTimeout is the time until
                                       which entire response is received from the upstream.
@@ -44445,6 +51515,13 @@ spec:
                                 type: object
                             type: object
                         type: object
+                        x-kubernetes-validations:
+                        - message: predictivePercent in preconnect policy only works
+                            with RoundRobin or Random load balancers
+                          rule: '!((has(self.connection) && has(self.connection.preconnect)
+                            && has(self.connection.preconnect.predictivePercent))
+                            && !(has(self.loadBalancer) && has(self.loadBalancer.type)
+                            && self.loadBalancer.type in [''Random'', ''RoundRobin'']))'
                       endSessionEndpoint:
                         description: |-
                           The OIDC Provider's [end session endpoint](https://openid.net/specs/openid-connect-core-1_0.html#RPLogout).
@@ -44484,13 +51561,14 @@ spec:
                       If not specified, uses the default redirect URI "%REQ(x-forwarded-proto)%://%REQ(:authority)%/oauth2/callback"
                     type: string
                   refreshToken:
+                    default: true
                     description: |-
                       RefreshToken indicates whether the Envoy should automatically refresh the
                       id token and access token when they expire.
                       When set to true, the Envoy will use the refresh token to get a new id token
                       and access token when they expire.
 
-                      If not specified, defaults to false.
+                      If not specified, defaults to true.
                     type: boolean
                   resources:
                     description: |-
@@ -44691,15 +51769,15 @@ spec:
             - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
               rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
                 : true'
-            - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute
+            - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute
               rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
-                ''GRPCRoute''] : true'
+                ''GRPCRoute'', ''TCPRoute''] : true'
             - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group ==
                 ''gateway.networking.k8s.io'') : true '
-            - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute
+            - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
-                ''HTTPRoute'', ''GRPCRoute'']) : true '
+                ''HTTPRoute'', ''GRPCRoute'', ''TCPRoute'']) : true '
             - message: if authorization.rules.principal.jwt is used, jwt must be defined
               rule: '(has(self.authorization) && has(self.authorization.rules) &&
                 self.authorization.rules.exists(r, has(r.principal.jwt))) ? has(self.jwt)
@@ -44909,8 +51987,38 @@ spec:
                       - name
                       type: object
                     conditions:
-                      description: Conditions describes the status of the Policy with
-                        respect to the given Ancestor.
+                      description: |-
+                        Conditions describes the status of the Policy with respect to the given Ancestor.
+
+                        <gateway:util:excludeFromCRD>
+
+                        Notes for implementors:
+
+                        Conditions are a listType `map`, which means that they function like a
+                        map with a key of the `type` field _in the k8s apiserver_.
+
+                        This means that implementations must obey some rules when updating this
+                        section.
+
+                        * Implementations MUST perform a read-modify-write cycle on this field
+                          before modifying it. That is, when modifying this field, implementations
+                          must be confident they have fetched the most recent version of this field,
+                          and ensure that changes they make are on that recent version.
+                        * Implementations MUST NOT remove or reorder Conditions that they are not
+                          directly responsible for. For example, if an implementation sees a Condition
+                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
+                          Condition.
+                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
+                          rather than creating more than one Condition of the same Type.
+                        * Implementations MUST always update the `observedGeneration` field of the
+                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
+                        * If the `observedGeneration` of a Condition is _greater than_ the value the
+                          implementation knows about, then it MUST NOT perform the update on that Condition,
+                          but must wait for a future reconciliation and status update. (The assumption is that
+                          the implementation's copy of the object is stale and an update will be re-triggered
+                          if relevant.)
+
+                        </gateway:util:excludeFromCRD>
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.
@@ -44993,10 +52101,12 @@ spec:
                       type: string
                   required:
                   - ancestorRef
+                  - conditions
                   - controllerName
                   type: object
                 maxItems: 16
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - ancestors
             type: object
@@ -45016,10 +52126,10 @@ metadata:
   name: envoy-gateway
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: gateway-helm/templates/envoy-gateway-config.yaml
@@ -45029,10 +52139,10 @@ metadata:
   name: envoy-gateway-config
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 data:
   envoy-gateway.yaml: |
@@ -45048,7 +52158,7 @@ data:
       kubernetes:
         rateLimitDeployment:
           container:
-            image: docker.io/envoyproxy/ratelimit:e74a664a
+            image: docker.io/envoyproxy/ratelimit:05c08d03
           patch:
             type: StrategicMerge
             value:
@@ -45059,7 +52169,7 @@ data:
                     - imagePullPolicy: IfNotPresent
                       name: envoy-ratelimit
         shutdownManager:
-          image: docker.io/envoyproxy/gateway:v1.5.9
+          image: docker.io/envoyproxy/gateway:v1.7.2
       type: Kubernetes
 ---
 # Source: gateway-helm/templates/envoy-gateway-rbac.yaml
@@ -45183,6 +52293,20 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - gateway.networking.x-k8s.io
+  resources:
+  - xlistenersets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.x-k8s.io
+  resources:
+  - xlistenersets/status
+  verbs:
+  - update
+- apiGroups:
   - ""
   resources:
   - pods
@@ -45215,10 +52339,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-infra-manager
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -45274,10 +52398,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-leader-election-role
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -45319,10 +52443,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-infra-manager
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45340,10 +52464,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-leader-election-rolebinding
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45362,12 +52486,13 @@ metadata:
   namespace: 'tigera-gateway'
   labels:
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 spec:
+  type: ClusterIP
   selector:
     control-plane: envoy-gateway
     app.kubernetes.io/name: gateway-helm
@@ -45397,10 +52522,10 @@ metadata:
   namespace: 'tigera-gateway'
   labels:
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -45431,7 +52556,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway:v1.5.9
+        image: docker.io/envoyproxy/gateway:v1.7.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -45500,10 +52625,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
@@ -45515,10 +52640,10 @@ kind: ClusterRole
 metadata:
   name: 'tigera-gateway-api-gateway-helm-certgen:tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
@@ -45548,10 +52673,10 @@ kind: ClusterRoleBinding
 metadata:
   name: 'tigera-gateway-api-gateway-helm-certgen:tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
@@ -45572,10 +52697,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
@@ -45597,10 +52722,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
@@ -45621,10 +52746,10 @@ metadata:
   name: tigera-gateway-api-gateway-helm-certgen
   namespace: 'tigera-gateway'
   labels:
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
@@ -45649,7 +52774,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: docker.io/envoyproxy/gateway:v1.5.9
+        image: docker.io/envoyproxy/gateway:v1.7.2
         imagePullPolicy: IfNotPresent
         name: envoy-gateway-certgen
         securityContext:
@@ -45679,10 +52804,10 @@ metadata:
     "helm.sh/hook-weight": "-1"
   labels:
     app.kubernetes.io/component: topology-injector
-    helm.sh/chart: gateway-helm-v1.5.9
+    helm.sh/chart: gateway-helm-v1.7.2
     app.kubernetes.io/name: gateway-helm
     app.kubernetes.io/instance: tigera-gateway-api
-    app.kubernetes.io/version: "v1.5.9"
+    app.kubernetes.io/version: "v1.7.2"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: topology.webhook.gateway.envoyproxy.io

--- a/pkg/render/gatewayapi/gateway_api_resources.yaml
+++ b/pkg/render/gatewayapi/gateway_api_resources.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: tigera-gateway
 ---
-# Source: gateway-helm/crds/gatewayapi-crds.yaml
+# Source: crds/gatewayapi-crds.yaml
 # Copyright 2025 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20682,7 +20682,7 @@ status:
   storedVersions: null
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_backends.yaml
+# Source: crds/generated/gateway.envoyproxy.io_backends.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -21161,7 +21161,7 @@ spec:
       status: {}
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+# Source: crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -24143,7 +24143,7 @@ spec:
       status: {}
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+# Source: crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -26055,7 +26055,7 @@ spec:
       status: {}
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+# Source: crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -28225,7 +28225,7 @@ spec:
       status: {}
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_envoypatchpolicies.yaml
+# Source: crds/generated/gateway.envoyproxy.io_envoypatchpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -28738,7 +28738,7 @@ spec:
       status: {}
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+# Source: crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -45367,7 +45367,7 @@ spec:
       status: {}
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
+# Source: crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -45844,7 +45844,7 @@ spec:
     subresources: {}
 
 ---
-# Source: gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+# Source: crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
## Description

Aligns the Envoy Gateway helm chart embedded in operator `release-v1.40` with the EG binary version already shipping on customer clusters.

**Type:** bug fix (drift between operator-rendered manifests and the actual controller binary).

### Why

There are two `ENVOY_GATEWAY_VERSION` knobs that must stay in sync:

1. `tigera/calico-private/third_party/envoy-gateway/Makefile` — controls the source tarball that builds the `tigera/envoy-gateway` controller binary image.
2. `tigera/operator/Makefile` — controls the upstream helm chart rendered into `pkg/render/gatewayapi/gateway_api_resources.yaml` (CRDs, RBAC, MutatingWebhookConfiguration, controller Deployment manifest, ConfigMap).

These drifted in the run-up to CE v3.22.4:

| Date | Side | Action |
|---|---|---|
| 2026-04-09 | calico-private `release-calient-v3.22` | EG v1.5.7 → v1.7.1 (CVE bump) |
| 2026-04-17 | calico-private `release-calient-v3.22` | EG v1.7.1 → v1.7.2 (CVE bump) |
| 2026-05-05 | operator | Tag `v1.40.10` (CE v3.22.4) — still ships EG v1.5.9 helm chart |

Result on a CE v3.22.4 cluster: controller pod binary is upstream EG v1.7.2, but the CRDs/RBAC/Deployment/ConfigMap/MutatingWebhookConfiguration come from v1.5.9. API server prunes v1.6+/v1.7+ fields on user CRs (e.g. `lateResponseHeaders` on `ClientTrafficPolicy`) before the binary ever sees them.

Beyond drift, EG v1.5 reached upstream EOL in Feb 2026; v1.7 is actively supported.

### Scope

- Bump `ENVOY_GATEWAY_VERSION` in `Makefile`: `v1.5.9` → `v1.7.2`.
- Regenerate `pkg/render/gatewayapi/gateway_api_resources.yaml` from `oci://docker.io/envoyproxy/gateway-helm` at `v1.7.2`.

Explicitly **not** in scope:

- `go.mod` bump for `github.com/envoyproxy/gateway`. Pulling that to v1.7.2 drags in `k8s.io/* 0.33 → 0.35`, `sigs.k8s.io/controller-runtime 0.21 → 0.23`, and `sigs.k8s.io/gateway-api 1.3 → 1.4`, which `release-v1.40` deliberately does not carry. The operator's render code (`pkg/render/gatewayapi`) only touches additive, shared fields on the EnvoyProxy typed CR — keeping the Go types at v1.5.9 is forward-compatible with the v1.7.2 CRD schema.
- The `OwningGateway{Name,Namespace}EnvVar` injection added to `l7-log-collector` on master (unrelated to the EG version bump; not backported to release-v1.40).

### Testing

- [x] `go vet ./pkg/render/gatewayapi/... ./pkg/controller/gatewayapi/...` — clean
- [x] `go build ./pkg/render/gatewayapi/... ./pkg/controller/gatewayapi/...` — clean
- [x] `grep lateResponseHeaders pkg/render/gatewayapi/gateway_api_resources.yaml` — present (was absent at v1.5.9)
- [ ] `make ut UT_DIR=./pkg/render/gatewayapi` — pending reviewer environment
- [ ] `make ut UT_DIR=./pkg/controller/gatewayapi` — pending reviewer environment
- [ ] FV against a real cluster — pending

### Behavior changes to verify before merging

EG v1.5.9 → v1.7.2 introduces several behavior changes that customer-facing CRs may rely on. Field-engineer-friendly summary: see internal `eg-15-to-17-behavior-delta.md`. The notable ones:

- TLS SAN requirement on listener certs (v1.6.0).
- Default ALPN `[h2, http/1.1]` (v1.6.0).
- Implicit `enforcingConsecutiveGatewayFailure=100` on BackendTrafficPolicy outlier detection (v1.6.0).
- `x-envoy-ratelimited` header no longer added by default (v1.6.0).
- `custom_response` filter ordering change (v1.7.0).
- `Accept-Encoding` stripped to upstream by default (v1.7.0).
- BackendTrafficPolicy `requestBuffer` validation tightening (v1.6.2).
- ConnectionLimit `Value` validation tightening (v1.7.1).
- TLS cipher suite default tightening (v1.7.2).

Most of these are controller-binary-side changes that are *already* in effect on CE v3.22.4 clusters because of the drift described above. This PR primarily exposes CRD fields and RBAC rules that match what the binary expects; it does not introduce new runtime behavior beyond what the binary is already doing.

### Components affected

- `pkg/render/gatewayapi` only.

### Issues

- Customer ask: `lateResponseHeaders` on `ClientTrafficPolicy` (added upstream in EG v1.6.0). Internal field-engineer ticket pending; will link before review.

## Release Note

```release-note
Aligned the bundled Envoy Gateway v1.7.2 helm chart / gateway api resources with the controller binary version shipping in this release. 
```

## For PR author

- [x] Tests for change — render code untouched; rendered yaml is the only behavioral surface and is verified by existing render suite.
- [ ] If changing pkg/apis/, run \`make gen-files\` — N/A
- [x] If changing versions, run \`make gen-versions\` — N/A (this is an EG chart version, not a CE component version)

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - \`kind/bug\` (fixes drift between operator-rendered manifests and shipping binary)
  - \`enterprise\` (applies to Calico Enterprise gateway-api install)
  - \`release-note-required\`
  - \`docs-pr-required\` if docs reference EG-version-specific features

cc @nelljerram

```
Bump envoy gateway CRDs to 1.7.2 to match the image version which is already at 1.7.2, so that all features are accessible to the end user.
```