### PR TITLE
Support enterprise whisker-backend with Linseed upstream

### DIFF
--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -79,6 +79,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	for _, secretName := range []string{
 		certificatemanagement.CASecretName,
 		goldmane.GoldmaneKeyPairSecret,
+		render.TigeraLinseedSecret,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("failed to add watch for secret %s/%s: %w", common.OperatorNamespace(), secretName, err)
@@ -178,12 +179,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if goldmaneCR, err := utils.GetIfExists[operatorv1.Goldmane](ctx, utils.DefaultInstanceKey, r.cli); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying for Goldmane CR", err, reqLogger)
-		return reconcile.Result{}, err
-	} else if goldmaneCR == nil {
-		r.status.SetDegraded(operatorv1.ResourceNotFound, "Goldmane CR not present; Goldmane is pre requisite for Whisker", err, reqLogger)
-		return reconcile.Result{}, nil
+	isEnterprise := installationSpec.Variant.IsEnterprise()
+
+	if !isEnterprise {
+		if goldmaneCR, err := utils.GetIfExists[operatorv1.Goldmane](ctx, utils.DefaultInstanceKey, r.cli); err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying for Goldmane CR", err, reqLogger)
+			return reconcile.Result{}, err
+		} else if goldmaneCR == nil {
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "Goldmane CR not present; Goldmane is pre requisite for Whisker", err, reqLogger)
+			return reconcile.Result{}, nil
+		}
 	}
 
 	pullSecrets, err := utils.GetInstallationPullSecrets(installationSpec, r.cli)
@@ -206,15 +211,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	var trustedBundleSecrets []string
+	if isEnterprise {
+		trustedBundleSecrets = append(trustedBundleSecrets, render.TigeraLinseedSecret)
+	} else {
+		trustedBundleSecrets = append(trustedBundleSecrets, goldmane.GoldmaneKeyPairSecret)
+	}
+
 	trustedBundle, err := certificateManager.CreateNamedTrustedBundleFromSecrets(
 		whisker.WhiskerDeploymentName,
 		r.cli,
 		common.OperatorNamespace(),
 		false,
-		goldmane.GoldmaneKeyPairSecret,
+		trustedBundleSecrets...,
 	)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the trusted bundle", err, reqLogger)
+		return reconcile.Result{}, err
 	}
 
 	preDefaultPatchFrom := client.MergeFrom(whiskerCR.DeepCopy())

--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -35,13 +35,17 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
+	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
+	rauth "github.com/tigera/operator/pkg/render/common/authentication"
 	"github.com/tigera/operator/pkg/render/goldmane"
 	"github.com/tigera/operator/pkg/render/whisker"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -73,6 +77,14 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	if err = c.WatchObject(&operatorv1.Goldmane{}, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("%s failed to watch for goldmane resource: %w", controllerName, err)
 	}
+	// Enterprise inputs: the Authentication CR wires Dex, and a
+	// ManagementClusterConnection marks a managed cluster, where nothing is deployed.
+	if err = c.WatchObject(&operatorv1.Authentication{}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("%s failed to watch for Authentication resource: %w", controllerName, err)
+	}
+	if err = c.WatchObject(&operatorv1.ManagementClusterConnection{}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("%s failed to watch for ManagementClusterConnection resource: %w", controllerName, err)
+	}
 
 	if err = utils.AddInstallationWatch(c); err != nil {
 		return fmt.Errorf("%s failed to watch Installation resource: %w", controllerName, err)
@@ -82,6 +94,8 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		certificatemanagement.CASecretName,
 		whisker.WhiskerKeyPairSecret,
 		goldmane.GoldmaneKeyPairSecret,
+		render.TigeraLinseedSecret,
+		render.DexTLSSecretName,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("failed to add watch for secret %s/%s: %w", common.OperatorNamespace(), secretName, err)
@@ -214,12 +228,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if goldmaneCR, err := utils.GetIfExists[operatorv1.Goldmane](ctx, utils.DefaultInstanceKey, r.cli); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying for Goldmane CR", err, reqLogger)
-		return reconcile.Result{}, err
-	} else if goldmaneCR == nil {
-		r.status.SetDegraded(operatorv1.ResourceNotFound, "Goldmane CR not present; Goldmane is pre requisite for Whisker", err, reqLogger)
-		return reconcile.Result{}, nil
+	isEnterprise := installationSpec.Variant.IsEnterprise()
+
+	if !isEnterprise {
+		if goldmaneCR, err := utils.GetIfExists[operatorv1.Goldmane](ctx, utils.DefaultInstanceKey, r.cli); err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying for Goldmane CR", err, reqLogger)
+			return reconcile.Result{}, err
+		} else if goldmaneCR == nil {
+			r.status.SetDegraded(operatorv1.ResourceNotFound, "Goldmane CR not present; Goldmane is pre requisite for Whisker", err, reqLogger)
+			return reconcile.Result{}, nil
+		}
+	} else {
+		// The flow logs UI is a manager module, and the manager runs on management
+		// and standalone clusters only. A managed cluster's flows are served by the
+		// management cluster's whisker-backend, so there is nothing to deploy here.
+		mcc, err := utils.GetManagementClusterConnection(ctx, r.cli)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to read ManagementClusterConnection", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		if mcc != nil {
+			reqLogger.V(1).Info("Managed cluster: whisker-backend is not deployed; flow logs are served by the management cluster")
+			r.status.ReadyToMonitor()
+			r.status.ClearDegraded()
+			return reconcile.Result{}, nil
+		}
 	}
 
 	pullSecrets, err := utils.GetInstallationPullSecrets(installationSpec, r.cli)
@@ -234,12 +267,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	whiskerCertificateNames := dns.GetServiceDNSNames(whisker.WhiskerName, whisker.WhiskerNamespace, r.clusterDomain)
-	whiskerCertificateNames = append(whiskerCertificateNames, "localhost")
-	whiskerKeyPair, err := certificateManager.GetOrCreateKeyPair(r.cli, whisker.WhiskerKeyPairSecret, whisker.WhiskerNamespace, whiskerCertificateNames)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating whisker TLS certificate", err, reqLogger)
-		return reconcile.Result{}, err
+	// The Whisker UI and its nginx TLS pair are OSS-only; in enterprise the UI
+	// is a manager UI module and only the backend is deployed.
+	var whiskerKeyPair certificatemanagement.KeyPairInterface
+	if !isEnterprise {
+		whiskerCertificateNames := dns.GetServiceDNSNames(whisker.WhiskerName, whisker.WhiskerNamespace, r.clusterDomain)
+		whiskerCertificateNames = append(whiskerCertificateNames, "localhost")
+		whiskerKeyPair, err = certificateManager.GetOrCreateKeyPair(r.cli, whisker.WhiskerKeyPairSecret, whisker.WhiskerNamespace, whiskerCertificateNames)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating whisker TLS certificate", err, reqLogger)
+			return reconcile.Result{}, err
+		}
 	}
 
 	whiskerBackendCertificateNames := dns.GetServiceDNSNames("whisker-backend", whisker.WhiskerNamespace, r.clusterDomain)
@@ -250,15 +288,54 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	var trustedBundleSecrets []string
+	var keyValidatorConfig rauth.KeyValidatorConfig
+	if isEnterprise {
+		// Linseed is the flow source. Without its certificate the backend cannot
+		// reach it, so wait rather than run a backend that fails every request.
+		linseedCert, err := certificateManager.GetCertificate(r.cli, render.TigeraLinseedSecret, common.OperatorNamespace())
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Failed to retrieve %s", render.TigeraLinseedSecret), err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		if linseedCert == nil {
+			r.status.SetDegraded(operatorv1.ResourceNotReady, "Linseed certificate is not available yet, waiting until it becomes available", nil, reqLogger)
+			return reconcile.Result{}, nil
+		}
+		trustedBundleSecrets = append(trustedBundleSecrets, render.TigeraLinseedSecret)
+
+		// Dex-issued user tokens are accepted once the Authentication CR is ready.
+		authenticationCR, err := eutils.GetAuthentication(ctx, r.cli)
+		if err != nil && !apierrors.IsNotFound(err) {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error while fetching Authentication", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		if authenticationCR != nil && authenticationCR.Status.State != operatorv1.TigeraStatusReady {
+			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Authentication is not ready, status: %s", authenticationCR.Status.State), nil, reqLogger)
+			return reconcile.Result{}, nil
+		}
+		if eutils.DexEnabled(authenticationCR) {
+			trustedBundleSecrets = append(trustedBundleSecrets, render.DexTLSSecretName)
+		}
+		keyValidatorConfig, err = eutils.GetKeyValidatorConfig(ctx, r.cli, authenticationCR, r.clusterDomain, false)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceValidationError, "Failed to process the authentication CR", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+	} else {
+		trustedBundleSecrets = append(trustedBundleSecrets, goldmane.GoldmaneKeyPairSecret)
+	}
+
 	trustedBundle, err := certificateManager.CreateNamedTrustedBundleFromSecrets(
 		whisker.WhiskerDeploymentName,
 		r.cli,
 		common.OperatorNamespace(),
 		false,
-		goldmane.GoldmaneKeyPairSecret,
+		trustedBundleSecrets...,
 	)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the trusted bundle", err, reqLogger)
+		return reconcile.Result{}, err
 	}
 
 	preDefaultPatchFrom := client.MergeFrom(whiskerCR.DeepCopy())
@@ -301,6 +378,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		WhiskerBackendKeyPair: backendKeyPair,
 		Whisker:               renderCR,
 		ClusterDomain:         r.clusterDomain,
+		KeyValidatorConfig:    keyValidatorConfig,
 	}
 
 	clusterInfo := &v3.ClusterInformation{}
