### PR TITLE
Manage ValidatingAdmissionPolicies in admission imports

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -355,6 +355,11 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 			os.Exit(1)
 		}
 
+		if err := admission.EnsureValidating(mgr.GetClient(), variant, v3CRDs, apiDiscovery.ServedVersion(admission.APIGroup, admission.KindValidatingPolicy), setupLog); err != nil {
+			setupLog.Error(err, "Failed to ensure ValidatingAdmissionPolicies are created")
+			os.Exit(1)
+		}
+
 		if bootstrapCRDs {
 			setupLog.Info("CRDs installed successfully")
 			os.Exit(0)

--- a/pkg/common/discovery/api.go
+++ b/pkg/common/discovery/api.go
@@ -24,6 +24,7 @@ import (
 // of) an API is available.
 var trackedGroupKinds = []schema.GroupKind{
 	{Group: "admissionregistration.k8s.io", Kind: "MutatingAdmissionPolicy"},
+	{Group: "admissionregistration.k8s.io", Kind: "ValidatingAdmissionPolicy"},
 }
 
 // APIDiscovery is a snapshot of which API versions a cluster serves for the set of GroupKinds the

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -941,6 +941,10 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
+	if err = r.updateValidatingAdmissionPolicies(ctx, instance, reqLogger); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Now that migrated config is stored in the installation resource, we no longer need
 	// to check if a migration is needed for the lifetime of the operator.
 	r.migrationChecked = true
@@ -2282,41 +2286,76 @@ func (r *ReconcileInstallation) updateMutatingAdmissionPolicies(ctx context.Cont
 	}
 
 	desired := admission.GetMutatingAdmissionPolicies(install.Spec.Variant, r.v3CRDs, mapAPIVersion)
-
-	// Build sets of desired resource names for comparison.
-	desiredMAPs := map[string]bool{}
-	desiredMAPBs := map[string]bool{}
-	for _, obj := range desired {
-		switch {
-		case admission.IsPolicyKind(obj):
-			desiredMAPs[obj.GetName()] = true
-		case admission.IsBindingKind(obj):
-			desiredMAPBs[obj.GetName()] = true
-		}
-	}
-
-	// Find stale managed resources at the discovered API version.
 	existingMAPs, existingMAPBs, err := admission.ListManaged(ctx, r.client, mapAPIVersion)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error listing managed MutatingAdmissionPolicy resources", err, log)
 		return err
 	}
+
+	return r.syncManagedAdmissionPolicies(ctx, install, log, desired, existingMAPs, existingMAPBs, admission.IsPolicyKind, admission.IsBindingKind, "Error syncing MutatingAdmissionPolicy resources")
+}
+
+func (r *ReconcileInstallation) updateValidatingAdmissionPolicies(ctx context.Context, install *operatorv1.Installation, log logr.Logger) error {
+	if !r.manageCRDs || !r.v3CRDs {
+		return nil
+	}
+
+	// ValidatingAdmissionPolicy reached GA (v1) well before MutatingAdmissionPolicy, so it has its own
+	// served version and is reconciled independently of whether the cluster serves MAPs. If the cluster
+	// doesn't serve it at all there's nothing to do, so skip rather than degrade.
+	vapAPIVersion := r.apiDiscovery.ServedVersion(admission.APIGroup, admission.KindValidatingPolicy)
+	if vapAPIVersion == "" {
+		log.Info("Kubernetes cluster does not serve ValidatingAdmissionPolicy, skipping")
+		return nil
+	}
+
+	desired := admission.GetValidatingAdmissionPolicies(install.Spec.Variant, r.v3CRDs, vapAPIVersion)
+	existingVAPs, existingVAPBs, err := admission.ListManagedValidating(ctx, r.client, vapAPIVersion)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error listing managed ValidatingAdmissionPolicy resources", err, log)
+		return err
+	}
+
+	return r.syncManagedAdmissionPolicies(ctx, install, log, desired, existingVAPs, existingVAPBs, admission.IsValidatingPolicyKind, admission.IsValidatingBindingKind, "Error syncing ValidatingAdmissionPolicy resources")
+}
+
+// syncManagedAdmissionPolicies creates or updates the desired admission policies and bindings and
+// deletes any operator-managed ones that are no longer desired, in a single pass. isPolicy/isBinding
+// bucket the desired objects by kind so stale existing resources can be identified by name.
+func (r *ReconcileInstallation) syncManagedAdmissionPolicies(
+	ctx context.Context,
+	install *operatorv1.Installation,
+	log logr.Logger,
+	desired, existingPolicies, existingBindings []client.Object,
+	isPolicy, isBinding func(client.Object) bool,
+	degradeMsg string,
+) error {
+	desiredPolicies := map[string]bool{}
+	desiredBindings := map[string]bool{}
+	for _, obj := range desired {
+		switch {
+		case isPolicy(obj):
+			desiredPolicies[obj.GetName()] = true
+		case isBinding(obj):
+			desiredBindings[obj.GetName()] = true
+		}
+	}
+
 	var toDelete []client.Object
-	for _, obj := range existingMAPs {
-		if !desiredMAPs[obj.GetName()] {
+	for _, obj := range existingPolicies {
+		if !desiredPolicies[obj.GetName()] {
 			toDelete = append(toDelete, obj)
 		}
 	}
-	for _, obj := range existingMAPBs {
-		if !desiredMAPBs[obj.GetName()] {
+	for _, obj := range existingBindings {
+		if !desiredBindings[obj.GetName()] {
 			toDelete = append(toDelete, obj)
 		}
 	}
 
-	// Create or update desired MAPs/MAPBs and delete any stale ones in a single pass.
 	handler := r.newComponentHandler(log, r.client, r.scheme, install)
 	if err := handler.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(desired, toDelete), nil); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error syncing MutatingAdmissionPolicy resources", err, log)
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, degradeMsg, err, log)
 		return err
 	}
 

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -2845,3 +2845,223 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 		Expect(componentHandler.objectsToCreate).To(HaveLen(4))
 	})
 })
