### PR TITLE
[v1.40] Wire OIDC env vars into dashboard-api sidecar

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -669,6 +669,10 @@ func (c *managerComponent) dashboardContainer() corev1.Container {
 		{Name: "HEALTH_PORT", Value: DashboardAPIHealthPort},
 	}
 
+	if c.cfg.KeyValidatorConfig != nil {
+		env = append(env, c.cfg.KeyValidatorConfig.RequiredEnv("")...)
+	}
+
 	mounts := append(
 		c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType()),
 		c.cfg.InternalTLSKeyPair.VolumeMount(c.SupportedOSType()),

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -488,6 +488,13 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			ValueFrom: nil,
 		}
 		Expect(d.Spec.Template.Spec.Containers[3].Env).To(ContainElement(oidcEnvVar))
+
+		// dashboard-api must get its own bare-prefixed OIDC_AUTH_* env vars so it can
+		// validate the bearer token voltron forwards on /dashboards/*.
+		dashboard := rtest.GetContainer(d.Spec.Template.Spec.Containers, render.DashboardAPIName)
+		Expect(dashboard).NotTo(BeNil())
+		Expect(dashboard.Env).To(ContainElement(corev1.EnvVar{Name: "OIDC_AUTH_ENABLED", Value: "true"}))
+		Expect(dashboard.Env).To(ContainElement(corev1.EnvVar{Name: "OIDC_AUTH_ISSUER", Value: "https://127.0.0.1/dex"}))
 	})
 
 	Describe("public ca bundle", func() {


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v1.40**: tigera/operator#4827

## Description

The `tigera-dashboard-api` sidecar in the `tigera-manager` pod was rendered without any OIDC config, so it rejected every bearer token voltron forwarded on `/dashboards/*`. Wire `KeyValidatorConfig` into the container the same way `managerUIAPIsContainer` does so dashboard-api can verify the token using its own OIDC settings.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Fixed 403 errors on custom dashboards for OIDC users.
```

## For PR author

- [x] Tests for change.
- ~~[ ] If changing pkg/apis/, run `make gen-files`~~
- ~~[ ] If changing versions, run `make gen-versions`~~

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