@@ -354,8 +432,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	keyPairOptions := []rcertificatemanagement.KeyPairOption{
-		rcertificatemanagement.NewKeyPairOption(whiskerKeyPair, true, true),
 		rcertificatemanagement.NewKeyPairOption(backendKeyPair, true, true),
+	}
+	if whiskerKeyPair != nil {
+		keyPairOptions = append(keyPairOptions, rcertificatemanagement.NewKeyPairOption(whiskerKeyPair, true, true))
 	}
 	if gatewayTLSKeyPair != nil {
 		keyPairOptions = append(keyPairOptions, rcertificatemanagement.NewKeyPairOption(gatewayTLSKeyPair, true, false))

--- a/pkg/controller/whisker/controller_test.go
+++ b/pkg/controller/whisker/controller_test.go
@@ -16,6 +16,7 @@ package whisker
 
 import (
 	"context"
+	"strings"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -44,6 +45,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/whisker"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,6 +53,16 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+// createLinseedCertificate stands in for the log storage controller, which
+// issues Linseed's serving certificate on management and standalone clusters.
+func createLinseedCertificate(ctx context.Context, cli client.Client) {
+	cm, err := certificatemanager.Create(cli, nil, "cluster.local", common.OperatorNamespace(), certificatemanager.AllowCACreation())
+	Expect(err).NotTo(HaveOccurred())
+	kp, err := cm.GetOrCreateKeyPair(cli, render.TigeraLinseedSecret, common.OperatorNamespace(), []string{render.TigeraLinseedSecret})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cli.Create(ctx, kp.Secret(common.OperatorNamespace()))).NotTo(HaveOccurred())
+}
 
 var _ = Describe("whisker controller tests", func() {
 	var (
@@ -332,6 +344,7 @@ var _ = Describe("whisker controller tests", func() {
 			reconciler.ext = trimIngressGateway{reconciler.ext}
 			createGatewayAPI()
 			setIngressGateway(nil)
+			createLinseedCertificate(ctx, cli)
 
 			stray := &gapi.Gateway{ObjectMeta: metav1.ObjectMeta{
 				Name:      gatewayName,
@@ -409,6 +422,67 @@ var _ = Describe("whisker controller tests", func() {
 				"the operator-created gateway namespace must be deleted, not leaked")
 		})
 	})
+	Context("enterprise reconciliation", func() {
+		var reconciler Reconciler
+		reconcileOnce := func() (reconcile.Result, error) {
+			return reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: "calico-system"}})
+		}
+		getDeployment := func() error {
+			return cli.Get(ctx, types.NamespacedName{Name: whisker.WhiskerDeploymentName, Namespace: whisker.WhiskerNamespace}, &appsv1.Deployment{})
+		}
+
+		BeforeEach(func() {
+			Expect(cli.Create(ctx, installation)).NotTo(HaveOccurred())
+			Expect(cli.Get(ctx, types.NamespacedName{Name: installation.Name}, installation)).NotTo(HaveOccurred())
+			installation.Status.Computed.Variant = operatorv1.CalicoEnterprise
+			Expect(cli.Status().Update(ctx, installation)).NotTo(HaveOccurred())
+			reconciler = Reconciler{
+				cli:      cli,
+				scheme:   scheme,
+				provider: operatorv1.ProviderNone,
+				status:   mockStatus,
+				ext:      extensions.Extensions{}.Whisker(),
+			}
+		})
+
+		It("waits for the Linseed certificate before deploying whisker-backend", func() {
+			// Without Linseed the backend would start and fail every request; the
+			// operator must report that instead of reporting Available.
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			mockStatus.AssertCalled(GinkgoT(), "SetDegraded", operatorv1.ResourceNotReady,
+				mock.MatchedBy(func(msg string) bool { return strings.Contains(msg, "Linseed") }), mock.Anything, mock.Anything)
+			Expect(getDeployment()).To(HaveOccurred(), "no backend until Linseed is reachable")
+		})
+
+		It("deploys whisker-backend wired for Voltron once the Linseed certificate exists", func() {
+			createLinseedCertificate(ctx, cli)
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			mockStatus.AssertNotCalled(GinkgoT(), "SetDegraded", operatorv1.ResourceNotReady, mock.Anything, mock.Anything, mock.Anything)
+
+			d := &appsv1.Deployment{}
+			Expect(cli.Get(ctx, types.NamespacedName{Name: whisker.WhiskerDeploymentName, Namespace: whisker.WhiskerNamespace}, d)).NotTo(HaveOccurred())
+			Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1), "enterprise deploys the backend only")
+			Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
+				corev1.EnvVar{Name: "MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: render.ManagerService(nil)}))
+		})
+
+		It("deploys nothing on a managed cluster and does not degrade", func() {
+			// The manager UI, and so the flow logs module, runs on the management
+			// cluster; its whisker-backend serves this cluster's flows.
+			Expect(cli.Create(ctx, &operatorv1.ManagementClusterConnection{
+				ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			})).NotTo(HaveOccurred())
+
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getDeployment()).To(HaveOccurred())
+			mockStatus.AssertNotCalled(GinkgoT(), "SetDegraded", operatorv1.ResourceNotReady, mock.Anything, mock.Anything, mock.Anything)
+			mockStatus.AssertCalled(GinkgoT(), "ReadyToMonitor")
+		})
+	})
+
 })
 
 // trimIngressGateway stands in for a variant that does not serve whisker's own

--- a/pkg/enterprise/controller/manager/manager_controller.go
+++ b/pkg/enterprise/controller/manager/manager_controller.go
@@ -146,6 +146,9 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	if err = c.WatchObject(&operatorv1.NonClusterHost{}, eventHandler); err != nil {
 		return fmt.Errorf("manager-controller failed to watch resource: %w", err)
 	}
+	if err = c.WatchObject(&operatorv1.Whisker{}, eventHandler); err != nil {
+		return fmt.Errorf("manager-controller failed to watch resource: %w", err)
+	}
 	if err = c.WatchObject(&operatorv1.Authentication{}, eventHandler); err != nil {
 		return fmt.Errorf("manager-controller failed to watch resource: %w", err)
 	}
@@ -662,6 +665,13 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to query NonClusterHost resource", err, logc)
 		return reconcile.Result{}, err
 	}
+
+	// The flow logs UI module and its Voltron route follow the Whisker CR.
+	whiskerCR, err := utils.GetIfExists[operatorv1.Whisker](ctx, utils.DefaultInstanceKey, r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to query Whisker resource", err, logc)
+		return reconcile.Result{}, err
+	}
 	if nonclusterhost != nil {
 		if _, _, _, err := url.ParseEndpoint(nonclusterhost.Spec.Endpoint); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to read parse endpoint from NonClusterHost resource", err, logc)
@@ -728,6 +738,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		Manager:                    instance,
 		Authentication:             authenticationCR,
 		KibanaEnabled:              kibanaEnabled,
+		WhiskerEnabled:             whiskerCR != nil,
 		RBACManagementEnabled:      rbacManagementEnabled,
 		CACertCommonName:           certificateManager.CACertCommonName(),
 		Cloud:                      r.opts.Cloud,

--- a/pkg/enterprise/whisker/extension.go
+++ b/pkg/enterprise/whisker/extension.go
@@ -15,13 +15,10 @@
 package whisker
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
-	rwhisker "github.com/tigera/operator/pkg/render/whisker"
 )
 
 const ingressGatewayWarning = "ingressgateway-variant"
@@ -51,18 +48,8 @@ func (e *Extension) ValidateAndDefault(cr *operatorv1.Whisker, st status.StatusM
 	return nil
 }
 
-// Modify dispatches over the components the whisker controller renders.
+// Modify is a no-op: the whisker render component shapes its objects per
+// variant itself, and Enterprise deploys whisker-backend.
 func (e *Extension) Modify(c render.Component, ri render.Inputs) render.Component {
-	switch c.(type) {
-	case *rwhisker.Component:
-		return extensions.Decorate(c, ri, e.variant, deleteWhisker)
-	default:
-		return c
-	}
-}
-
-// deleteWhisker moves everything whisker rendered to the delete list. Enterprise has
-// no whisker, so an install upgraded from Calico cleans up after itself.
-func deleteWhisker(create, del []client.Object) ([]client.Object, []client.Object) {
-	return nil, append(del, create...)
+	return c
 }

--- a/pkg/enterprise/whisker/extension_test.go
+++ b/pkg/enterprise/whisker/extension_test.go
@@ -45,15 +45,14 @@ var _ = Describe("whisker enterprise render extension", func() {
 		})
 	}
 
