### PR TITLE
RBAC: add globalreports/status to calico-apiserver ClusterRole

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1444,6 +1444,7 @@ func (c *apiServerComponent) tigeraAPIServerClusterRole() *rbacv1.ClusterRole {
 				"globalalerts/status",
 				"globalalerttemplates",
 				"globalreports",
+				"globalreports/status",
 				"globalreporttypes",
 				"globalthreatfeeds",
 				"globalthreatfeeds/status",

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -425,6 +425,37 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		}))
 	})
 
+	It("should grant the calico-apiserver SA write access to globalreports/status", func() {
+		component, err := render.APIServer(cfg)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		resources, _ := component.Objects()
+
+		cr := rtest.GetResource(resources, "calico-apiserver", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+
+		// Find the backing-storage rule and assert it covers globalreports/status.
+		// Without this, compliance-controller can't update status.lastScheduledReportJob
+		// and no compliance jobs ever run.
+		var found bool
+		for _, rule := range cr.Rules {
+			hasGlobalReports := false
+			hasGlobalReportsStatus := false
+			for _, r := range rule.Resources {
+				if r == "globalreports" {
+					hasGlobalReports = true
+				}
+				if r == "globalreports/status" {
+					hasGlobalReportsStatus = true
+				}
+			}
+			if hasGlobalReports {
+				found = true
+				Expect(hasGlobalReportsStatus).To(BeTrue(), "calico-apiserver ClusterRole rule covering globalreports must also cover globalreports/status")
+				Expect(rule.Verbs).To(ContainElement("update"))
+			}
+		}
+		Expect(found).To(BeTrue(), "calico-apiserver ClusterRole should have a rule covering globalreports")
+	})
+
 	It("should render L7 Admission Controller with default config when SidecarInjection is Enabled", func() {
 		sidecarEnabled := operatorv1.SidecarEnabled
 		cfg.ApplicationLayer = &operatorv1.ApplicationLayer{


### PR DESCRIPTION
The `calico-apiserver` ClusterRole grants `update` on `globalreports` but omits the `globalreports/status` subresource. Compliance-controller (running with the `calico-system/calico-apiserver` SA) can't write `status.lastScheduledReportJob`, so no compliance report Jobs are ever scheduled - the UI shows configured reports but no archived data is produced.

Peer rules in the same ClusterRole already include their `/status` subresource (`globalthreatfeeds/status`, `deeppacketinspections/status`, `policyrecommendationscopes/status`). `globalreports/status` is the one that got missed.

Fixes EV-6635.

```release-note
Fixes an issue where Calico Enterprise compliance reports were never scheduled due to a missing RBAC permission on the calico-apiserver ClusterRole.
```