### PR TITLE
Remove FIPS mode support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1018,7 +1018,6 @@ gen-enterprise-imageset: $(BUILD_DIR)
 	@echo "  images:" >> $(BUILD_DIR)/imageset-enterprise.yaml
 	@docker run $(OPERATOR_IMAGE) --print-images=$(enterprise_img_filter) | \
 	  grep -v "Failed to read" | \
-	  grep -v -e fips | \
 	while read -r line; do \
 	  echo "Adding digest for $${line}"; \
 	  digest=$$($(CRANE) digest $${line}$(double_quote)); \
@@ -1037,7 +1036,6 @@ gen-calico-imageset: $(BUILD_DIR)
 	@echo "  images:" >> $(BUILD_DIR)/imageset-calico.yaml
 	@docker run $(OPERATOR_IMAGE) --print-images=$(calico_img_filter) | \
 	  grep -v "Failed to read" | \
-	  grep -v -e fips | \
 	while read -r line; do \
 	  echo "Adding digest for $${line}"; \
 	  digest=$$($(CRANE) digest $${line}$(double_quote)); \
@@ -1046,7 +1044,7 @@ gen-calico-imageset: $(BUILD_DIR)
 	done
 ifeq ($(OLD_STYLE_PRINT_IMAGE),true)
 	@docker run $(OPERATOR_IMAGE) --print-images=list | \