-	It("queues everything whisker rendered for deletion", func() {
+	It("leaves the enterprise whisker render unmodified", func() {
 		base := component(operatorv1.CalicoEnterprise)
 		baseCreate, baseDelete := base.Objects()
 		Expect(baseCreate).NotTo(BeEmpty())
 
 		create, del := ext.Whisker().Modify(base, renderInputs(operatorv1.CalicoEnterprise)).Objects()
-		Expect(create).To(BeEmpty())
-		Expect(del).To(HaveLen(len(baseCreate) + len(baseDelete)))
-		Expect(del).To(ContainElements(baseCreate))
+		Expect(create).To(HaveLen(len(baseCreate)))
+		Expect(del).To(HaveLen(len(baseDelete)))
 	})
 
 	It("leaves whisker alone when the installation is Calico", func() {

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -290,6 +290,10 @@ func (h *NetworkPolicyHelper) ManagerSourceEntityRule() v3.EntityRule {
 	return CreateSourceEntityRule(h.namespace("calico-system"), "calico-manager")
 }
 
+func (h *NetworkPolicyHelper) WhiskerSourceEntityRule() v3.EntityRule {
+	return CreateSourceEntityRule(h.namespace("calico-system"), "whisker")
+}
+
 func (h *NetworkPolicyHelper) APIServerSourceEntityRule(v operatorv1.ProductVariant) v3.EntityRule {
 	return CreateSourceEntityRule(h.namespace("calico-system"), "calico-apiserver")
 }

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -298,6 +298,10 @@ func (h *NetworkPolicyHelper) ManagerSourceEntityRule() v3.EntityRule {
 	return CreateSourceEntityRule(h.namespace("calico-system"), "calico-manager")
 }
 
+func (h *NetworkPolicyHelper) WhiskerSourceEntityRule() v3.EntityRule {
+	return CreateSourceEntityRule(h.namespace("calico-system"), "whisker")
+}
+
 func (h *NetworkPolicyHelper) APIServerSourceEntityRule(v operatorv1.ProductVariant) v3.EntityRule {
 	return CreateSourceEntityRule(h.namespace("calico-system"), "calico-apiserver")
 }

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -512,6 +512,13 @@ func (c *dexComponent) calicoSystemNetworkPolicy(installationVariant operatorv1.
 					Source:      networkpolicy.DefaultHelper().APIServerSourceEntityRule(installationVariant),
 					Destination: dexIngressPortDestination,
 				},
+				// whisker-backend verifies Dex-issued user tokens against Dex's signing keys.
+				{
+					Action:      v3.Allow,
+					Protocol:    &networkpolicy.TCPProtocol,
+					Source:      networkpolicy.DefaultHelper().WhiskerSourceEntityRule(),
+					Destination: dexIngressPortDestination,
+				},
 			},
 			Egress: egressRules,
 		},

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -672,6 +672,12 @@ func (l *linseed) linseedCalicoSystemPolicy() *v3.NetworkPolicy {
 			Source:      networkpolicyHelper.APIServerSourceEntityRule(l.cfg.Installation.Variant),
 			Destination: linseedIngressDestinationEntityRule,
 		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Source:      networkpolicyHelper.WhiskerSourceEntityRule(),
+			Destination: linseedIngressDestinationEntityRule,
+		},
 	}
 
 	if l.cfg.HasDPIResource {

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -695,6 +695,12 @@ func (l *linseed) linseedCalicoSystemPolicy() *v3.NetworkPolicy {
 			Source:      networkpolicyHelper.APIServerSourceEntityRule(l.cfg.Installation.Variant),
 			Destination: linseedIngressDestinationEntityRule,
 		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Source:      networkpolicyHelper.WhiskerSourceEntityRule(),
+			Destination: linseedIngressDestinationEntityRule,
+		},
 	}
 
 	if l.cfg.HasDPIResource {

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -101,15 +101,24 @@ const (
 
 // ManagementClusterConnection configuration constants
 const (
-	ManagerName              = "calico-manager"
-	UIAPIsName               = "calico-ui-apis"
-	VoltronName              = "calico-voltron"
-	VoltronTunnelSecretName  = "calico-management-cluster-connection"
-	defaultVoltronPort       = "9443"
-	defaultTunnelVoltronPort = "9449"
-	DashboardAPIPort         = "8444"
-	DashboardAPIHealthPort   = "8090"
-	DashboardAPIName         = "calico-dashboard-api"
+	ManagerName = "calico-manager"
+	UIAPIsName  = "calico-ui-apis"
+
+	// Whisker-backend Service coordinates, mirroring pkg/render/whisker —
+	// importing that package here would create an import cycle (it imports
+	// render).
+	WhiskerNamespace          = "calico-system"
+	WhiskerDeploymentName     = "whisker"
+	WhiskerBackendServiceName = "whisker-backend"
+	WhiskerBackendServicePort = 8443
+	WhiskerBackendTargetPort  = 3002
+	VoltronName               = "calico-voltron"
+	VoltronTunnelSecretName   = "calico-management-cluster-connection"
+	defaultVoltronPort        = "9443"
+	defaultTunnelVoltronPort  = "9449"
+	DashboardAPIPort          = "8444"
+	DashboardAPIHealthPort    = "8090"
+	DashboardAPIName          = "calico-dashboard-api"
 
 	// VoltronAdditionalTunnelSecretName is the name of an optional, pre-provisioned secret
 	// in the truth namespace that holds an additional CA used by Voltron for tunnel server
@@ -213,6 +222,11 @@ type ManagerConfiguration struct {
 	Manager        *operatorv1.Manager
 	Authentication *operatorv1.Authentication
 	KibanaEnabled  bool
+
+	// WhiskerEnabled reports whether a Whisker CR exists, so the manager serves
+	// the flow logs UI module and Voltron proxies /whisker-backend to the
+	// whisker-backend Service.
+	WhiskerEnabled bool
 
 	// RBACManagementEnabled reports whether to render the RBAC management UI access.
 	// The controller has already applied the variant, the admin's gate and tenancy.
@@ -510,6 +524,7 @@ func (c *managerComponent) managerEnvVars() []corev1.EnvVar {
 		{Name: "CNX_POLICY_RECOMMENDATION_SUPPORT", Value: "true"},
 		{Name: "ENABLE_MULTI_CLUSTER_MANAGEMENT", Value: strconv.FormatBool(c.cfg.ManagementCluster != nil)},
 		{Name: "ENABLE_KIBANA", Value: strconv.FormatBool(c.cfg.KibanaEnabled)},
+		{Name: "SUPPORTS_FLOW_LOGS", Value: strconv.FormatBool(c.cfg.WhiskerEnabled)},
 	}
 
 	envs = append(envs, c.managerOAuth2EnvVars()...)
@@ -604,6 +619,17 @@ func (c *managerComponent) voltronContainer() corev1.Container {
 		{Name: "VOLTRON_ENABLE_NONCLUSTER_HOST", Value: strconv.FormatBool(c.cfg.NonClusterHost != nil)},
 		{Name: "VOLTRON_TUNNEL_PORT", Value: defaultTunnelVoltronPort},
 		{Name: "VOLTRON_DEFAULT_FORWARD_SERVER", Value: defaultForwardServer},
+	}
+
+	if c.cfg.WhiskerEnabled {
+		env = append(env,
+			corev1.EnvVar{
+				Name: "VOLTRON_WHISKER_BACKEND_ENDPOINT",
+				Value: fmt.Sprintf("https://%s.%s.svc.%s:%d",
+					WhiskerBackendServiceName, WhiskerNamespace, c.cfg.ClusterDomain, WhiskerBackendServicePort),
+			},
+			corev1.EnvVar{Name: "VOLTRON_WHISKER_BACKEND_CA_BUNDLE_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
+		)
 	}
 
 	if c.cfg.VoltronRouteConfig != nil {
@@ -1361,6 +1387,16 @@ func (c *managerComponent) managerCalicoSystemNetworkPolicy() *v3.NetworkPolicy 
 					Name:      FluentBitInputService,
 				},
 			},
+		})
+	}
+
+	if c.cfg.WhiskerEnabled {
+		// Voltron proxies the manager UI's /whisker-backend requests to the
+		// whisker-backend Service.
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.CreateEntityRule(WhiskerNamespace, WhiskerDeploymentName, WhiskerBackendTargetPort),
 		})
 	}
 

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -259,6 +259,54 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		}))
 	})
 
