### PR TITLE
Update enterprise CRDs

### DIFF
--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -1479,6 +1479,16 @@ spec:
                     ExcludeL7SourceInfo - Aggregate over all other fields ignoring the source aggregated name, namespace, and type.
                   pattern: ^(?i)(IncludeL7SourceInfo|IncludeL7SourceInfoNoPort|ExcludeL7SourceInfo)?$
                   type: string
+                l7LogsFileAggregationTLSSNI:
+                  description: |-
+                    L7LogsFileAggregationTLSSNI controls whether the TLS Server Name Indication (SNI)
+                    participates in the aggregation key for L7 logs.
+                    [Default: IncludeL7TLSSNI - SNI is part of the aggregation key]
+                    Accepted values:
+                    IncludeL7TLSSNI - Include the SNI in the aggregation key.
+                    ExcludeL7TLSSNI - Aggregate over all other fields ignoring the SNI entirely.
+                  pattern: ^(?i)(IncludeL7TLSSNI|ExcludeL7TLSSNI)?$
+                  type: string
                 l7LogsFileAggregationTrimURL:
                   description: |-
                     L7LogsFileAggregationTrimURL is used to choose the type of aggregation for the url on L7 log entries.
@@ -1528,6 +1538,12 @@ spec:
                     [Default: 300s]
                   pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                   type: string
+                l7ObservabilityEnabled:
+                  description: |-
+                    L7ObservabilityEnabled enables eBPF-based L7 HTTP and TLS observability.
+                    It is dataplane-agnostic - works with eBPF, iptables, or nftables.
+                    Requires kernel 5.17+. [Default: false]
+                  type: boolean
                 liveMigrationRouteConvergenceTime:
                   description: |-
                     LiveMigrationRouteConvergenceTime is the time to keep elevated route priority after a

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -1478,6 +1478,16 @@ spec:
                     ExcludeL7SourceInfo - Aggregate over all other fields ignoring the source aggregated name, namespace, and type.
                   pattern: ^(?i)(IncludeL7SourceInfo|IncludeL7SourceInfoNoPort|ExcludeL7SourceInfo)?$
                   type: string
+                l7LogsFileAggregationTLSSNI:
+                  description: |-
+                    L7LogsFileAggregationTLSSNI controls whether the TLS Server Name Indication (SNI)
+                    participates in the aggregation key for L7 logs.
+                    [Default: IncludeL7TLSSNI - SNI is part of the aggregation key]
+                    Accepted values:
+                    IncludeL7TLSSNI - Include the SNI in the aggregation key.
+                    ExcludeL7TLSSNI - Aggregate over all other fields ignoring the SNI entirely.
+                  pattern: ^(?i)(IncludeL7TLSSNI|ExcludeL7TLSSNI)?$
+                  type: string
                 l7LogsFileAggregationTrimURL:
                   description: |-
                     L7LogsFileAggregationTrimURL is used to choose the type of aggregation for the url on L7 log entries.
@@ -1527,6 +1537,12 @@ spec:
                     [Default: 300s]
                   pattern: ^([0-9]+(\\.[0-9]+)?(ms|s|m|h))*$
                   type: string
+                l7ObservabilityEnabled:
+                  description: |-
+                    L7ObservabilityEnabled enables eBPF-based L7 HTTP and TLS observability.
+                    It is dataplane-agnostic - works with eBPF, iptables, or nftables.
+                    Requires kernel 5.17+. [Default: false]
+                  type: boolean
                 liveMigrationRouteConvergenceTime:
                   description: |-
                     LiveMigrationRouteConvergenceTime is the time to keep elevated route priority after a


### PR DESCRIPTION
## Description

Update enterprise CRDs with new felixconfig parameters: `l7ObservabilityEnabled` and `l7LogsFileAggregationTLSSNI`.

Related to the new eBPF-based L7 observability support introduced in PR https://github.com/tigera/calico-private/pull/11749.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