-	  grep -v -e "Failed to read" -e fips | \
+	  grep -v -e "Failed to read" | \
 	  grep -e 'tigera/key-cert-provisioner' | \
 	while read -r line; do \
 	  echo "Adding digest for $${line}"; \

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	"fmt"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -222,9 +221,8 @@ type InstallationSpec struct {
 	// CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 	CalicoNodeWindowsDaemonSet *CalicoNodeWindowsDaemonSet `json:"calicoNodeWindowsDaemonSet,omitempty"`
 
-	// FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
-	// Only supported for Variant=Calico.
-	// Default: Disabled
+	// Deprecated. FIPS mode is no longer supported. Setting fipsMode to Enabled marks the
+	// installation degraded.
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	// +optional
 	FIPSMode *FIPSMode `json:"fipsMode,omitempty"`
@@ -1140,11 +1138,6 @@ type CertificateManagement struct {
 // IsFIPSModeEnabled is a convenience function for turning a FIPSMode reference into a bool.
 func IsFIPSModeEnabled(mode *FIPSMode) bool {
 	return mode != nil && *mode == FIPSModeEnabled
-}
-
-// IsFIPSModeEnabledString is a convenience function for turning a FIPSMode reference into a string formatted bool.
-func IsFIPSModeEnabledString(mode *FIPSMode) string {
-	return fmt.Sprintf("%t", IsFIPSModeEnabled(mode))
 }
 
 type WindowsNodeSpec struct {

--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -36,14 +36,6 @@ var (
 		imagePath: "{{ .ImagePath }}",
 		variant:   calicoVariant,
 	}
-
-	ComponentCalicoNodeFIPS = Component{
-		Version:   "{{ .Version }}-fips",
-		Image:     "{{ .Image }}",
-		Registry:  "{{ .Registry }}",
-		imagePath: "{{ .ImagePath }}",
-		variant:   calicoVariant,
-	}
 {{- end }}
 {{ with index .Components  "node-windows" }}
 	ComponentCalicoNodeWindows = Component{
@@ -134,20 +126,11 @@ var (
 		imagePath: "{{ .ImagePath }}",
 		variant:   calicoVariant,
 	}
-
-	ComponentCalicoFIPS = Component{
-		Version:   "{{ .Version }}-fips",
-		Image:     "{{ .Image }}",
-		Registry:  "{{ .Registry }}",
-		imagePath: "{{ .ImagePath }}",
-		variant:   calicoVariant,
-	}
 {{- end }}
 
 	CalicoImages = []Component{
 		ComponentCalicoCNIWindows,
 		ComponentCalicoNode,
-		ComponentCalicoNodeFIPS,
 		ComponentCalicoNodeWindows,
 		ComponentCalicoWhisker,
 		ComponentCalicoEnvoyGateway,
@@ -158,6 +141,5 @@ var (
 		ComponentCalicoIstioZTunnel,
 		ComponentCalicoIstioProxyv2,
 		ComponentCalico,
-		ComponentCalicoFIPS,
 	}
 )

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -36,14 +36,6 @@ var (
 		variant:   calicoVariant,
 	}
 
-	ComponentCalicoNodeFIPS = Component{
-		Version:   "master-fips",
-		Image:     "node",
-		Registry:  "",
-		imagePath: "",
-		variant:   calicoVariant,
-	}
-
 	ComponentCalicoNodeWindows = Component{
 		Version:   "master",
 		Image:     "node-windows",
@@ -124,18 +116,9 @@ var (
 		variant:   calicoVariant,
 	}
 
-	ComponentCalicoFIPS = Component{
-		Version:   "master-fips",
-		Image:     "calico",
-		Registry:  "",
-		imagePath: "",
-		variant:   calicoVariant,
-	}
-
 	CalicoImages = []Component{
 		ComponentCalicoCNIWindows,
 		ComponentCalicoNode,
-		ComponentCalicoNodeFIPS,
 		ComponentCalicoNodeWindows,
 		ComponentCalicoWhisker,
 		ComponentCalicoEnvoyGateway,
@@ -146,6 +129,5 @@ var (
 		ComponentCalicoIstioZTunnel,
 		ComponentCalicoIstioProxyv2,
 		ComponentCalico,
-		ComponentCalicoFIPS,
 	}
 )

--- a/pkg/components/combined.go
+++ b/pkg/components/combined.go
@@ -23,14 +23,10 @@ import (
 const CalicoBinaryPath = "/usr/bin/calico"
 
 // CombinedCalicoImage returns the combined calico/calico Component for the given installation.
-// The right Component is selected based on the installation variant (Calico OSS vs. Calico Enterprise)
-// and FIPS mode. FIPS + Enterprise is rejected at admission so it is not represented here.
+// The right Component is selected based on the installation variant (Calico OSS vs. Calico Enterprise).
 func CombinedCalicoImage(installation *operatorv1.InstallationSpec) Component {
 	if installation.Variant.IsEnterprise() {
 		return ComponentTigeraCalico
-	}
-	if operatorv1.IsFIPSModeEnabled(installation.FIPSMode) {
-		return ComponentCalicoFIPS
 	}
 	return ComponentCalico
 }

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -414,8 +414,8 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 		}
 	}
 
-	if operatorv1.IsFIPSModeEnabled(instance.Spec.FIPSMode) && instance.Spec.Variant.IsEnterprise() {
-		return fmt.Errorf("installation spec.FIPSMode=%v combined with spec.Variant=%s is not supported", *instance.Spec.FIPSMode, instance.Spec.Variant)
+	if operatorv1.IsFIPSModeEnabled(instance.Spec.FIPSMode) {
+		return fmt.Errorf("installation spec.FIPSMode=%v is not supported; FIPS mode has been removed", *instance.Spec.FIPSMode)
 	}
 
 	if instance.Spec.KubernetesProvider != operatorv1.ProviderAKS && instance.Spec.Azure != nil {

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -1260,8 +1260,8 @@ var _ = Describe("Installation validation tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
-	Describe("validate FIPSMode combined with Variant", func() {
-		DescribeTable("test that FIPSMode is not allowed in combination with Enterprise",
+	Describe("validate FIPSMode", func() {
+		DescribeTable("test that FIPSMode=Enabled is rejected since FIPS mode has been removed",
 			func(variant operator.ProductVariant, fipsMode operator.FIPSMode, expectErr bool) {
 				instance.Spec.Variant = variant
 				instance.Spec.FIPSMode = &fipsMode
@@ -1274,7 +1274,7 @@ var _ = Describe("Installation validation tests", func() {
 			},
 
 			Entry("Product: Calico FipsMode: Disabled", operator.Calico, operator.FIPSModeDisabled, false),
-			Entry("Product: Calico FipsMode: Enabled", operator.Calico, operator.FIPSModeEnabled, false),
+			Entry("Product: Calico FipsMode: Enabled", operator.Calico, operator.FIPSModeEnabled, true),
 			Entry("Product: CalicoEnterprise FipsMode: Disabled", operator.CalicoEnterprise, operator.FIPSModeDisabled, false),
 			Entry("Product: CalicoEnterprise FipsMode: Enabled", operator.CalicoEnterprise, operator.FIPSModeEnabled, true),
 		)

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -1098,29 +1098,6 @@ var _ = Describe("Manager controller tests", func() {
 				})
 			})
 
-			Context("FIPS reconciliation", func() {
-				BeforeEach(func() {
-					fipsEnabled := operatorv1.FIPSModeEnabled
-					installation.Spec.FIPSMode = &fipsEnabled
-					Expect(c.Update(
-						ctx,
-						installation,
-					)).NotTo(HaveOccurred())
-				})
-				It("should not require presence of ElasticSearch ConfigMap", func() {
-					Expect(c.Delete(ctx, relasticsearch.NewClusterConfig("cluster", 1, 1, 1).ConfigMap())).NotTo(HaveOccurred())
-					elasticConfigMapKey := client.ObjectKey{
-						Name:      relasticsearch.ClusterConfigConfigMapName,
-						Namespace: common.OperatorNamespace(),
-					}
-					elasticConfigMap := corev1.ConfigMap{}
-					Expect(c.Get(ctx, elasticConfigMapKey, &elasticConfigMap)).To(HaveOccurred())
-
-					_, err := r.Reconcile(ctx, reconcile.Request{})
-					Expect(err).ShouldNot(HaveOccurred())
-				})
-			})
-
 			Context("non-cluster host", func() {
 				It("should read NonClusterHost resource", func() {
 					nonclusterhost := &operatorv1.NonClusterHost{

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -7149,9 +7149,8 @@ spec:
                   type: object
                 fipsMode:
                   description: |-
-                    FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
-                    Only supported for Variant=Calico.
-                    Default: Disabled
+                    Deprecated. FIPS mode is no longer supported. Setting fipsMode to Enabled marks the
+                    installation degraded.
                   enum:
                     - Enabled
                     - Disabled
@@ -16563,9 +16562,8 @@ spec:
                       type: object
                     fipsMode:
                       description: |-
-                        FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
-                        Only supported for Variant=Calico.
-                        Default: Disabled
+                        Deprecated. FIPS mode is no longer supported. Setting fipsMode to Enabled marks the
+                        installation degraded.
                       enum:
                         - Enabled
                         - Disabled

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2485,20 +2485,6 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 				Effect:   corev1.TaintEffectNoSchedule,
 			}))
 		})
-
-		It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
-			fipsEnabled := operatorv1.FIPSModeEnabled
-			cfg.Installation.FIPSMode = &fipsEnabled
-
-			component, err := render.APIServer(cfg)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(component.ResolveImages(nil)).To(BeNil())
-			resources, _ := component.Objects()
-
-			d := rtest.GetResource(resources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-			Expect(d.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
-		})
 	})
 
 	Context("multi-tenant", func() {

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -314,19 +314,6 @@ var _ = Describe("CSI rendering tests", func() {
 		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(Equal(expectedImage))
 	})
 
-	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		cfg.Installation.FIPSMode = &fipsEnabled
-		cfg.Installation.Variant = operatorv1.Calico
-
-		comp := render.CSI(&cfg)
-		Expect(comp.ResolveImages(nil)).To(BeNil())
-		createObjs, _ := comp.Objects()
-		dsResource := rtest.GetResource(createObjs, "csi-node-driver", common.CalicoNamespace, "apps", "v1", "DaemonSet")
-		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
-		Expect(dsResource.(*appsv1.DaemonSet).Spec.Template.Spec.Containers[1].Image).To(ContainSubstring("-fips"))
-	})
-
 	It("should render the labels when the provider is openshift", func() {
 		cfg.OpenShift = true
 		comp := render.CSI(&cfg)

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -688,25 +688,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(passed).To(Equal(true))
 	})
 
-	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		cfg.Installation.FIPSMode = &fipsEnabled
-		cfg.Installation.Variant = operatorv1.Calico
-		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
-		Expect(component.ResolveImages(nil)).To(BeNil())
-		resources, _ := component.Objects()
-		depResource := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment")
-		Expect(depResource).ToNot(BeNil())
-		deployment := depResource.(*appsv1.Deployment)
-
-		for _, container := range deployment.Spec.Template.Spec.Containers {
-			if container.Name == kubecontrollers.KubeController {
-				Expect(container.Image).To(ContainSubstring("-fips"))
-				break
-			}
-		}
-	})
-
 	It("should add the OIDC prefix env variables", func() {
 		instance.Variant = operatorv1.CalicoEnterprise
 		cfg.LogStorageExists = true

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -187,8 +187,6 @@ func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	switch {
 	case c.cfg.Installation.Variant.IsEnterprise():
 		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNode, reg, path, prefix, is))
-	case operatorv1.IsFIPSModeEnabled(c.cfg.Installation.FIPSMode):
-		c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNodeFIPS, reg, path, prefix, is))
 	default:
 		c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNode, reg, path, prefix, is))
 	}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -3087,31 +3087,6 @@ var _ = Describe("Node rendering tests", func() {
 				rtest.ExpectEnv(deploy.Spec.Template.Spec.Containers[0].Env, "CALICO_EARLY_NETWORKING", render.BGPLayoutPath)
 			})
 
-			It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
-				fipsEnabled := operatorv1.FIPSModeEnabled
-				cfg.Installation.FIPSMode = &fipsEnabled
-				cfg.Installation.Variant = operatorv1.Calico
-				cfg.Installation.NodeMetricsPort = ptr.To(int32(123))
-
-				certificateManager, err := certificatemanager.Create(cli, nil, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
-				Expect(err).NotTo(HaveOccurred())
-
-				cfg.PrometheusServerTLS = certificateManager.KeyPair()
-				component := render.Node(&cfg)
-				Expect(component.ResolveImages(nil)).To(BeNil())
-
-				resources, _ := component.Objects()
-				nodeDSObj := rtest.GetResource(resources, common.NodeDaemonSetName, common.CalicoNamespace, "apps", "v1", "DaemonSet")
-				Expect(nodeDSObj).ToNot(BeNil())
-
-				nodeDS, ok := nodeDSObj.(*appsv1.DaemonSet)
-				Expect(ok).To(BeTrue())
-
-				Expect(nodeDS.Spec.Template.Spec.Containers[0].Name).To(Equal("calico-node"))
-				Expect(nodeDS.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring("-fips"))
-				verifyInitContainers(nodeDS, cfg.Installation)
-			})
-
 			Context("With calico-node DaemonSet overrides", func() {
 				rr1 := corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -3403,10 +3378,6 @@ func verifyInitContainers(ds *appsv1.DaemonSet, instance *operatorv1.Installatio
 		rtest.ExpectEnv(cniContainer.Env, "CNI_CONF_NAME", "10-calico.conflist")
 		rtest.ExpectEnv(cniContainer.Env, "SLEEP", "false")
 		cniImage := fmt.Sprintf("quay.io/%s%s:%s", components.CalicoImagePath, components.ComponentCalico.Image, components.ComponentCalico.Version)
-		if instance.FIPSMode != nil && *instance.FIPSMode == operatorv1.FIPSModeEnabled {
-			// Calico combined image has a -fips variant when FIPS mode is enabled.
-			cniImage = fmt.Sprintf("quay.io/%s%s:%s", components.CalicoImagePath, components.ComponentCalicoFIPS.Image, components.ComponentCalicoFIPS.Version)
-		}
 		if instance.Variant.IsEnterprise() {
 			cniImage = fmt.Sprintf("%s%s%s:%s", components.TigeraRegistry, components.TigeraImagePath, components.ComponentTigeraCalico.Image, components.ComponentTigeraCalico.Version)
 		}
@@ -3461,10 +3432,6 @@ func verifyInitContainers(ds *appsv1.DaemonSet, instance *operatorv1.Installatio
 	ebpfBootstrap := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
 	Expect(ebpfBootstrap).NotTo(BeNil())
 	ebpfImage := fmt.Sprintf("quay.io/%s%s:%s", components.CalicoImagePath, components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)
-	if instance.FIPSMode != nil && *instance.FIPSMode == operatorv1.FIPSModeEnabled {
-		// Calico Node image should have -fips suffix when FIPS mode is enabled.
-		ebpfImage = fmt.Sprintf("quay.io/%s%s:%s-fips", components.CalicoImagePath, components.ComponentCalicoNode.Image, components.ComponentCalicoNode.Version)
-	}
 	if instance.Variant.IsEnterprise() {
 		ebpfImage = components.TigeraRegistry + "tigera/node:" + components.ComponentTigeraNode.Version
 	}
@@ -3498,8 +3465,6 @@ func verifyInitContainers(ds *appsv1.DaemonSet, instance *operatorv1.Installatio
 		Expect(flexvolContainer).NotTo(BeNil())
 		if instance.Variant.IsEnterprise() {
 			Expect(flexvolContainer.Image).To(Equal(fmt.Sprintf("%s%s%s:%s", components.TigeraRegistry, components.TigeraImagePath, components.ComponentTigeraCalico.Image, components.ComponentTigeraCalico.Version)))
-		} else if operatorv1.IsFIPSModeEnabled(instance.FIPSMode) {
-			Expect(flexvolContainer.Image).To(Equal(fmt.Sprintf("quay.io/%s%s:%s", components.CalicoImagePath, components.ComponentCalicoFIPS.Image, components.ComponentCalicoFIPS.Version)))
 		} else {
 			Expect(flexvolContainer.Image).To(Equal(fmt.Sprintf("quay.io/%s%s:%s", components.CalicoImagePath, components.ComponentCalico.Image, components.ComponentCalico.Version)))
 		}

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -287,23 +287,6 @@ var _ = Describe("Typha rendering tests", func() {
 		))
 	})
 
-	It("should render the correct env and/or images when FIPS mode is enabled (OSS)", func() {
-		cfg.Installation.Variant = operatorv1.Calico
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		cfg.Installation.FIPSMode = &fipsEnabled
-		component := render.Typha(&cfg)
-		Expect(component.ResolveImages(nil)).To(BeNil())
-		resources, _ := component.Objects()
-		dResource := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment")
-		Expect(dResource).ToNot(BeNil())
-
-		d := dResource.(*appsv1.Deployment)
-		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
-
-		tc := d.Spec.Template.Spec.Containers[0]
-		Expect(tc.Image).To(ContainSubstring("-fips"))
-	})
-
 	It("should include updates needed for migration of core components from kube-system namespace", func() {
 		expectedResources := []struct {
 			name    string

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Webhooks rendering tests", func() {
 
 		rtest.ExpectResources(resources, expectedResources)
 
-		// Verify the Calico (non-enterprise, non-FIPS) variant uses the combined calico/calico image with Command set.
+		// Verify the Calico (non-enterprise) variant uses the combined calico/calico image with Command set.
 		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(
@@ -122,23 +122,6 @@ var _ = Describe("Webhooks rendering tests", func() {
 			Resources: []string{"managedclusters"},
 			Verbs:     []string{"list", "watch", "update"},
 		}))
-	})
-
-	It("should use the combined image and Cobra Command for Calico FIPS", func() {
-		fipsEnabled := operatorv1.FIPSModeEnabled
-		installation.FIPSMode = &fipsEnabled
-		component := webhooks.Component(cfg)
-		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
-		resources, _ := component.Objects()
-
-		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(dep.Spec.Template.Spec.Containers).To(HaveLen(1))
-		Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(
-			fmt.Sprintf("test-registry.com/%s%s:%s",
-				components.CalicoImagePath,
-				components.ComponentCalicoFIPS.Image,
-				components.ComponentCalicoFIPS.Version)))
-		Expect(dep.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{components.CalicoBinaryPath, "component", "webhooks"}))
 	})
 
 	It("should render all resources for Enterprise with the correct image", func() {

--- a/pkg/tls/certificatemanagement/csr.go
+++ b/pkg/tls/certificatemanagement/csr.go
@@ -94,8 +94,8 @@ func CreateCSRInitContainer(
 }
 
 // ResolveCSRInitImage resolves the image needed for the CSR init container, taking into account the
-// specified ImageSet. The init container reuses the combined calico/calico image (or its FIPS variant
-// for OSS) and dispatches into the key-cert-provisioner Cobra subcommand.
+// specified ImageSet. The init container reuses the combined calico/calico image and dispatches into
+// the key-cert-provisioner Cobra subcommand.
 func ResolveCSRInitImage(inst *operatorv1.InstallationSpec, is *operatorv1.ImageSet) (string, error) {
 	return components.GetReference(components.CombinedCalicoImage(inst), inst.Registry, inst.ImagePath, inst.ImagePrefix, is)
 }


### PR DESCRIPTION
Removes FIPS mode support from the operator, alongside the FIPS removal in the calico repo (https://github.com/projectcalico/calico/pull/12883).

The Installation `fipsMode` field stays in the API but is now deprecated. When it is set to Enabled the installation is marked degraded, since the `-fips` images are no longer built or published. The `-fips` image variants and the rendering paths that selected them are removed.

```release-note
The Installation fipsMode field is deprecated. FIPS mode is no longer supported, and setting fipsMode to Enabled marks the installation degraded.
```
