### PR TITLE
[release-v1.42] Grant calico-apiserver RBAC for managedclusters/status

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1468,6 +1468,7 @@ func (c *apiServerComponent) tigeraAPIServerClusterRole() *rbacv1.ClusterRole {
 				"globalthreatfeeds/status",
 				"licensekeys",
 				"managedclusters",
+				"managedclusters/status",
 				"networks",
 				"packetcaptures",
 				"policyrecommendationscopes",


### PR DESCRIPTION
Backport of https://github.com/tigera/operator/pull/4843 to release-v1.42. Follow-up to https://github.com/tigera/operator/pull/4824.

The original change granted calico-manager (voltron's SA) update access to managedclusters/status on the projectcalico.org aggregated API. That gets voltron past its own auth check, but when the aggregated apiserver proxies the status write through to the backing CRD it does so as the calico-apiserver SA, which still lacked managedclusters/status on crd.projectcalico.org. The result is voltron loops on:

    managedclusters.crd.projectcalico.org "<name>" is forbidden: User "system:serviceaccount:calico-system:calico-apiserver" cannot update resource "managedclusters/status" in API group "crd.projectcalico.org"

ManagedClusters then never get a Connected condition, es-kube-controllers treats them as disconnected, and the LicenseKey never reaches the managed cluster. Verified on a live management cluster that adding this permission lets voltron set the status and unblocks the license sync.

```release-note
Fixes an issue where the LicenseKey was not copied to managed clusters in a multi-cluster management setup, due to missing RBAC on the Calico apiserver service account.
```