+	It("should wire the flow logs UI module when whisker is enabled", func() {
+		resourcesToCreate, _ := renderObjects(renderConfig{
+			installation:   installation,
+			ns:             render.ManagerNamespace,
+			whiskerEnabled: true,
+		})
+		deployment := rtest.GetResource(resourcesToCreate, render.ManagerDeploymentName, render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+
+		manager := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.ManagerName)
+		Expect(manager.Env).To(ContainElement(corev1.EnvVar{Name: "SUPPORTS_FLOW_LOGS", Value: "true"}))
+
+		voltron := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.VoltronName)
+		Expect(voltron.Env).To(ContainElement(corev1.EnvVar{
+			Name:  "VOLTRON_WHISKER_BACKEND_ENDPOINT",
+			Value: "https://whisker-backend.calico-system.svc.cluster.local:8443",
+		}))
+		Expect(voltron.Env).To(ContainElement(corev1.EnvVar{
+			Name:  "VOLTRON_WHISKER_BACKEND_CA_BUNDLE_PATH",
+			Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt",
+		}))
+
+		np := rtest.GetResource(resourcesToCreate, render.ManagerPolicyName, render.ManagerNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
+		found := false
+		for _, rule := range np.Spec.Egress {
+			if rule.Destination.Selector == networkpolicy.KubernetesAppSelector("whisker") {
+				found = true
+				Expect(rule.Destination).To(Equal(networkpolicy.CreateEntityRule("calico-system", "whisker", 3002)))
+			}
+		}
+		Expect(found).To(BeTrue(), "expected manager egress to whisker-backend")
+	})
+
+	It("should not set the flow logs env when whisker is absent", func() {
+		resourcesToCreate, _ := renderObjects(renderConfig{
+			installation: installation,
+			ns:           render.ManagerNamespace,
+		})
+		deployment := rtest.GetResource(resourcesToCreate, render.ManagerDeploymentName, render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+
+		manager := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.ManagerName)
+		Expect(manager.Env).To(ContainElement(corev1.EnvVar{Name: "SUPPORTS_FLOW_LOGS", Value: "false"}))
+
+		voltron := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.VoltronName)
+		for _, e := range voltron.Env {
+			Expect(e.Name).NotTo(HavePrefix("VOLTRON_WHISKER_BACKEND"))
+		}
+	})
+
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
 		resourcesToCreate, _ := renderObjects(renderConfig{
 			oidc:              false,
@@ -1868,6 +1916,7 @@ type renderConfig struct {
 	rbacManagementEnabled bool
 	cloud                 bool
 	voltronMetricsEnabled bool
+	whiskerEnabled        bool
 	cloudResources        render.ManagerCloudResources
 }
 
@@ -1925,6 +1974,7 @@ func renderObjects(roc renderConfig) ([]client.Object, []client.Object) {
 		Installation:          roc.installation,
 		ManagementCluster:     roc.managementCluster,
 		NonClusterHost:        roc.nonClusterHost,
+		WhiskerEnabled:        roc.whiskerEnabled,
 		TunnelServerCert:      tunnelSecret,
 		VoltronLinseedKeyPair: voltronLinseedKP,
 		InternalTLSKeyPair:    internalTraffic,

--- a/pkg/render/testutils/expected_policies/dex.json
+++ b/pkg/render/testutils/expected_policies/dex.json
@@ -78,6 +78,19 @@
           "selector": "k8s-app == 'calico-apiserver'",
           "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            5556
+          ]
+        }
       }
     ],
     "egress": [

--- a/pkg/render/testutils/expected_policies/dex_ocp.json
+++ b/pkg/render/testutils/expected_policies/dex_ocp.json
@@ -78,6 +78,19 @@
           "selector": "k8s-app == 'calico-apiserver'",
           "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            5556
+          ]
+        }
       }
     ],
     "egress": [

--- a/pkg/render/testutils/expected_policies/linseed.json
+++ b/pkg/render/testutils/expected_policies/linseed.json
@@ -182,6 +182,19 @@
             8444
           ]
         }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
       }
     ],
     "egress": [

--- a/pkg/render/testutils/expected_policies/linseed.json
+++ b/pkg/render/testutils/expected_policies/linseed.json
@@ -117,6 +117,19 @@
             8444
           ]
         }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
       }
     ],
     "egress": [

--- a/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
@@ -185,6 +185,19 @@
       },
       {
         "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
         "destination": {
           "ports": [
             8444

--- a/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
@@ -120,6 +120,19 @@
       },
       {
         "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
         "destination": {
           "ports": [
             8444

--- a/pkg/render/testutils/expected_policies/linseed_ocp.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp.json
@@ -182,6 +182,19 @@
             8444
           ]
         }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
       }
     ],
     "egress": [

--- a/pkg/render/testutils/expected_policies/linseed_ocp.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp.json
@@ -117,6 +117,19 @@
             8444
           ]
         }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
       }
     ],
     "egress": [

--- a/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
@@ -185,6 +185,19 @@
       },
       {
         "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
         "destination": {
           "ports": [
             8444

--- a/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
@@ -120,6 +120,19 @@
       },
       {
         "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "selector": "k8s-app == 'whisker'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
+        },
+        "destination": {
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
         "destination": {
           "ports": [
             8444

--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/utils/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,7 @@ import (
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
@@ -51,10 +53,13 @@ const (
 	WhiskerContainerName        = "whisker"
 	WhiskerBackendContainerName = "whisker-backend"
 
-	WhiskerBackendKeyPairSecret = "whisker-backend-key-pair"
-	GoldmaneDeploymentName      = "goldmane"
-	GoldmaneServicePort         = 7443
-	GoldmaneNamespace           = common.CalicoNamespace
+	WhiskerBackendKeyPairSecret   = "whisker-backend-key-pair"
+	WhiskerBackendClusterRoleName = "whisker-backend"
+	WhiskerBackendLinseedAPIGroup = "linseed.tigera.io"
+
+	GoldmaneDeploymentName = "goldmane"
+	GoldmaneServicePort    = 7443
+	GoldmaneNamespace      = common.CalicoNamespace
 
 	configMapName    = "whisker-nginx-config"
 	configVolumeName = "nginx-config"
@@ -124,20 +129,20 @@ func (c *Component) Objects() ([]client.Object, []client.Object) {
 
 	toCreate := []client.Object{
 		c.serviceAccount(),
-		c.nginxConfigMap(),
 		deployment,
-		c.whiskerService(),
 		c.networkPolicy(),
+	}
+
+	if c.isEnterprise() {
+		toCreate = append(toCreate, c.whiskerBackendClusterRole(), c.whiskerBackendClusterRoleBinding())
+	} else {
+		// The nginx config and Service front the Whisker UI, which is not rendered for enterprise.
+		toCreate = append(toCreate, c.nginxConfigMap(), c.whiskerService())
 	}
 
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(WhiskerNamespace, c.cfg.PullSecrets...)...)...)
 
-	// Whisker needs to be removed if the installation is not Calico, since it's not supported (yet!) for any other variant.
 	var toDelete []client.Object
-	if c.cfg.Installation.Variant != operatorv1.Calico {
-		toDelete = toCreate
-		toCreate = nil
-	}
 
 	toDelete = append(toDelete, c.deprecatedObjects()...)
 
@@ -152,6 +157,49 @@ func (c *Component) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: WhiskerServiceAccountName, Namespace: WhiskerNamespace},
+	}
+}
+
+func (c *Component) whiskerBackendClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: WhiskerBackendClusterRoleName},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{WhiskerBackendLinseedAPIGroup},
+				Resources: []string{"flows"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
+			},
+		},
+	}
+}
+
+func (c *Component) whiskerBackendClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: WhiskerBackendClusterRoleName},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     WhiskerBackendClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      WhiskerServiceAccountName,
+				Namespace: WhiskerNamespace,
+			},
+		},
 	}
 }
 
@@ -192,18 +240,44 @@ func (c *Component) whiskerService() *corev1.Service {
 	}
 }
 