+
+var _ = Describe("updateValidatingAdmissionPolicies", func() {
+	var (
+		ctx              context.Context
+		cancel           context.CancelFunc
+		r                ReconcileInstallation
+		scheme           *runtime.Scheme
+		mockStatus       *status.MockStatus
+		componentHandler *fakeComponentHandler
+		log              logr.Logger
+		installation     *operator.Installation
+	)
+
+	clientFor := func(initial ...client.Object) client.Client {
+		return ctrlrfake.DefaultFakeClientBuilder(scheme).WithObjects(initial...).Build()
+	}
+
+	discoveryFor := func(vapVersion string) *discovery.APIDiscovery {
+		m := map[schema.GroupKind]string{}
+		if vapVersion != "" {
+			m[admission.ValidatingPolicyGroupKind] = vapVersion
+		}
+		return discovery.NewStaticAPIDiscovery(m)
+	}
+
+	BeforeEach(func() {
+		log = logr.Discard()
+		ctx, cancel = context.WithCancel(context.Background())
+
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
+		Expect(operator.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(admissionregistrationv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(admissionregistrationv1alpha1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(admissionv1beta1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+		componentHandler = newFakeComponentHandler()
+		installation = &operator.Installation{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec: operator.InstallationSpec{
+				Variant: operator.Calico,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	It("should create v1 VAPs when v1 is served", func() {
+		r = ReconcileInstallation{
+			client:       clientFor(),
+			scheme:       scheme,
+			status:       mockStatus,
+			manageCRDs:   true,
+			v3CRDs:       true,
+			apiDiscovery: discoveryFor(admission.VersionV1),
+			newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+				return componentHandler
+			},
+		}
+
+		Expect(r.updateValidatingAdmissionPolicies(ctx, installation, log)).NotTo(HaveOccurred())
+		Expect(componentHandler.objectsToCreate).To(HaveLen(2))
+
+		var vapCount, vapbCount int
+		for _, obj := range componentHandler.objectsToCreate {
+			switch obj.(type) {
+			case *admissionregistrationv1.ValidatingAdmissionPolicy:
+				vapCount++
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(admission.ManagedVAPLabel, admission.ManagedVAPLabelValue))
+			case *admissionregistrationv1.ValidatingAdmissionPolicyBinding:
+				vapbCount++
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(admission.ManagedVAPLabel, admission.ManagedVAPLabelValue))
+			}
+		}
+		Expect(vapCount).To(Equal(1))
+		Expect(vapbCount).To(Equal(1))
+	})
+
+	It("should create v1beta1 VAPs when only v1beta1 is served", func() {
+		r = ReconcileInstallation{
+			client:       clientFor(),
+			scheme:       scheme,
+			status:       mockStatus,
+			manageCRDs:   true,
+			v3CRDs:       true,
+			apiDiscovery: discoveryFor(admission.VersionV1Beta1),
+			newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+				return componentHandler
+			},
+		}
+
+		Expect(r.updateValidatingAdmissionPolicies(ctx, installation, log)).NotTo(HaveOccurred())
+		Expect(componentHandler.objectsToCreate).To(HaveLen(2))
+
+		var vapCount, vapbCount int
+		for _, obj := range componentHandler.objectsToCreate {
+			switch obj.(type) {
+			case *admissionv1beta1.ValidatingAdmissionPolicy:
+				vapCount++
+			case *admissionv1beta1.ValidatingAdmissionPolicyBinding:
+				vapbCount++
+			}
+		}
+		Expect(vapCount).To(Equal(1))
+		Expect(vapbCount).To(Equal(1))
+	})
+
+	It("should create v1alpha1 VAPs when only v1alpha1 is served", func() {
+		r = ReconcileInstallation{
+			client:       clientFor(),
+			scheme:       scheme,
+			status:       mockStatus,
+			manageCRDs:   true,
+			v3CRDs:       true,
+			apiDiscovery: discoveryFor(admission.VersionV1Alpha1),
+			newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+				return componentHandler
+			},
+		}
+
+		Expect(r.updateValidatingAdmissionPolicies(ctx, installation, log)).NotTo(HaveOccurred())
+		Expect(componentHandler.objectsToCreate).To(HaveLen(2))
+	})
+
+	It("should skip without degrading when no served version exists", func() {
+		r = ReconcileInstallation{
+			client:       clientFor(),
+			scheme:       scheme,
+			status:       mockStatus,
+			manageCRDs:   true,
+			v3CRDs:       true,
+			apiDiscovery: discoveryFor(""),
+			newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+				return componentHandler
+			},
+		}
+
+		Expect(r.updateValidatingAdmissionPolicies(ctx, installation, log)).NotTo(HaveOccurred())
+		Expect(componentHandler.objectsToCreate).To(BeEmpty())
+		mockStatus.AssertNotCalled(GinkgoT(), "SetDegraded", operator.ResourceNotReady, mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	It("should not create VAPs when v3CRDs=false", func() {
+		r = ReconcileInstallation{
+			client:       clientFor(),
+			scheme:       scheme,
+			status:       mockStatus,
+			manageCRDs:   true,
+			v3CRDs:       false,
+			apiDiscovery: discoveryFor(admission.VersionV1),
+			newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+				return componentHandler
+			},
+		}
+
+		Expect(r.updateValidatingAdmissionPolicies(ctx, installation, log)).NotTo(HaveOccurred())
+		Expect(componentHandler.objectsToCreate).To(BeEmpty())
+	})
+
+	It("should delete stale v1 VAPs with managed label", func() {
+		staleVAP := &admissionregistrationv1.ValidatingAdmissionPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "stale-policy",
+				Labels: map[string]string{admission.ManagedVAPLabel: admission.ManagedVAPLabelValue},
+			},
+		}
+		staleVAPB := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "stale-binding",
+				Labels: map[string]string{admission.ManagedVAPLabel: admission.ManagedVAPLabelValue},
+			},
+		}
+
+		r = ReconcileInstallation{
+			client:       clientFor(staleVAP, staleVAPB),
+			scheme:       scheme,
+			status:       mockStatus,
+			manageCRDs:   true,
+			v3CRDs:       true,
+			apiDiscovery: discoveryFor(admission.VersionV1),
+			newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+				return componentHandler
+			},
+		}
+
+		Expect(r.updateValidatingAdmissionPolicies(ctx, installation, log)).NotTo(HaveOccurred())
+		Expect(componentHandler.objectsToCreate).To(HaveLen(2))
+		Expect(componentHandler.objectsToDelete).To(HaveLen(2))
+		deletedNames := map[string]bool{}
+		for _, obj := range componentHandler.objectsToDelete {
+			deletedNames[obj.GetName()] = true
+		}
+		Expect(deletedNames).To(HaveKey("stale-policy"))
+		Expect(deletedNames).To(HaveKey("stale-binding"))
+	})
+
+	It("should work with Enterprise variant", func() {
+		r = ReconcileInstallation{
+			client:       clientFor(),
+			scheme:       scheme,
+			status:       mockStatus,
+			manageCRDs:   true,
+			v3CRDs:       true,
+			apiDiscovery: discoveryFor(admission.VersionV1),
+			newComponentHandler: func(logr.Logger, client.Client, *runtime.Scheme, metav1.Object) utils.ComponentHandler {
+				return componentHandler
+			},
+		}
+
+		installation.Spec.Variant = operator.CalicoEnterprise
+
+		Expect(r.updateValidatingAdmissionPolicies(ctx, installation, log)).NotTo(HaveOccurred())
+		Expect(componentHandler.objectsToCreate).To(HaveLen(2))
+	})
+})

