### PR TITLE
 [CI-1997] Add operator secrets RoleBinding for tigera-manager namespace in dex component

### DIFF
--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -135,6 +135,7 @@ func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 		c.allowTigeraNetworkPolicy(c.cfg.Installation.Variant),
 		networkpolicy.AllowTigeraDefaultDeny(DexNamespace),
 		CreateOperatorSecretsRoleBinding(DexNamespace),
+		CreateOperatorSecretsRoleBinding(ManagerNamespace),
 		c.serviceAccount(),
 		c.deployment(),
 		c.service(),


### PR DESCRIPTION
Ensure the operator ServiceAccount has RBAC to manage secrets in the
  `tigera-manager` namespace when the Authentication CR is configured.

  ### Problem

  On fresh installs with Authentication/OIDC configured, the `authentication`
  TigeraStatus can degrade with a secrets forbidden error in `tigera-manager`.
  This occurs when the authentication controller reconciles before the
  manager controller has fully initialized, as the necessary RoleBinding
  may not yet exist in `tigera-manager`.

  ### Fix

  Add `CreateOperatorSecretsRoleBinding(ManagerNamespace)` to the dex
  component's `Objects()` in `pkg/render/dex.go`, ensuring the RoleBinding
  is present regardless of controller reconciliation order.

 
  **Workaround:** Manually create the RoleBinding


```release-note
Fix RBAC error preventing operator from creating secrets in tigera-manager namespace on fresh installs with Authentication CR configured
```
