### PR TITLE
Update managed CRDs before persisting Installation defaults (#4881)

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -903,6 +903,13 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		utils.SetInstallationFinalizer(instance, render.OperatorCompleteFinalizer)
 	}
 
+	// Update CRDs before persisting defaults. Defaulting can set a value only this operator version's
+	// CRD accepts (e.g. an autodetected kubernetesProvider=Kind); on upgrade the old served CRD would
+	// otherwise reject the write and the reconcile would loop before ever reaching the CRD update.
+	if err = r.updateCRDs(ctx, instance.Spec.Variant, reqLogger); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Write the discovered configuration back to the API. This is essentially a poor-man's defaulting, and
 	// ensures that we don't surprise anyone by changing defaults in a future version of the operator.
 	// Note that we only write the 'base' installation back. We don't want to write the changes from 'overlay', as those should only
@@ -929,10 +936,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			r.status.SetDegraded(operatorv1.InvalidConfigurationError, "Invalid computed config", err, reqLogger)
 			return reconcile.Result{}, err
 		}
-	}
-
-	if err = r.updateCRDs(ctx, instance.Spec.Variant, reqLogger); err != nil {
-		return reconcile.Result{}, err
 	}
 
 	if err = r.updateMutatingAdmissionPolicies(ctx, instance, reqLogger); err != nil {


### PR DESCRIPTION
Cherry-pick of #4881 to `release-v1.42`.

Upgrading the operator on a kind cluster could get stuck, with the `calico` TigeraStatus going `Degraded` and the install never progressing, reporting `spec.kubernetesProvider: Unsupported value: "Kind"` on a loop.

The operator autodetects the Kubernetes provider and writes it back to the Installation, but it did that before updating its managed CRDs. On an upgrade across the version that added the `Kind` provider value, the older CRD still being served rejected the write, and the reconcile bailed out before ever reaching the CRD update, so it never refreshed the CRD that would accept the value. This moves the CRD update ahead of the write-back so the autodetected value is accepted.

Tracked in CORE-12945.

```release-note
Fixes an operator upgrade that could stall on kind clusters, looping on an unsupported "Kind" kubernetesProvider value instead of completing.
```
