### PR TITLE
Bump ECK Elasticsearch/Kibana version to 8.19.16

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.22.0-1.0
   eck-kibana:
-    version: 8.18.4
+    version: 8.19.16
   kibana:
     image: tigera/kibana
     version: v3.22.0-1.0
   eck-elasticsearch:
-    version: 8.18.4
+    version: 8.19.16
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.22.0-1.0

--- a/hack/gen-versions/calico.go.tpl
+++ b/hack/gen-versions/calico.go.tpl
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hack/gen-versions/components.go
+++ b/hack/gen-versions/components.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hack/gen-versions/enterprise.go.tpl
+++ b/hack/gen-versions/enterprise.go.tpl
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hack/gen-versions/main.go
+++ b/hack/gen-versions/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.18.4",
+		Version:  "8.19.16",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.18.4",
+		Version:  "8.19.16",
 		Registry: "",
 	}
 


### PR DESCRIPTION

  ## Summary
- Bump ECK Elasticsearch/Kibana version to 8.19.16

```release-note
 ECK Elasticsearch and Kibana version  to 8.19.16.
```

  
