### PR TITLE
gatewayapi: split envoy-gateway controller policy ingress by IP family

### DIFF
--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -1438,8 +1438,15 @@ func gatewayAPIControllerPolicy(namespace string, openShift bool) *v3.NetworkPol
 				{
 					Action:   v3.Allow,
 					Protocol: &networkpolicy.TCPProtocol,
-					// Dual-stack and IPv6-only need ::/0 in addition to 0.0.0.0/0.
-					Source: v3.EntityRule{Nets: []string{"0.0.0.0/0", "::/0"}},
+					Source:   v3.EntityRule{Nets: []string{"0.0.0.0/0"}},
+					Destination: v3.EntityRule{
+						Ports: networkpolicy.Ports(9443, 18000, 18001, 18002, 19001),
+					},
+				},
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Source:   v3.EntityRule{Nets: []string{"::/0"}},
 					Destination: v3.EntityRule{
 						Ports: networkpolicy.Ports(9443, 18000, 18001, 18002, 19001),
 					},


### PR DESCRIPTION
- a single v3 NetworkPolicy rule can't mix IPv4 and IPv6 CIDRs; the apiserver rejected 0.0.0.0/0 + ::/0 in one Source.Nets, looping the reconcile
- split into one rule per family, matching apiserver.go

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
