### PR TITLE
Use component subcommand for Windows node probes and preStop

### DIFF
--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -747,8 +747,8 @@ func (c *windowsComponent) windowsVolumeMounts() []corev1.VolumeMount {
 
 // windowsLivenessReadinessProbes creates the node's liveness and readiness probes.
 func (c *windowsComponent) windowsLivenessReadinessProbes() (*corev1.Probe, *corev1.Probe) {
-	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "node", "health", "--felix-live"}
-	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "node", "health", "--felix-ready"}
+	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-live"}
+	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-ready"}
 
 	lp := &corev1.Probe{
 		ProbeHandler:        corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: livenessCmd}},
@@ -769,7 +769,7 @@ func (c *windowsComponent) windowsLivenessReadinessProbes() (*corev1.Probe, *cor
 func (c *windowsComponent) windowsLifecycle() *corev1.Lifecycle {
 	return &corev1.Lifecycle{
 		PreStop: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{
-			Command: []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "node", "shutdown"},
+			Command: []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "shutdown"},
 		}},
 	}
 }

--- a/pkg/render/windows_test.go
+++ b/pkg/render/windows_test.go
@@ -2721,9 +2721,9 @@ var _ = Describe("Windows rendering tests", func() {
 // The unused argument is kept temporarily so existing call sites compile while the OSS/Enterprise distinction
 // is being phased out.
 func verifyWindowsProbesAndLifecycle(ds *appsv1.DaemonSet, _ bool) {
-	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "node", "health", "--felix-live"}
-	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "node", "health", "--felix-ready"}
-	preStopCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "node", "shutdown"}
+	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-live"}
+	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-ready"}
+	preStopCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "shutdown"}
 
 	expectedLiveness := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
## Description

calico-node on Windows is moving onto the combined `calico` binary (projectcalico/calico#12624), the same unification Linux already went through. In that binary `node`, `felix`, and `confd` live under the `component` subcommand, so the old top-level `node` command no longer exists.

The Windows node render still pointed the felix container's liveness/readiness probes and the preStop hook at `calico-node.exe node health` / `node shutdown`. Against the combined binary those fail with `unknown command "node"`, so the felix container fails its probes and the node crash-loops. This updates them to `component node health` / `component node shutdown`, matching what node.go already does for the Linux render.

This pairs with the Windows service-script changes in projectcalico/calico#12624 - that PR can't get the Windows FV node Ready until the operator renders the probes against the new command tree, so this needs to land first.

Tested with `make ut UT_DIR=./pkg/render GINKGO_FOCUS="Windows rendering tests"` (render unit tests updated and passing).

Related: projectcalico/calico#12624

## Release Note

```release-note
None
```
