### PR TITLE
Bump ECK Elasticsearch/Kibana version to 8.19.16

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.22.5
   eck-kibana:
-    version: 8.19.15
+    version: 8.19.16
   kibana:
     image: tigera/kibana
     version: v3.22.5
   eck-elasticsearch:
-    version: 8.19.15
+    version: 8.19.16
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.22.5

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.19.15",
+		Version:  "8.19.16",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.19.15",
+		Version:  "8.19.16",
 		Registry: "",
 	}
 


### PR DESCRIPTION

  ## Summary
- Bump ECK Elasticsearch/Kibana version to 8.19.16

```release-note
 ECK Elasticsearch and Kibana version  to 8.19.16.
```

  
