### PR TITLE
Drop resourceNames from tigera-network-admin uisettings rule

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -2038,11 +2038,6 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 	// calico-webhooks UISettings handler (which narrows access via a SAR on
 	// uisettingsgroups/data) gets invoked instead of being short-circuited by
 	// kube-apiserver RBAC.
-	//
-	// No resourceNames: UISettings names have the form "<group>.<kind>.<name>"
-	// (e.g. "cluster-settings.layer.foo"), and RBAC resourceNames is exact match,
-	// so scoping by group prefix here wouldn't work. The webhook does the
-	// group-level narrowing.
 	if !c.cfg.RequiresAggregationServer {
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{"projectcalico.org"},

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -2038,12 +2038,16 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 	// calico-webhooks UISettings handler (which narrows access via a SAR on
 	// uisettingsgroups/data) gets invoked instead of being short-circuited by
 	// kube-apiserver RBAC.
+	//
+	// No resourceNames: UISettings names have the form "<group>.<kind>.<name>"
+	// (e.g. "cluster-settings.layer.foo"), and RBAC resourceNames is exact match,
+	// so scoping by group prefix here wouldn't work. The webhook does the
+	// group-level narrowing.
 	if !c.cfg.RequiresAggregationServer {
 		rules = append(rules, rbacv1.PolicyRule{
-			APIGroups:     []string{"projectcalico.org"},
-			Resources:     []string{"uisettings"},
-			Verbs:         []string{"create", "update", "delete", "patch"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"uisettings"},
+			Verbs:     []string{"create", "update", "delete", "patch"},
 		})
 	}
 

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -415,9 +415,7 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		// In CRD/webhooks mode the calico-uisettings-passthrough ClusterRole is not deployed, so
 		// tigera-network-admin needs to grant write access to uisettings itself for the
 		// calico-webhooks UISettings handler to do the narrowing instead of being short-circuited
-		// by kube-apiserver RBAC. No resourceNames: UISettings names have the form
-		// "<group>.<kind>.<name>" so exact-match resourceNames wouldn't work; the webhook
-		// enforces group-level access.
+		// by kube-apiserver RBAC.
 		networkAdmin := rtest.GetResource(resources, "tigera-network-admin", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
 			APIGroups: []string{"projectcalico.org"},

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -415,13 +415,14 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		// In CRD/webhooks mode the calico-uisettings-passthrough ClusterRole is not deployed, so
 		// tigera-network-admin needs to grant write access to uisettings itself for the
 		// calico-webhooks UISettings handler to do the narrowing instead of being short-circuited
-		// by kube-apiserver RBAC.
+		// by kube-apiserver RBAC. No resourceNames: UISettings names have the form
+		// "<group>.<kind>.<name>" so exact-match resourceNames wouldn't work; the webhook
+		// enforces group-level access.
 		networkAdmin := rtest.GetResource(resources, "tigera-network-admin", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
-			APIGroups:     []string{"projectcalico.org"},
-			Resources:     []string{"uisettings"},
-			Verbs:         []string{"create", "update", "delete", "patch"},
-			ResourceNames: []string{"cluster-settings", "user-settings"},
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"uisettings"},
+			Verbs:     []string{"create", "update", "delete", "patch"},
 		}))
 	})
 


### PR DESCRIPTION
Follow-up to #4834. The new rule granted write verbs on `uisettings` but scoped them with `resourceNames: ["cluster-settings", "user-settings"]`. UISettings names actually have the form `<group>.<kind>.<name>` (e.g. `cluster-settings.layer.tigera-infrastructure`), and RBAC `resourceNames` is exact match, so the rule never matched a real create request - users bound to `tigera-network-admin` in v3 CRD mode hit a 403 when the UI tried to create a Service Graph layer.

Drop the `resourceNames` so the group-level narrowing happens in the calico-webhooks UISettings handler, which is how the rule's comment said it was meant to work.

```release-note
Fixes a 403 when creating UISettings (e.g. Service Graph layers) as a tigera-network-admin user in v3 CRD / webhooks mode.
```