### PR TITLE
[release-v1.42] Strip apiserver endpoint env vars on non-cluster-host Typha by default

### DIFF
--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -16,6 +16,7 @@ package render
 
 import (
 	"fmt"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -689,11 +690,14 @@ func (c *typhaComponent) typhaEnvVarsNonClusterHost() []corev1.EnvVar {
 	envVars = replaceOrAppendEnvVar(envVars, "TYPHA_CLIENTURISAN", c.cfg.TLS.NodeNonClusterHostURISAN)
 
 	// NCH Typha runs pod-networked, so the host-network apiserver endpoint
-	// (e.g. MKE's proxy.local) may not be reachable.
-	if podEp := c.cfg.K8sServiceEpPodNetwork; podEp.Host != "" && podEp.Port != "" {
-		envVars = replaceOrAppendEnvVar(envVars, "KUBERNETES_SERVICE_HOST", podEp.Host)
-		envVars = replaceOrAppendEnvVar(envVars, "KUBERNETES_SERVICE_PORT", podEp.Port)
-	}
+	// (e.g. MKE's proxy.local) may not be reachable. Strip the inherited env
+	// vars so we fall back to the default kubernetes Service that kubelet
+	// injects into every pod, then re-add a pod-network endpoint if one was
+	// configured explicitly.
+	envVars = slices.DeleteFunc(envVars, func(e corev1.EnvVar) bool {
+		return e.Name == "KUBERNETES_SERVICE_HOST" || e.Name == "KUBERNETES_SERVICE_PORT"
+	})
+	envVars = append(envVars, c.cfg.K8sServiceEpPodNetwork.EnvVars()...)
 
 	// Tell the health aggregator to listen on all interfaces.
 	envVars = append(envVars, corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"})

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -199,7 +199,28 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Host).To(BeEmpty())
 	})
 
-	It("should override KUBERNETES_SERVICE_HOST/PORT on the non-cluster-host Typha when a pod-network endpoint is configured", func() {
+	It("should strip the host-network apiserver endpoint from the non-cluster-host Typha and fall back to the default Service", func() {
+		cfg.K8sServiceEp = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
+
+		component := render.Typha(&cfg)
+		resources, _ := component.Objects()
+
+		// NCH Typha is pod-networked; let kubelet's default service injection take over.
+		d := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		for _, e := range d.Spec.Template.Spec.Containers[0].Env {
+			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_HOST"))
+			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_PORT"))
+		}
+
+		// The host-networked Typha still gets the configured endpoint.
+		dMain := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
+		Expect(dMain.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "proxy.local"},
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "6444"},
+		))
+	})
+
+	It("should respect an explicit pod-network apiserver endpoint on the non-cluster-host Typha when configured", func() {
 		cfg.K8sServiceEp = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
 		cfg.K8sServiceEpPodNetwork = k8sapi.ServiceEndpoint{Host: "10.96.0.1", Port: "443"}
 
@@ -210,13 +231,6 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
 			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "10.96.0.1"},
 			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "443"},
-		))
-
-		// The host-networked Typha should still use the host-network endpoint.
-		dMain := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(dMain.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "proxy.local"},
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "6444"},
 		))
 	})
 


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/4846 (follow-up to https://github.com/tigera/operator/pull/4840 / https://github.com/tigera/operator/pull/4842) to `release-v1.42`. Requested for inclusion in the v3.23.1 patch release.

The non-cluster-host Typha runs pod-networked but inherits `KUBERNETES_SERVICE_HOST/PORT` from the host-network endpoint. The earlier cherry-pick (#4842) only overrode those env vars when a pod-network endpoint was explicitly configured, which left the MKE failure mode in place when the customer hadn't set one. This change always strips the inherited host-network values so kubelet's default-service injection takes over, then re-adds the pod-network endpoint if one was configured.

Clean cherry-pick.

Related: https://tigera.atlassian.net/browse/CI-1987

```release-note
NONE
```
