### PR TITLE
istio: grant waypoint controller namespaced secret-write via RoleBinding

### DIFF
--- a/pkg/controller/istio/waypoint/waypoint_secrets_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_secrets_controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -177,8 +178,17 @@ func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconc
 			}
 		}
 
-		// Build desired secrets for each target namespace.
+		// Build desired resources for each target namespace. The operator's
+		// cluster-wide secrets grant is read-only; writing a secret into a
+		// namespace requires a tigera-operator-secrets RoleBinding there. Render
+		// that RoleBinding (ordered before the secrets so the operator can create
+		// them — the controller re-reconciles to absorb RBAC propagation lag on
+		// first create) followed by the copied pull secrets.
 		for ns := range targetNamespaces {
+			rb := render.CreateOperatorSecretsRoleBinding(ns)
+			rb.Labels = map[string]string{WaypointPullSecretLabel: "true"}
+			toCreate = append(toCreate, rb)
+
 			copied := secret.CopyToNamespace(ns, pullSecrets...)
 			for _, s := range copied {
 				if s.Labels == nil {
@@ -190,14 +200,24 @@ func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconc
 		}
 	}
 
-	// Build the desired set keyed on (namespace, name) so that renamed or removed
-	// secrets are correctly detected as stale.
+	// Build the desired sets keyed on (namespace, name), per kind, so that
+	// renamed or removed resources are correctly detected as stale.
 	desiredSecrets := map[types.NamespacedName]bool{}
+	desiredRoleBindings := map[types.NamespacedName]bool{}
 	for _, obj := range toCreate {
-		desiredSecrets[types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}] = true
+		key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+		switch obj.(type) {
+		case *rbacv1.RoleBinding:
+			desiredRoleBindings[key] = true
+		default:
+			desiredSecrets[key] = true
+		}
 	}
 
-	// List all existing secrets managed by this controller and mark stale ones for deletion.
+	// List existing secrets managed by this controller and mark stale ones for
+	// deletion. Secrets are appended to toDelete before RoleBindings so that each
+	// secret is removed while the operator still holds write access in its
+	// namespace (the RoleBinding grants that access).
 	existingSecrets := &corev1.SecretList{}
 	if err := r.List(ctx, existingSecrets, client.MatchingLabels{WaypointPullSecretLabel: "true"}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to list waypoint pull secrets: %w", err)
@@ -207,6 +227,20 @@ func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconc
 		key := types.NamespacedName{Namespace: s.Namespace, Name: s.Name}
 		if !desiredSecrets[key] {
 			toDelete = append(toDelete, s)
+		}
+	}
+
+	// List existing RoleBindings managed by this controller and mark stale ones
+	// for deletion (after the secrets, per the ordering note above).
+	existingRoleBindings := &rbacv1.RoleBindingList{}
+	if err := r.List(ctx, existingRoleBindings, client.MatchingLabels{WaypointPullSecretLabel: "true"}); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to list waypoint pull secret rolebindings: %w", err)
+	}
+	for i := range existingRoleBindings.Items {
+		rb := &existingRoleBindings.Items[i]
+		key := types.NamespacedName{Namespace: rb.Namespace, Name: rb.Name}
+		if !desiredRoleBindings[key] {
+			toDelete = append(toDelete, rb)
 		}
 	}
 

--- a/pkg/controller/istio/waypoint/waypoint_secrets_controller_test.go
+++ b/pkg/controller/istio/waypoint/waypoint_secrets_controller_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,6 +35,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/render"
 )
 
 var _ = Describe("Waypoint pull secrets controller tests", func() {
@@ -163,6 +165,13 @@ var _ = Describe("Waypoint pull secrets controller tests", func() {
 		return secretList.Items
 	}
 
+	listTrackedRoleBindings := func() []rbacv1.RoleBinding {
+		rbList := &rbacv1.RoleBindingList{}
+		err := cli.List(ctx, rbList, client.MatchingLabels{WaypointPullSecretLabel: "true"})
+		Expect(err).NotTo(HaveOccurred())
+		return rbList.Items
+	}
+
 	Context("when no pull secrets are configured", func() {
 		It("should not create any secrets", func() {
 			Expect(cli.Create(ctx, installation)).NotTo(HaveOccurred())
@@ -198,6 +207,21 @@ var _ = Describe("Waypoint pull secrets controller tests", func() {
 			Expect(secrets[0].Namespace).To(Equal("user-ns"))
 			Expect(secrets[0].Name).To(Equal("my-pull-secret"))
 			Expect(secrets[0].Labels[WaypointPullSecretLabel]).To(Equal("true"))
+		})
+
+		It("should create a tigera-operator-secrets RoleBinding so the operator can write secrets in the waypoint namespace", func() {
+			createWaypointGateway("waypoint", "user-ns")
+
+			_, err := doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			rbs := listTrackedRoleBindings()
+			Expect(rbs).To(HaveLen(1))
+			Expect(rbs[0].Namespace).To(Equal("user-ns"))
+			Expect(rbs[0].Name).To(Equal(render.TigeraOperatorSecrets))
+			Expect(rbs[0].RoleRef.Kind).To(Equal("ClusterRole"))
+			Expect(rbs[0].RoleRef.Name).To(Equal(render.TigeraOperatorSecrets))
+			Expect(rbs[0].Labels[WaypointPullSecretLabel]).To(Equal("true"))
 		})
 
 		It("should copy pull secrets only once for multiple gateways in same namespace", func() {
@@ -246,8 +270,9 @@ var _ = Describe("Waypoint pull secrets controller tests", func() {
 			_, err = doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			// Secrets should be cleaned up.
+			// Secrets and the RoleBinding should be cleaned up.
 			Expect(listTrackedSecrets()).To(BeEmpty())
+			Expect(listTrackedRoleBindings()).To(BeEmpty())
 		})
 
 		It("should not take action for non-matching gatewayClassName", func() {
@@ -349,8 +374,9 @@ var _ = Describe("Waypoint pull secrets controller tests", func() {
 			_, err = doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			// All secrets should be cleaned up.
+			// All secrets and RoleBindings should be cleaned up.
 			Expect(listTrackedSecrets()).To(BeEmpty())
+			Expect(listTrackedRoleBindings()).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
The waypoint pull-secrets controller copies the Installation pull secret into namespaces that contain istio-waypoint Gateways so waypoint pods can pull the Istio proxy image from a private registry. The operator's cluster-wide secrets grant is read-only, so CopyToNamespace is RBAC-denied in a user namespace.

Render a per-namespace tigera-operator-secrets RoleBinding in each waypoint namespace (ordered before the copied secrets, cleaned up after them so write access persists while the secrets are removed), mirroring how egressgateway obtains namespaced secret-write. Unit tests (fake client) and GKE node-cred environments masked this gap.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
