### PR TITLE
core-12827: bump k8s build image to k8s1.36.1, go 1.26.3, llvm 21.1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.26.2-llvm20.1.8-k8s1.35.4
-CALICO_BASE_VER ?= ubi9-1776708455
+GO_BUILD_VER?=1.26.3-llvm21.1.8-k8s1.36.1
+CALICO_BASE_VER ?= ubi9-1779935431
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)
 SRC_FILES=$(shell find ./pkg -name '*.go')

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator/api
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/envoyproxy/gateway v1.7.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Description

Bumps the build toolchain to Kubernetes 1.36.1.

- `GO_BUILD_VER`: `1.26.2-llvm20.1.8-k8s1.35.4` → `1.26.3-llvm21.1.8-k8s1.36.1` (go 1.26.2→1.26.3, llvm 20.1.8→21.1.8, k8s 1.35.4→1.36.1)
- `CALICO_BASE_VER`: `ubi9-1776708455` → `ubi9-1779935431`
- `go` directive in `go.mod` and `api/go.mod`: `1.26.2` → `1.26.3` to match the build image toolchain

The `k8s.io/*` Go libraries are already at `v0.36.1` on master, so no module changes were needed.

## Verification

- `make image` builds successfully against the new go-build and base images
- Forced `make build` recompiles all packages cleanly (BoringCrypto check passes)
- `make generate` produces no diffs

**Release note:**
```release-note
Bump Kubernetes dependencies to v1.36.1.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)