+func (c *Component) isEnterprise() bool {
+	return c.cfg.Installation.Variant.IsEnterprise()
+}
+
 func (c *Component) whiskerBackendContainer() corev1.Container {
+	env := []corev1.EnvVar{
+		{Name: "LOG_LEVEL", Value: "INFO"},
+		{Name: "PORT", Value: "3002"},
+	}
+
+	if c.isEnterprise() {
+		env = append(env,
+			corev1.EnvVar{Name: "TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
+			corev1.EnvVar{Name: "TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+			corev1.EnvVar{Name: "WHISKER_BACKEND_UPSTREAM", Value: "linseed"},
+			corev1.EnvVar{
+				Name:  "LINSEED_URL",
+				Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, render.ElasticsearchNamespace, false, false),
+			},
+			corev1.EnvVar{Name: "LINSEED_CA_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
+			corev1.EnvVar{Name: "LINSEED_TOKEN_PATH", Value: render.GetLinseedTokenPath(false)},
+			corev1.EnvVar{Name: "LINSEED_CLUSTER_ID", Value: render.DefaultElasticsearchClusterName},
+			corev1.EnvVar{Name: "LINSEED_CLIENT_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
+			corev1.EnvVar{Name: "LINSEED_CLIENT_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+		)
+	} else {
+		env = append(env,
+			corev1.EnvVar{Name: "GOLDMANE_HOST", Value: fmt.Sprintf("goldmane.%s.svc.%s:7443", GoldmaneNamespace, c.cfg.ClusterDomain)},
+			corev1.EnvVar{Name: "TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
+			corev1.EnvVar{Name: "TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+		)
+	}
+
 	return corev1.Container{
-		Name:    WhiskerBackendContainerName,
-		Image:   c.calicoImage,
-		Command: []string{components.CalicoBinaryPath, "component", "whisker-backend"},
-		Env: []corev1.EnvVar{
-			{Name: "LOG_LEVEL", Value: "INFO"},
-			{Name: "PORT", Value: "3002"},
-			{Name: "GOLDMANE_HOST", Value: fmt.Sprintf("goldmane.%s.svc.%s:7443", GoldmaneNamespace, c.cfg.ClusterDomain)},
-			{Name: "TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
-			{Name: "TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
-		},
+		Name:            WhiskerBackendContainerName,
+		Image:           c.calicoImage,
+		Command:         []string{components.CalicoBinaryPath, "component", "whisker-backend"},
+		Env:             env,
 		SecurityContext: securitycontext.NewNonRootContext(),
 		VolumeMounts: append(
 			c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType()),
@@ -217,24 +291,29 @@ func (c *Component) deployment() *appsv1.Deployment {
 		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
-	ctrs := []corev1.Container{c.whiskerContainer(), c.whiskerBackendContainer()}
-
 	volumes := []corev1.Volume{
 		// Add the trusted cert bundle volume to the pod.
 		c.cfg.TrustedCertBundle.Volume(),
 
 		// Add the whisker backend key pair volume to the pod.
 		c.cfg.WhiskerBackendKeyPair.Volume(),
+	}
+
+	// For enterprise only the whisker-backend is rendered; the Whisker UI (SPA) and its
+	// nginx config are managed separately.
+	ctrs := []corev1.Container{c.whiskerBackendContainer()}
+	if !c.isEnterprise() {
+		ctrs = []corev1.Container{c.whiskerContainer(), c.whiskerBackendContainer()}
 
 		// Volume for nginx config from config map.
-		{
+		volumes = append(volumes, corev1.Volume{
 			Name: configVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
 				},
 			},
-		},
+		})
 	}
 
 	return &appsv1.Deployment{
@@ -266,16 +345,32 @@ func (c *Component) deployment() *appsv1.Deployment {
 }
 
 func (c *Component) networkPolicy() *v3.NetworkPolicy {
-	egressRules := []v3.Rule{
-		{
+	var egressRules []v3.Rule
+
+	if c.isEnterprise() {
+		egressRules = append(egressRules,
+			v3.Rule{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: networkpolicy.DefaultHelper().LinseedEntityRule(),
+			},
+			v3.Rule{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: networkpolicy.KubeAPIServerEntityRule,
+			},
+		)
+	} else {
+		egressRules = append(egressRules, v3.Rule{
 			Action:   v3.Allow,
 			Protocol: &networkpolicy.TCPProtocol,
 			Destination: v3.EntityRule{
 				Selector: networkpolicy.KubernetesAppSelector(GoldmaneDeploymentName),
 				Ports:    networkpolicy.Ports(GoldmaneServicePort),
 			},
-		},
+		})
 	}
+
 	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, c.cfg.OpenShift)
 
 	return &v3.NetworkPolicy{

--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -16,10 +16,13 @@ package whisker
 
 import (
 	"fmt"
+	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +35,10 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/authentication"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
+	"github.com/tigera/operator/pkg/render/common/configmap"
+	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/secret"
@@ -53,12 +59,21 @@ const (
 	WhiskerContainerName        = "whisker"
 	WhiskerBackendContainerName = "whisker-backend"
 
-	WhiskerKeyPairSecret        = "whisker-key-pair"
-	WhiskerBackendKeyPairSecret = "whisker-backend-key-pair"
-	WhiskerServicePort          = 8443
-	GoldmaneDeploymentName      = "goldmane"
-	GoldmaneServicePort         = 7443
-	GoldmaneNamespace           = common.CalicoNamespace
+	WhiskerKeyPairSecret          = "whisker-key-pair"
+	WhiskerBackendKeyPairSecret   = "whisker-backend-key-pair"
+	WhiskerBackendClusterRoleName = "whisker-backend"
+	WhiskerBackendLinseedAPIGroup = "linseed.tigera.io"
+	WhiskerServicePort            = 8443
+
+	// The enterprise Service in front of the whisker-backend container, dialed
+	// by Voltron to serve the manager UI's /whisker-backend requests.
+	WhiskerBackendServiceName = "whisker-backend"
+	WhiskerBackendServicePort = 8443
+	WhiskerBackendTargetPort  = 3002
+
+	GoldmaneDeploymentName = "goldmane"
+	GoldmaneServicePort    = 7443
+	GoldmaneNamespace      = common.CalicoNamespace
 
 	// GatewayResourcePrefix names the CIG resources exposing Whisker.
 	GatewayResourcePrefix = "calico-whisker"
@@ -98,6 +113,11 @@ type Configuration struct {
 	ClusterType           string
 	ClusterDomain         string
 
+	// KeyValidatorConfig lets whisker-backend accept the Dex-issued tokens the
+	// manager UI sends for a logged-in user. It is nil when the cluster has no
+	// Authentication CR, and always nil for Calico, which has no Dex.
+	KeyValidatorConfig authentication.KeyValidatorConfig
+
 	// IngressGatewayNamespace, when non-empty, is the namespace of the CIG
 	// Envoy proxy that fronts Whisker. The NetworkPolicy gains a scoped
 	// ingress rule from those proxy pods; Whisker is deny-all otherwise.
@@ -118,9 +138,12 @@ func (c *Component) ResolveImages(is *operatorv1.ImageSet) error {
 
 	var err error
 
-	c.whiskerImage, err = components.GetReference(components.ComponentCalicoWhisker, reg, path, prefix, is)
-	if err != nil {
-		return err
+	// The whisker UI image is OSS-only; Enterprise ImageSets do not carry it.
+	if !c.isEnterprise() {
+		c.whiskerImage, err = components.GetReference(components.ComponentCalicoWhisker, reg, path, prefix, is)
+		if err != nil {
+			return err
+		}
 	}
 	c.calicoImage, err = components.ReferenceFor(components.ImageKeyCalico, c.cfg.Installation, is)
 	return err
@@ -138,15 +161,32 @@ func (c *Component) Objects() ([]client.Object, []client.Object) {
 
 	toCreate := []client.Object{
 		c.serviceAccount(),
-		c.nginxConfigMap(),
 		deployment,
-		c.whiskerService(),
 		c.networkPolicy(),
+	}
+
+	if c.isEnterprise() {
+		toCreate = append(toCreate, c.whiskerBackendClusterRole(), c.whiskerBackendClusterRoleBinding(), c.whiskerBackendService())
+		if c.cfg.KeyValidatorConfig != nil {
+			toCreate = append(toCreate, secret.ToRuntimeObjects(c.cfg.KeyValidatorConfig.RequiredSecrets(WhiskerNamespace)...)...)
+			toCreate = append(toCreate, configmap.ToRuntimeObjects(c.cfg.KeyValidatorConfig.RequiredConfigMaps(WhiskerNamespace)...)...)
+		}
+	} else {
+		// The nginx config and Service front the Whisker UI, which is not rendered for enterprise.
+		toCreate = append(toCreate, c.nginxConfigMap(), c.whiskerService())
 	}
 
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(WhiskerNamespace, c.cfg.PullSecrets...)...)...)
 
 	toDelete := c.deprecatedObjects()
+
+	// Clean up the other variant's objects on a variant switch; GC will not,
+	// since the owning Whisker CR still exists.
+	if c.isEnterprise() {
+		toDelete = append(toDelete, c.nginxConfigMap(), c.whiskerService())
+	} else {
+		toDelete = append(toDelete, c.whiskerBackendClusterRole(), c.whiskerBackendClusterRoleBinding(), c.whiskerBackendService())
+	}
 
 	return toCreate, toDelete
 }
@@ -159,6 +199,70 @@ func (c *Component) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: WhiskerServiceAccountName, Namespace: WhiskerNamespace},
+	}
+}
+
+func (c *Component) whiskerBackendClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: WhiskerBackendClusterRoleName},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{WhiskerBackendLinseedAPIGroup},
+				Resources: []string{"flows"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
+			},
+			{
+				// Read by the RBAC calculator, which works out which flows a user
+				// may see so the Linseed query can be scoped to them. The same
+				// grant ui-apis holds for its AuthorizationReview calculator.
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"clusterroles", "clusterrolebindings", "roles", "rolebindings"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				// The calculator resolves namespaced RBAC across every namespace.
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+				Verbs:     []string{"list"},
+			},
+			{
+				// Tiered policy permissions expand per tier, so the calculator
+				// needs the tier list.
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"tiers"},
+				Verbs:     []string{"list"},
+			},
+		},
+	}
+}
+
+func (c *Component) whiskerBackendClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: WhiskerBackendClusterRoleName},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     WhiskerBackendClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      WhiskerServiceAccountName,
+				Namespace: WhiskerNamespace,
+			},
+		},
 	}
 }
 
@@ -200,24 +304,82 @@ func (c *Component) whiskerService() *corev1.Service {
 	}
 }
 
-func (c *Component) whiskerBackendContainer() corev1.Container {
-	return corev1.Container{
-		Name:    WhiskerBackendContainerName,
-		Image:   c.calicoImage,
-		Command: []string{components.CalicoBinaryPath, "component", "whisker-backend"},
-		Env: []corev1.EnvVar{
-			{Name: "LOG_LEVEL", Value: "INFO"},
-			{Name: "PORT", Value: "3002"},
-			{Name: "GOLDMANE_HOST", Value: fmt.Sprintf("goldmane.%s.svc.%s:7443", GoldmaneNamespace, c.cfg.ClusterDomain)},
-			{Name: "TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
-			{Name: "TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
-			{Name: "SERVER_TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
-			{Name: "SERVER_TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+// whiskerBackendService exposes the whisker-backend container to Voltron,
+// which proxies the manager UI's /whisker-backend requests to it. The Whisker
+// UI itself is a manager UI module in enterprise, so unlike the OSS whisker
+// Service this fronts only the backend.
+func (c *Component) whiskerBackendService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      WhiskerBackendServiceName,
+			Namespace: WhiskerNamespace,
 		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				Port:       WhiskerBackendServicePort,
+				TargetPort: intstr.FromInt(WhiskerBackendTargetPort),
+			}},
+			Selector: map[string]string{
+				"k8s-app": WhiskerDeploymentName,
+			},
+		},
+	}
+}
+
+func (c *Component) isEnterprise() bool {
+	return c.cfg.Installation.Variant.IsEnterprise()
+}
+
+func (c *Component) whiskerBackendContainer() corev1.Container {
+	env := []corev1.EnvVar{
+		{Name: "LOG_LEVEL", Value: "INFO"},
+		{Name: "PORT", Value: "3002"},
+		{Name: "TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
+		{Name: "TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+		{Name: "SERVER_TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
+		{Name: "SERVER_TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+	}
+
+	if c.isEnterprise() {
+		env = append(env,
+			corev1.EnvVar{Name: "WHISKER_BACKEND_UPSTREAM", Value: "linseed"},
+			corev1.EnvVar{
+				Name:  "LINSEED_URL",
+				Value: relasticsearch.LinseedEndpoint(c.SupportedOSType(), c.cfg.ClusterDomain, render.ElasticsearchNamespace, false, false),
+			},
+			corev1.EnvVar{Name: "LINSEED_CA_PATH", Value: c.cfg.TrustedCertBundle.MountPath()},
+			corev1.EnvVar{Name: "LINSEED_TOKEN_PATH", Value: render.GetLinseedTokenPath(false)},
+			corev1.EnvVar{Name: "LINSEED_CLUSTER_ID", Value: render.DefaultElasticsearchClusterName},
+			corev1.EnvVar{Name: "LINSEED_CLIENT_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
+			corev1.EnvVar{Name: "LINSEED_CLIENT_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+			// A request for a managed cluster is authorized against that cluster
+			// through Voltron, whose certificate is in the trusted bundle.
+			corev1.EnvVar{Name: "MULTI_CLUSTER_FORWARDING_CA", Value: c.cfg.TrustedCertBundle.MountPath()},
+			corev1.EnvVar{Name: "MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: render.ManagerService(nil)},
+		)
+		if c.cfg.KeyValidatorConfig != nil {
+			env = append(env, c.cfg.KeyValidatorConfig.RequiredEnv("")...)
+		}
+	} else {
+		env = append(env,
+			corev1.EnvVar{Name: "GOLDMANE_HOST", Value: fmt.Sprintf("goldmane.%s.svc.%s:7443", GoldmaneNamespace, c.cfg.ClusterDomain)},
+		)
+	}
+
+	mounts := append(
+		c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType()),
+		c.cfg.WhiskerBackendKeyPair.VolumeMount(c.SupportedOSType()))
+	if c.cfg.KeyValidatorConfig != nil {
+		mounts = append(mounts, c.cfg.KeyValidatorConfig.RequiredVolumeMounts()...)
+	}
+
+	return corev1.Container{
+		Name:            WhiskerBackendContainerName,
+		Image:           c.calicoImage,
+		Command:         []string{components.CalicoBinaryPath, "component", "whisker-backend"},
+		Env:             env,
 		SecurityContext: securitycontext.NewNonRootContext(),
-		VolumeMounts: append(
-			c.cfg.TrustedCertBundle.VolumeMounts(c.SupportedOSType()),
-			c.cfg.WhiskerBackendKeyPair.VolumeMount(c.SupportedOSType())),
+		VolumeMounts:    mounts,
 	}
 }
 
@@ -227,35 +389,47 @@ func (c *Component) deployment() *appsv1.Deployment {
 		tolerations = append(tolerations, rmeta.TolerateGKEARM64NoSchedule)
 	}
 
-	ctrs := []corev1.Container{c.whiskerContainer(), c.whiskerBackendContainer()}
-
 	volumes := []corev1.Volume{
 		// Add the trusted cert bundle volume to the pod.
 		c.cfg.TrustedCertBundle.Volume(),
+	}
+	if !c.isEnterprise() {
+		// The whisker TLS key pair used by nginx for HTTPS.
+		volumes = append(volumes, c.cfg.WhiskerKeyPair.Volume())
+	}
+	// Add the whisker backend key pair volume to the pod.
+	volumes = append(volumes, c.cfg.WhiskerBackendKeyPair.Volume())
+	if c.cfg.KeyValidatorConfig != nil {
+		volumes = append(volumes, c.cfg.KeyValidatorConfig.RequiredVolumes()...)
+	}
 
-		// Add the whisker TLS key pair volume (used by nginx for HTTPS).
-		c.cfg.WhiskerKeyPair.Volume(),
+	// Key pairs are served at process startup, so rotate the pod when one
+	// changes. The trusted bundle is only used by a client that picks up
+	// changes without a restart.
+	annotations := map[string]string{
+		c.cfg.WhiskerBackendKeyPair.HashAnnotationKey(): c.cfg.WhiskerBackendKeyPair.HashAnnotationValue(),
+	}
+	if c.cfg.KeyValidatorConfig != nil {
+		maps.Copy(annotations, c.cfg.KeyValidatorConfig.RequiredAnnotations())
+	}
 
-		// Add the whisker backend key pair volume to the pod.
-		c.cfg.WhiskerBackendKeyPair.Volume(),
+	// For enterprise only the whisker-backend is rendered: the Whisker UI is a
+	// manager UI module, so the SPA container, its nginx config and the nginx
+	// TLS key pair are not deployed.
+	ctrs := []corev1.Container{c.whiskerBackendContainer()}
+	if !c.isEnterprise() {
+		ctrs = []corev1.Container{c.whiskerContainer(), c.whiskerBackendContainer()}
 
 		// Volume for nginx config from config map.
-		{
+		volumes = append(volumes, corev1.Volume{
 			Name: configVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
 				},
 			},
-		},
-	}
-
-	// Both key pairs are served at process startup (nginx and the backend), so
-	// rotate the pod when either changes. The trusted bundle is only used by a
-	// client that picks up changes without a restart.
-	annotations := map[string]string{
-		c.cfg.WhiskerKeyPair.HashAnnotationKey():        c.cfg.WhiskerKeyPair.HashAnnotationValue(),
-		c.cfg.WhiskerBackendKeyPair.HashAnnotationKey(): c.cfg.WhiskerBackendKeyPair.HashAnnotationValue(),
+		})
+		annotations[c.cfg.WhiskerKeyPair.HashAnnotationKey()] = c.cfg.WhiskerKeyPair.HashAnnotationValue()
 	}
 
 	return &appsv1.Deployment{
@@ -288,16 +462,46 @@ func (c *Component) deployment() *appsv1.Deployment {
 }
 
 func (c *Component) networkPolicy() *v3.NetworkPolicy {
-	egressRules := []v3.Rule{
-		{
+	var egressRules []v3.Rule
+
+	if c.isEnterprise() {
+		egressRules = append(egressRules,
+			v3.Rule{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: networkpolicy.DefaultHelper().LinseedEntityRule(),
+			},
+			v3.Rule{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: networkpolicy.KubeAPIServerEntityRule,
+			},
+			// Managed-cluster requests are authorized through Voltron.
+			v3.Rule{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: networkpolicy.DefaultHelper().ManagerEntityRule(),
+			},
+		)
+		if c.cfg.KeyValidatorConfig != nil {
+			// Dex-issued tokens are verified against Dex's signing keys.
+			egressRules = append(egressRules, v3.Rule{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: render.DexEntityRule,
+			})
+		}
+	} else {
+		egressRules = append(egressRules, v3.Rule{
 			Action:   v3.Allow,
 			Protocol: &networkpolicy.TCPProtocol,
 			Destination: v3.EntityRule{
 				Selector: networkpolicy.KubernetesAppSelector(GoldmaneDeploymentName),
 				Ports:    networkpolicy.Ports(GoldmaneServicePort),
 			},
-		},
+		})
 	}
+
 	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, c.cfg.OpenShift)
 
 	var ingressRules []v3.Rule
@@ -312,6 +516,18 @@ func (c *Component) networkPolicy() *v3.NetworkPolicy {
 			},
 			Destination: v3.EntityRule{
 				Ports: networkpolicy.Ports(WhiskerServicePort),
+			},
+		})
+	}
+
+	if c.isEnterprise() {
+		// Voltron proxies the manager UI's /whisker-backend requests here.
+		ingressRules = append(ingressRules, v3.Rule{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Source:   networkpolicy.DefaultHelper().ManagerSourceEntityRule(),
+			Destination: v3.EntityRule{
+				Ports: networkpolicy.Ports(WhiskerBackendTargetPort),
 			},
 		})
 	}

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -22,12 +22,16 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/whisker"
@@ -35,10 +39,11 @@ import (
 )
 
 var (
-	defaultTLSKeyPair        = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
-	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
-	numExpectedObjects       = 5
-	numDeprecatedObjects     = 1
+	defaultTLSKeyPair            = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
+	defaultTrustedCertBundle     = certificatemanagement.CreateTrustedBundle(nil)
+	numExpectedObjects           = 5
+	numEnterpriseExpectedObjects = 5 // ServiceAccount + Deployment + NetworkPolicy + ClusterRole + ClusterRoleBinding (no nginx ConfigMap/Service)
+	numDeprecatedObjects         = 1
 )
 
 var _ = Describe("ComponentRendering", func() {
@@ -60,7 +65,7 @@ var _ = Describe("ComponentRendering", func() {
 			},
 			numExpectedObjects, numDeprecatedObjects,
 		),
-		Entry("Should return objects to delete when variant is not Calico",
+		Entry("Should return objects to create when variant is CalicoEnterprise",
 			&whisker.Configuration{
 				Installation: &operatorv1.InstallationSpec{
 					KubernetesProvider: operatorv1.ProviderGKE,
@@ -70,7 +75,7 @@ var _ = Describe("ComponentRendering", func() {
 				WhiskerBackendKeyPair: defaultTLSKeyPair,
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 			},
-			0, numExpectedObjects+numDeprecatedObjects,
+			numEnterpriseExpectedObjects, numDeprecatedObjects,
 		),
 	)
 
@@ -169,7 +174,165 @@ var _ = Describe("ComponentRendering", func() {
 				},
 			},
 		),
+		Entry("Should return enterprise deployment with Linseed env vars when variant is CalicoEnterprise",
+			&whisker.Configuration{
+				Installation: &operatorv1.InstallationSpec{
+					KubernetesProvider: operatorv1.ProviderGKE,
+					Variant:            operatorv1.CalicoEnterprise,
+				},
+				TrustedCertBundle:     defaultTrustedCertBundle,
+				WhiskerBackendKeyPair: defaultTLSKeyPair,
+				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+				ClusterID:             "test-cluster-id",
+				CalicoVersion:         "test-calico-version",
+				ClusterType:           "test-cluster-type",
+				ClusterDomain:         "cluster.domain",
+			},
+			&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      whisker.WhiskerDeploymentName,
+					Namespace: whisker.WhiskerNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: whisker.WhiskerDeploymentName,
+						},
+						Spec: corev1.PodSpec{
+							ServiceAccountName: whisker.WhiskerServiceAccountName,
+							Tolerations:        append(rmeta.TolerateCriticalAddonsAndControlPlane, rmeta.TolerateGKEARM64NoSchedule),
+							Containers: []corev1.Container{
+								{
+									Name:    whisker.WhiskerBackendContainerName,
+									Image:   "gcr.io/unique-caldron-775/cnx/tigera/calico:master",
+									Command: []string{"/usr/bin/calico", "component", "whisker-backend"},
+									Env: []corev1.EnvVar{
+										{Name: "LOG_LEVEL", Value: "INFO"},
+										{Name: "PORT", Value: "3002"},
+										{Name: "TLS_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
+										{Name: "TLS_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
+										{Name: "WHISKER_BACKEND_UPSTREAM", Value: "linseed"},
+										{Name: "LINSEED_URL", Value: "https://tigera-linseed.tigera-elasticsearch.svc"},
+										{Name: "LINSEED_CA_PATH", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
+										{Name: "LINSEED_TOKEN_PATH", Value: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
+										{Name: "LINSEED_CLUSTER_ID", Value: render.DefaultElasticsearchClusterName},
+										{Name: "LINSEED_CLIENT_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
+										{Name: "LINSEED_CLIENT_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
+									},
+									SecurityContext: securitycontext.NewNonRootContext(),
+									VolumeMounts: append(
+										defaultTrustedCertBundle.VolumeMounts(rmeta.OSTypeLinux),
+										defaultTLSKeyPair.VolumeMount(rmeta.OSTypeLinux)),
+								},
+							},
+							Volumes: []corev1.Volume{
+								defaultTrustedCertBundle.Volume(),
+								defaultTLSKeyPair.Volume(),
+							},
+						},
+					},
+				},
+			},
+		),
 	)
+
+	It("should render network policy with Goldmane egress for Calico variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, whisker.WhiskerPolicyName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Egress).To(HaveLen(2))
+		Expect(np.Spec.Egress[0].Destination.Selector).To(Equal(networkpolicy.KubernetesAppSelector(whisker.GoldmaneDeploymentName)))
+		Expect(np.Spec.Egress[0].Destination.Ports).To(Equal(networkpolicy.Ports(whisker.GoldmaneServicePort)))
+	})
+
+	It("should render Linseed RBAC for enterprise variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.CalicoEnterprise,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		cr, err := rtest.GetResourceOfType[*rbacv1.ClusterRole](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(cr.Rules).To(HaveLen(3))
+		Expect(cr.Rules[0].APIGroups).To(Equal([]string{whisker.WhiskerBackendLinseedAPIGroup}))
+		Expect(cr.Rules[0].Resources).To(Equal([]string{"flows"}))
+		Expect(cr.Rules[0].Verbs).To(Equal([]string{"get"}))
+		Expect(cr.Rules[1].APIGroups).To(Equal([]string{"authentication.k8s.io"}))
+		Expect(cr.Rules[1].Resources).To(Equal([]string{"tokenreviews"}))
+		Expect(cr.Rules[1].Verbs).To(Equal([]string{"create"}))
+		Expect(cr.Rules[2].APIGroups).To(Equal([]string{"authorization.k8s.io"}))
+		Expect(cr.Rules[2].Resources).To(Equal([]string{"subjectaccessreviews"}))
+		Expect(cr.Rules[2].Verbs).To(Equal([]string{"create"}))
+
+		crb, err := rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(crb.RoleRef.Name).To(Equal(whisker.WhiskerBackendClusterRoleName))
+		Expect(crb.Subjects).To(HaveLen(1))
+		Expect(crb.Subjects[0].Name).To(Equal(whisker.WhiskerServiceAccountName))
+		Expect(crb.Subjects[0].Namespace).To(Equal(whisker.WhiskerNamespace))
+	})
+
+	It("should not render Linseed RBAC for Calico variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		_, err := rtest.GetResourceOfType[*rbacv1.ClusterRole](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).Should(HaveOccurred())
+		_, err = rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).Should(HaveOccurred())
+	})
+
+	It("should render network policy with Linseed egress for enterprise variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.CalicoEnterprise,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, whisker.WhiskerPolicyName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Egress).To(HaveLen(3))
+		Expect(np.Spec.Egress[0].Destination).To(Equal(networkpolicy.DefaultHelper().LinseedEntityRule()))
+		Expect(np.Spec.Egress[1].Destination).To(Equal(networkpolicy.KubeAPIServerEntityRule))
+	})
 
 	It("should generate an IPv4-only NGINX configuration", func() {
 		cfg := &whisker.Configuration{

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -22,13 +22,17 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
@@ -38,17 +42,22 @@ import (
 )
 
 var (
-	defaultWhiskerKeyPair    = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: whisker.WhiskerKeyPairSecret}}, nil, "")
-	defaultTLSKeyPair        = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
-	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
-	numExpectedObjects       = 5
-	numDeprecatedObjects     = 1
+	defaultWhiskerKeyPair        = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: whisker.WhiskerKeyPairSecret}}, nil, "")
+	defaultTLSKeyPair            = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
+	defaultTrustedCertBundle     = certificatemanagement.CreateTrustedBundle(nil)
+	numExpectedObjects           = 5
+	numEnterpriseExpectedObjects = 6 // ServiceAccount + Deployment + NetworkPolicy + ClusterRole + ClusterRoleBinding + backend Service (no nginx ConfigMap or UI Service)
+
+	// The deprecated k8s NetworkPolicy plus the other variant's objects.
+	numCalicoDeletedObjects     = 4 // + backend ClusterRole, ClusterRoleBinding, and Service
+	numEnterpriseDeletedObjects = 3 // + nginx ConfigMap and UI Service
 
 	// calicoImageRef resolves the combined calico/calico image exactly as the
 	// renderer does, so the expected image tracks the pinned ComponentCalico
 	// version on any branch (:master on master, :v3.32.x on release-v1.43)
 	// rather than a hardcoded tag.
-	calicoImageRef, _ = components.GetReference(components.CombinedCalicoImage(&operatorv1.InstallationSpec{Variant: operatorv1.Calico}), "", "", "", nil)
+	calicoImageRef, _           = components.GetReference(components.CombinedCalicoImage(&operatorv1.InstallationSpec{Variant: operatorv1.Calico}), "", "", "", nil)
+	enterpriseCalicoImageRef, _ = components.GetReference(components.CombinedCalicoImage(&operatorv1.InstallationSpec{Variant: operatorv1.CalicoEnterprise}), "", "", "", nil)
 	// whiskerImageRef resolves the whisker image the same way the renderer does.
 	whiskerImageRef, _ = components.GetReference(components.ComponentCalicoWhisker, "", "", "", nil)
 )
@@ -71,11 +80,27 @@ var _ = Describe("ComponentRendering", func() {
 				WhiskerBackendKeyPair: defaultTLSKeyPair,
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 			},
-			numExpectedObjects, numDeprecatedObjects,
+			numExpectedObjects, numCalicoDeletedObjects,
+		),
+		Entry("Should return objects to create when variant is CalicoEnterprise",
+			&whisker.Configuration{
+				Installation: &operatorv1.InstallationSpec{
+					KubernetesProvider: operatorv1.ProviderGKE,
+					Variant:            operatorv1.CalicoEnterprise,
+				},
+				TrustedCertBundle: defaultTrustedCertBundle,
+				// No WhiskerKeyPair: the controller creates it only for OSS.
+				WhiskerBackendKeyPair: defaultTLSKeyPair,
+				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+			},
+			numEnterpriseExpectedObjects, numEnterpriseDeletedObjects,
 		),
 	)
 
 	DescribeTable("Whisker Deployment", func(cfg *whisker.Configuration, expected *appsv1.Deployment) {
+		if cfg.Installation.Variant.IsEnterprise() {
+			DeferCleanup(components.UseImages(components.EnterpriseImages))
+		}
 		component := whisker.Whisker(cfg)
 		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
 		objsToCreate, _ := component.Objects()
@@ -149,11 +174,11 @@ var _ = Describe("ComponentRendering", func() {
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},
 										{Name: "PORT", Value: "3002"},
-										{Name: "GOLDMANE_HOST", Value: "goldmane.calico-system.svc.cluster.domain:7443"},
 										{Name: "TLS_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
 										{Name: "TLS_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
 										{Name: "SERVER_TLS_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
 										{Name: "SERVER_TLS_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
+										{Name: "GOLDMANE_HOST", Value: "goldmane.calico-system.svc.cluster.domain:7443"},
 									},
 									SecurityContext: securitycontext.NewNonRootContext(),
 									VolumeMounts: append(
@@ -179,7 +204,271 @@ var _ = Describe("ComponentRendering", func() {
 				},
 			},
 		),
+		Entry("Should return enterprise deployment with Linseed env vars when variant is CalicoEnterprise",
+			&whisker.Configuration{
+				Installation: &operatorv1.InstallationSpec{
+					KubernetesProvider: operatorv1.ProviderGKE,
+					Variant:            operatorv1.CalicoEnterprise,
+				},
+				TrustedCertBundle:     defaultTrustedCertBundle,
+				WhiskerBackendKeyPair: defaultTLSKeyPair,
+				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+				ClusterID:             "test-cluster-id",
+				CalicoVersion:         "test-calico-version",
+				ClusterType:           "test-cluster-type",
+				ClusterDomain:         "cluster.domain",
+			},
+			&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      whisker.WhiskerDeploymentName,
+					Namespace: whisker.WhiskerNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To(int32(1)),
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: whisker.WhiskerDeploymentName,
+							Annotations: map[string]string{
+								defaultTLSKeyPair.HashAnnotationKey(): defaultTLSKeyPair.HashAnnotationValue(),
+							},
+						},
+						Spec: corev1.PodSpec{
+							ServiceAccountName: whisker.WhiskerServiceAccountName,
+							Tolerations:        append(rmeta.TolerateCriticalAddonsAndControlPlane, rmeta.TolerateGKEARM64NoSchedule),
+							Containers: []corev1.Container{
+								{
+									Name:    whisker.WhiskerBackendContainerName,
+									Image:   enterpriseCalicoImageRef,
+									Command: []string{"/usr/bin/calico", "component", "whisker-backend"},
+									Env: []corev1.EnvVar{
+										{Name: "LOG_LEVEL", Value: "INFO"},
+										{Name: "PORT", Value: "3002"},
+										{Name: "TLS_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
+										{Name: "TLS_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
+										{Name: "SERVER_TLS_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
+										{Name: "SERVER_TLS_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
+										{Name: "WHISKER_BACKEND_UPSTREAM", Value: "linseed"},
+										{Name: "LINSEED_URL", Value: "https://tigera-linseed.tigera-elasticsearch.svc"},
+										{Name: "LINSEED_CA_PATH", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
+										{Name: "LINSEED_TOKEN_PATH", Value: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
+										{Name: "LINSEED_CLUSTER_ID", Value: render.DefaultElasticsearchClusterName},
+										{Name: "LINSEED_CLIENT_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
+										{Name: "LINSEED_CLIENT_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
+										{Name: "MULTI_CLUSTER_FORWARDING_CA", Value: "/etc/pki/tls/certs/tigera-ca-bundle.crt"},
+										{Name: "MULTI_CLUSTER_FORWARDING_ENDPOINT", Value: render.ManagerService(nil)},
+									},
+									SecurityContext: securitycontext.NewNonRootContext(),
+									VolumeMounts: append(
+										defaultTrustedCertBundle.VolumeMounts(rmeta.OSTypeLinux),
+										defaultTLSKeyPair.VolumeMount(rmeta.OSTypeLinux)),
+								},
+							},
+							Volumes: []corev1.Volume{
+								defaultTrustedCertBundle.Volume(),
+								defaultTLSKeyPair.Volume(),
+							},
+						},
+					},
+				},
+			},
+		),
 	)
+
+	It("should render network policy with Goldmane egress for Calico variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerKeyPair:        defaultWhiskerKeyPair,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, whisker.WhiskerPolicyName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Egress).To(HaveLen(2))
+		Expect(np.Spec.Egress[0].Destination.Selector).To(Equal(networkpolicy.KubernetesAppSelector(whisker.GoldmaneDeploymentName)))
+		Expect(np.Spec.Egress[0].Destination.Ports).To(Equal(networkpolicy.Ports(whisker.GoldmaneServicePort)))
+	})
+
+	It("should render Linseed RBAC for enterprise variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.CalicoEnterprise,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		cr, err := rtest.GetResourceOfType[*rbacv1.ClusterRole](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(cr.Rules).To(HaveLen(6))
+		Expect(cr.Rules[0].APIGroups).To(Equal([]string{whisker.WhiskerBackendLinseedAPIGroup}))
+		Expect(cr.Rules[0].Resources).To(Equal([]string{"flows"}))
+		Expect(cr.Rules[0].Verbs).To(Equal([]string{"get"}))
+		Expect(cr.Rules[1].APIGroups).To(Equal([]string{"authentication.k8s.io"}))
+		Expect(cr.Rules[1].Resources).To(Equal([]string{"tokenreviews"}))
+		Expect(cr.Rules[1].Verbs).To(Equal([]string{"create"}))
+		Expect(cr.Rules[2].APIGroups).To(Equal([]string{"authorization.k8s.io"}))
+		Expect(cr.Rules[2].Resources).To(Equal([]string{"subjectaccessreviews"}))
+		Expect(cr.Rules[2].Verbs).To(Equal([]string{"create"}))
+		// The RBAC calculator reads the cluster's RBAC graph, every namespace and
+		// the tier list to work out which flows a user may see.
+		Expect(cr.Rules[3].APIGroups).To(Equal([]string{"rbac.authorization.k8s.io"}))
+		Expect(cr.Rules[3].Resources).To(Equal([]string{"clusterroles", "clusterrolebindings", "roles", "rolebindings"}))
+		Expect(cr.Rules[3].Verbs).To(Equal([]string{"get", "list", "watch"}))
+		Expect(cr.Rules[4].APIGroups).To(Equal([]string{""}))
+		Expect(cr.Rules[4].Resources).To(Equal([]string{"namespaces"}))
+		Expect(cr.Rules[4].Verbs).To(Equal([]string{"list"}))
+		Expect(cr.Rules[5].APIGroups).To(Equal([]string{"projectcalico.org"}))
+		Expect(cr.Rules[5].Resources).To(Equal([]string{"tiers"}))
+		Expect(cr.Rules[5].Verbs).To(Equal([]string{"list"}))
+
+		crb, err := rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(crb.RoleRef.Name).To(Equal(whisker.WhiskerBackendClusterRoleName))
+		Expect(crb.Subjects).To(HaveLen(1))
+		Expect(crb.Subjects[0].Name).To(Equal(whisker.WhiskerServiceAccountName))
+		Expect(crb.Subjects[0].Namespace).To(Equal(whisker.WhiskerNamespace))
+	})
+
+	It("should render the backend Service and manager ingress for enterprise variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.CalicoEnterprise,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		// Voltron dials this Service to serve the manager UI's /whisker-backend
+		// requests; it fronts only the backend container.
+		svc, err := rtest.GetResourceOfType[*corev1.Service](objsToCreate, whisker.WhiskerBackendServiceName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(svc.Spec.Ports).To(ConsistOf(corev1.ServicePort{
+			Port:       whisker.WhiskerBackendServicePort,
+			TargetPort: intstr.FromInt(whisker.WhiskerBackendTargetPort),
+		}))
+		Expect(svc.Spec.Selector).To(Equal(map[string]string{"k8s-app": whisker.WhiskerDeploymentName}))
+
+		// The UI Service and nginx config are OSS-only.
+		_, err = rtest.GetResourceOfType[*corev1.Service](objsToCreate, whisker.WhiskerName, whisker.WhiskerNamespace)
+		Expect(err).Should(HaveOccurred())
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, whisker.WhiskerPolicyName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Ingress).To(HaveLen(1))
+		Expect(np.Spec.Ingress[0].Source).To(Equal(networkpolicy.DefaultHelper().ManagerSourceEntityRule()))
+		Expect(np.Spec.Ingress[0].Destination.Ports).To(Equal(networkpolicy.Ports(whisker.WhiskerBackendTargetPort)))
+	})
+
+	It("should not render Linseed RBAC for Calico variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerKeyPair:        defaultWhiskerKeyPair,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		_, err := rtest.GetResourceOfType[*rbacv1.ClusterRole](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).Should(HaveOccurred())
+		_, err = rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, whisker.WhiskerBackendClusterRoleName, "")
+		Expect(err).Should(HaveOccurred())
+	})
+
+	It("should render network policy with Linseed egress for enterprise variant", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.CalicoEnterprise,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, whisker.WhiskerPolicyName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Egress).To(HaveLen(4))
+		Expect(np.Spec.Egress[0].Destination).To(Equal(networkpolicy.DefaultHelper().LinseedEntityRule()))
+		Expect(np.Spec.Egress[1].Destination).To(Equal(networkpolicy.KubeAPIServerEntityRule))
+		// Managed-cluster RBAC is evaluated through Voltron.
+		Expect(np.Spec.Egress[2].Destination).To(Equal(networkpolicy.DefaultHelper().ManagerEntityRule()))
+	})
+
+	It("should wire Dex into whisker-backend for enterprise when authentication is configured", func() {
+		authn := &operatorv1.Authentication{Spec: operatorv1.AuthenticationSpec{
+			ManagerDomain: "https://127.0.0.1",
+			OIDC:          &operatorv1.AuthenticationOIDC{IssuerURL: "https://accounts.google.com", UsernameClaim: "email"},
+		}}
+		dexCfg := render.NewDexKeyValidatorConfig(authn, dns.DefaultClusterDomain)
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.CalicoEnterprise,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+			KeyValidatorConfig:    dexCfg,
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		// The backend gets the same OIDC settings, volumes and mounts as the
+		// other Dex-authenticating components.
+		deployment, err := rtest.GetResourceOfType[*appsv1.Deployment](objsToCreate, whisker.WhiskerName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		backend := deployment.Spec.Template.Spec.Containers[0]
+		Expect(dexCfg.RequiredEnv("")).NotTo(BeEmpty())
+		for _, e := range dexCfg.RequiredEnv("") {
+			Expect(backend.Env).To(ContainElement(e))
+		}
+		for _, m := range dexCfg.RequiredVolumeMounts() {
+			Expect(backend.VolumeMounts).To(ContainElement(m))
+		}
+		for _, v := range dexCfg.RequiredVolumes() {
+			Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElement(v))
+		}
+		for k, v := range dexCfg.RequiredAnnotations() {
+			Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(k, v))
+		}
+
+		// Token verification needs Dex's signing keys.
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, whisker.WhiskerPolicyName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Egress).To(ContainElement(HaveField("Destination", Equal(render.DexEntityRule))))
+
+		// Dex's CA travels with the pod into the whisker namespace.
+		for _, s := range dexCfg.RequiredSecrets(whisker.WhiskerNamespace) {
+			_, err := rtest.GetResourceOfType[*corev1.Secret](objsToCreate, s.Name, whisker.WhiskerNamespace)
+			Expect(err).ShouldNot(HaveOccurred(), s.Name)
+		}
+	})
 
 	It("should generate an IPv4-only NGINX configuration", func() {
 		cfg := &whisker.Configuration{


### PR DESCRIPTION
## Description

New feature: deploy `whisker-backend` for Calico Enterprise, backed by Linseed.

For enterprise the Whisker UI is a manager UI module, so only the `whisker-backend` container is rendered — no SPA container, nginx config, UI Service or nginx TLS key pair. The backend gets the Linseed upstream env, mTLS client certs, a ClusterRole for Linseed flows plus the RBAC reads it needs (roles/bindings, namespaces, tiers), and Linseed's network policy admits it.

**Prerequisites and variants**
- The controller waits for Linseed's certificate (`tigera-secure-linseed-cert`) before rendering and reports `ResourceNotReady` until then, so a cluster without log storage degrades instead of running a backend that fails every request.
- On a **managed cluster** nothing is deployed and the status stays Available: the manager UI runs on the management cluster, whose whisker-backend serves those flows through the multi-cluster forwarding proxy. The backend is wired for that (`MULTI_CLUSTER_FORWARDING_CA/ENDPOINT`, egress to Voltron).
- When an **Authentication** CR is ready, the backend gets the same Dex settings as the other Dex-authenticating components (`OIDC_AUTH_*`, Dex CA in the trusted bundle, egress to Dex), and **Dex's network policy admits whisker-backend** for key fetches. The controller degrades while the Authentication CR is not ready.
- Watches added for Authentication, ManagementClusterConnection and the Dex TLS secret.

**Manager** wires the module up when a Whisker CR exists: `SUPPORTS_FLOW_LOGS` for the UI feature flag, a Voltron `/whisker-backend` proxy target pointing at the new Service, and the manager/whisker network policies allow that path.

**Testing.** Render and controller unit tests (Dex env/volumes/egress, MCM env, manager egress, Linseed gate degrade/proceed, managed-cluster no-op; Dex policy goldens). Validated live on a standalone enterprise rig: the operator-rendered Deployment carried the MCM and OIDC env, the Dex policy admitted whisker-backend, and a Dex-issued LDAP user token was accepted end to end through Voltron.

Companion: tigera/calico-private#12086 (whisker-backend), tigera/calico-private#12089 (Whisker CR manifests).

## Release Note

```release-note
Calico Enterprise deploys whisker-backend, backed by Linseed, when a Whisker resource exists on a standalone or management cluster. It waits for Linseed's certificate, accepts Dex-issued user tokens when an Authentication resource is configured, and is not deployed on managed clusters.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files` (no API changes)
- [ ] If changing versions, run `make gen-versions` (no version changes)

**AI assistance:** Claude Code helped write the rendering, controller gating, tests and this description; every change was reviewed and validated live by the author.
