### PR TITLE
Bump  Elasticsearch/Kibana version 8.19.15 → 8.19.16

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -54,14 +54,14 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v3.9.1
+    version: v3.12.0
   prometheus:
     image: prometheus
     version: master
   # coreos-alertmanager holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
-    version: v0.30.1
+    version: v0.31.1
   alertmanager:
     image: alertmanager
     version: master

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -26,13 +26,13 @@ components:
     version: master
   # eck-kibana holds the version of Kibana built for tigera/kibana
   eck-kibana:
-    version: 8.19.15
+    version: 8.19.16
   kibana:
     image: kibana
     version: master
   # eck-elasticsearch holds the version of Elasticsearch built for tigera/elasticsearch
   eck-elasticsearch:
-    version: 8.19.15
+    version: 8.19.16
   elasticsearch:
     image: elasticsearch
     version: master

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -163,7 +163,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = Component{
-		Version: "v3.9.1",
+		Version: "v3.12.0",
 		variant: enterpriseVariant,
 	}
 
@@ -176,7 +176,7 @@ var (
 	}
 
 	ComponentCoreOSAlertmanager = Component{
-		Version: "v0.30.1",
+		Version: "v0.31.1",
 		variant: enterpriseVariant,
 	}
 

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -45,12 +45,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version: "8.19.15",
+		Version: "8.19.16",
 		variant: enterpriseVariant,
 	}
 
 	ComponentEckKibana = Component{
-		Version: "8.19.15",
+		Version: "8.19.16",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
  ## Summary
  - Bump `eck-elasticsearch` and `eck-kibana` versions from `8.19.15` to `8.19.16`


```release-note
ECK Elasticsearch and Kibana version bumped from 8.19.15 to 8.19.16 for CVE remediation.
```