--- a/pkg/imports/admission/admission.go
+++ b/pkg/imports/admission/admission.go
@@ -42,7 +42,13 @@ const (
 	// ManagedMAPLabelValue is the label value for operator-managed MAP resources.
 	ManagedMAPLabelValue = "managed"
 
-	// APIGroup is the API group for MutatingAdmissionPolicy resources.
+	// ManagedVAPLabel is the label key applied to operator-managed ValidatingAdmissionPolicy and
+	// ValidatingAdmissionPolicyBinding resources.
+	ManagedVAPLabel = "operator.tigera.io/validating-admission-policy"
+	// ManagedVAPLabelValue is the label value for operator-managed VAP resources.
+	ManagedVAPLabelValue = "managed"
+
+	// APIGroup is the API group for MutatingAdmissionPolicy and ValidatingAdmissionPolicy resources.
 	APIGroup = "admissionregistration.k8s.io"
 	// VersionV1 is the GA API version (k8s 1.36+).
 	VersionV1 = "v1"
@@ -55,11 +61,24 @@ const (
 	KindPolicy = "MutatingAdmissionPolicy"
 	// KindBinding is the MutatingAdmissionPolicyBinding kind.
 	KindBinding = "MutatingAdmissionPolicyBinding"
+
+	// KindValidatingPolicy is the ValidatingAdmissionPolicy kind.
+	KindValidatingPolicy = "ValidatingAdmissionPolicy"
+	// KindValidatingBinding is the ValidatingAdmissionPolicyBinding kind.
+	KindValidatingBinding = "ValidatingAdmissionPolicyBinding"
 )
 
 // PolicyGroupKind is the GroupKind for MutatingAdmissionPolicy. Exposed so the API discovery
 // registry in cmd/main.go can pre-resolve its served version at startup.
 var PolicyGroupKind = schema.GroupKind{Group: APIGroup, Kind: KindPolicy}
+
+// ValidatingPolicyGroupKind is the GroupKind for ValidatingAdmissionPolicy. Exposed so the API
+// discovery registry in cmd/main.go can pre-resolve its served version at startup.
+var ValidatingPolicyGroupKind = schema.GroupKind{Group: APIGroup, Kind: KindValidatingPolicy}
+
+// policyParseFunc parses a single YAML document into a typed admission policy object at the given
+// API version, returning a nil object (and nil error) for kinds it does not handle.
+type policyParseFunc func(doc []byte, filename, apiVersion string) (client.Object, error)
 
 var (
 	//go:embed calico
@@ -70,9 +89,26 @@ var (
 
 // GetMutatingAdmissionPolicies returns MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding
 // objects for the given variant, typed at the requested API version. These are only applicable
-// when v3 CRDs are enabled.
-// Each returned object is labeled with ManagedMAPLabel to enable stale resource cleanup.
+// when v3 CRDs are enabled. Each returned object is labeled with ManagedMAPLabel to enable stale
+// resource cleanup.
 func GetMutatingAdmissionPolicies(variant opv1.ProductVariant, v3 bool, apiVersion string) []client.Object {
+	return getAdmissionPolicies(variant, v3, apiVersion, parseMutatingAdmissionPolicyYAML, ManagedMAPLabel, ManagedMAPLabelValue)
+}
+
+// GetValidatingAdmissionPolicies returns ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+// objects for the given variant, typed at the requested API version. These are only applicable when
+// v3 CRDs are enabled. Each returned object is labeled with ManagedVAPLabel to enable stale resource
+// cleanup.
+func GetValidatingAdmissionPolicies(variant opv1.ProductVariant, v3 bool, apiVersion string) []client.Object {
+	return getAdmissionPolicies(variant, v3, apiVersion, parseValidatingAdmissionPolicyYAML, ManagedVAPLabel, ManagedVAPLabelValue)
+}
+
+// getAdmissionPolicies reads the embedded admission policy files for the given variant and returns
+// the documents that parseFn recognizes, each labeled with labelKey=labelValue. The mutating and
+// validating policies live in the same embedded files, so parseFn returns a nil object for kinds
+// outside its family and we skip those - this lets each path pick up only its own kinds at its own
+// served API version.
+func getAdmissionPolicies(variant opv1.ProductVariant, v3 bool, apiVersion string, parseFn policyParseFunc, labelKey, labelValue string) []client.Object {
 	if !v3 || apiVersion == "" {
 		return nil
 	}
@@ -106,14 +142,12 @@ func GetMutatingAdmissionPolicies(variant opv1.ProductVariant, v3 bool, apiVersi
 				continue
 			}
 
-			obj, err := parseAdmissionPolicyYAML(doc, entry.Name(), apiVersion)
+			obj, err := parseFn(doc, entry.Name(), apiVersion)
 			if err != nil {
 				panic(fmt.Sprintf("Failed to parse admission policy %s: %v", entry.Name(), err))
 			}
 			if obj == nil {
-				// The admission directory also carries policy kinds we don't manage here
-				// (e.g. the ValidatingAdmissionPolicy that protects built-in tiers), which
-				// parse to a nil object. Skip those.
+				// Not a kind this path manages (the files mix mutating and validating policies).
 				continue
 			}
 
@@ -122,7 +156,7 @@ func GetMutatingAdmissionPolicies(variant opv1.ProductVariant, v3 bool, apiVersi
 			if labels == nil {
 				labels = map[string]string{}
 			}
-			labels[ManagedMAPLabel] = ManagedMAPLabelValue
+			labels[labelKey] = labelValue
 			obj.SetLabels(labels)
 
 			objs = append(objs, obj)
@@ -137,19 +171,29 @@ func GetMutatingAdmissionPolicies(variant opv1.ProductVariant, v3 bool, apiVersi
 // version of MutatingAdmissionPolicy on the cluster), a warning is logged and the function returns
 // nil. MAPs are only installed when v3 CRDs are enabled.
 func Ensure(c client.Client, variant string, v3 bool, apiVersion string, log logr.Logger) error {
+	return ensure(c, GetMutatingAdmissionPolicies(opv1.ProductVariant(variant), v3, apiVersion), v3, apiVersion, log)
+}
+
+// EnsureValidating ensures that ValidatingAdmissionPolicies necessary for bootstrapping exist in the
+// cluster, mirroring Ensure. ValidatingAdmissionPolicy has its own served version (it reached GA well
+// before MutatingAdmissionPolicy), so it is bootstrapped independently and is not gated on whether the
+// cluster serves MutatingAdmissionPolicy.
+func EnsureValidating(c client.Client, variant string, v3 bool, apiVersion string, log logr.Logger) error {
+	return ensure(c, GetValidatingAdmissionPolicies(opv1.ProductVariant(variant), v3, apiVersion), v3, apiVersion, log)
+}
+
+func ensure(c client.Client, objs []client.Object, v3 bool, apiVersion string, log logr.Logger) error {
 	if !v3 {
 		return nil
 	}
 
 	if apiVersion == "" {
-		log.Info("MutatingAdmissionPolicy API not available on cluster, skipping bootstrap")
+		log.Info("admission policy API not available on cluster, skipping bootstrap")
 		return nil
 	}
 
-	objs := GetMutatingAdmissionPolicies(opv1.ProductVariant(variant), v3, apiVersion)
-
 	for _, obj := range objs {
-		log.Info("ensuring MutatingAdmissionPolicy resource exists", "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+		log.Info("ensuring admission policy resource exists", "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		// Cancel explicitly rather than using defer, since defer only runs at
 		// function return and would leak contexts across loop iterations.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -161,12 +205,12 @@ func Ensure(c client.Client, variant string, v3 bool, apiVersion string, log log
 
 			// If the API is not available, log a warning and skip.
 			if errors.IsNotFound(err) || errors.IsForbidden(err) {
-				log.Info("MutatingAdmissionPolicy API not available, skipping", "error", err)
+				log.Info("admission policy API not available, skipping", "error", err)
 				return nil
 			}
 
 			// Log an error but continue. We'll handle any persistent issues in the core controller's reconciliation loop.
-			log.Error(err, "Failed to create MutatingAdmissionPolicy resource", "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+			log.Error(err, "Failed to create admission policy resource", "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		} else {
 			cancel()
 		}
@@ -174,12 +218,12 @@ func Ensure(c client.Client, variant string, v3 bool, apiVersion string, log log
 	return nil
 }
 
-// parseAdmissionPolicyYAML parses a YAML document into either a MutatingAdmissionPolicy
+// parseMutatingAdmissionPolicyYAML parses a YAML document into either a MutatingAdmissionPolicy
 // or MutatingAdmissionPolicyBinding at the requested API version. The MAP types are identical
 // in shape across v1alpha1, v1beta1, and v1, so we deserialize the same YAML into the requested
 // target type and overwrite TypeMeta to reflect the chosen GroupVersion. Documents of any other
 // kind return a nil object and nil error so the caller can skip them.
-func parseAdmissionPolicyYAML(doc []byte, filename, apiVersion string) (client.Object, error) {
+func parseMutatingAdmissionPolicyYAML(doc []byte, filename, apiVersion string) (client.Object, error) {
 	var meta struct {
 		Kind string `json:"kind"`
 	}
@@ -248,6 +292,79 @@ func parseAdmissionPolicyYAML(doc []byte, filename, apiVersion string) (client.O
 	return nil, nil
 }
 
+// parseValidatingAdmissionPolicyYAML parses a YAML document into either a ValidatingAdmissionPolicy
+// or ValidatingAdmissionPolicyBinding at the requested API version, mirroring
+// parseMutatingAdmissionPolicyYAML. Documents of any other kind return a nil object and nil error
+// so the caller can skip them.
+func parseValidatingAdmissionPolicyYAML(doc []byte, filename, apiVersion string) (client.Object, error) {
+	var meta struct {
+		Kind string `json:"kind"`
+	}
+	if err := yaml.Unmarshal(doc, &meta); err != nil {
+		return nil, fmt.Errorf("unable to determine kind from %s: %v", filename, err)
+	}
+
+	gv := APIGroup + "/" + apiVersion
+
+	switch apiVersion {
+	case VersionV1:
+		switch meta.Kind {
+		case KindValidatingPolicy:
+			obj := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+			if err := yaml.Unmarshal(doc, obj); err != nil {
+				return nil, fmt.Errorf("unable to parse ValidatingAdmissionPolicy from %s: %v", filename, err)
+			}
+			obj.TypeMeta = metav1.TypeMeta{Kind: meta.Kind, APIVersion: gv}
+			return obj, nil
+		case KindValidatingBinding:
+			obj := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+			if err := yaml.Unmarshal(doc, obj); err != nil {
+				return nil, fmt.Errorf("unable to parse ValidatingAdmissionPolicyBinding from %s: %v", filename, err)
+			}
+			obj.TypeMeta = metav1.TypeMeta{Kind: meta.Kind, APIVersion: gv}
+			return obj, nil
+		}
+	case VersionV1Beta1:
+		switch meta.Kind {
+		case KindValidatingPolicy:
+			obj := &admissionv1beta1.ValidatingAdmissionPolicy{}
+			if err := yaml.Unmarshal(doc, obj); err != nil {
+				return nil, fmt.Errorf("unable to parse ValidatingAdmissionPolicy from %s: %v", filename, err)
+			}
+			obj.TypeMeta = metav1.TypeMeta{Kind: meta.Kind, APIVersion: gv}
+			return obj, nil
+		case KindValidatingBinding:
+			obj := &admissionv1beta1.ValidatingAdmissionPolicyBinding{}
+			if err := yaml.Unmarshal(doc, obj); err != nil {
+				return nil, fmt.Errorf("unable to parse ValidatingAdmissionPolicyBinding from %s: %v", filename, err)
+			}
+			obj.TypeMeta = metav1.TypeMeta{Kind: meta.Kind, APIVersion: gv}
+			return obj, nil
+		}
+	case VersionV1Alpha1:
+		switch meta.Kind {
+		case KindValidatingPolicy:
+			obj := &admissionregistrationv1alpha1.ValidatingAdmissionPolicy{}
+			if err := yaml.Unmarshal(doc, obj); err != nil {
+				return nil, fmt.Errorf("unable to parse ValidatingAdmissionPolicy from %s: %v", filename, err)
+			}
+			obj.TypeMeta = metav1.TypeMeta{Kind: meta.Kind, APIVersion: gv}
+			return obj, nil
+		case KindValidatingBinding:
+			obj := &admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding{}
+			if err := yaml.Unmarshal(doc, obj); err != nil {
+				return nil, fmt.Errorf("unable to parse ValidatingAdmissionPolicyBinding from %s: %v", filename, err)
+			}
+			obj.TypeMeta = metav1.TypeMeta{Kind: meta.Kind, APIVersion: gv}
+			return obj, nil
+		}
+	default:
+		return nil, fmt.Errorf("unsupported ValidatingAdmissionPolicy API version %q", apiVersion)
+	}
+	// Not a VAP kind we manage here.
+	return nil, nil
+}
+
 // ListManaged returns the operator-managed MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding
 // objects currently present on the cluster at the given API version. Returns nil if apiVersion is empty.
 func ListManaged(ctx context.Context, c client.Client, apiVersion string) (policies, bindings []client.Object, err error) {
@@ -309,6 +426,68 @@ func ListManaged(ctx context.Context, c client.Client, apiVersion string) (polic
 	return policies, bindings, nil
 }
 
+// ListManagedValidating returns the operator-managed ValidatingAdmissionPolicy and
+// ValidatingAdmissionPolicyBinding objects currently present on the cluster at the given API version,
+// mirroring ListManaged. Returns nil if apiVersion is empty.
+func ListManagedValidating(ctx context.Context, c client.Client, apiVersion string) (policies, bindings []client.Object, err error) {
+	if apiVersion == "" {
+		return nil, nil, nil
+	}
+	switch apiVersion {
+	case VersionV1:
+		vapList := &admissionregistrationv1.ValidatingAdmissionPolicyList{}
+		if err := c.List(ctx, vapList, client.MatchingLabels{ManagedVAPLabel: ManagedVAPLabelValue}); err != nil {
+			return nil, nil, fmt.Errorf("listing ValidatingAdmissionPolicies: %w", err)
+		}
+		for i := range vapList.Items {
+			policies = append(policies, &vapList.Items[i])
+		}
+
+		bindList := &admissionregistrationv1.ValidatingAdmissionPolicyBindingList{}
+		if err := c.List(ctx, bindList, client.MatchingLabels{ManagedVAPLabel: ManagedVAPLabelValue}); err != nil {
+			return nil, nil, fmt.Errorf("listing ValidatingAdmissionPolicyBindings: %w", err)
+		}
+		for i := range bindList.Items {
+			bindings = append(bindings, &bindList.Items[i])
+		}
+	case VersionV1Beta1:
+		vapList := &admissionv1beta1.ValidatingAdmissionPolicyList{}
+		if err := c.List(ctx, vapList, client.MatchingLabels{ManagedVAPLabel: ManagedVAPLabelValue}); err != nil {
+			return nil, nil, fmt.Errorf("listing ValidatingAdmissionPolicies: %w", err)
+		}
+		for i := range vapList.Items {
+			policies = append(policies, &vapList.Items[i])
+		}
+
+		bindList := &admissionv1beta1.ValidatingAdmissionPolicyBindingList{}
+		if err := c.List(ctx, bindList, client.MatchingLabels{ManagedVAPLabel: ManagedVAPLabelValue}); err != nil {
+			return nil, nil, fmt.Errorf("listing ValidatingAdmissionPolicyBindings: %w", err)
+		}
+		for i := range bindList.Items {
+			bindings = append(bindings, &bindList.Items[i])
+		}
+	case VersionV1Alpha1:
+		vapList := &admissionregistrationv1alpha1.ValidatingAdmissionPolicyList{}
+		if err := c.List(ctx, vapList, client.MatchingLabels{ManagedVAPLabel: ManagedVAPLabelValue}); err != nil {
+			return nil, nil, fmt.Errorf("listing ValidatingAdmissionPolicies: %w", err)
+		}
+		for i := range vapList.Items {
+			policies = append(policies, &vapList.Items[i])
+		}
+
+		bindList := &admissionregistrationv1alpha1.ValidatingAdmissionPolicyBindingList{}
+		if err := c.List(ctx, bindList, client.MatchingLabels{ManagedVAPLabel: ManagedVAPLabelValue}); err != nil {
+			return nil, nil, fmt.Errorf("listing ValidatingAdmissionPolicyBindings: %w", err)
+		}
+		for i := range bindList.Items {
+			bindings = append(bindings, &bindList.Items[i])
+		}
+	default:
+		return nil, nil, fmt.Errorf("unsupported ValidatingAdmissionPolicy API version %q", apiVersion)
+	}
+	return policies, bindings, nil
+}
+
 // IsPolicyKind returns whether obj is a MutatingAdmissionPolicy (any served version).
 func IsPolicyKind(obj client.Object) bool {
 	switch obj.(type) {
@@ -322,6 +501,24 @@ func IsPolicyKind(obj client.Object) bool {
 func IsBindingKind(obj client.Object) bool {
 	switch obj.(type) {
 	case *admissionregistrationv1.MutatingAdmissionPolicyBinding, *admissionv1beta1.MutatingAdmissionPolicyBinding, *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding:
+		return true
+	}
+	return false
+}
+
+// IsValidatingPolicyKind returns whether obj is a ValidatingAdmissionPolicy (any served version).
+func IsValidatingPolicyKind(obj client.Object) bool {
+	switch obj.(type) {
+	case *admissionregistrationv1.ValidatingAdmissionPolicy, *admissionv1beta1.ValidatingAdmissionPolicy, *admissionregistrationv1alpha1.ValidatingAdmissionPolicy:
+		return true
+	}
+	return false
+}
+
+// IsValidatingBindingKind returns whether obj is a ValidatingAdmissionPolicyBinding (any served version).
+func IsValidatingBindingKind(obj client.Object) bool {
+	switch obj.(type) {
+	case *admissionregistrationv1.ValidatingAdmissionPolicyBinding, *admissionv1beta1.ValidatingAdmissionPolicyBinding, *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding:
 		return true
 	}
 	return false

--- a/pkg/imports/admission/admission.go
+++ b/pkg/imports/admission/admission.go
@@ -110,6 +110,12 @@ func GetMutatingAdmissionPolicies(variant opv1.ProductVariant, v3 bool, apiVersi
 			if err != nil {
 				panic(fmt.Sprintf("Failed to parse admission policy %s: %v", entry.Name(), err))
 			}
+			if obj == nil {
+				// The admission directory also carries policy kinds we don't manage here
+				// (e.g. the ValidatingAdmissionPolicy that protects built-in tiers), which
+				// parse to a nil object. Skip those.
+				continue
+			}
 
 			// Add managed label for stale resource cleanup.
 			labels := obj.GetLabels()
@@ -171,7 +177,8 @@ func Ensure(c client.Client, variant string, v3 bool, apiVersion string, log log
 // parseAdmissionPolicyYAML parses a YAML document into either a MutatingAdmissionPolicy
 // or MutatingAdmissionPolicyBinding at the requested API version. The MAP types are identical
 // in shape across v1alpha1, v1beta1, and v1, so we deserialize the same YAML into the requested
-// target type and overwrite TypeMeta to reflect the chosen GroupVersion.
+// target type and overwrite TypeMeta to reflect the chosen GroupVersion. Documents of any other
+// kind return a nil object and nil error so the caller can skip them.
 func parseAdmissionPolicyYAML(doc []byte, filename, apiVersion string) (client.Object, error) {
 	var meta struct {
 		Kind string `json:"kind"`
@@ -237,7 +244,8 @@ func parseAdmissionPolicyYAML(doc []byte, filename, apiVersion string) (client.O
 	default:
 		return nil, fmt.Errorf("unsupported MutatingAdmissionPolicy API version %q", apiVersion)
 	}
-	return nil, fmt.Errorf("unexpected kind %q in %s", meta.Kind, filename)
+	// Not a MAP kind we manage here.
+	return nil, nil
 }
 
 // ListManaged returns the operator-managed MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding

--- a/pkg/imports/admission/admission_test.go
+++ b/pkg/imports/admission/admission_test.go
@@ -118,4 +118,77 @@ var _ = Describe("MutatingAdmissionPolicies", func() {
 			}
 		})
 	})
+
+	Describe("GetValidatingAdmissionPolicies", func() {
+		It("returns Calico v1 VAPs when discovered version is v1", func() {
+			objs := GetValidatingAdmissionPolicies(opv1.Calico, true, VersionV1)
+			Expect(objs).To(HaveLen(2))
+
+			var vapCount, vapbCount int
+			for _, obj := range objs {
+				switch o := obj.(type) {
+				case *admissionregistrationv1.ValidatingAdmissionPolicy:
+					vapCount++
+					Expect(o.APIVersion).To(Equal(APIGroup + "/" + VersionV1))
+				case *admissionregistrationv1.ValidatingAdmissionPolicyBinding:
+					vapbCount++
+					Expect(o.APIVersion).To(Equal(APIGroup + "/" + VersionV1))
+				}
+				Expect(obj.GetName()).ToNot(BeEmpty())
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(ManagedVAPLabel, ManagedVAPLabelValue))
+			}
+			Expect(vapCount).To(Equal(1))
+			Expect(vapbCount).To(Equal(1))
+		})
+
+		It("returns Calico v1beta1 VAPs when discovered version is v1beta1", func() {
+			objs := GetValidatingAdmissionPolicies(opv1.Calico, true, VersionV1Beta1)
+			Expect(objs).To(HaveLen(2))
+
+			var vapCount, vapbCount int
+			for _, obj := range objs {
+				switch obj.(type) {
+				case *admissionv1beta1.ValidatingAdmissionPolicy:
+					vapCount++
+				case *admissionv1beta1.ValidatingAdmissionPolicyBinding:
+					vapbCount++
+				}
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(ManagedVAPLabel, ManagedVAPLabelValue))
+			}
+			Expect(vapCount).To(Equal(1))
+			Expect(vapbCount).To(Equal(1))
+		})
+
+		It("returns Calico v1alpha1 VAPs when discovered version is v1alpha1", func() {
+			objs := GetValidatingAdmissionPolicies(opv1.Calico, true, VersionV1Alpha1)
+			Expect(objs).To(HaveLen(2))
+
+			var vapCount, vapbCount int
+			for _, obj := range objs {
+				switch obj.(type) {
+				case *admissionregistrationv1alpha1.ValidatingAdmissionPolicy:
+					vapCount++
+				case *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding:
+					vapbCount++
+				}
+				Expect(obj.GetLabels()).To(HaveKeyWithValue(ManagedVAPLabel, ManagedVAPLabelValue))
+			}
+			Expect(vapCount).To(Equal(1))
+			Expect(vapbCount).To(Equal(1))
+		})
+
+		It("returns Enterprise VAPs at the chosen version", func() {
+			objs := GetValidatingAdmissionPolicies(opv1.CalicoEnterprise, true, VersionV1)
+			Expect(objs).To(HaveLen(2))
+		})
+
+		It("returns empty when v3=false", func() {
+			Expect(GetValidatingAdmissionPolicies(opv1.Calico, false, VersionV1)).To(BeEmpty())
+			Expect(GetValidatingAdmissionPolicies(opv1.CalicoEnterprise, false, VersionV1)).To(BeEmpty())
+		})
+
+		It("returns empty when apiVersion is empty", func() {
+			Expect(GetValidatingAdmissionPolicies(opv1.Calico, true, "")).To(BeEmpty())
+		})
+	})
 })

--- a/pkg/imports/admission/calico/protect-builtin-tiers.yaml
+++ b/pkg/imports/admission/calico/protect-builtin-tiers.yaml
@@ -1,0 +1,28 @@
+---
+# ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
+# (default, kube-admin, kube-baseline). These tiers are required for correct
+# operation and should never be deleted.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        resources: ["tiers"]
+        operations: ["DELETE"]
+  validations:
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  policyName: protect-builtin-tiers.projectcalico.org
+  validationActions:
+    - Deny

--- a/pkg/imports/admission/enterprise/protect-builtin-tiers.yaml
+++ b/pkg/imports/admission/enterprise/protect-builtin-tiers.yaml
@@ -1,0 +1,28 @@
+---
+# ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
+# (default, kube-admin, kube-baseline). These tiers are required for correct
+# operation and should never be deleted.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        resources: ["tiers"]
+        operations: ["DELETE"]
+  validations:
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  policyName: protect-builtin-tiers.projectcalico.org
+  validationActions:
+    - Deny

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -45,6 +45,19 @@ spec:
                     Controllers enables and configures individual Kubernetes
                     controllers
                   properties:
+                    applicationLayer:
+                      description: |-
+                        ApplicationLayer enables and configures the application-layer subsystem
+                        (WAF, GlobalWAF, WAFPlugin, validation). Operator-managed; users should
+                        not edit this field directly. Non-nil enables the subsystem; activation
+                        is gated on a valid Calico Enterprise license.
+                      properties:
+                        reconcilerPeriod:
+                          description:
+                            "ReconcilerPeriod is the period to perform reconciliation.
+                            [Default: 30s]"
+                          type: string
+                      type: object
                     federatedServices:
                       description:
                         FederatedServices enables and configures the federatedservices
@@ -295,6 +308,19 @@ spec:
                         Controllers enables and configures individual Kubernetes
                         controllers
                       properties:
+                        applicationLayer:
+                          description: |-
+                            ApplicationLayer enables and configures the application-layer subsystem
+                            (WAF, GlobalWAF, WAFPlugin, validation). Operator-managed; users should
+                            not edit this field directly. Non-nil enables the subsystem; activation
+                            is gated on a valid Calico Enterprise license.
+                          properties:
+                            reconcilerPeriod:
+                              description:
+                                "ReconcilerPeriod is the period to perform
+                                reconciliation. [Default: 30s]"
+                              type: string
+                          type: object
                         federatedServices:
                           description:
                             FederatedServices enables and configures the

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_globalwafplugins.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_globalwafplugins.yaml
@@ -1,0 +1,182 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalwafplugins.applicationlayer.projectcalico.org
+spec:
+  group: applicationlayer.projectcalico.org
+  names:
+    kind: GlobalWAFPlugin
+    listKind: GlobalWAFPluginList
+    plural: globalwafplugins
+    shortNames:
+      - gwafplugin
+    singular: globalwafplugin
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.description
+          name: Description
+          type: string
+        - jsonPath: .status.ruleCount
+          name: Rules
+          type: integer
+        - jsonPath: .status.namespaceCount
+          name: Namespaces
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3
+      schema:
+        openAPIV3Schema:
+          description: GlobalWAFPlugin is the Schema for cluster-wide custom WAF plugins
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GlobalWAFPluginSpec defines a cluster-wide custom WAF plugin
+              properties:
+                after:
+                  description: |-
+                    After contains raw SecAction/SecRule directives that run AFTER CRS rules.
+                    Use for post-processing, logging, or cleanup.
+                    Equivalent to CRS *-after.conf files.
+                  maxLength: 65536
+                  type: string
+                before:
+                  description: |-
+                    Before contains raw SecAction/SecRule directives that run BEFORE CRS rules.
+                    Use for pre-processing, initialization, or early blocking.
+                    Equivalent to CRS *-before.conf files.
+                  maxLength: 65536
+                  type: string
+                config:
+                  description: |-
+                    Config contains raw SecAction/SecRule directives for plugin configuration.
+                    These run first and typically set tx.* variables.
+                    Equivalent to CRS *-config.conf files.
+                  maxLength: 65536
+                  type: string
+                description:
+                  description:
+                    Description is a human-readable description of what this
+                    plugin does
+                  maxLength: 1024
+                  type: string
+                rules:
+                  description: |-
+                    Rules contains the main SecAction/SecRule directives for this plugin.
+                    These run alongside CRS rules. Ordering across plugins follows array
+                    position in the consuming policy's spec.plugins[].
+                  maxLength: 65536
+                  type: string
+              type: object
+              x-kubernetes-validations:
+                - message: plugin must define at least one of config, before, rules, after
+                  rule:
+                    (has(self.config) && size(self.config) > 0) || (has(self.before)
+                    && size(self.before) > 0) || (has(self.rules) && size(self.rules)
+                    > 0) || (has(self.after) && size(self.after) > 0)
+            status:
+              description: |-
+                GlobalWAFPluginStatus defines the observed state.
+
+                Conditions emitted by the controller:
+                  - Accepted   (DirectivesValid / InvalidDirectives)
+              properties:
+                conditions:
+                  description: Conditions represent the latest available observations
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                namespaceCount:
+                  description: |-
+                    NamespaceCount is the number of namespaces with at least one WAFPolicy
+                    referencing this plugin. Kept as a bounded aggregate (not a
+                    ReferencedBy list) because a Global plugin can fan out to many
+                    namespaces; a list would churn the status payload as policies come
+                    and go. Different denominator from GlobalWAFPolicyStatus.NamespaceCount
+                    (which counts namespaces using the policy itself).
+                  type: integer
+                ruleCount:
+                  description:
+                    RuleCount is the number of SecRule directives in this
+                    plugin
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_globalwafpolicies.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_globalwafpolicies.yaml
@@ -1,0 +1,252 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalwafpolicies.applicationlayer.projectcalico.org
+spec:
+  group: applicationlayer.projectcalico.org
+  names:
+    kind: GlobalWAFPolicy
+    listKind: GlobalWAFPolicyList
+    plural: globalwafpolicies
+    shortNames:
+      - gwafp
+    singular: globalwafpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.defaultAction
+          name: Action
+          type: string
+        - jsonPath: .spec.coreRuleSet.state
+          name: CRS
+          type: string
+        - jsonPath: .spec.coreRuleSet.paranoiaLevel
+          name: Paranoia
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3
+      schema:
+        openAPIV3Schema:
+          description: GlobalWAFPolicy is the Schema for cluster-wide WAF configuration
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GlobalWAFPolicySpec defines the desired state
+              properties:
+                coreRuleSet:
+                  description: CoreRuleSet configures the OWASP Core Rule Set
+                  properties:
+                    enabled:
+                      description: |-
+                        Enabled is the deprecated boolean form. Read for backward compatibility
+                        with v0.2.x CRs; new CRs should set State. If both fields are set,
+                        State wins.
+
+                        Deprecated: use State.
+                      type: boolean
+                    paranoiaLevel:
+                      default: 1
+                      description: ParanoiaLevel sets the CRS paranoia level (1-4)
+                      maximum: 4
+                      minimum: 1
+                      type: integer
+                    state:
+                      default: Enabled
+                      description: State enables or disables the OWASP CRS baseline.
+                      enum:
+                        - Enabled
+                        - Disabled
+                      type: string
+                  type: object
+                defaultAction:
+                  default: Detect
+                  description: DefaultAction specifies what happens when a rule matches
+                  enum:
+                    - Detect
+                    - Block
+                  type: string
+                plugins:
+                  description: |-
+                    Plugins references GlobalWAFPlugins
+                    These plugins are applied to all namespaces
+                  items:
+                    description: |-
+                      PluginRef references a plugin by kind + name. Kind makes the
+                      reference target explicit; without it, "is this naming a Global or a
+                      namespace plugin?" had to be inferred from which policy's spec.plugins[]
+                      the reference appeared in. The default is WAFPlugin (namespace-scoped) for
+                      backward-compat with v0.2.x CRs that omit Kind.
+
+                      Note: in this release the resolved scope still follows the parent policy
+                      (GlobalWAFPolicy.spec.plugins[] resolves as Global; WAFPolicy.spec.plugins[]
+                      resolves as namespace-scoped). Cross-scope lookup (e.g. WAFPolicy
+                      referencing a GlobalWAFPlugin) is a future addition; the Kind field
+                      here is type-level disclosure of intent that the reconciler can validate
+                      against in a later release.
+                    properties:
+                      kind:
+                        default: WAFPlugin
+                        description: |-
+                          Kind selects between namespace-scoped (WAFPlugin) and cluster-scoped
+                          (GlobalWAFPlugin) plugin types.
+                        enum:
+                          - WAFPlugin
+                          - GlobalWAFPlugin
+                        type: string
+                      name:
+                        description: Name is the name of the plugin resource.
+                        maxLength: 253
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: |-
+                GlobalWAFPolicyStatus defines the observed state.
+
+                Conditions emitted by the controller:
+                  - Licensed   (LicenseValid / LicenseBlocked)
+                  - Accepted   (Accepted / Invalid / PluginNotFound)
+                  - Ready      (Ready / NotReady / ConflictingGlobalPolicy)
+              properties:
+                conditions:
+                  description: Conditions represent the latest available observations
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                inheritedFromGlobal:
+                  description: |-
+                    InheritedFromGlobal is always nil for GlobalWAFPolicy. The field is
+                    declared for symmetry with WAFPolicyStatus so generated clients (Go,
+                    TS) can share a single attribution shape across scopes.
+                  type: string
+                lastApplied:
+                  description: LastApplied is the timestamp of the last successful application
+                  format: date-time
+                  type: string
+                namespaceCount:
+                  description: |-
+                    NamespaceCount is the number of namespaces in which a WAFPolicy targets
+                    resources covered by this Global policy. Different denominator from
+                    GlobalWAFPluginStatus.NamespaceCount (which counts namespaces where a
+                    policy references the plugin).
+                  type: integer
+                renderedConfigMapRefs:
+                  description: |-
+                    RenderedConfigMapRefs enumerates ConfigMaps the controller has emitted
+                    from this GlobalWAFPolicy, one per namespace that consumed it. Capped
+                    at 50 entries; see RenderedConfigMapRefsTruncated. When the cap is
+                    exceeded, the surfaced entries are the lexically-first 50 namespace
+                    names (sorted ascending by namespace), so the truncation is
+                    deterministic across reconciles; use NamespaceCount to recover the
+                    untruncated total.
+                  items:
+                    description: |-
+                      RenderedConfigMapRef identifies the ConfigMap into which the controller
+                      materialised the merged WAF rule set for a policy. CLI tools and status
+                      consumers resolve this reference instead of reconstructing the name.
+                    properties:
+                      name:
+                        maxLength: 253
+                        type: string
+                      namespace:
+                        maxLength: 253
+                        type: string
+                      resourceVersion:
+                        maxLength: 253
+                        type: string
+                    required:
+                      - name
+                      - namespace
+                    type: object
+                  type: array
+                renderedConfigMapRefsTruncated:
+                  description: |-
+                    RenderedConfigMapRefsTruncated is true when the full set exceeded the
+                    50-entry status cap. Consumers should use NamespaceCount for totals.
+                  type: boolean
+              type: object
+          type: object
+          x-kubernetes-validations:
+            - message: GlobalWAFPolicy is a singleton; the only permitted name is 'default'
+              rule: self.metadata.name == 'default'
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_globalwafvalidationpolicies.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_globalwafvalidationpolicies.yaml
@@ -1,0 +1,303 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: globalwafvalidationpolicies.applicationlayer.projectcalico.org
+spec:
+  group: applicationlayer.projectcalico.org
+  names:
+    kind: GlobalWAFValidationPolicy
+    listKind: GlobalWAFValidationPolicyList
+    plural: globalwafvalidationpolicies
+    shortNames:
+      - gwafvp
+    singular: globalwafvalidationpolicy
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.enforcementMode
+          name: Mode
+          type: string
+        - jsonPath: .status.passingCount
+          name: Passing
+          type: integer
+        - jsonPath: .status.violatingPolicies
+          name: Violating
+          type: integer
+        - jsonPath: .status.summary
+          name: Summary
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3
+      schema:
+        openAPIV3Schema:
+          description: |-
+            GlobalWAFValidationPolicy defines cluster-wide validation rules that merged
+            WAF configurations must pass. Used by Cluster Operators to enforce security
+            requirements across all namespaces.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                GlobalWAFValidationPolicySpec defines cluster-wide validation
+                rules
+              properties:
+                enforcementMode:
+                  default: Audit
+                  description: |-
+                    EnforcementMode determines how validation failures are handled
+                    - Audit: Log warnings but generate EnvoyExtensionPolicy anyway
+                    - Enforce: Block EnvoyExtensionPolicy generation on critical failures
+                  enum:
+                    - Audit
+                    - Enforce
+                  type: string
+                namespaceSelector:
+                  description: |-
+                    NamespaceSelector limits which namespaces this validation policy applies to.
+                    If empty, applies to all namespaces.
+
+                    Standard metav1.LabelSelector semantics: every namespace — including
+                    `default` — is matched against the selector's labels, with no implicit
+                    special-casing. Since k8s 1.21 every namespace carries an auto-applied
+                    `kubernetes.io/metadata.name=<ns-name>` label, so the canonical way to
+                    scope down to specific namespaces (including `default`) is a
+                    matchExpressions on that label.
+                  properties:
+                    matchExpressions:
+                      description:
+                        matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description:
+                              key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                rules:
+                  description: Rules defines the validation rules to apply
+                  items:
+                    description:
+                      ValidationRule defines a single CEL-based validation
+                      rule
+                    properties:
+                      expression:
+                        description: |-
+                          Expression is a CEL expression that must evaluate to true for validation to pass.
+                          Available variables:
+                            - directives: []string - the final merged directive list
+                            - config.action: string - effective action ("Detect" or "Block")
+                            - config.crsState: string - CRS state ("Enabled" or "Disabled")
+                            - config.paranoiaLevel: int - effective paranoia level (1-4)
+                            - source.globalPolicy: string - name of GlobalWAFPolicy
+                            - source.namespacePolicy: string - name of WAFPolicy (if any)
+                            - source.globalPlugins: []string - names of global plugins applied
+                            - source.namespacePlugins: []string - names of namespace plugins applied
+                        maxLength: 16384
+                        minLength: 1
+                        type: string
+                      message:
+                        description: Message is displayed when validation fails
+                        maxLength: 1024
+                        type: string
+                      name:
+                        description: Name is a unique identifier for this rule
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      severity:
+                        default: warning
+                        description: Severity determines the impact of this rule failing
+                        enum:
+                          - info
+                          - warning
+                          - critical
+                        type: string
+                    required:
+                      - expression
+                      - name
+                    type: object
+                  minItems: 1
+                  type: array
+              required:
+                - rules
+              type: object
+            status:
+              description: |-
+                GlobalWAFValidationPolicyStatus defines the observed state.
+
+                Conditions emitted by the controller:
+                  - Ready      (Evaluated)
+              properties:
+                conditions:
+                  description: Conditions represent the latest available observations
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                evaluatedCount:
+                  description: EvaluatedCount is the number of WAF policies evaluated
+                  type: integer
+                lastEvaluated:
+                  description: LastEvaluated is the timestamp of the last evaluation
+                  format: date-time
+                  type: string
+                passingCount:
+                  description: PassingCount is the number of policies passing all rules
+                  type: integer
+                summary:
+                  description: Summary provides a quick overview of validation state
+                  maxLength: 1024
+                  type: string
+                violatingPolicies:
+                  description: |-
+                    ViolatingPolicies lists all WAF policies that failed validation.
+                    Useful for COs to centrally see which namespaces need attention.
+                  items:
+                    description:
+                      ViolatingPolicy identifies a WAF policy that failed
+                      validation
+                    properties:
+                      action:
+                        description: "Action taken: Audited or Rejected"
+                        maxLength: 253
+                        type: string
+                      failedRules:
+                        description: FailedRules lists the rules that this policy violated
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Name is the name of the WAFPolicy
+                        maxLength: 253
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the violating policy
+                        maxLength: 253
+                        type: string
+                      severity:
+                        description: Severity is the highest severity of the failures
+                        enum:
+                          - info
+                          - warning
+                          - critical
+                        type: string
+                    required:
+                      - name
+                      - namespace
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_wafplugins.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_wafplugins.yaml
@@ -1,0 +1,236 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: wafplugins.applicationlayer.projectcalico.org
+spec:
+  group: applicationlayer.projectcalico.org
+  names:
+    kind: WAFPlugin
+    listKind: WAFPluginList
+    plural: wafplugins
+    shortNames:
+      - wafplugin
+    singular: wafplugin
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.description
+          name: Description
+          type: string
+        - jsonPath: .status.ruleCount
+          name: Rules
+          type: integer
+        - jsonPath: .status.referencedByCount
+          name: Refs
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3
+      schema:
+        openAPIV3Schema:
+          description: WAFPlugin is the Schema for namespace-scoped custom WAF plugins
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                WAFPluginSpec defines a custom WAF plugin with CRS 4-style
+                structure
+              properties:
+                after:
+                  description: |-
+                    After contains raw SecAction/SecRule directives that run AFTER CRS rules.
+                    Use for post-processing, logging, or cleanup.
+                    Equivalent to CRS *-after.conf files.
+                  maxLength: 65536
+                  type: string
+                before:
+                  description: |-
+                    Before contains raw SecAction/SecRule directives that run BEFORE CRS rules.
+                    Use for pre-processing, initialization, or early blocking.
+                    Equivalent to CRS *-before.conf files.
+                  maxLength: 65536
+                  type: string
+                config:
+                  description: |-
+                    Config contains raw SecAction/SecRule directives for plugin configuration.
+                    These run first and typically set tx.* variables.
+                    Equivalent to CRS *-config.conf files.
+                  maxLength: 65536
+                  type: string
+                description:
+                  description:
+                    Description is a human-readable description of what this
+                    plugin does
+                  maxLength: 1024
+                  type: string
+                rules:
+                  description: |-
+                    Rules contains the main SecAction/SecRule directives for this plugin.
+                    These run alongside CRS rules. Ordering across plugins follows array
+                    position in the consuming policy's spec.plugins[].
+                  maxLength: 65536
+                  type: string
+              type: object
+              x-kubernetes-validations:
+                - message: plugin must define at least one of config, before, rules, after
+                  rule:
+                    (has(self.config) && size(self.config) > 0) || (has(self.before)
+                    && size(self.before) > 0) || (has(self.rules) && size(self.rules)
+                    > 0) || (has(self.after) && size(self.after) > 0)
+            status:
+              description: |-
+                WAFPluginStatus defines the observed state.
+
+                Conditions emitted by the controller:
+                  - Accepted   (DirectivesValid / InvalidDirectives)
+              properties:
+                conditions:
+                  description: Conditions represent the latest available observations
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                referencedBy:
+                  description: |-
+                    ReferencedBy enumerates the policies that name this plugin in their
+                    spec.plugins[]. Sorted: namespace asc, name asc, kind asc. Updated
+                    every reconcile so client-side filtering is unnecessary. Capped at
+                    50 entries (matching RenderedConfigMapRefs on GlobalWAFPolicy) so a
+                    runaway WAFPolicy population can't blow up the status payload; when
+                    the cap is hit ReferencedByTruncated is set and the scalar
+                    ReferencedByCount above remains authoritative for "how many
+                    actually reference me".
+                  items:
+                    description: |-
+                      PolicyRef identifies a policy that references a plugin. Used by plugin
+                      status.referencedBy to give kubectl-readable reverse-index entries
+                      without packing identifiers into a single string.
+
+                      Current scope-binding (this release): the plugin reconciler resolves
+                      references from the parent policy's scope — WAFPolicy.spec.plugins[]
+                      resolves namespace-scoped, GlobalWAFPolicy.spec.plugins[] resolves
+                      cluster-scoped. Cross-scope lookup is a future addition; the Kind field
+                      below is type-level disclosure of intent for a later release.
+                    properties:
+                      kind:
+                        description: Kind identifies the referencing policy kind.
+                        enum:
+                          - WAFPolicy
+                          - GlobalWAFPolicy
+                        type: string
+                      name:
+                        description: Name is the name of the referencing policy.
+                        maxLength: 253
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referencing policy. Unset for
+                          cluster-scoped GlobalWAFPolicy entries (pointer so unset is
+                          distinguishable from explicit empty, per the optional-fields-are-
+                          pointers convention).
+                        maxLength: 253
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 50
+                  type: array
+                referencedByCount:
+                  description: |-
+                    ReferencedByCount is the total number of policies referencing this
+                    plugin — always the true population size, never bounded by the
+                    50-entry list cap on ReferencedBy. Backs the `Refs` printcolumn so
+                    `kubectl get wafplugin` shows the real fan-in even when ReferencedBy
+                    is truncated.
+                  type: integer
+                referencedByTruncated:
+                  description: |-
+                    ReferencedByTruncated is true when the consuming-policy set exceeded
+                    the 50-entry cap on ReferencedBy. Consumers should fall back to a
+                    label-selector list query rather than relying on ReferencedBy alone;
+                    ReferencedByCount remains accurate regardless.
+                  type: boolean
+                ruleCount:
+                  description:
+                    RuleCount is the number of SecRule directives in this
+                    plugin
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
@@ -1,0 +1,360 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: wafpolicies.applicationlayer.projectcalico.org
+spec:
+  group: applicationlayer.projectcalico.org
+  names:
+    kind: WAFPolicy
+    listKind: WAFPolicyList
+    plural: wafpolicies
+    shortNames:
+      - wafp
+    singular: wafpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.action
+          name: Action
+          type: string
+        - jsonPath: .status.pluginCount
+          name: Plugins
+          type: integer
+        - jsonPath: .status.validation.status
+          name: Validation
+          type: string
+        - jsonPath: .status.validation.securityPosture
+          name: Posture
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3
+      schema:
+        openAPIV3Schema:
+          description: WAFPolicy is the Schema for namespace-scoped WAF configuration
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: WAFPolicySpec defines the desired state
+              properties:
+                action:
+                  description: |-
+                    Action overrides the global default action for this namespace.
+                    Nil means inherit from GlobalWAFPolicy; an explicit value overrides
+                    the global default. Subject to validation policy enforcement.
+                  enum:
+                    - Detect
+                    - Block
+                  type: string
+                coreRuleSet:
+                  description: |-
+                    CoreRuleSet configures the OWASP Core Rule Set for this namespace
+                    If not specified, inherits from GlobalWAFPolicy
+                  properties:
+                    enabled:
+                      description: |-
+                        Enabled is the deprecated boolean form. Read for backward compatibility
+                        with v0.2.x CRs; new CRs should set State. If both fields are set,
+                        State wins.
+
+                        Deprecated: use State.
+                      type: boolean
+                    paranoiaLevel:
+                      default: 1
+                      description: ParanoiaLevel sets the CRS paranoia level (1-4)
+                      maximum: 4
+                      minimum: 1
+                      type: integer
+                    state:
+                      default: Enabled
+                      description: State enables or disables the OWASP CRS baseline.
+                      enum:
+                        - Enabled
+                        - Disabled
+                      type: string
+                  type: object
+                plugins:
+                  description: Plugins references WAFPlugins in this namespace
+                  items:
+                    description: |-
+                      PluginRef references a plugin by kind + name. Kind makes the
+                      reference target explicit; without it, "is this naming a Global or a
+                      namespace plugin?" had to be inferred from which policy's spec.plugins[]
+                      the reference appeared in. The default is WAFPlugin (namespace-scoped) for
+                      backward-compat with v0.2.x CRs that omit Kind.
+
+                      Note: in this release the resolved scope still follows the parent policy
+                      (GlobalWAFPolicy.spec.plugins[] resolves as Global; WAFPolicy.spec.plugins[]
+                      resolves as namespace-scoped). Cross-scope lookup (e.g. WAFPolicy
+                      referencing a GlobalWAFPlugin) is a future addition; the Kind field
+                      here is type-level disclosure of intent that the reconciler can validate
+                      against in a later release.
+                    properties:
+                      kind:
+                        default: WAFPlugin
+                        description: |-
+                          Kind selects between namespace-scoped (WAFPlugin) and cluster-scoped
+                          (GlobalWAFPlugin) plugin types.
+                        enum:
+                          - WAFPlugin
+                          - GlobalWAFPlugin
+                        type: string
+                      name:
+                        description: Name is the name of the plugin resource.
+                        maxLength: 253
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                targetRefs:
+                  description:
+                    TargetRefs specifies Gateway API references (Gateway,
+                    HTTPRoute)
+                  items:
+                    description: PolicyTargetReference identifies a Gateway API resource
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: Group is the group of the target resource
+                        maxLength: 253
+                        type: string
+                      kind:
+                        description: Kind is the kind of the target resource
+                        enum:
+                          - Gateway
+                          - HTTPRoute
+                        maxLength: 253
+                        type: string
+                      name:
+                        description: Name is the name of the target resource
+                        maxLength: 253
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: only group gateway.networking.k8s.io is supported for targetRefs
+                  rule:
+                    "!has(self.targetRefs) || self.targetRefs.all(ref, ref.group ==
+                    'gateway.networking.k8s.io')"
+            status:
+              description: |-
+                WAFPolicyStatus defines the observed state.
+
+                Conditions emitted by the controller:
+                  - Licensed   (LicenseValid / LicenseInGracePeriod / LicenseExpired /
+                    LicenseInvalid / LicenseBlocked)
+                  - Accepted   (Accepted / Invalid / Conflicted / PluginNotFound /
+                    ReplicaUnmanaged / ValidationFailed)
+                  - Programmed (ConfigurationApplied / WASMUnavailable / CheckerError /
+                    NotAttempted)
+                  - Ready      (Ready / NotReady)
+              properties:
+                conditions:
+                  description: Conditions represent the latest available observations
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                inheritedFromGlobal:
+                  description: |-
+                    InheritedFromGlobal names the GlobalWAFPolicy whose plugin merge
+                    contributed an inherited error (e.g. an Invalid reason on the Accepted
+                    condition) to this policy. Nil when the failure is self-authored or
+                    no failure is present. UI consumers use this to render a "Inherited
+                    from GlobalWAFPolicy/<name>" attribution badge that deep-links to the
+                    offending Global resource.
+                  type: string
+                lastApplied:
+                  description: LastApplied is the timestamp of the last successful application
+                  format: date-time
+                  type: string
+                pluginCount:
+                  description: PluginCount is the number of plugins applied
+                  type: integer
+                renderedConfigMapRef:
+                  description: |-
+                    RenderedConfigMapRef points to the ConfigMap the controller emitted
+                    for this namespace. Unset until the first successful reconcile.
+                  properties:
+                    name:
+                      maxLength: 253
+                      type: string
+                    namespace:
+                      maxLength: 253
+                      type: string
+                    resourceVersion:
+                      maxLength: 253
+                      type: string
+                  required:
+                    - name
+                    - namespace
+                  type: object
+                validation:
+                  description: |-
+                    Validation contains the results of validation policy evaluation.
+                    Shows whether the policy passed, was audited (warnings logged), or rejected.
+                  properties:
+                    failures:
+                      description:
+                        Failures contains details about failed validation
+                        rules
+                      items:
+                        description:
+                          ValidationFailure describes a single validation
+                          rule failure
+                        properties:
+                          message:
+                            description: Message explains why validation failed
+                            maxLength: 1024
+                            type: string
+                          policyKind:
+                            description: PolicyKind is Global or Namespace-scoped
+                            enum:
+                              - GlobalWAFValidationPolicy
+                              - WAFValidationPolicy
+                            maxLength: 253
+                            type: string
+                          policyName:
+                            description:
+                              PolicyName is the name of the validation policy
+                              that failed
+                            maxLength: 253
+                            type: string
+                          rule:
+                            description:
+                              Rule is the name of the specific rule that
+                              failed
+                            maxLength: 63
+                            type: string
+                          severity:
+                            description: Severity of the failure
+                            enum:
+                              - info
+                              - warning
+                              - critical
+                            type: string
+                        required:
+                          - policyKind
+                          - policyName
+                          - rule
+                          - severity
+                        type: object
+                      type: array
+                    lastEvaluated:
+                      description: LastEvaluated is when validation was last performed
+                      format: date-time
+                      type: string
+                    securityPosture:
+                      description:
+                        SecurityPosture is the security posture based on
+                        all validation results
+                      enum:
+                        - Compliant
+                        - Warning
+                        - Degraded
+                        - Critical
+                      type: string
+                    status:
+                      description: |-
+                        Status is the overall validation outcome. Denormalized from the
+                        Validated x Programmed conditions so the `kubectl get wafpolicy`
+                        printcolumn can show a single readable scalar; CRD printcolumns can
+                        only read one JSONPath, not compute from two conditions. The
+                        conditions are authoritative — if this field and the conditions ever
+                        diverge in a future change, the conditions win and this field is the
+                        rendered projection. Valid = Validated/True + Programmed/True;
+                        Audited = Validated/False + Programmed/True (Audit mode);
+                        Rejected = Validated/False + Programmed/False (Enforce mode blocked).
+                      enum:
+                        - Valid
+                        - Audited
+                        - Rejected
+                      type: string
+                  required:
+                    - status
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_wafvalidationpolicies.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/applicationlayer.projectcalico.org_wafvalidationpolicies.yaml
@@ -1,0 +1,229 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: wafvalidationpolicies.applicationlayer.projectcalico.org
+spec:
+  group: applicationlayer.projectcalico.org
+  names:
+    kind: WAFValidationPolicy
+    listKind: WAFValidationPolicyList
+    plural: wafvalidationpolicies
+    shortNames:
+      - wafvp
+    singular: wafvalidationpolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.enforcementMode
+          name: Mode
+          type: string
+        - jsonPath: .status.securityPosture
+          name: Posture
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3
+      schema:
+        openAPIV3Schema:
+          description: |-
+            WAFValidationPolicy defines namespace-scoped validation rules for Application
+            Operators to self-validate their WAF configuration. Useful for catching
+            mistakes like accidentally removing required plugins.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: WAFValidationPolicySpec defines namespace validation rules
+              properties:
+                enforcementMode:
+                  default: Audit
+                  description: |-
+                    EnforcementMode determines how validation failures are handled
+                    - Audit: Log warnings but generate EnvoyExtensionPolicy anyway
+                    - Enforce: Block EnvoyExtensionPolicy generation on critical failures
+                    Note: Namespace policies can only Enforce if GlobalPolicy allows it
+                  enum:
+                    - Audit
+                    - Enforce
+                  type: string
+                rules:
+                  description: Rules defines the validation rules to apply
+                  items:
+                    description:
+                      ValidationRule defines a single CEL-based validation
+                      rule
+                    properties:
+                      expression:
+                        description: |-
+                          Expression is a CEL expression that must evaluate to true for validation to pass.
+                          Available variables:
+                            - directives: []string - the final merged directive list
+                            - config.action: string - effective action ("Detect" or "Block")
+                            - config.crsState: string - CRS state ("Enabled" or "Disabled")
+                            - config.paranoiaLevel: int - effective paranoia level (1-4)
+                            - source.globalPolicy: string - name of GlobalWAFPolicy
+                            - source.namespacePolicy: string - name of WAFPolicy (if any)
+                            - source.globalPlugins: []string - names of global plugins applied
+                            - source.namespacePlugins: []string - names of namespace plugins applied
+                        maxLength: 16384
+                        minLength: 1
+                        type: string
+                      message:
+                        description: Message is displayed when validation fails
+                        maxLength: 1024
+                        type: string
+                      name:
+                        description: Name is a unique identifier for this rule
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      severity:
+                        default: warning
+                        description: Severity determines the impact of this rule failing
+                        enum:
+                          - info
+                          - warning
+                          - critical
+                        type: string
+                    required:
+                      - expression
+                      - name
+                    type: object
+                  minItems: 1
+                  type: array
+              required:
+                - rules
+              type: object
+            status:
+              description: |-
+                WAFValidationPolicyStatus defines the observed state.
+                No conditions are emitted by the controller for this type today; the Conditions
+                field is reserved for future use.
+              properties:
+                conditions:
+                  description: Conditions represent the latest available observations
+                  items:
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastEvaluated:
+                  description: LastEvaluated is the timestamp of the last evaluation
+                  format: date-time
+                  type: string
+                securityPosture:
+                  description:
+                    SecurityPosture is the overall posture based on validation
+                    results
+                  enum:
+                    - Compliant
+                    - Warning
+                    - Degraded
+                    - Critical
+                  type: string
+                validationResults:
+                  description: ValidationResults contains results for each rule
+                  items:
+                    description:
+                      ValidationResult represents the result of a single
+                      validation rule
+                    properties:
+                      message:
+                        description: Message is the failure message (if failed)
+                        maxLength: 1024
+                        type: string
+                      passed:
+                        description: Passed indicates whether the rule passed
+                        type: boolean
+                      rule:
+                        description: Rule is the name of the validation rule
+                        maxLength: 63
+                        type: string
+                      severity:
+                        description: Severity is the severity level of this rule
+                        enum:
+                          - info
+                          - warning
+                          - critical
+                        type: string
+                    required:
+                      - passed
+                      - rule
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_kubecontrollersconfigurations.yaml
@@ -48,6 +48,19 @@ spec:
                     Controllers enables and configures individual Kubernetes
                     controllers
                   properties:
+                    applicationLayer:
+                      description: |-
+                        ApplicationLayer enables and configures the application-layer subsystem
+                        (WAF, GlobalWAF, WAFPlugin, validation). Operator-managed; users should
+                        not edit this field directly. Non-nil enables the subsystem; activation
+                        is gated on a valid Calico Enterprise license.
+                      properties:
+                        reconcilerPeriod:
+                          description:
+                            "ReconcilerPeriod is the period to perform reconciliation.
+                            [Default: 30s]"
+                          type: string
+                      type: object
                     federatedServices:
                       description:
                         FederatedServices enables and configures the federatedservices
@@ -298,6 +311,19 @@ spec:
                         Controllers enables and configures individual Kubernetes
                         controllers
                       properties:
+                        applicationLayer:
+                          description: |-
+                            ApplicationLayer enables and configures the application-layer subsystem
+                            (WAF, GlobalWAF, WAFPlugin, validation). Operator-managed; users should
+                            not edit this field directly. Non-nil enables the subsystem; activation
+                            is gated on a valid Calico Enterprise license.
+                          properties:
+                            reconcilerPeriod:
+                              description:
+                                "ReconcilerPeriod is the period to perform
+                                reconciliation. [Default: 30s]"
+                              type: string
+                          type: object
                         federatedServices:
                           description:
                             FederatedServices enables and configures the


### PR DESCRIPTION
The admission import directories now hold both mutating and validating policies (the new protect-builtin-tiers policy that blocks deletion of the built-in tiers). The operator manages the validating policy and its binding the same way it manages the mutating ones: bootstraps them at startup, reconciles them, and cleans up stale managed copies.

ValidatingAdmissionPolicy has been served since k8s 1.30, well before MutatingAdmissionPolicy (1.32), so its served version is discovered independently. A cluster that serves validating but not mutating policies still gets tier protection, and we skip without degrading on clusters that serve neither.

Also pulls in the regenerated pkg/imports files, which were out of date against calico master and were breaking CI.

```release-note
None
```
