### PR TITLE
fix(gatewayapi): split envoy-gateway NetworkPolicy ingress by IP family

### DIFF
--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -1434,12 +1434,22 @@ func gatewayAPIControllerPolicy(namespace string, openShift bool) *v3.NetworkPol
 			Selector: EnvoyGatewayPolicySelector,
 			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 			// 9443: webhook. 18000-18002: xDS. 19001: metrics.
+			// A single Calico rule's Nets must be one address family, so the
+			// IPv4 and IPv6 allow-from-anywhere CIDRs are split into separate
+			// rules (dual-stack and IPv6-only clusters both need ::/0).
 			Ingress: []v3.Rule{
 				{
 					Action:   v3.Allow,
 					Protocol: &networkpolicy.TCPProtocol,
-					// Dual-stack and IPv6-only need ::/0 in addition to 0.0.0.0/0.
-					Source: v3.EntityRule{Nets: []string{"0.0.0.0/0", "::/0"}},
+					Source:   v3.EntityRule{Nets: []string{"0.0.0.0/0"}},
+					Destination: v3.EntityRule{
+						Ports: networkpolicy.Ports(9443, 18000, 18001, 18002, 19001),
+					},
+				},
+				{
+					Action:   v3.Allow,
+					Protocol: &networkpolicy.TCPProtocol,
+					Source:   v3.EntityRule{Nets: []string{"::/0"}},
 					Destination: v3.EntityRule{
 						Ports: networkpolicy.Ports(9443, 18000, 18001, 18002, 19001),
 					},

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1734,6 +1734,12 @@ value:
 		Expect(err).NotTo(HaveOccurred())
 		Expect(policy.Spec.Tier).To(Equal("calico-system"))
 		Expect(policy.Spec.Selector).To(Equal(EnvoyGatewayPolicySelector))
+		// A single Calico rule's Nets must be one address family — the ingress
+		// allow is split per family, not {"0.0.0.0/0","::/0"} in one rule, which
+		// Calico rejects ("rule contains both IPv4 and IPv6 CIDRs").
+		Expect(policy.Spec.Ingress).To(HaveLen(2))
+		Expect(policy.Spec.Ingress[0].Source.Nets).To(Equal([]string{"0.0.0.0/0"}))
+		Expect(policy.Spec.Ingress[1].Source.Nets).To(Equal([]string{"::/0"}))
 		_, err = rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, "calico-system.default-deny", common.CalicoNamespace)
 		Expect(err).To(HaveOccurred(), "must not render default-deny in calico-system")
 	})


### PR DESCRIPTION
## Description

Bug fix. The `calico-system.envoy-gateway` NetworkPolicy ingress allow put both `0.0.0.0/0` and `::/0` in a single rule's `Source.Nets`, which Calico rejects ("rule contains both IPv4 and IPv6 CIDRs"), so the policy fails to apply on dual-stack and IPv6 clusters. Split the allow into one rule per address family.

Split out of #4821 — standalone fix, no WAF dependency.

Tested: `go test ./pkg/render/gatewayapi/...` — asserts the ingress is rendered as two per-family rules.

## Release Note

```release-note
Fixed the envoy-gateway NetworkPolicy failing to apply on dual-stack and IPv6 clusters: the ingress allow mixed IPv4 and IPv6 CIDRs in a single rule, which Calico rejects. The rule is now split per IP family.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `release-note-required`
  - `docs-not-required`