### PR TITLE
Strip apiserver endpoint env vars on non-cluster-host Typha by default

### DIFF
--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -658,6 +658,23 @@ func (c *typhaComponent) typhaEnvVars(typhaSecret certificatemanagement.KeyPairI
 	return typhaEnv
 }
 
+func removeEnvVars(envVars []corev1.EnvVar, keys ...string) []corev1.EnvVar {
+	out := envVars[:0]
+	for _, e := range envVars {
+		drop := false
+		for _, k := range keys {
+			if e.Name == k {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 func replaceOrAppendEnvVar(envVars []corev1.EnvVar, key, value string) []corev1.EnvVar {
 	found := false
 	for i := range envVars {
@@ -681,11 +698,12 @@ func (c *typhaComponent) typhaEnvVarsNonClusterHost() []corev1.EnvVar {
 	envVars = replaceOrAppendEnvVar(envVars, "TYPHA_CLIENTURISAN", c.cfg.TLS.NodeNonClusterHostURISAN)
 
 	// NCH Typha runs pod-networked, so the host-network apiserver endpoint
-	// (e.g. MKE's proxy.local) may not be reachable.
-	if podEp := c.cfg.K8sServiceEpPodNetwork; podEp.Host != "" && podEp.Port != "" {
-		envVars = replaceOrAppendEnvVar(envVars, "KUBERNETES_SERVICE_HOST", podEp.Host)
-		envVars = replaceOrAppendEnvVar(envVars, "KUBERNETES_SERVICE_PORT", podEp.Port)
-	}
+	// (e.g. MKE's proxy.local) may not be reachable. Strip the inherited env
+	// vars so we fall back to the default kubernetes Service that kubelet
+	// injects into every pod, then re-add a pod-network endpoint if one was
+	// configured explicitly.
+	envVars = removeEnvVars(envVars, "KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT")
+	envVars = append(envVars, c.cfg.K8sServiceEpPodNetwork.EnvVars()...)
 
 	// Tell the health aggregator to listen on all interfaces.
 	envVars = append(envVars, corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"})

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -16,6 +16,7 @@ package render
 
 import (
 	"fmt"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -658,23 +659,6 @@ func (c *typhaComponent) typhaEnvVars(typhaSecret certificatemanagement.KeyPairI
 	return typhaEnv
 }
 
-func removeEnvVars(envVars []corev1.EnvVar, keys ...string) []corev1.EnvVar {
-	out := envVars[:0]
-	for _, e := range envVars {
-		drop := false
-		for _, k := range keys {
-			if e.Name == k {
-				drop = true
-				break
-			}
-		}
-		if !drop {
-			out = append(out, e)
-		}
-	}
-	return out
-}
-
 func replaceOrAppendEnvVar(envVars []corev1.EnvVar, key, value string) []corev1.EnvVar {
 	found := false
 	for i := range envVars {
@@ -702,7 +686,9 @@ func (c *typhaComponent) typhaEnvVarsNonClusterHost() []corev1.EnvVar {
 	// vars so we fall back to the default kubernetes Service that kubelet
 	// injects into every pod, then re-add a pod-network endpoint if one was
 	// configured explicitly.
-	envVars = removeEnvVars(envVars, "KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT")
+	envVars = slices.DeleteFunc(envVars, func(e corev1.EnvVar) bool {
+		return e.Name == "KUBERNETES_SERVICE_HOST" || e.Name == "KUBERNETES_SERVICE_PORT"
+	})
 	envVars = append(envVars, c.cfg.K8sServiceEpPodNetwork.EnvVars()...)
 
 	// Tell the health aggregator to listen on all interfaces.

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -217,7 +217,28 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Host).To(BeEmpty())
 	})
 
-	It("should override KUBERNETES_SERVICE_HOST/PORT on the non-cluster-host Typha when a pod-network endpoint is configured", func() {
+	It("should strip the host-network apiserver endpoint from the non-cluster-host Typha and fall back to the default Service", func() {
+		cfg.K8sServiceEp = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
+
+		component := render.Typha(&cfg)
+		resources, _ := component.Objects()
+
+		// NCH Typha is pod-networked; let kubelet's default service injection take over.
+		d := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		for _, e := range d.Spec.Template.Spec.Containers[0].Env {
+			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_HOST"))
+			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_PORT"))
+		}
+
+		// The host-networked Typha still gets the configured endpoint.
+		dMain := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(dMain.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "proxy.local"},
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "6444"},
+		))
+	})
+
+	It("should respect an explicit pod-network apiserver endpoint on the non-cluster-host Typha when configured", func() {
 		cfg.K8sServiceEp = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
 		cfg.K8sServiceEpPodNetwork = k8sapi.ServiceEndpoint{Host: "10.96.0.1", Port: "443"}
 
@@ -228,13 +249,6 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
 			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "10.96.0.1"},
 			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "443"},
-		))
-
-		// The host-networked Typha should still use the host-network endpoint.
-		dMain := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(dMain.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "proxy.local"},
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "6444"},
 		))
 	})
 


### PR DESCRIPTION
Follow-up to https://github.com/tigera/operator/pull/4840.

The previous fix only overrode `KUBERNETES_SERVICE_HOST/PORT` on the non-cluster-host Typha when an explicit pod-network endpoint was configured. If it wasn't, the NCH Typha still inherited the host-network endpoint (e.g. `proxy.local:6444` on MKE) and crashlooped just like before.

Since the NCH Typha runs pod-networked, it should default to the in-cluster `kubernetes` Service that kubelet injects into every pod. Always strip the inherited env vars in `typhaEnvVarsNonClusterHost`, and only re-add them if `K8sServiceEpPodNetwork` is set explicitly.

Related: https://tigera.atlassian.net/browse/CI-1987
```release-note
None
```