### PR TITLE
Point Windows install-cni at the cni image's calico.exe

### DIFF
--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -453,10 +453,10 @@ func (c *windowsComponent) cniContainer() corev1.Container {
 		{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
 	}
 
-	// The combined calico binary ships in the cni-windows image at
-	// /opt/cni/bin/calico.exe (Linux uses /usr/bin/calico in the node image).
-	// Keep the binary path and the Image in sync: the node image's
-	// /CalicoWindows/calico-node.exe would not resolve in the cni image.
+	// install-cni runs the cni image, which ships the combined binary at
+	// /opt/cni/bin/calico.exe. The node containers below run the node image,
+	// which ships the same binary at /CalicoWindows/calico.exe. Keep each
+	// command's path in sync with the image it runs in.
 	return corev1.Container{
 		Name:            "install-cni",
 		Image:           c.cniImage,
@@ -751,8 +751,8 @@ func (c *windowsComponent) windowsVolumeMounts() []corev1.VolumeMount {
 
 // windowsLivenessReadinessProbes creates the node's liveness and readiness probes.
 func (c *windowsComponent) windowsLivenessReadinessProbes() (*corev1.Probe, *corev1.Probe) {
-	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-live"}
-	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-ready"}
+	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico.exe", "component", "node", "health", "--felix-live"}
+	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico.exe", "component", "node", "health", "--felix-ready"}
 
 	lp := &corev1.Probe{
 		ProbeHandler:        corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: livenessCmd}},
@@ -773,7 +773,7 @@ func (c *windowsComponent) windowsLivenessReadinessProbes() (*corev1.Probe, *cor
 func (c *windowsComponent) windowsLifecycle() *corev1.Lifecycle {
 	return &corev1.Lifecycle{
 		PreStop: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{
-			Command: []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "shutdown"},
+			Command: []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico.exe", "component", "node", "shutdown"},
 		}},
 	}
 }

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -453,10 +453,14 @@ func (c *windowsComponent) cniContainer() corev1.Container {
 		{MountPath: "/host/etc/cni/net.d", Name: "cni-net-dir"},
 	}
 
+	// The combined calico binary ships in the cni-windows image at
+	// /opt/cni/bin/calico.exe (Linux uses /usr/bin/calico in the node image).
+	// Keep the binary path and the Image in sync: the node image's
+	// /CalicoWindows/calico-node.exe would not resolve in the cni image.
 	return corev1.Container{
 		Name:            "install-cni",
 		Image:           c.cniImage,
-		Command:         []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "cni", "install"},
+		Command:         []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/opt/cni/bin/calico.exe", "component", "cni", "install"},
 		Env:             cniEnv,
 		SecurityContext: securitycontext.NewWindowsHostProcessContext(),
 		VolumeMounts:    cniVolumeMounts,

--- a/pkg/render/windows_test.go
+++ b/pkg/render/windows_test.go
@@ -2721,9 +2721,9 @@ var _ = Describe("Windows rendering tests", func() {
 // The unused argument is kept temporarily so existing call sites compile while the OSS/Enterprise distinction
 // is being phased out.
 func verifyWindowsProbesAndLifecycle(ds *appsv1.DaemonSet, _ bool) {
-	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-live"}
-	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "health", "--felix-ready"}
-	preStopCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico-node.exe", "component", "node", "shutdown"}
+	livenessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico.exe", "component", "node", "health", "--felix-live"}
+	readinessCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico.exe", "component", "node", "health", "--felix-ready"}
+	preStopCmd := []string{"$env:CONTAINER_SANDBOX_MOUNT_POINT/CalicoWindows/calico.exe", "component", "node", "shutdown"}
 
 	expectedLiveness := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
Follow-up to #4880. That change pointed the Windows install-cni container at `calico-node.exe component cni install`, but the container runs the cni-windows image, which doesn't carry that binary. install-cni crashed with "The system cannot find the path specified" and the Windows node never initialised.

Point install-cni at `/opt/cni/bin/calico.exe`, the combined binary the cni image now ships (see projectcalico/calico#12909). Also rename the node container's `calico-node.exe` references to `calico.exe` to match the calico-side rename, so the binary has one name across Windows. Mirrors the Linux install-cni container, which pairs the calico image with `/usr/bin/calico component cni install`.

```release-note
NONE
```
