### PR TITLE
[release-v1.40] Use pod-network k8s service endpoint for non-cluster-host Typha

### DIFF
--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -16,6 +16,7 @@ package render
 
 import (
 	"fmt"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -670,14 +671,9 @@ func (c *typhaComponent) typhaEnvVarsNonClusterHost() []corev1.EnvVar {
 	// (e.g. MKE's proxy.local) may not be reachable. Strip the inherited env
 	// vars so we fall back to the default kubernetes Service that kubelet
 	// injects into every pod.
-	out := envVars[:0]
-	for _, e := range envVars {
-		if e.Name == "KUBERNETES_SERVICE_HOST" || e.Name == "KUBERNETES_SERVICE_PORT" {
-			continue
-		}
-		out = append(out, e)
-	}
-	envVars = out
+	envVars = slices.DeleteFunc(envVars, func(e corev1.EnvVar) bool {
+		return e.Name == "KUBERNETES_SERVICE_HOST" || e.Name == "KUBERNETES_SERVICE_PORT"
+	})
 
 	// Tell the health aggregator to listen on all interfaces.
 	envVars = append(envVars, corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"})

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -666,6 +666,19 @@ func (c *typhaComponent) typhaEnvVarsNonClusterHost() []corev1.EnvVar {
 	envVars = replaceOrAppendEnvVar(envVars, "TYPHA_CLIENTCN", c.cfg.TLS.NodeNonClusterHostCommonName)
 	envVars = replaceOrAppendEnvVar(envVars, "TYPHA_CLIENTURISAN", c.cfg.TLS.NodeNonClusterHostURISAN)
 
+	// NCH Typha runs pod-networked, so the host-network apiserver endpoint
+	// (e.g. MKE's proxy.local) may not be reachable. Strip the inherited env
+	// vars so we fall back to the default kubernetes Service that kubelet
+	// injects into every pod.
+	out := envVars[:0]
+	for _, e := range envVars {
+		if e.Name == "KUBERNETES_SERVICE_HOST" || e.Name == "KUBERNETES_SERVICE_PORT" {
+			continue
+		}
+		out = append(out, e)
+	}
+	envVars = out
+
 	// Tell the health aggregator to listen on all interfaces.
 	envVars = append(envVars, corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"})
 	return envVars

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -199,6 +199,27 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Host).To(BeEmpty())
 	})
 
+	It("should strip the host-network apiserver endpoint from the non-cluster-host Typha", func() {
+		cfg.K8sServiceEp = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
+
+		component := render.Typha(&cfg)
+		resources, _ := component.Objects()
+
+		// NCH Typha is pod-networked; let kubelet's default service injection take over.
+		d := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		for _, e := range d.Spec.Template.Spec.Containers[0].Env {
+			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_HOST"))
+			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_PORT"))
+		}
+
+		// The host-networked Typha still gets the configured endpoint.
+		dMain := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(dMain.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "proxy.local"},
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "6444"},
+		))
+	})
+
 	It("should use custom client common name when specified for non-cluster host Typha deployment", func() {
 		cfg.TLS.NodeNonClusterHostCommonName = "custom-nch-cn"
 		component := render.Typha(&cfg)


### PR DESCRIPTION
This branch (and the corresponding Calico Enterprise v3.22.x line) doesn't have https://github.com/tigera/operator/pull/4474 in it, so a direct cherry-pick of https://github.com/tigera/operator/pull/4840 + https://github.com/tigera/operator/pull/4846 doesn't apply cleanly. This is a minimal, self-contained backport that fixes the customer-reported failure mode without pulling the larger pod-network ServiceEndpoint refactor onto a stable branch.

The non-cluster-host Typha deployment runs pod-networked but inherits `KUBERNETES_SERVICE_HOST/PORT` from the host-network endpoint. On MKE clusters that resolves to `proxy.local:6444`, which pods can't resolve, so the deployment crashloops with DNS timeouts during the iptables-to-eBPF migration. Strip those env vars in `typhaEnvVarsNonClusterHost` so the NCH Typha falls back to the in-cluster kubernetes Service that kubelet injects into every pod.

Requested for inclusion in the v3.22.6 patch release.

Related: https://tigera.atlassian.net/browse/CI-1987

```release-note
Fixes the non-cluster-host Typha deployment crashlooping on clusters where the host-network kube-apiserver endpoint is not reachable from pod-networked pods (e.g. MKE proxy.local).
```
